### PR TITLE
virtiofsd: allow broker-prepared vms runtime dir

### DIFF
--- a/nixos-modules/minijail-profiles.nix
+++ b/nixos-modules/minijail-profiles.nix
@@ -153,7 +153,7 @@ let
 
   profileIdFor = name: nodeId: "vm-${name}-${nodeId}";
   stateDirOf = name: "${toString cfg.store.stateDir}/${name}";
-  runtimeDirOf = name: "/run/nixling/${name}";
+  runtimeDirOf = name: "/run/nixling/vms/${name}";
   audioRuntimeDirOf = name: "/run/nixling/vms/${name}";
   videoRuntimeDirOf = name: "/run/nixling-video/${name}";
   gpuRuntimeDirOf = name: "/run/nixling-gpu/${name}";


### PR DESCRIPTION
## Summary

- Align virtiofsd minijail writable runtime dir with the broker-prepared socket root under `/run/nixling/vms/<vm>`.
- Fixes `SpawnRunner failed at virtiofsd-nl-hkeys` when the broker prepares per-VM runtime sockets under the vms runtime root.

## Validation

- `nix eval --impure --raw --expr 'let f = builtins.getFlake (toString ./.); in if f ? nixosModules then "ok" else throw "missing modules"'`
