### PR TITLE
Fix nixling switch/boot/test: emit closure hostGeneration so store-view intents exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+### Fixed
+
+- `nixling switch` / `boot` / `test` no longer fail with `broker-error`
+  ("no store-view intent in the trusted bundle"). The per-VM closure
+  artifact now emits a populated `hostGeneration` (a deterministic,
+  content-derived store-view generation), so the broker builds a
+  store-view intent for every VM instead of skipping it. Previously
+  live activation was impossible and the only way to apply a new
+  generation was `nixling down <vm> --apply` followed by
+  `nixling up <vm> --apply`. The per-VM `/nix/store` hardlink farm now
+  also fails closed on a store-view generation collision (two distinct
+  closures of one VM mapping to the same generation number) instead of
+  unioning them, by pinning the closure identity in the generation
+  marker.
+
 ## [1.2] - 2026-06-03
 
 Primarily a stabilization release per

--- a/docs/reference/daemon-api.md
+++ b/docs/reference/daemon-api.md
@@ -172,23 +172,23 @@ names are rejected during deserialization.
 | `OpenFuseRequest` | struct | [`OpenFuseRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L693) | struct { `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
 | `PrepareDirRequest` | struct | [`PrepareDirRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L704) | struct { `vm_id`: `VmId`; `path_class`: `PathClass`; `tracing_span_id`: `Option<TracingSpanId>` } |
 | `PrepareStoreViewRequest` | struct | [`PrepareStoreViewRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L713) | struct { `vm_id`: `VmId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `StoreSyncRequest` | struct | [`StoreSyncRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L727) | struct { `vm_id`: `VmId`; `bundle_closure_ref`: `BundleClosureRef`; `generation`: `u32`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `SetBridgePortFlagsRequest` | struct | [`SetBridgePortFlagsRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L761) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `SetSocketAclRequest` | struct | [`SetSocketAclRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L770) | struct { `bundle_socket_intent_ref`: `BundleOpId`; `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `SetupMountNamespaceRequest` | struct | [`SetupMountNamespaceRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L780) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `UpdateHostsFileRequest` | struct | [`UpdateHostsFileRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L791) | struct { `bundle_hosts_intent_ref`: `BundleOpId`; `destroy`: `bool`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `UsbipBindRequest` | struct | [`UsbipBindRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L803) | struct { `bus_id`: `String`; `vm_id`: `VmId` } |
-| `UsbipBindFirewallRuleRequest` | struct | [`UsbipBindFirewallRuleRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L819) | struct { `bundle_usbip_firewall_intent_ref`: `BundleOpId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `UsbipProxyReconcileRequest` | struct | [`UsbipProxyReconcileRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L827) | struct { `scope_id`: `ScopeId` } |
-| `UsbipUnbindRequest` | struct | [`UsbipUnbindRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L833) | struct { `bus_id`: `String` } |
-| `SignalRunnerRequest` | struct | [`SignalRunnerRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L886) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `signal`: `RunnerSignal`; `pid`: `Option<i32>`; `expected_start_time_ticks`: `Option<u64>`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `DeregisterRunnerPidfdRequest` | struct | [`DeregisterRunnerPidfdRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L908) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `SpawnRunnerRequest` | struct | [`SpawnRunnerRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L985) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `role`: `RunnerRole`; `bundle_runner_intent_ref`: `BundleOpId`; `runtime_allocations`: `Vec<RunnerAllocation>`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `SeedDnsmasqLeaseRequest` | struct | [`SeedDnsmasqLeaseRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1133) | struct { `vm_id`: `VmId`; `scope_id`: `ScopeId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `BindMountFromHardlinkFarmRequest` | struct | [`BindMountFromHardlinkFarmRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1145) | struct { `vm_id`: `VmId`; `bundle_store_view_intent_ref`: `Option<BundleOpId>`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `OwnershipMatrixCheckRequest` | struct | [`OwnershipMatrixCheckRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1160) | struct { `vm_id`: `VmId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `SshHostKeyPreflightRequest` | struct | [`SshHostKeyPreflightRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1171) | struct { `vm_id`: `VmId`; `tracing_span_id`: `Option<TracingSpanId>` } |
-| `DiskInitRequest` | struct | [`DiskInitRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1189) | struct { `vm_id`: `VmId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `StoreSyncRequest` | struct | [`StoreSyncRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L730) | struct { `vm_id`: `VmId`; `bundle_closure_ref`: `BundleClosureRef`; `generation`: `u32`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `SetBridgePortFlagsRequest` | struct | [`SetBridgePortFlagsRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L764) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `SetSocketAclRequest` | struct | [`SetSocketAclRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L773) | struct { `bundle_socket_intent_ref`: `BundleOpId`; `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `SetupMountNamespaceRequest` | struct | [`SetupMountNamespaceRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L783) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `UpdateHostsFileRequest` | struct | [`UpdateHostsFileRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L794) | struct { `bundle_hosts_intent_ref`: `BundleOpId`; `destroy`: `bool`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `UsbipBindRequest` | struct | [`UsbipBindRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L806) | struct { `bus_id`: `String`; `vm_id`: `VmId` } |
+| `UsbipBindFirewallRuleRequest` | struct | [`UsbipBindFirewallRuleRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L822) | struct { `bundle_usbip_firewall_intent_ref`: `BundleOpId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `UsbipProxyReconcileRequest` | struct | [`UsbipProxyReconcileRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L830) | struct { `scope_id`: `ScopeId` } |
+| `UsbipUnbindRequest` | struct | [`UsbipUnbindRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L836) | struct { `bus_id`: `String` } |
+| `SignalRunnerRequest` | struct | [`SignalRunnerRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L889) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `signal`: `RunnerSignal`; `pid`: `Option<i32>`; `expected_start_time_ticks`: `Option<u64>`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `DeregisterRunnerPidfdRequest` | struct | [`DeregisterRunnerPidfdRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L911) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `SpawnRunnerRequest` | struct | [`SpawnRunnerRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L988) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `role`: `RunnerRole`; `bundle_runner_intent_ref`: `BundleOpId`; `runtime_allocations`: `Vec<RunnerAllocation>`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `SeedDnsmasqLeaseRequest` | struct | [`SeedDnsmasqLeaseRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1136) | struct { `vm_id`: `VmId`; `scope_id`: `ScopeId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `BindMountFromHardlinkFarmRequest` | struct | [`BindMountFromHardlinkFarmRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1148) | struct { `vm_id`: `VmId`; `bundle_store_view_intent_ref`: `Option<BundleOpId>`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `OwnershipMatrixCheckRequest` | struct | [`OwnershipMatrixCheckRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1163) | struct { `vm_id`: `VmId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `SshHostKeyPreflightRequest` | struct | [`SshHostKeyPreflightRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1174) | struct { `vm_id`: `VmId`; `tracing_span_id`: `Option<TracingSpanId>` } |
+| `DiskInitRequest` | struct | [`DiskInitRequest`](../../packages/nixling-ipc/src/broker_wire.rs#L1192) | struct { `vm_id`: `VmId`; `tracing_span_id`: `Option<TracingSpanId>` } |
 <!-- END AUTO-GENERATED: request-types -->
 
 <!-- BEGIN AUTO-GENERATED: response-types -->
@@ -223,16 +223,16 @@ names are rejected during deserialization.
 | `BrokerErrorResponse` | struct | [`BrokerErrorResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L428) | struct { `kind`: `String`; `operation`: `String`; `target_wave`: `Option<String>`; `message`: `String`; `action`: `String` } |
 | `HelloResponse` | struct | [`HelloResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L442) | struct { `server_version`: `String`; `selected_version`: `String`; `capabilities`: `Vec<String>` } |
 | `OpenPidfdResponse` | struct | [`OpenPidfdResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L670) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `pid`: `i32`; `verified_start_time_ticks`: `u64`; `pidfd_index`: `u32` } |
-| `StoreSyncResponse` | struct | [`StoreSyncResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L742) | struct { `vm`: `String`; `generation`: `u32`; `hardlink_farm_path`: `String`; `closure_count`: `u32` } |
-| `AckResponse` | struct | [`AckResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L839) | struct { `accepted`: `bool`; `operation`: `String` } |
-| `TapReadyResponse` | struct | [`TapReadyResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L846) | struct { `bridge`: `Option<IfName>`; `tap`: `IfName` } |
-| `ExportBrokerAuditResponse` | struct | [`ExportBrokerAuditResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L853) | struct { `lines`: `Vec<String>` } |
-| `BridgePortFlagsResponse` | struct | [`BridgePortFlagsResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L859) | struct { `bridge`: `IfName`; `isolated`: `bool`; `neigh_suppress`: `bool`; `port`: `IfName` } |
-| `ValidateBundleResponse` | struct | [`ValidateBundleResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L868) | struct { `valid`: `bool` } |
-| `SignalRunnerResponse` | struct | [`SignalRunnerResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L900) | struct { `signaled`: `bool`; `vm_id`: `VmId`; `role_id`: `RoleId` } |
-| `DeregisterRunnerPidfdResponse` | struct | [`DeregisterRunnerPidfdResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L917) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `removed`: `bool` } |
-| `SpawnRunnerResponse` | struct | [`SpawnRunnerResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L1047) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `role`: `RunnerRole`; `pid`: `i32`; `start_time_ticks`: `u64`; `pidfd_index`: `u32` } |
-| `PollChildReapedResponse` | struct | [`PollChildReapedResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L1250) | struct { `notifications`: `Vec<ChildReapedNotification>` } |
+| `StoreSyncResponse` | struct | [`StoreSyncResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L745) | struct { `vm`: `String`; `generation`: `u32`; `hardlink_farm_path`: `String`; `closure_count`: `u32` } |
+| `AckResponse` | struct | [`AckResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L842) | struct { `accepted`: `bool`; `operation`: `String` } |
+| `TapReadyResponse` | struct | [`TapReadyResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L849) | struct { `bridge`: `Option<IfName>`; `tap`: `IfName` } |
+| `ExportBrokerAuditResponse` | struct | [`ExportBrokerAuditResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L856) | struct { `lines`: `Vec<String>` } |
+| `BridgePortFlagsResponse` | struct | [`BridgePortFlagsResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L862) | struct { `bridge`: `IfName`; `isolated`: `bool`; `neigh_suppress`: `bool`; `port`: `IfName` } |
+| `ValidateBundleResponse` | struct | [`ValidateBundleResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L871) | struct { `valid`: `bool` } |
+| `SignalRunnerResponse` | struct | [`SignalRunnerResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L903) | struct { `signaled`: `bool`; `vm_id`: `VmId`; `role_id`: `RoleId` } |
+| `DeregisterRunnerPidfdResponse` | struct | [`DeregisterRunnerPidfdResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L920) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `removed`: `bool` } |
+| `SpawnRunnerResponse` | struct | [`SpawnRunnerResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L1050) | struct { `vm_id`: `VmId`; `role_id`: `RoleId`; `role`: `RunnerRole`; `pid`: `i32`; `start_time_ticks`: `u64`; `pidfd_index`: `u32` } |
+| `PollChildReapedResponse` | struct | [`PollChildReapedResponse`](../../packages/nixling-ipc/src/broker_wire.rs#L1253) | struct { `notifications`: `Vec<ChildReapedNotification>` } |
 <!-- END AUTO-GENERATED: response-types -->
 
 ## Per-VM lifecycle state
@@ -266,12 +266,12 @@ state-machine node.
 | Type | Kind | Rust definition | Shape |
 | --- | --- | --- | --- |
 | `ActivationMode` | enum | [`ActivationMode`](../../packages/nixling-ipc/src/broker_wire.rs#L266) | `Switch`; `Boot`; `Test`; `Rollback` |
-| `RunnerSignal` | enum | [`RunnerSignal`](../../packages/nixling-ipc/src/broker_wire.rs#L878) | `Term`; `Kill`; `Quit` |
-| `RunnerRole` | enum | [`RunnerRole`](../../packages/nixling-ipc/src/broker_wire.rs#L936) | `CloudHypervisor`; `Virtiofsd`; `Swtpm`; `SwtpmFlush`; `Gpu`; `Audio`; `Video`; `VsockRelay`; `Usbip`; `OtelHostBridge` |
-| `RunnerAllocationKind` | enum | [`RunnerAllocationKind`](../../packages/nixling-ipc/src/broker_wire.rs#L1025) | `VsockCid`; `TapFdSlot`; `ApiSocketPath` |
-| `BrokerCallerRole` | enum | [`BrokerCallerRole`](../../packages/nixling-ipc/src/broker_wire.rs#L1091) | `AdminUid` — struct { `uid`: `u32` }; `LauncherUid` — struct { `uid`: `u32` }; `RootUid` — struct { `uid`: `u32` }; `NotAuthorized` |
-| `ChildExitKind` | enum | [`ChildExitKind`](../../packages/nixling-ipc/src/broker_wire.rs#L1202) | `Exited`; `Signaled`; `Killed` |
-| `BrokerNotification` | enum | [`BrokerNotification`](../../packages/nixling-ipc/src/broker_wire.rs#L1240) | `ChildReaped` — (ChildReapedNotification); `Unknown` |
+| `RunnerSignal` | enum | [`RunnerSignal`](../../packages/nixling-ipc/src/broker_wire.rs#L881) | `Term`; `Kill`; `Quit` |
+| `RunnerRole` | enum | [`RunnerRole`](../../packages/nixling-ipc/src/broker_wire.rs#L939) | `CloudHypervisor`; `Virtiofsd`; `Swtpm`; `SwtpmFlush`; `Gpu`; `Audio`; `Video`; `VsockRelay`; `Usbip`; `OtelHostBridge` |
+| `RunnerAllocationKind` | enum | [`RunnerAllocationKind`](../../packages/nixling-ipc/src/broker_wire.rs#L1028) | `VsockCid`; `TapFdSlot`; `ApiSocketPath` |
+| `BrokerCallerRole` | enum | [`BrokerCallerRole`](../../packages/nixling-ipc/src/broker_wire.rs#L1094) | `AdminUid` — struct { `uid`: `u32` }; `LauncherUid` — struct { `uid`: `u32` }; `RootUid` — struct { `uid`: `u32` }; `NotAuthorized` |
+| `ChildExitKind` | enum | [`ChildExitKind`](../../packages/nixling-ipc/src/broker_wire.rs#L1205) | `Exited`; `Signaled`; `Killed` |
+| `BrokerNotification` | enum | [`BrokerNotification`](../../packages/nixling-ipc/src/broker_wire.rs#L1243) | `ChildReaped` — (ChildReapedNotification); `Unknown` |
 | `KnownFeatureFlag` | enum | [`KnownFeatureFlag`](../../packages/nixling-ipc/src/lib.rs#L140) | `TypedErrors`; `ManifestV04`; `StatusCheckBridges`; `ExportBrokerAudit` |
 | `MutatingVerbOutcome` | enum | [`MutatingVerbOutcome`](../../packages/nixling-ipc/src/public_wire.rs#L324) | `DryRunPlanned`; `Applied`; `ApiReadyTimeout`; `NotYetImplemented`; `BrokerError`; `InvalidRequest` |
 | `UsbipProbeStatus` | enum | [`UsbipProbeStatus`](../../packages/nixling-ipc/src/public_wire.rs#L408) | `Bound`; `Unbound` |

--- a/docs/reference/schemas/v2/wire-protocol.json
+++ b/docs/reference/schemas/v2/wire-protocol.json
@@ -4700,7 +4700,7 @@
       "additionalProperties": false
     },
     "StoreSyncRequest": {
-      "description": "Store-sync request. The broker resolves the closure intent row keyed by `vm_id` (canonical id form `\"store-view:vm:<vm>\"`) and refuses the op if `bundle_closure_ref` does not match. The broker also refuses if the wire-supplied `generation` does not match the bundle's resolved generation — generations are monotonic, so a stale daemon must not race the activator.",
+      "description": "Store-sync request. The broker resolves the closure intent row keyed by `vm_id` (canonical id form `\"store-view:vm:<vm>\"`) and refuses the op if `bundle_closure_ref` does not match. The broker also refuses if the wire-supplied `generation` does not match the bundle's resolved generation. The generation is a content-derived stable equality token (see `closures-json.nix`), not a monotonic counter: the daemon and broker both read it from the same trusted bundle, so a mismatch means a stale daemon is racing the activator and the op is refused fail-closed.",
       "type": "object",
       "required": [
         "bundleClosureRef",

--- a/nixos-modules/closures-json.nix
+++ b/nixos-modules/closures-json.nix
@@ -44,12 +44,30 @@ let
       relativePath = "closures/${name}.json";
       file = pkgs.runCommand "nixling-${name}-closure.json" { nativeBuildInputs = [ pkgs.python3 ]; } ''
         python - "$out" "${closure}/store-paths" <<'PY'
+        import hashlib
         import json
         import sys
 
         out, store_paths = sys.argv[1], sys.argv[2]
         with open(store_paths, encoding="utf-8") as f:
             paths = [line.strip() for line in f if line.strip()]
+
+        # Deterministic per-VM store-view generation. Derived at eval
+        # time from the toplevel store path (whose Nix-base32 hash
+        # component already captures the full closure content), reduced
+        # to a non-zero u32 so it fits the broker's store-sync /
+        # activation generation field. The broker's
+        # `build_store_view_intents` SKIPS any closure whose
+        # `hostGeneration` is null, so leaving this null disables every
+        # store-view intent and breaks `nixling switch`/`boot`/`test`.
+        # Stable per closure (no runtime state), changes whenever the
+        # closure changes. The astronomically-rare u32 collision between
+        # two distinct closures of the same VM is caught fail-closed by
+        # the hardlink-farm generation-marker identity check
+        # (packages/nixling-host/src/hardlink_farm.rs::build_farm).
+        host_generation = (
+            int(hashlib.sha256("${top}".encode("utf-8")).hexdigest(), 16) % 4294967295
+        ) + 1
 
         data = {
             "schemaVersion": "v2",
@@ -60,7 +78,7 @@ let
             "runnerParityPath": "${runner}",
             "runnerParityOk": True,
             "generation": {
-                "hostGeneration": None,
+                "hostGeneration": host_generation,
                 "vmGeneration": None,
                 "sourceRevision": None,
                 "generatedAt": None,

--- a/packages/nixling-core/src/bundle_resolver.rs
+++ b/packages/nixling-core/src/bundle_resolver.rs
@@ -394,6 +394,26 @@ pub struct ResolvedStoreViewIntent {
     pub closure_paths: Vec<PathBuf>,
 }
 
+impl ResolvedStoreViewIntent {
+    /// Stable per-closure identity for this store-view generation,
+    /// derived from the toplevel store-path basename (whose Nix-base32
+    /// hash component captures the full closure content). Written into
+    /// the hardlink-farm generation marker's `closure_hash` so that a
+    /// u32 generation-number collision between two *distinct* closures
+    /// of the same VM is detected fail-closed instead of silently
+    /// unioning two closures into one store view (which would corrupt
+    /// rollback). Falls back to the vm+generation tuple only when the
+    /// target view path has no basename (should never happen for a
+    /// resolved intent).
+    pub fn closure_identity(&self) -> String {
+        self.target_view_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| format!("toplevel:{name}"))
+            .unwrap_or_else(|| format!("store-view:{}:{}", self.vm, self.generation))
+    }
+}
+
 /// Resolved host-GC intent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedGcIntent {
@@ -2991,8 +3011,28 @@ mod tests {
     }
 
     #[test]
-    fn host_reconcile_and_store_preflight_emit_executable_vm_start_intents() {
-        let root = test_root("vm-start-intents");
+    fn closure_identity_uses_toplevel_basename() {
+        let intent = ResolvedStoreViewIntent {
+            intent_id: intent_id_store_view("corp-vm"),
+            vm: "corp-vm".to_owned(),
+            generation: 42,
+            hardlink_farm_path: PathBuf::from("/var/lib/nixling/vms/corp-vm/store-view"),
+            target_view_path: PathBuf::from(
+                "/var/lib/nixling/vms/corp-vm/store-view/generations/42/abc123-nixos-system-corp",
+            ),
+            closure_paths: Vec::new(),
+        };
+        // Identity is the toplevel basename (carries the Nix input hash),
+        // so two distinct closures of one VM never share an identity even
+        // if their u32 generation numbers collide.
+        assert_eq!(
+            intent.closure_identity(),
+            "toplevel:abc123-nixos-system-corp"
+        );
+    }
+
+    #[test]
+    fn host_reconcile_and_store_preflight_emit_executable_vm_start_intents() {        let root = test_root("vm-start-intents");
         let resolver = build_personal_dev_bundle(&root);
 
         let host = resolver

--- a/packages/nixling-host/src/hardlink_farm.rs
+++ b/packages/nixling-host/src/hardlink_farm.rs
@@ -52,6 +52,17 @@ pub enum HardlinkFarmError {
     MarkerMissing { generation_dir: String },
     /// Marker file present but unparseable as JSON.
     MarkerUnparseable { path: String, detail: String },
+    /// The target generation dir already holds a *different* closure
+    /// than the one being built. This is the fail-closed guard for an
+    /// (astronomically rare) u32 store-view generation-number collision
+    /// between two distinct closures of the same VM: rather than union
+    /// both closures into one generation dir (which would corrupt
+    /// rollback + the activated store view), refuse the build.
+    GenerationCollision {
+        generation_dir: String,
+        existing: String,
+        incoming: String,
+    },
     /// I/O error during a primitive operation.
     Io { path: String, detail: String },
 }
@@ -70,6 +81,15 @@ impl std::fmt::Display for HardlinkFarmError {
             Self::MarkerUnparseable { path, detail } => {
                 write!(f, "marker {path}: {detail}")
             }
+            Self::GenerationCollision {
+                generation_dir,
+                existing,
+                incoming,
+            } => write!(
+                f,
+                "store-view generation collision at {generation_dir}: already holds closure \
+                 `{existing}`, refusing to build `{incoming}` over it"
+            ),
             Self::Io { path, detail } => write!(f, "I/O error on {path}: {detail}"),
         }
     }
@@ -192,6 +212,38 @@ pub fn build_farm(
     let generation_dir = store_root
         .join("generations")
         .join(generation_number.to_string());
+    // Fail-closed collision guard: the store-view generation number is
+    // a content-derived u32 (see closures-json.nix). If this generation
+    // dir already exists with a marker for a DIFFERENT closure, two
+    // distinct closures of this VM collided onto the same u32. Refuse
+    // rather than hardlink the new closure on top of the old one (which
+    // would produce a mixed store view and corrupt rollback). Reusing a
+    // dir for the SAME closure stays idempotent.
+    let existing_marker_path = generation_dir.join("marker.json");
+    if generation_dir.exists() {
+        if existing_marker_path.exists() {
+            let existing = read_generation_marker(&generation_dir)?;
+            if existing.closure_hash != marker.closure_hash {
+                return Err(HardlinkFarmError::GenerationCollision {
+                    generation_dir: generation_dir.display().to_string(),
+                    existing: existing.closure_hash,
+                    incoming: marker.closure_hash.clone(),
+                });
+            }
+        } else {
+            // Populated generation dir with no trusted marker: a build
+            // that crashed before write_generation_marker. It is never
+            // activatable (swap_current_symlink + read_generation_marker
+            // both require the marker) and its contents can't be trusted
+            // to belong to this closure — so a colliding closure must not
+            // be hardlinked on top of it. Rebuild the generation from
+            // scratch instead of unioning the partial leftovers.
+            std::fs::remove_dir_all(&generation_dir).map_err(|e| HardlinkFarmError::Io {
+                path: generation_dir.display().to_string(),
+                detail: e.to_string(),
+            })?;
+        }
+    }
     std::fs::create_dir_all(&generation_dir).map_err(|e| HardlinkFarmError::Io {
         path: generation_dir.display().to_string(),
         detail: e.to_string(),
@@ -467,6 +519,115 @@ mod tests {
         let marker = read_generation_marker(&generation_dir).unwrap();
         assert_eq!(marker.generation_number, 7);
         assert_eq!(marker.vm, "corp-vm");
+    }
+
+    #[test]
+    fn build_farm_idempotent_for_same_closure() {
+        let dir = tempdir().unwrap();
+        let source_root = dir.path().join("source-store");
+        let farm_root = dir.path().join("farm");
+        let system_path = source_root.join("abc-system");
+        std::fs::create_dir_all(&system_path).unwrap();
+        std::fs::write(system_path.join("payload"), b"data").unwrap();
+        let marker = GenerationMarker {
+            closure_hash: "toplevel:abc-system".to_owned(),
+            nixling_version: "0.4.0".to_owned(),
+            activated_at: "2026-05-29T09:00:00Z".to_owned(),
+            vm: "corp-vm".to_owned(),
+            generation_number: 7,
+        };
+        // Building the same closure into the same generation twice is a
+        // no-op-equivalent: the second call reuses the dir + marker.
+        build_farm(&farm_root, 7, std::slice::from_ref(&system_path), &marker).unwrap();
+        build_farm(&farm_root, 7, std::slice::from_ref(&system_path), &marker).unwrap();
+    }
+
+    #[test]
+    fn build_farm_refuses_generation_collision() {
+        let dir = tempdir().unwrap();
+        let source_root = dir.path().join("source-store");
+        let farm_root = dir.path().join("farm");
+        // Two DISTINCT closures (different toplevel identity) that
+        // collided onto the same u32 generation number.
+        let closure_a = source_root.join("aaa-system");
+        let closure_b = source_root.join("bbb-system");
+        std::fs::create_dir_all(&closure_a).unwrap();
+        std::fs::create_dir_all(&closure_b).unwrap();
+        std::fs::write(closure_a.join("payload"), b"a").unwrap();
+        std::fs::write(closure_b.join("payload"), b"b").unwrap();
+
+        build_farm(
+            &farm_root,
+            42,
+            std::slice::from_ref(&closure_a),
+            &GenerationMarker {
+                closure_hash: "toplevel:aaa-system".to_owned(),
+                nixling_version: "0.4.0".to_owned(),
+                activated_at: "2026-05-29T09:00:00Z".to_owned(),
+                vm: "corp-vm".to_owned(),
+                generation_number: 42,
+            },
+        )
+        .unwrap();
+
+        // Same generation number, different closure identity → refuse
+        // fail-closed rather than union the two closures.
+        let result = build_farm(
+            &farm_root,
+            42,
+            std::slice::from_ref(&closure_b),
+            &GenerationMarker {
+                closure_hash: "toplevel:bbb-system".to_owned(),
+                nixling_version: "0.4.0".to_owned(),
+                activated_at: "2026-05-29T09:00:00Z".to_owned(),
+                vm: "corp-vm".to_owned(),
+                generation_number: 42,
+            },
+        );
+        assert!(matches!(
+            result,
+            Err(HardlinkFarmError::GenerationCollision { .. })
+        ));
+        // The original closure's store view is untouched.
+        assert!(farm_root.join("generations/42/aaa-system/payload").exists());
+        assert!(!farm_root.join("generations/42/bbb-system/payload").exists());
+    }
+
+    #[test]
+    fn build_farm_rebuilds_markerless_partial_generation() {
+        let dir = tempdir().unwrap();
+        let source_root = dir.path().join("source-store");
+        let farm_root = dir.path().join("farm");
+        let closure = source_root.join("ccc-system");
+        std::fs::create_dir_all(&closure).unwrap();
+        std::fs::write(closure.join("payload"), b"c").unwrap();
+
+        // Simulate a crashed earlier build: a populated generation dir
+        // with leftover files but NO marker.json.
+        let stale_dir = farm_root.join("generations").join("9");
+        std::fs::create_dir_all(&stale_dir).unwrap();
+        std::fs::write(stale_dir.join("leftover-from-crash"), b"stale").unwrap();
+
+        // Building a (different) closure into the same generation must
+        // NOT union the stale leftovers: it rebuilds from scratch.
+        build_farm(
+            &farm_root,
+            9,
+            std::slice::from_ref(&closure),
+            &GenerationMarker {
+                closure_hash: "toplevel:ccc-system".to_owned(),
+                nixling_version: "0.4.0".to_owned(),
+                activated_at: "2026-05-29T09:00:00Z".to_owned(),
+                vm: "corp-vm".to_owned(),
+                generation_number: 9,
+            },
+        )
+        .unwrap();
+
+        assert!(stale_dir.join("ccc-system/payload").exists());
+        assert!(!stale_dir.join("leftover-from-crash").exists());
+        let marker = read_generation_marker(&stale_dir).unwrap();
+        assert_eq!(marker.closure_hash, "toplevel:ccc-system");
     }
 
     #[test]

--- a/packages/nixling-ipc/src/broker_wire.rs
+++ b/packages/nixling-ipc/src/broker_wire.rs
@@ -720,8 +720,11 @@ pub struct PrepareStoreViewRequest {
 /// by `vm_id` (canonical id form `"store-view:vm:<vm>"`) and refuses
 /// the op if `bundle_closure_ref` does not match. The broker also
 /// refuses if the wire-supplied `generation` does not match the bundle's
-/// resolved generation — generations are monotonic, so a stale daemon
-/// must not race the activator.
+/// resolved generation. The generation is a content-derived stable
+/// equality token (see `closures-json.nix`), not a monotonic counter:
+/// the daemon and broker both read it from the same trusted bundle, so
+/// a mismatch means a stale daemon is racing the activator and the op
+/// is refused fail-closed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StoreSyncRequest {

--- a/packages/nixling-priv-broker/src/live_handlers.rs
+++ b/packages/nixling-priv-broker/src/live_handlers.rs
@@ -360,10 +360,19 @@ pub fn live_run_activation(
                 })?;
             let generation_dir =
                 generation_dir(&store_view_intent.hardlink_farm_path, rollback_generation);
-            hardlink_farm::read_generation_marker(&generation_dir)
+            let rollback_marker = hardlink_farm::read_generation_marker(&generation_dir)
                 .map_err(|err| LiveHandlerError::Activation(err.to_string()))?;
-            let target_view_path =
-                target_view_for_generation(store_view_intent, rollback_generation)?;
+            // The rolled-back generation may hold a DIFFERENT closure
+            // than the current bundle intent, so the toplevel basename
+            // for the target view must come from the rollback
+            // generation's own marker — NOT the current intent's
+            // basename (which would point at a non-existent
+            // `generations/<old-gen>/<current-basename>`).
+            let target_view_path = rollback_target_view_path(
+                store_view_intent,
+                rollback_generation,
+                &rollback_marker,
+            )?;
             if !target_view_path.exists() {
                 return Err(LiveHandlerError::Activation(format!(
                     "rollback target store view missing at {}",
@@ -476,6 +485,37 @@ fn target_view_for_generation(
         ))
     })?;
     Ok(generation_dir(&intent.hardlink_farm_path, generation).join(target_name))
+}
+
+/// Resolve the target store-view path for a ROLLBACK to `generation`.
+///
+/// Unlike a forward activation, the rolled-back generation may hold a
+/// different closure than the current bundle intent, so the toplevel
+/// basename is recovered from that generation's own marker
+/// (`closure_hash == "toplevel:<basename>"`, written by
+/// [`ResolvedStoreViewIntent::closure_identity`]). Falls back to the
+/// current intent's basename only for a marker written before the
+/// `toplevel:` identity format (defensive; such markers never reached
+/// activation in practice because store-view intents were absent).
+fn rollback_target_view_path(
+    intent: &ResolvedStoreViewIntent,
+    generation: u64,
+    marker: &hardlink_farm::GenerationMarker,
+) -> Result<PathBuf, LiveHandlerError> {
+    let dir = generation_dir(&intent.hardlink_farm_path, generation);
+    if let Some(basename) = marker.closure_hash.strip_prefix("toplevel:") {
+        // Must be a single, non-traversing path component (a Nix store
+        // basename). Reject anything with separators / `.` / `..` so a
+        // malformed marker can never escape the generation dir.
+        if !basename.is_empty()
+            && !basename.contains('/')
+            && basename != "."
+            && basename != ".."
+        {
+            return Ok(dir.join(basename));
+        }
+    }
+    target_view_for_generation(intent, generation)
 }
 
 fn read_current_generation(hardlink_farm_path: &Path) -> Result<Option<u64>, LiveHandlerError> {
@@ -2135,8 +2175,55 @@ mod tests {
         }
     }
 
-    fn sample_gc_intent() -> ResolvedGcIntent {
-        ResolvedGcIntent {
+    #[test]
+    fn rollback_target_view_path_uses_rolled_back_marker_basename() {
+        let intent = ResolvedStoreViewIntent {
+            intent_id: "store-view:vm:alpha".to_owned(),
+            vm: "alpha".to_owned(),
+            generation: 99,
+            hardlink_farm_path: PathBuf::from("/var/lib/nixling/vms/alpha/store-view"),
+            target_view_path: PathBuf::from(
+                "/var/lib/nixling/vms/alpha/store-view/generations/99/current-system",
+            ),
+            closure_paths: Vec::new(),
+        };
+        let marker = hardlink_farm::GenerationMarker {
+            closure_hash: "toplevel:old-system".to_owned(),
+            nixling_version: "test".to_owned(),
+            activated_at: "test".to_owned(),
+            vm: "alpha".to_owned(),
+            generation_number: 7,
+        };
+        // Rollback to gen 7 (closure `old-system`) must target the OLD
+        // basename, not the current intent's `current-system`.
+        assert_eq!(
+            rollback_target_view_path(&intent, 7, &marker).unwrap(),
+            PathBuf::from("/var/lib/nixling/vms/alpha/store-view/generations/7/old-system"),
+        );
+
+        // Defensive fallback: a pre-`toplevel:` marker format resolves
+        // to the current intent's basename (old behavior).
+        let legacy = hardlink_farm::GenerationMarker {
+            closure_hash: "store-view:alpha:7".to_owned(),
+            ..marker.clone()
+        };
+        assert_eq!(
+            rollback_target_view_path(&intent, 7, &legacy).unwrap(),
+            PathBuf::from("/var/lib/nixling/vms/alpha/store-view/generations/7/current-system"),
+        );
+
+        // A malformed marker with path traversal is rejected → fallback.
+        let evil = hardlink_farm::GenerationMarker {
+            closure_hash: "toplevel:../escape".to_owned(),
+            ..marker.clone()
+        };
+        assert_eq!(
+            rollback_target_view_path(&intent, 7, &evil).unwrap(),
+            PathBuf::from("/var/lib/nixling/vms/alpha/store-view/generations/7/current-system"),
+        );
+    }
+
+    fn sample_gc_intent() -> ResolvedGcIntent {        ResolvedGcIntent {
             intent_id: "gc:host".to_owned(),
             retained_store_paths: vec![
                 PathBuf::from("/nix/store/aaaaaaaaaaaaaaaa-alpha"),

--- a/packages/nixling-priv-broker/src/ops/exec_reconcile.rs
+++ b/packages/nixling-priv-broker/src/ops/exec_reconcile.rs
@@ -53,6 +53,13 @@ pub enum ReconcileExecError {
     },
     /// The target generation dir exists but lacks the trusted marker.
     MarkerMissing { generation_dir: String },
+    /// The target store-view generation dir already holds a different
+    /// closure (u32 generation-number collision); refused fail-closed.
+    StoreViewGenerationCollision {
+        generation_dir: String,
+        existing: String,
+        incoming: String,
+    },
     /// I/O error writing /proc/sys/* or /etc/hosts.
     Io { path: String, detail: String },
     /// Mount-namespace staging or activation-script setup failed.
@@ -80,6 +87,15 @@ impl std::fmt::Display for ReconcileExecError {
             Self::MarkerMissing { generation_dir } => {
                 write!(f, "generation {generation_dir} lacks marker.json")
             }
+            Self::StoreViewGenerationCollision {
+                generation_dir,
+                existing,
+                incoming,
+            } => write!(
+                f,
+                "store-view generation collision at {generation_dir}: already holds closure \
+                 `{existing}`, refusing to build `{incoming}` over it"
+            ),
             Self::Io { path, detail } => write!(f, "I/O error on {path}: {detail}"),
             Self::MountNamespace { detail } => write!(f, "mount namespace: {detail}"),
             Self::InvalidInput { detail } => write!(f, "invalid input: {detail}"),
@@ -533,7 +549,7 @@ impl ReconcileExecutor for SystemReconcileExecutor {
             intent.generation,
             &intent.closure_paths,
             &GenerationMarker {
-                closure_hash: format!("store-view:{}:{}", intent.vm, intent.generation),
+                closure_hash: intent.closure_identity(),
                 nixling_version: env!("CARGO_PKG_VERSION").to_owned(),
                 activated_at: format!("unix-{}", current_unix_ms()),
                 vm: intent.vm.clone(),
@@ -835,6 +851,15 @@ fn map_hardlink_farm_error(error: HardlinkFarmError) -> ReconcileExecError {
         HardlinkFarmError::MarkerMissing { generation_dir } => {
             ReconcileExecError::MarkerMissing { generation_dir }
         }
+        HardlinkFarmError::GenerationCollision {
+            generation_dir,
+            existing,
+            incoming,
+        } => ReconcileExecError::StoreViewGenerationCollision {
+            generation_dir,
+            existing,
+            incoming,
+        },
         HardlinkFarmError::MarkerUnparseable { path, detail }
         | HardlinkFarmError::Io { path, detail } => ReconcileExecError::Io { path, detail },
     }
@@ -1109,7 +1134,7 @@ mod fake {
                 intent.generation,
                 &intent.closure_paths,
                 &GenerationMarker {
-                    closure_hash: format!("fake-store-view:{}:{}", intent.vm, intent.generation),
+                    closure_hash: intent.closure_identity(),
                     nixling_version: "fake".to_owned(),
                     activated_at: "fake".to_owned(),
                     vm: intent.vm.clone(),

--- a/packages/nixling-priv-broker/src/ops/store_sync.rs
+++ b/packages/nixling-priv-broker/src/ops/store_sync.rs
@@ -137,7 +137,7 @@ pub fn run_store_sync(
     hardlink_farm::reconcile_stale_swap_tmp(&intent.hardlink_farm_path)?;
 
     let marker = GenerationMarker {
-        closure_hash: format!("store-sync:{}:{}", intent.vm, resolved_generation),
+        closure_hash: intent.closure_identity(),
         nixling_version: env!("CARGO_PKG_VERSION").to_owned(),
         activated_at: format!("unix-{}", current_unix_ms()),
         vm: intent.vm.clone(),


### PR DESCRIPTION
## Problem

Daemon-mode `nixling switch` / `boot` / `test` always failed with
`broker-error` (exit 78). The broker audit log shows the real error:

```
op=RunActivation disposition=bundle-intent-missing
error_kind=Broker.BundleIntentMissing
error_message="no store-view intent in the trusted bundle for opaque id `<vm>`"
```

The only way to apply a new VM generation was the
`nixling down <vm> --apply` + `nixling up <vm> --apply` workaround.

## Root cause

`nixos-modules/closures-json.nix` has emitted the per-VM closure
`generation` block as **all-null** (`hostGeneration: null`) since the
v1.0 daemon-only rewrite. The broker resolver's
`build_store_view_intents` **skips** any closure whose
`host_generation` is null, so the trusted bundle ended up with **zero**
store-view intents.

`RunActivation` (switch/boot/test) hard-requires a store-view intent →
always errored. `vmStart` (up/down) only prepares one `if let Some(intent)`,
so it tolerated the absence — which is exactly why down+up worked.

Verified against the live bundle (`/etc/nixling/closures/<vm>.json`) and
the broker audit log.

## Fix

- **`closures-json.nix`** now emits a deterministic, content-derived
  `hostGeneration` = `sha256(toplevel path) % (2^32-1) + 1` (non-zero
  u32). Stable per closure, changes when the closure changes, no runtime
  state. Verified end-to-end (built the `corp-vm` closure →
  `"hostGeneration":3271411828`).
- **Collision hardening.** Because the generation is a u32 content hash,
  two distinct closures of one VM could astronomically-rarely collide.
  The hardlink-farm generation marker now pins the **closure identity**
  (toplevel basename, via `ResolvedStoreViewIntent::closure_identity()`),
  and `build_farm` **fails closed** (`GenerationCollision`) instead of
  unioning two closures into one store view. A **markerless partial**
  generation dir (crashed earlier build) is rebuilt from scratch rather
  than hardlinked over.
- **Rollback fix.** Rollback now resolves its target store-view basename
  from the rolled-back generation's **own marker** instead of the
  current bundle intent, so rolling back to a different closure no longer
  looks for a non-existent `generations/<old-gen>/<current-basename>`.
- Corrected the `StoreSyncRequest` "generations are monotonic" doc
  comment to "content-derived equality token"; regenerated
  `wire-protocol.json` + `daemon-api.md`.
- CHANGELOG `[Unreleased]` Fixed entry.

## Tests

New regression tests: `build_farm_refuses_generation_collision`,
`build_farm_idempotent_for_same_closure`,
`build_farm_rebuilds_markerless_partial_generation`,
`closure_identity_uses_toplevel_basename`,
`rollback_target_view_path_uses_rolled_back_marker_basename`.

Validation: both cargo workspaces build; `cargo test --workspace` +
broker `cargo test` (default + `layer1-bootstrap`) green; clippy clean
on changed files; Nix parse + closure emitter build OK; schema-drift
gate green.

## Out of scope (pre-existing, not touched)

These exist on `main` independently of this change:
- broker clippy errors at `runtime.rs:3994` and `disk_init.rs:496-498`
- CLI-schema drift in `docs/reference/cli-output/status.schema.json`
  (`gen-cli-schemas` wants `ApiReadyStatusV1` added)