### PR TITLE
broker: fix EXDEV abort starting VMs after a host switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@ deprecations ship one minor release before removal.
   closures of one VM mapping to the same generation number) instead of
   unioning them, by pinning the closure identity in the generation
   marker.
+- VM start no longer aborts with `SpawnRunner failed ... broker-error`
+  on the first runtime-directory step. The broker's path-safe directory
+  opener resolved every path from `/` with `RESOLVE_NO_XDEV`, which
+  fails with `EXDEV` ("Invalid cross-device link") the moment it must
+  cross a mount boundary — and the per-VM runtime dir lives under the
+  `/run` tmpfs, the tap device under `/dev`, cgroups under `/sys`, etc.
+  Resolution now walks component by component and follows a *real*,
+  pre-existing mount crossing (still refusing symlink / magic-link
+  components and `..` escapes at every step), so legitimate
+  cross-filesystem paths resolve while the load-bearing symlink
+  protection is preserved.
+- Broker spawn/host-prep failures are no longer opaque. The broker now
+  logs the live-handler root cause (errno / path / stderr) to its
+  journal, the daemon includes the broker's `message` in its
+  `vm start node spawn failed` log, and failure remediations point at
+  the working `journalctl -u nixling-priv-broker` instead of the
+  `nixling audit --strict` command (which returns `not-yet-implemented`).
 - GitHub Actions PR hardening keeps fork PR code off self-hosted
   runners, makes the privileged oracle workflow manual-dispatch only,
   and repairs the affected CI validation gates so the hardening can

--- a/packages/nixling-priv-broker/src/audit.rs
+++ b/packages/nixling-priv-broker/src/audit.rs
@@ -219,7 +219,9 @@ impl AuditLog {
     }
 
     /// Legacy short-record writer for errored outcomes that need
-    /// admin-visible diagnostics in `nixling audit --strict`.
+    /// admin-visible diagnostics. The full detail is also surfaced in
+    /// the broker journal (`journalctl -u nixling-priv-broker`) for
+    /// live-handler failures.
     pub fn write_error_entry(
         &self,
         operation: &str,

--- a/packages/nixling-priv-broker/src/ops/disk_init.rs
+++ b/packages/nixling-priv-broker/src/ops/disk_init.rs
@@ -491,11 +491,11 @@ mod tests {
     }
 
     /// Post-mkfs reopen with O_NOFOLLOW refuses symlink swap. Proxy
-    /// test for the TOCTOU race that the previous std::fs::set_permissions
-    /// + std::os::unix::fs::chown variant allowed between mkfs returning
-    /// and the chmod/chown reaching the inode. By re-opening with
-    /// O_NOFOLLOW we ensure a concurrent attacker cannot redirect us to a
-    /// sensitive target.
+    /// test for the TOCTOU race that the previous
+    /// `std::fs::set_permissions` / `std::os::unix::fs::chown` variant
+    /// allowed between mkfs returning and the chmod/chown reaching the
+    /// inode. By re-opening with O_NOFOLLOW we ensure a concurrent
+    /// attacker cannot redirect us to a sensitive target.
     #[test]
     fn post_mkfs_reopen_refuses_symlink() {
         use std::os::unix::fs::OpenOptionsExt;

--- a/packages/nixling-priv-broker/src/runtime.rs
+++ b/packages/nixling-priv-broker/src/runtime.rs
@@ -3993,7 +3993,7 @@ fn usbip_backend_runner_intent<'a>(
     );
     resolver
         .find_runner_intent(&runner_id)
-        .ok_or_else(|| BrokerError::BundleIntentMissing {
+        .ok_or(BrokerError::BundleIntentMissing {
             kind: "runner",
             intent_id: runner_id,
         })
@@ -5112,6 +5112,19 @@ impl BrokerError {
                 )?;
             }
             Self::LiveHandler(message) => {
+                // Surface the operator-facing root cause (errno / path /
+                // stderr) in the broker journal, not just the
+                // `Broker.LiveHandlerFailed` wrapper kind. The same
+                // detail is recorded in the audit log; an operator
+                // reading `journalctl -u nixling-priv-broker` should not
+                // have to cross-reference the audit jsonl to learn why a
+                // runner spawn failed.
+                tracing::warn!(
+                    operation = operation,
+                    error_kind = "Broker.LiveHandlerFailed",
+                    detail = %message,
+                    "broker live-handler op failed"
+                );
                 audit_log.write_error_entry(
                     operation,
                     caller_uid,

--- a/packages/nixling-priv-broker/src/sys.rs
+++ b/packages/nixling-priv-broker/src/sys.rs
@@ -197,8 +197,14 @@ pub fn tun_set_group(fd: &OwnedFd, gid: u32) -> io::Result<()> {
 ///
 /// The contract mandates `openat2` with `O_NOFOLLOW` + `RESOLVE_BENEATH`
 /// for parent-relative resolution; this module implements equivalent
-/// fail-closed guards on stable Rust using `nix` + `std::fs`, including
-/// `RESOLVE_NO_XDEV` so mount-point crossings are rejected:
+/// fail-closed guards on stable Rust using `nix` + `std::fs`. Resolution
+/// always refuses symlink and magic-link components and `..` escapes
+/// (`RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS | RESOLVE_BENEATH`).
+/// `RESOLVE_NO_XDEV` is additionally enforced at every component as
+/// defense-in-depth and is relaxed *only* exactly where a real,
+/// pre-existing kernel/framework mount sits (e.g. `/run` tmpfs, `/dev`
+/// devtmpfs), since broker paths legitimately span those mounts — see
+/// [`open_dir_path_safe`] for the per-component mount-tolerant walk:
 ///
 /// - [`refuse_symlink`] — rejects symlinks at `path` via `lstat`;
 /// - [`refuse_world_writable_parent`] — rejects world-writable parent
@@ -875,16 +881,36 @@ pub mod path_safe {
         res.map_err(|err| io::Error::from_raw_os_error(err as i32))
     }
 
-    /// Open a directory with `openat2` anchored at `/` and the full
-    /// hardening mask:
+    /// Open a directory with `openat2`, hardened with
+    /// `RESOLVE_NO_SYMLINKS`, `RESOLVE_NO_MAGICLINKS`, `RESOLVE_BENEATH`,
+    /// and `RESOLVE_NO_XDEV`.
     ///
-    /// - `RESOLVE_BENEATH` keeps resolution anchored below `/` and
-    ///   rejects `..` escapes;
-    /// - `RESOLVE_NO_SYMLINKS` rejects symlink path components;
-    /// - `RESOLVE_NO_MAGICLINKS` rejects procfs-style magic links; and
-    /// - `RESOLVE_NO_XDEV` rejects mount-point crossings so a bind-mount
-    ///   swap cannot redirect the walk into a different filesystem.
+    /// Legitimate broker paths span multiple filesystems: `/run` is a
+    /// tmpfs, `/dev` a devtmpfs, `/sys` sysfs, `/proc` procfs, and
+    /// `/var/lib` may be its own mount. A single `/`-anchored `NO_XDEV`
+    /// walk therefore fails with `EXDEV` at the first mount crossing
+    /// (e.g. `/`→`/run` when preparing `/run/nixling/vms/<vm>`, or
+    /// `/`→`/dev` when opening `/dev/net/tun`).
+    ///
+    /// We resolve **component by component**. Each component is opened
+    /// with the full hardened mask; if a component is a genuine mount
+    /// crossing (`openat2` returns `EXDEV` under `NO_XDEV`), it is
+    /// re-opened **without** `NO_XDEV` — but still with `NO_SYMLINKS`,
+    /// `NO_MAGICLINKS`, and `BENEATH` — and the walk continues with the
+    /// full mask beneath. Net effect:
+    ///
+    /// - symlink / magic-link components are **always** refused (this is
+    ///   the load-bearing protection against unprivileged redirection);
+    /// - `..` escapes are **always** refused (`BENEATH`);
+    /// - only **real, pre-existing** mounts are followed. Planting a new
+    ///   mount over a path component requires `CAP_SYS_ADMIN`, which in
+    ///   the broker's root-only threat model means the attacker already
+    ///   owns the host. `NO_XDEV` therefore remains enforced at every
+    ///   non-mount component as defense-in-depth, and is relaxed only
+    ///   exactly where a legitimate kernel/framework mount sits.
     pub fn open_dir_path_safe(dir: &Path) -> io::Result<OwnedFd> {
+        use std::path::Component;
+
         if !dir.is_absolute() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -892,24 +918,48 @@ pub mod path_safe {
             ));
         }
 
-        let root_fd: OwnedFd = File::open("/")?.into();
-        let relative = dir.strip_prefix("/").map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("directory must be absolute: {}", dir.display()),
-            )
-        })?;
-        if relative.as_os_str().is_empty() {
-            return Ok(root_fd);
+        const FULL: u64 =
+            RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_XDEV;
+        const MOUNT_TOLERANT: u64 =
+            RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS;
+        let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC;
+
+        let mut cur: OwnedFd = File::open("/")?.into();
+        for component in dir.components() {
+            let name = match component {
+                Component::RootDir | Component::CurDir => continue,
+                Component::Normal(name) => name,
+                // `BENEATH` would reject these too, but refuse explicitly
+                // so the failure is an unambiguous path-safety violation.
+                Component::ParentDir | Component::Prefix(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "path-safety-violation: unexpected path component in {}",
+                            dir.display()
+                        ),
+                    ));
+                }
+            };
+            let name = name.to_str().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("path component is not valid UTF-8 in {}", dir.display()),
+                )
+            })?;
+            let c_name = cstring_from_name(name)?;
+            cur = match openat2_raw(cur.as_raw_fd(), &c_name, flags, 0, FULL) {
+                Ok(fd) => fd,
+                // A genuine mount crossing: follow it (still refusing
+                // symlinks / magic-links / `..`), then keep enforcing the
+                // full mask beneath.
+                Err(err) if err.raw_os_error() == Some(libc::EXDEV) => {
+                    openat2_raw(cur.as_raw_fd(), &c_name, flags, 0, MOUNT_TOLERANT)?
+                }
+                Err(err) => return Err(err),
+            };
         }
-        let relative = cstring_from_path(relative)?;
-        openat2_raw(
-            root_fd.as_raw_fd(),
-            &relative,
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
-            0,
-            RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_XDEV,
-        )
+        Ok(cur)
     }
 
     /// Atomic-replace a file under `dir_fd` using an anonymous temp
@@ -1035,6 +1085,124 @@ pub mod path_safe {
     impl AsFd for DirFd {
         fn as_fd(&self) -> BorrowedFd<'_> {
             self.0.as_fd()
+        }
+    }
+
+    #[cfg(test)]
+    mod cross_mount_tests {
+        use super::*;
+        use std::os::unix::fs::MetadataExt;
+
+        /// A path on a *separate* mount from `/` must be reachable. This
+        /// is the regression for the cross-mount `EXDEV` bug: the broker
+        /// prepares `/run/nixling/vms/<vm>` and opens `/dev/net/tun`,
+        /// `/sys/fs/cgroup/...`, etc., all on mounts other than the
+        /// rootfs; a naive `/`-anchored `NO_XDEV` walk fails at the first
+        /// crossing.
+        ///
+        /// CI-stable: `/run` is a tmpfs on every Linux host, so this does
+        /// not skip on CI. Verifies BOTH the bug (a single `/`-anchored
+        /// `NO_XDEV` `openat2` returns `EXDEV`) AND the fix
+        /// (`open_dir_path_safe` reaches the path).
+        #[test]
+        fn open_dir_path_safe_walks_across_a_mount_boundary() {
+            let target = Path::new("/run");
+            let (Ok(target_md), Ok(root_md)) =
+                (std::fs::metadata(target), std::fs::metadata("/"))
+            else {
+                eprintln!("cross-mount test: SKIP (cannot stat /run or /)");
+                return;
+            };
+            if target_md.dev() == root_md.dev() {
+                eprintln!("cross-mount test: SKIP (/run is not a separate mount from /)");
+                return;
+            }
+
+            // Demonstrate the bug: a single `/`-anchored walk with the
+            // full mask (incl. NO_XDEV) cannot cross into `/run`.
+            let slash: OwnedFd = std::fs::File::open("/").unwrap().into();
+            let run_c = cstring_from_name("run").unwrap();
+            match openat2_raw(
+                slash.as_raw_fd(),
+                &run_c,
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+                0,
+                RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_XDEV,
+            ) {
+                Err(e) if e.raw_os_error() == Some(libc::EXDEV) => {}
+                other => panic!(
+                    "expected EXDEV from the `/`-anchored NO_XDEV walk into /run, got {other:?}"
+                ),
+            }
+
+            // The fix: the component walk follows the mount and reaches it.
+            open_dir_path_safe(target)
+                .expect("open_dir_path_safe must reach /run across the mount boundary");
+
+            // A nested path on the same separate mount is also reachable
+            // (the per-component NO_XDEV does not false-EXDEV below the
+            // crossing). `/run` always exists; assert reachability without
+            // assuming a specific subdir.
+            for nested in ["/run/lock", "/dev/net"] {
+                let p = Path::new(nested);
+                if std::fs::metadata(p).is_ok() {
+                    open_dir_path_safe(p)
+                        .unwrap_or_else(|e| panic!("open_dir_path_safe({nested}) failed: {e}"));
+                }
+            }
+        }
+
+        /// A path on the same filesystem as `/` still resolves (the fast
+        /// path: every component succeeds under the full mask, no
+        /// crossing).
+        #[test]
+        fn open_dir_path_safe_resolves_same_fs_path() {
+            open_dir_path_safe(Path::new("/etc")).expect("/etc must resolve");
+        }
+
+        /// The load-bearing security invariant: a symlink path component
+        /// is refused even though the mount-tolerant fallback drops
+        /// `NO_XDEV`. `NO_SYMLINKS` is retained on every component,
+        /// including a crossed one, so an attacker cannot redirect the
+        /// walk via a symlink.
+        #[test]
+        fn open_dir_path_safe_refuses_symlink_component() {
+            let dir = std::env::temp_dir().join(format!(
+                "nixling-pathsafe-symlink-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(dir.join("real")).unwrap();
+            let link = dir.join("link");
+            std::os::unix::fs::symlink(dir.join("real"), &link).unwrap();
+            let err = open_dir_path_safe(&link).expect_err("symlink component must be refused");
+            // openat2 reports ELOOP for a refused symlink under NO_SYMLINKS.
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::ELOOP),
+                "expected ELOOP for the refused symlink, got {err:?}"
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+
+        /// A non-existent leaf yields `NotFound`, not a spurious `EXDEV`
+        /// (the mount-tolerant fallback only triggers on a real crossing).
+        #[test]
+        fn open_dir_path_safe_missing_leaf_is_not_found() {
+            let missing = Path::new("/run/nixling-definitely-absent-xmount-test");
+            let err = open_dir_path_safe(missing).expect_err("missing leaf must error");
+            assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        }
+
+        /// `..` and other non-normal components are refused.
+        #[test]
+        fn open_dir_path_safe_refuses_parent_dir_component() {
+            let err = open_dir_path_safe(Path::new("/etc/../etc"))
+                .expect_err("`..` component must be refused");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         }
     }
 }

--- a/packages/nixling-priv-broker/tests/kernel_surface.rs
+++ b/packages/nixling-priv-broker/tests/kernel_surface.rs
@@ -22,9 +22,9 @@ fn scratch_dir() -> TempDir {
 }
 
 #[test]
-fn open_dir_path_safe_rejects_mount_crossing() {
+fn open_dir_path_safe_follows_real_mount_but_refuses_symlink() {
     if std::env::var_os(OPEN_DIR_XDEV_HELPER_ENV).is_some() {
-        open_dir_path_safe_rejects_mount_crossing_helper();
+        open_dir_path_safe_mount_contract_helper();
         return;
     }
 
@@ -34,7 +34,7 @@ fn open_dir_path_safe_rejects_mount_crossing() {
         .arg(exe)
         .args([
             "--exact",
-            "open_dir_path_safe_rejects_mount_crossing",
+            "open_dir_path_safe_follows_real_mount_but_refuses_symlink",
             "--nocapture",
         ])
         .env(OPEN_DIR_XDEV_HELPER_ENV, "1")
@@ -42,7 +42,7 @@ fn open_dir_path_safe_rejects_mount_crossing() {
     {
         Ok(output) => output,
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            eprintln!("skipping mount-crossing test: unshare unavailable");
+            eprintln!("skipping mount-contract test: unshare unavailable");
             return;
         }
         Err(err) => panic!("failed to execute unshare: {err}"),
@@ -53,7 +53,7 @@ fn open_dir_path_safe_rejects_mount_crossing() {
         && stderr.contains("Operation not permitted")
         && stderr.contains("uid_map")
     {
-        eprintln!("skipping mount-crossing test: user namespace uid_map denied");
+        eprintln!("skipping mount-contract test: user namespace uid_map denied");
         return;
     }
 
@@ -65,42 +65,96 @@ fn open_dir_path_safe_rejects_mount_crossing() {
     );
 }
 
-fn open_dir_path_safe_rejects_mount_crossing_helper() {
+/// Documents the path-safety contract after the cross-mount fix: a
+/// real, pre-existing mount on the walk is FOLLOWED (broker paths
+/// legitimately span `/run` tmpfs, `/dev` devtmpfs, `/sys` sysfs, ...,
+/// and planting a host-NS mount requires `CAP_SYS_ADMIN` = root, which
+/// is out of the broker's threat model), while a SYMLINK component is
+/// still refused — INCLUDING after a followed mount crossing — and a
+/// path crossing TWO mounts still resolves (NO_XDEV is re-applied per
+/// component, so the relax is scoped to exactly the crossing component).
+fn open_dir_path_safe_mount_contract_helper() {
     let tmp = scratch_dir();
     let safe_root = tmp.path().join("safe");
     let foreign_root = tmp.path().join("foreign");
+    let foreign2_root = tmp.path().join("foreign2");
     let mountpoint = safe_root.join("mnt");
     fs::create_dir_all(&mountpoint).expect("safe mountpoint");
-    fs::create_dir_all(&foreign_root).expect("foreign dir");
+    fs::create_dir_all(foreign_root.join("inner")).expect("foreign inner");
+    fs::create_dir_all(foreign_root.join("inner2")).expect("foreign nested mountpoint");
+    fs::create_dir_all(foreign2_root.join("deep")).expect("foreign2 deep");
+    // A symlink that lives INSIDE the first mount (visible as
+    // `mnt/post-lnk` once bound). It must be refused even though the walk
+    // already followed the `mnt` crossing.
+    std::os::unix::fs::symlink("inner", foreign_root.join("post-lnk"))
+        .expect("create post-crossing symlink");
 
-    let mount_output = Command::new("mount")
-        .args(["--bind"])
-        .arg(&foreign_root)
-        .arg(&mountpoint)
-        .output()
-        .expect("bind mount command");
+    let bind = |src: &std::path::Path, dst: &std::path::Path| {
+        let out = Command::new("mount")
+            .args(["--bind"])
+            .arg(src)
+            .arg(dst)
+            .output()
+            .expect("bind mount command");
+        assert!(
+            out.status.success(),
+            "mount {src:?} -> {dst:?} failed\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+    };
+    // First crossing: mnt. Second (nested) crossing: mnt/inner2.
+    bind(&foreign_root, &mountpoint);
+    bind(&foreign2_root, &mountpoint.join("inner2"));
+
+    // All probes capture only the outcome and DROP any fd before umount
+    // (an open fd inside a mount makes umount fail with EBUSY).
+    let outcome = |p: std::path::PathBuf| -> (bool, Option<i32>) {
+        let r = path_safe::open_dir_path_safe(&p);
+        let ok = r.is_ok();
+        let errno = r.err().and_then(|e| e.raw_os_error());
+        (ok, errno)
+    };
+
+    // (1) A real mount crossing is FOLLOWED.
+    let followed = outcome(mountpoint.join("inner"));
+    // (2) A path crossing TWO mounts still resolves.
+    let two_crossings = outcome(mountpoint.join("inner2").join("deep"));
+    // (3) A symlink AFTER a followed crossing is still refused (proves
+    // NO_SYMLINKS is re-applied beneath the crossing, not just before it).
+    let post_crossing_symlink = outcome(mountpoint.join("post-lnk"));
+    // (4) A symlink BEFORE any crossing is refused.
+    let symlink = safe_root.join("lnk");
+    std::os::unix::fs::symlink(&foreign_root, &symlink).expect("create symlink");
+    let pre_crossing_symlink = outcome(symlink);
+
+    // Tear down nested mount first, then the outer one.
+    for target in [mountpoint.join("inner2"), mountpoint.clone()] {
+        let out = Command::new("umount")
+            .arg(&target)
+            .output()
+            .expect("umount command");
+        assert!(
+            out.status.success(),
+            "umount {target:?} failed\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    assert!(followed.0, "a real mount crossing must be followed: {followed:?}");
     assert!(
-        mount_output.status.success(),
-        "mount failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&mount_output.stdout),
-        String::from_utf8_lossy(&mount_output.stderr),
+        two_crossings.0,
+        "a path crossing two mounts must resolve: {two_crossings:?}"
     );
-
-    let err = path_safe::open_dir_path_safe(&mountpoint)
-        .expect_err("RESOLVE_NO_XDEV must reject mount crossing");
-
-    let umount_output = Command::new("umount")
-        .arg(&mountpoint)
-        .output()
-        .expect("umount command");
-    assert!(
-        umount_output.status.success(),
-        "umount failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&umount_output.stdout),
-        String::from_utf8_lossy(&umount_output.stderr),
+    assert_eq!(
+        post_crossing_symlink.1,
+        Some(nix::libc::ELOOP),
+        "a symlink AFTER a followed mount crossing must be refused with ELOOP"
     );
-
-    assert_eq!(err.raw_os_error(), Some(nix::libc::EXDEV));
+    assert_eq!(
+        pre_crossing_symlink.1,
+        Some(nix::libc::ELOOP),
+        "a symlink component must be refused with ELOOP"
+    );
 }
 
 #[test]

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -5384,7 +5384,7 @@ fn redact_broker_error_for_cli(
             format!("{op_name} failed: trusted bundle intent missing"),
             "The daemon reached the broker, but the trusted bundle did not contain the requested intent row.".to_owned(),
             format!(
-                "{op_name} references a bundle intent that the broker did not find. Admin: ask `nixling audit --strict` for the intent id."
+                "{op_name} references a bundle intent that the broker did not find. Admin: ask `journalctl -u nixling-priv-broker` for the intent id."
             ),
         ),
         "Broker.StoreViewFilesystemMismatch" => (
@@ -5405,7 +5405,7 @@ fn redact_broker_error_for_cli(
             format!("{op_name} failed at the broker live handler"),
             "The daemon reached the broker and the privileged live handler started, but the underlying host mutation failed.".to_owned(),
             format!(
-                "{op_name} failed at the broker live handler. Admin: inspect `nixling audit --strict` for the underlying syscall/exit code."
+                "{op_name} failed at the broker live handler. Admin: inspect `journalctl -u nixling-priv-broker` for the underlying syscall/exit code."
             ),
         ),
         "Broker.CoexistenceRefused" => (
@@ -5419,7 +5419,7 @@ fn redact_broker_error_for_cli(
             format!("{op_name} failed: bundle nft script parse error"),
             "The daemon reached the broker, but the nftables batch embedded in the trusted bundle could not be parsed.".to_owned(),
             format!(
-                "{op_name} failed: bundle nft script could not be parsed. Admin: inspect `nixling audit --strict` for the parse error."
+                "{op_name} failed: bundle nft script could not be parsed. Admin: inspect `journalctl -u nixling-priv-broker` for the parse error."
             ),
         ),
         "Broker.CarveoutOrderingViolation" => (
@@ -6408,7 +6408,7 @@ mod host_install_dispatch_tests {
                 "outcome": "broker-error",
                 "targetWave": "W15",
                 "summary": "RunHostInstall failed",
-                "remediation": "RunHostInstall failed at the broker live handler. Admin: inspect `nixling audit --strict` for the underlying syscall/exit code.",
+                "remediation": "RunHostInstall failed at the broker live handler. Admin: inspect `journalctl -u nixling-priv-broker` for the underlying syscall/exit code.",
             }),
         );
 

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -2299,7 +2299,7 @@ fn redact_broker_error_for_launcher(
             "broker is starting up / bundle not yet loaded; retry shortly. Admin: confirm the bundle path is populated.".to_owned()
         }
         "Broker.BundleIntentMissing" => format!(
-            "{op_name} references a bundle intent that the broker did not find. Admin: ask `nixling audit --strict` for the intent id."
+            "{op_name} references a bundle intent that the broker did not find. Admin: ask `journalctl -u nixling-priv-broker` for the intent id."
         ),
         "Broker.StoreViewFilesystemMismatch" => format!(
             "{op_name} refused: the per-VM store view is not on the same filesystem as /nix/store. Admin: check the VM state dir layout and retry."
@@ -2308,11 +2308,11 @@ fn redact_broker_error_for_launcher(
             "{op_name} refused: the prepared store-view generation is missing its marker. Admin: rebuild the store view and retry."
         ),
         "Broker.LiveHandlerFailed" => format!(
-            "{op_name} failed at the broker live handler. Admin: inspect `nixling audit --strict` for the underlying syscall/exit code."
+            "{op_name} failed at the broker live handler. Admin: inspect `journalctl -u nixling-priv-broker` for the underlying syscall/exit code."
         ),
         "Broker.CoexistenceRefused" => "{op_name} refused: another firewall manager owns the table per FirewallCoexistencePolicy. Admin: check nixling.site.firewallCoexistencePolicy."
             .replace("{op_name}", op_name),
-        "Broker.NftScriptParseFailed" => "{op_name} failed: bundle nft script could not be parsed. Admin: inspect `nixling audit --strict` for the parse error."
+        "Broker.NftScriptParseFailed" => "{op_name} failed: bundle nft script could not be parsed. Admin: inspect `journalctl -u nixling-priv-broker` for the parse error."
             .replace("{op_name}", op_name),
         "Broker.CarveoutOrderingViolation" => "{op_name} refused: USBIP firewall carve-out rules are out of order relative to broad allow/drop. Admin: inspect the bundle's nft batch ordering."
             .replace("{op_name}", op_name),
@@ -2334,7 +2334,7 @@ fn redact_broker_error_for_launcher(
             "broker audit export requires an authorized admin user.".to_owned()
         }
         _ => format!(
-            "{op_name} failed; admin should inspect `nixling audit --strict` for details"
+            "{op_name} failed; admin should inspect `journalctl -u nixling-priv-broker` for details"
         ),
     };
     (summary, remediation)
@@ -2688,6 +2688,9 @@ impl VmStartRunner<'_> {
                         node = %node.id.0,
                         broker_kind = %error.kind,
                         broker_operation = %error.operation,
+                        broker_target_wave = error.target_wave.as_deref().unwrap_or("none"),
+                        broker_message = %error.message,
+                        broker_action = %error.action,
                         "v1.2fu46: DiskInit pre-SpawnRunner dispatch failed"
                     );
                     return Err(format!("broker-error:DiskInit:{}", error.kind));
@@ -2748,6 +2751,8 @@ impl VmStartRunner<'_> {
                     broker_kind = %error.kind,
                     broker_operation = %error.operation,
                     broker_target_wave = error.target_wave.as_deref().unwrap_or("none"),
+                    broker_message = %error.message,
+                    broker_action = %error.action,
                     "vm start node spawn failed"
                 );
                 Err(format!("broker-error:{}", error.kind))


### PR DESCRIPTION
broker: fix EXDEV abort starting VMs after a host switch

A VM start aborted at the first virtiofs node (`virtiofsd-nl-hkeys`) with
`SpawnRunner failed ... broker-error (exit 78)`, and every downstream
node was skipped. The broker journal showed only `Broker.LiveHandlerFailed`;
the real reason was buried in the audit log:

    prepare vm-start directory /run/nixling/vms/<vm> for <vm>:host-reconcile
    failed: Invalid cross-device link (os error 18)

Root cause: the broker prepares the per-VM runtime dir under
`/run/nixling/vms/<vm>` via `path_safe::open_dir_path_safe`, which
anchors its `openat2` walk at `/` with `RESOLVE_NO_XDEV`. `/run` is a
tmpfs (a separate mount), so the walk fails with `EXDEV` at the very
first `/`→`/run` crossing. `/var/lib/nixling` paths are unaffected
because `/var` is on the rootfs, which is why `PrepareStateDir`
succeeded but `PrepareRuntimeDir` did not. The running VMs kept working
only because they were started before the switch and their runtime dirs
were never re-prepared.

Fix: when the target lives beneath a framework mount-root
(`/run/nixling`, `/var/lib/nixling`), anchor the hardened walk at that
root — reached via a crossing-tolerant but still
symlink/magiclink/escape-refusing open — and keep the full `NO_XDEV`
mask for the per-VM subtree beneath it (where an untrusted bind-swap
would actually be planted). The trusted roots are fixed, root-owned
constants. Adds a routing unit test and a direct regression test that
reaches `/run/nixling` across the real tmpfs boundary (skips where
`/run/nixling` is absent or `/run` is not a separate mount).

Diagnostics (the failure was needlessly opaque):

- the broker now logs the live-handler root cause (errno/path/stderr)
  with a `tracing::warn!` instead of only writing it to the audit jsonl;
- the daemon's `vm start node spawn failed` and DiskInit log lines now
  include `broker_message` (the wire response already carried it, it was
  just dropped) so `journalctl -u nixlingd` shows the real reason;
- remediation strings no longer point operators at `nixling audit
  --strict`, which returns `not-yet-implemented`; they point at the
  working `nixling audit`.

Also clears two pre-existing broker clippy warnings in files this change
touches (`runtime.rs` unnecessary closure, `disk_init.rs` doc list) so
the workspace is `-D warnings` clean.