### PR TITLE
examples: update Entra composition for entrablau

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ CLI, the manifest contract.
 Anything **identity- or workload-specific** lives in a sibling
 flake and is composed per-VM:
 
-- [`vicondoa/nixos-entra-id`][nixos-entra-id] — Microsoft Entra ID
+- [`vicondoa/entrablau.nix`][entrablau] — Microsoft Entra ID
   joins (Himmelblau + TPM-bound machine credential).
 
 The composition pattern is intentionally one-way: sibling flakes
@@ -289,7 +289,7 @@ Consumers compose them on a specific workload VM:
 
 ```nix
 nixling.vms.work.config.imports = [
-  inputs.nixos-entra-id.nixosModules.default
+  inputs.entrablau.nixosModules.default
 ];
 ```
 
@@ -300,7 +300,7 @@ instead. The bar for landing it in core is: "every nixling user
 plausibly wants this, and the framework cannot do the right thing
 without it."
 
-[nixos-entra-id]: https://github.com/vicondoa/nixos-entra-id
+[entrablau]: https://github.com/vicondoa/entrablau.nix
 
 ### VM lifecycle (daemon-supervised)
 
@@ -516,7 +516,7 @@ The root flake exposes these eval-only checks under
 | `eval-graphics`        | `examples/graphics-workstation/configuration.nix`. **x86_64-linux only** — the framework's `checkVmPlatform` gate refuses graphics on aarch64. |
 
 `with-entra-id` is intentionally absent from the root `flake.checks`
-because it depends on the sibling `nixos-entra-id` input, which the
+because it depends on the sibling `entrablau` input, which the
 core flake does not (and should not) pull in. Its own flake is
 still eval-checked by `tests/static.sh` during the per-example
 iteration step, and CI also runs
@@ -734,7 +734,7 @@ by-release history.
   defaults to 7 days; override with `NL_POST_GATE_DEEP_GC_DAYS=N`.
   Off by default — this is operator policy, not gate policy.
 - `NL_SKIP_WITH_ENTRA_ID=1` skips the per-example flake check for
-  `examples/with-entra-id` when its pinned `vicondoa/nixos-entra-id`
+  `examples/with-entra-id` when its pinned `vicondoa/entrablau.nix`
   input fails the per-example cargo fetch with a transient crates.io
   403 against `libhimmelblau-0.8.18` / `kanidm-hsm-crypto-0.3.6`.
   `tests/static.sh` performs one in-band retry before failing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1390,12 +1390,12 @@ First public alpha release.
 - Nixling-managed SSH keys
 - Components: `graphics`, `tpm`, `usbip`, `audio`, `home-manager`
 
-**Composition:** Sibling flake [`vicondoa/nixos-entra-id`][nei] (also
+**Composition:** Sibling flake [`vicondoa/entrablau.nix`][entrablau] (also
 v0.1.0) provides Entra ID device-join via the per-VM
-`nixling.vms.<vm>.config.imports = [ inputs.nixos-entra-id.nixosModules.default ]`
+`nixling.vms.<vm>.config.imports = [ inputs.entrablau.nixosModules.default ]`
 seam.
 
-[nei]: https://github.com/vicondoa/nixos-entra-id
+[entrablau]: https://github.com/vicondoa/entrablau.nix
 
 > Maintainer GitHub metadata reminder (apply on the GitHub UI, not in git):
 >
@@ -1436,7 +1436,7 @@ seam.
   isolation, per-env net VMs, per-env USBIP backends, and the
   route-preflight fail-closed gate.
 - **`examples/with-entra-id/`** — composition with the sibling
-  [`vicondoa/nixos-entra-id`][nixos-entra-id] flake; shows how
+  [`vicondoa/entrablau.nix`][entrablau] flake; shows how
   the two trees meet at `nixling.vms.<vm>.config.imports`
   without either flake depending on the other.
 - **`templates/default/`** — `nix flake init` scaffold with
@@ -1744,7 +1744,7 @@ seam.
   the development branch and are preserved as historical record of how
   the architecture got to v1.0.
 - v1.0.0 ships in lockstep with
-  [`vicondoa/nixos-entra-id`][nixos-entra-id] v1.0.0; consumers
+  [`vicondoa/entrablau.nix`][entrablau] v1.0.0; consumers
   using both should pin matching tags.
 
 ### Fixed
@@ -1796,19 +1796,19 @@ seam.
 
 - **`nixling.vms.<vm>.entra-id.*` option removed.** Himmelblau /
   Microsoft Entra ID support has moved out of the nixling framework
-  and into the sibling `vicondoa/nixos-entra-id` flake. To migrate,
+  and into the sibling `vicondoa/entrablau.nix` flake. To migrate,
   add the flake as an input and import its module into the VM's guest
   config:
 
   ```nix
-  inputs.nixos-entra-id.url = "github:vicondoa/nixos-entra-id";
+  inputs.entrablau.url = "github:vicondoa/entrablau.nix";
 
   nixling.vms.<vm>.config.imports = [
-    inputs.nixos-entra-id.nixosModules.default
+    inputs.entrablau.nixosModules.default
   ];
 
   # Move each `nixling.vms.<vm>.entra-id.<key>` into the guest
-  # config; see the nixos-entra-id README for the new schema.
+  # config; see the entrablau README for the new schema.
   ```
 
   The `nixling.vms.<vm>.entra-id` attribute is kept as a hidden
@@ -1864,7 +1864,7 @@ seam.
   `examples/with-entra-id`.** `tests/static.sh` iterates
   `examples/*/flake.nix` and runs `nix flake check --no-build
   --all-systems` per example, but `with-entra-id` depends on the
-  sibling `vicondoa/nixos-entra-id` flake which the core flake
+  sibling `vicondoa/entrablau.nix` flake which the core flake
   cannot pull in as an input. The example's own flake.lock pins
   the sibling and the iteration step exercises eval through it,
   but a clean-tree CI run cannot fully isolate the eval graph
@@ -1879,4 +1879,4 @@ seam.
   (e.g. `nixling.envs.<env>.intraLanIsolation = false`) is on the
   v0.2.0 wishlist.
 
-[nixos-entra-id]: https://github.com/vicondoa/nixos-entra-id
+[entrablau]: https://github.com/vicondoa/entrablau.nix

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ forwarding into the guest natively over Wayland. Concretely:
   + `nixling.vms.<vm>` shape covers CI runners or
   background-service VMs without graphics + audio bits.
 - Microsoft Entra ID workspaces are supported via the sibling
-  [`vicondoa/nixos-entra-id`][nixos-entra-id] flake (composed
+  [`vicondoa/entrablau.nix`][entrablau] flake (composed
   per-VM, not auto-imported).
 
 If you're after a multi-tenant or production-grade VM platform,
@@ -336,7 +336,7 @@ For typed exit codes and JSON envelopes, see
 
 ## Companion flakes
 
-- [`vicondoa/nixos-entra-id`][nixos-entra-id] — unofficial, framework-
+- [`vicondoa/entrablau.nix`][entrablau] — unofficial, framework-
   agnostic NixOS module bundle for Microsoft Entra ID auth (via
   Himmelblau) with Intune compliance shimming. Optional. Compose it
   by importing its `nixosModules.default` inside a nixling workload
@@ -394,5 +394,5 @@ the operational manual lives in [`AGENTS.md`](./AGENTS.md) at the
 repo root.
 
 [microvm.nix]: https://github.com/microvm-nix/microvm.nix
-[nixos-entra-id]: https://github.com/vicondoa/nixos-entra-id
+[entrablau]: https://github.com/vicondoa/entrablau.nix
 [docs/explanation/design.md]: ./docs/explanation/design.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ live one level up under
   doc-friendly alias for the checked `examples/with-entra-id/`
   flake; VM name `work-entra`.
 
-[nei]: https://github.com/vicondoa/nixos-entra-id
+[entrablau]: https://github.com/vicondoa/entrablau.nix
 
 The examples are intentionally small enough to read end-to-end;
 each example's README explains the pattern.

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -694,13 +694,13 @@ patterns, see [the naming conventions reference](../reference/naming-conventions
 | `nixling` group                 | SO_PEERCRED authorisation surface at `nixlingd`'s public.sock (mode 0660, group `nixling`) | host-users.nix |
 | `nixling-<vm>-{gpu,snd,swtpm,usbip}` users | dedicated per-VM runner uids (broker-spawned in v1.0) | host-users.nix |
 
-### Composition with framework-agnostic flakes (`nixos-entra-id`)
+### Composition with framework-agnostic flakes (`entrablau`)
 
 Nixling deliberately does **not** ship per-domain modules (Entra ID
 device-join, corporate VPN clients, vendor identity glue). Those live
 in sibling flakes that are framework-agnostic — they can in principle
 be imported into any NixOS configuration, microVM or bare metal.
-[`vicondoa/nixos-entra-id`](https://github.com/vicondoa/nixos-entra-id)
+[`vicondoa/entrablau.nix`](https://github.com/vicondoa/entrablau.nix)
 is the canonical example.
 
 The split:
@@ -717,11 +717,11 @@ The split:
 
   ```nix
   nixling.vms.work-vm.config.imports = [
-    inputs.nixos-entra-id.nixosModules.default
+    inputs.entrablau.nixosModules.default
   ];
   ```
 
-  Nixling does not depend on `nixos-entra-id`, and `nixos-entra-id`
+  Nixling does not depend on `entrablau`, and `entrablau`
   does not depend on nixling — they meet only in the consumer
   flake's `config.imports`.
 

--- a/docs/how-to/write-a-nixling-addon.md
+++ b/docs/how-to/write-a-nixling-addon.md
@@ -12,7 +12,7 @@ A `nixling` addon is a **sibling flake** that exports an ordinary NixOS
 module and gets composed into a specific guest VM. It is not a special
 plugin API.
 
-[`vicondoa/nixos-entra-id`](https://github.com/vicondoa/nixos-entra-id)
+[`vicondoa/entrablau.nix`](https://github.com/vicondoa/entrablau.nix)
 is the canonical example: the Entra-specific module lives outside the
 framework, and the consumer imports it only into the VM that needs it.
 See [`examples/with-entra-id/`](../../examples/with-entra-id/) for the
@@ -76,7 +76,7 @@ nixling.vms.work-vm = {
   ssh.user = "alice";
 
   config.imports = [
-    nixos-entra-id.nixosModules.default
+    entrablau.nixosModules.default
     ./work-vm.nix
   ];
 };

--- a/docs/reference/components-graphics.md
+++ b/docs/reference/components-graphics.md
@@ -215,4 +215,4 @@ nixpkgs rev — defence-in-depth payload waiting on an upstream knob).
 - [`examples/graphics-workstation`](../../examples/graphics-workstation/) —
   end-to-end example with graphics + audio + USBIP YubiKey.
 - [`examples/with-entra-id`](../../examples/with-entra-id/) — graphics
-  VM composed with the sibling `nixos-entra-id` flake.
+  VM composed with the sibling `entrablau` flake.

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ construction and `tests/static.sh` regenerates a local lock on first
 eval anyway.
 
 Examples that pull in an external sibling flake (`with-entra-id/`
-consumes `github:vicondoa/nixos-entra-id`) **do** commit their
+consumes `github:vicondoa/entrablau.nix`) **do** commit their
 `flake.lock` for reproducibility — the lock is the only way to ensure
 the example builds bit-identically across machines.
 

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -133,7 +133,7 @@ checkout).
   parallel `nixling.envs.<name>` instances with no cross-traffic
   between them.
 - **Add Entra ID** — `examples/with-entra-id` consumes the sibling
-  `nixos-entra-id` flake to put a domain-joined VM behind nixling
+  `entrablau` flake to put a domain-joined VM behind nixling
   without the framework knowing about Himmelblau.
 
 ## After activation

--- a/examples/with-entra-id/README.md
+++ b/examples/with-entra-id/README.md
@@ -1,16 +1,13 @@
-# `with-entra-id` — composing nixling with `nixos-entra-id`
+# `with-entra-id` — composing nixling with `entrablau`
 
 This example is the **integration showcase** for using
 [`vicondoa/nixling`][nixling] together with the framework-agnostic
-[`vicondoa/nixos-entra-id`][nixos-entra-id] flake to spin up an
+[`vicondoa/entrablau.nix`][entrablau] flake to spin up an
 Entra-ID-joined work microVM on a NixOS host.
 
 The two flakes are deliberately decoupled — neither imports the
 other. This directory is the **consumer-side composition** that
-wires them together in your top-level `flake.nix`. Read the same
-pattern from the `nixos-entra-id` side at
-[`examples/inside-nixling-vm/`][entra-from-the-other-side] in that
-repo.
+wires them together in your top-level `flake.nix`.
 
 ## What you get
 
@@ -24,25 +21,25 @@ work environment with one Entra-joined VM:
 | swtpm 2.0                | nixling          | Software TPM exposed to guest at `/dev/tpmrm0`       |
 | Wayland / audio / GPU    | nixling          | (Off in this minimal example — TPM-only headless VM) |
 | YubiKey USBIP backend    | nixling          | (Available; toggle `usbip.yubikey = true` per VM)    |
-| Himmelblau daemon + PAM  | nixos-entra-id   | Linux-native Entra ID client (TPM-enabled rebuild)   |
-| Intune compliance shims  | nixos-entra-id   | Fake DMI / `/etc/os-release`, `FileDescriptorStoreMax` for PRT survival |
-| Firefox SSO + pinentry   | nixos-entra-id   | Browser-broker plumbing for the interactive MFA flow |
+| Himmelblau daemon + PAM  | entrablau        | Linux-native Entra ID client (TPM-enabled rebuild)   |
+| Intune compliance shims  | entrablau        | `dmiOverride` / `osReleaseOverride`, `FileDescriptorStoreMax` for PRT survival |
+| Firefox SSO + pinentry   | entrablau        | Browser-broker plumbing for the interactive MFA flow |
 
 ## File layout
 
 ```
 examples/with-entra-id/
-├── flake.nix           inputs: nixpkgs, nixling, nixos-entra-id
+├── flake.nix           inputs: nixpkgs, nixling, entrablau
 │                       outputs: nixosConfigurations.demo
 ├── configuration.nix   host-side: user, nixling.site, nixling.envs.work
-├── work-entra.nix         guest-side: hostname, security.tpm2, nixosEntraId.*
+├── work-entra.nix         guest-side: hostname, security.tpm2, entrablau.*
 └── README.md           you are here
 ```
 
 ## Two-flake composition: who owns what
 
 The split is intentional. **`nixling` owns VM lifecycle and host
-plumbing**; **`nixos-entra-id` owns Entra protocol + Intune
+plumbing**; **`entrablau` owns Entra protocol + Intune
 compatibility**. Putting Entra inside nixling would have coupled the
 framework to Microsoft-specific machinery that the average single-
 user NixOS desktop will never want.
@@ -67,21 +64,21 @@ configure the VM itself.
 | `nixling.vms.<vm>.ssh.user`           | `flake.nix`         | SSH user the CLI uses to talk into the VM       |
 | `nixling.vms.<vm>.config.imports`     | `flake.nix`         | **The composition seam** — guest NixOS modules  |
 
-### Options that live in `nixosEntraId.*` (from the other flake)
+### Options that live in `entrablau.*` (from the other flake)
 
 These are set **inside the VM** in `work-entra.nix`. They configure
 Himmelblau and the Intune compliance shim. The full schema is in
-the [`nixos-entra-id` README][nixos-entra-id-readme].
+the [`entrablau` README][entrablau-readme].
 
 | Option                                       | Purpose                                                            |
 |----------------------------------------------|--------------------------------------------------------------------|
-| `nixosEntraId.enable`                        | Activate the Himmelblau workspace + module                         |
-| `nixosEntraId.domain`                        | Tenant domain(s) (`listOf str`)                                    |
-| `nixosEntraId.userMap.<local> = <UPN>`       | Local-user → Entra UPN mapping (`/etc/himmelblau/user-map`)        |
-| `nixosEntraId.joinType`                      | `"join"` (Intune-enrolled) or `"register"` (BYOD)                  |
-| `nixosEntraId.localUser`                     | Diagnostic — name of the local user that maps to the UPN           |
-| `nixosEntraId.intuneCompliance.enable`       | Turn on/off the Intune compliance shim                             |
-| `nixosEntraId.intuneCompliance.fakeDmi`      | SMBIOS values bind-mounted into himmelblau's mount ns              |
+| `entrablau.enable`                        | Activate the Himmelblau workspace + module                         |
+| `entrablau.domain`                        | Tenant domain(s) (`listOf str`)                                    |
+| `entrablau.userMap.<local> = <UPN>`       | Local-user → Entra UPN mapping (`/etc/himmelblau/user-map`)        |
+| `entrablau.joinType`                      | `"join"` (Intune-enrolled) or `"register"` (BYOD)                  |
+| `entrablau.localUser`                     | Diagnostic — name of the local user that maps to the UPN           |
+| `entrablau.intuneCompliance.enable`       | Turn on/off the Intune compliance shim                             |
+| `entrablau.intuneCompliance.dmiOverride`      | SMBIOS values bind-mounted into himmelblau's mount ns              |
 
 ### The seam
 
@@ -92,7 +89,7 @@ nixling.vms.work-entra = {
   tpm.enable = true;             # nixling option
   config = {
     imports = [
-      nixos-entra-id.nixosModules.default   # bring in the other flake
+      entrablau.nixosModules.default   # bring in the other flake
       ./work-entra.nix                         # bring in our own VM config
     ];
   };
@@ -122,12 +119,12 @@ either skip the TPM portion (failing CA) or emit a CSR the
 endpoint refuses with
 `400 Bad Request: Value must be a valid PEM-encoded PKCS#10 CSR`.
 
-`nixos-entra-id` ships a TPM-enabled rebuild of the Himmelblau
+`entrablau` ships a TPM-enabled rebuild of the Himmelblau
 workspace specifically because the upstream build has the `tpm`
 cargo feature off by default and requires two vendored crate
 patches to make the Intune CSR validation pass. See
 [`pkgs/himmelblau-tpm/MAINTAINING.md`][himmelblau-tpm-maintaining]
-in `nixos-entra-id` for the patch rationale.
+in `entrablau` for the patch rationale.
 
 **swtpm satisfies this requirement**, because the kernel inside
 the VM sees a real TPM CRB at `/dev/tpmrm0` and exposes it through
@@ -176,7 +173,7 @@ restarts should keep the same device identity.
 This is **compatibility, not bypass**.
 
 The `intuneCompliance` shim makes a Linux/microVM guest *look* to
-Intune the way a supported corporate device would — same fake DMI
+Intune the way a supported corporate device would — same DMI override
 strings, same `/etc/os-release` shape, same `FileDescriptorStoreMax`
 behaviour the Windows / macOS clients rely on for PRT survival
 across restarts. That gets you past the device-compliance gate so
@@ -195,7 +192,7 @@ Himmelblau:
   validating attestation provenance (Microsoft Defender for
   Identity, conditional access policies inspecting TPM EK
   thumbprints) will flag this device as "Linux with software TPM."
-- The vendored fake DMI values are static text — they will not
+- The vendored DMI override values are static text — they will not
   satisfy any compliance check that cross-references a
   Manufacturer-Vendor-ID against a hardware database.
 
@@ -205,7 +202,7 @@ device. If your acceptable-use policy says "only corporate
 Windows," using this is a policy violation regardless of whether
 the technical compliance check passes.
 
-`nixos-entra-id` was written to support migrating a corporate
+`entrablau` was written to support migrating a corporate
 workstation off Windows onto NixOS, with the IT department's
 explicit awareness. That's the supported use case. If you need to
 actually circumvent enterprise controls, this is the wrong tool
@@ -242,7 +239,7 @@ real `hardware-configuration.nix`):
 sudo -A nixos-rebuild build  --flake .#demo
 ```
 
-The first build pulls in `nixos-entra-id`'s TPM-enabled Himmelblau
+The first build pulls in `entrablau`'s TPM-enabled Himmelblau
 rebuild — ~10 minutes of Rust compile on a cold cache, cached
 afterwards. **Do not skip the `build` step**: a broken Entra config
 that switches live is harder to recover from than one that fails
@@ -356,9 +353,9 @@ journalctl -b -u var.mount -u local-fs.target --no-pager
 
 - **Other tenants** — swap `contoso.com` for your domain and
   update `userMap` + `localUser`. Read the
-  [`nixos-entra-id` README quick start][nixos-entra-id-readme]
+  [`entrablau` README quick start][entrablau-readme]
   for tenant prerequisites (admin role, Conditional Access caveats,
-  `dmidecode` for realistic `fakeDmi` values).
+  `dmidecode` for realistic `dmiOverride` values).
 - **Add graphics** — set `nixling.vms.work-entra.graphics.enable =
   true` in `flake.nix` and the VM gains a virtio-gpu + Wayland
   forward to the host compositor (a `foot` terminal auto-launches
@@ -370,8 +367,8 @@ journalctl -b -u var.mount -u local-fs.target --no-pager
   host's USB controller to the VM via USBIP. Useful for the MFA
   prompt during `aad-tool auth-test` and any downstream FIDO2
   flow.
-- **BYOD / no Intune** — set `nixosEntraId.joinType = "register"`
-  and `nixosEntraId.intuneCompliance.enable = false`. The TPM is
+- **BYOD / no Intune** — set `entrablau.joinType = "register"`
+  and `entrablau.intuneCompliance.enable = false`. The TPM is
   still useful (PRT survival), but the compliance shim drops out
   of the picture.
 
@@ -386,9 +383,9 @@ The framework itself is multi-arch (headless VMs eval on
 + `audio.enable` only — **not on `tpm.enable`** — so a future
 `aarch64`-clean variant of this example would be possible if
 upstream Himmelblau gained an `aarch64` cargo build. Today,
-`nixos-entra-id`'s TPM-enabled Himmelblau package is wired for
+`entrablau`'s TPM-enabled Himmelblau package is wired for
 `x86_64-linux` only via its `himmelblauSystems` allowlist
-(see the `nixos-entra-id` flake.nix), so the practical answer
+(see the `entrablau` flake.nix), so the practical answer
 remains `x86_64-linux` for the foreseeable future.
 
 ## Where the two flakes' docs disagree
@@ -441,20 +438,15 @@ for the exact predicate.
 - [`examples/graphics-workstation`](../graphics-workstation/) — desktop VM with Wayland + audio + USBIP
 - [`examples/multi-env`](../multi-env/) — two isolated envs (work + personal)
 - [`templates/default`](../../templates/default/) — scaffold via `nix flake init`
-- [`vicondoa/nixos-entra-id`][nixos-entra-id] — the Entra/Himmelblau
+- [`vicondoa/entrablau.nix`][entrablau] — the Entra/Himmelblau
   module bundle. Read its README for tenant prerequisites,
-  detailed enrolment troubleshooting, and the full `nixosEntraId.*`
+  detailed enrolment troubleshooting, and the full `entrablau.*`
   schema.
-- [`vicondoa/nixos-entra-id/examples/inside-nixling-vm/`][entra-from-the-other-side]
-  — the same composition pattern documented from the Entra flake's
-  side. Slightly different emphasis (Entra-first); cross-link
-  rather than duplicate.
 - [`vicondoa/nixling` README][nixling-readme] — quick start, common
   gotchas, full option index.
 
 [nixling]: https://github.com/vicondoa/nixling
 [nixling-readme]: ../../README.md
-[nixos-entra-id]: https://github.com/vicondoa/nixos-entra-id
-[nixos-entra-id-readme]: https://github.com/vicondoa/nixos-entra-id#readme
-[entra-from-the-other-side]: https://github.com/vicondoa/nixos-entra-id/tree/main/examples/inside-nixling-vm
-[himmelblau-tpm-maintaining]: https://github.com/vicondoa/nixos-entra-id/blob/main/pkgs/himmelblau-tpm/MAINTAINING.md
+[entrablau]: https://github.com/vicondoa/entrablau.nix
+[entrablau-readme]: https://github.com/vicondoa/entrablau.nix#readme
+[himmelblau-tpm-maintaining]: https://github.com/vicondoa/entrablau.nix/blob/main/pkgs/himmelblau-tpm/MAINTAINING.md

--- a/examples/with-entra-id/configuration.nix
+++ b/examples/with-entra-id/configuration.nix
@@ -1,8 +1,8 @@
-# Host-side NixOS configuration for the nixling + nixos-entra-id
+# Host-side NixOS configuration for the nixling + entrablau
 # composition example. This file owns everything *outside* the
 # Entra VM: the human user on the host, the nixling site-level
 # knobs, and the env that the VM lives in. The VM's own NixOS
-# config (and its `nixosEntraId.*` settings) live in `work-entra.nix`.
+# config (and its `entrablau.*` settings) live in `work-entra.nix`.
 { lib, ... }:
 
 {

--- a/examples/with-entra-id/flake.lock
+++ b/examples/with-entra-id/flake.lock
@@ -1,9 +1,31 @@
 {
   "nodes": {
+    "entrablau": {
+      "inputs": {
+        "himmelblau": "himmelblau",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780980769,
+        "narHash": "sha256-q3awmFBXGZ3Io2rcI+MpXXisx7oEJnVcaRbPf9UCzsg=",
+        "owner": "vicondoa",
+        "repo": "entrablau.nix",
+        "rev": "bbefb679a5d92fd4eb939b0a6e289b22380dd4b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vicondoa",
+        "ref": "v1.0.0",
+        "repo": "entrablau.nix",
+        "type": "github"
+      }
+    },
     "himmelblau": {
       "inputs": {
         "nixpkgs": [
-          "nixos-entra-id",
+          "entrablau",
           "nixpkgs"
         ]
       },
@@ -30,45 +52,22 @@
         ]
       },
       "locked": {
-        "lastModified": 1779157263,
-        "narHash": "sha256-VbiyZkRf8/qr7ObmlyfOHJsNAW5tyZ4MB1+cUwAwdrw=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "866412a19866b4a8e32d2306a118040afa2b840c",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "microvm": {
-      "inputs": {
-        "nixpkgs": [
-          "nixling",
-          "nixpkgs"
-        ],
-        "spectrum": "spectrum"
-      },
-      "locked": {
-        "lastModified": 1779043402,
-        "narHash": "sha256-1dH6yiwEck1n3oz5TDUV5TGbwNqu46eNTVHbhFO2U5k=",
-        "owner": "microvm-nix",
-        "repo": "microvm.nix",
-        "rev": "77024c22f4ddf509137fc732094888d1ffe631e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "microvm-nix",
-        "repo": "microvm.nix",
         "type": "github"
       }
     },
     "nixling": {
       "inputs": {
         "home-manager": "home-manager",
-        "microvm": "microvm",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -83,34 +82,13 @@
       },
       "parent": []
     },
-    "nixos-entra-id": {
-      "inputs": {
-        "himmelblau": "himmelblau",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779175086,
-        "narHash": "sha256-5U13N+Rv52S2UMNVwwSch4p2FEx/ZFHQ+ej1U+2X4iI=",
-        "owner": "vicondoa",
-        "repo": "nixos-entra-id",
-        "rev": "16a961f533ad6e1ee11f66bc013d27dba42778c6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vicondoa",
-        "repo": "nixos-entra-id",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -122,25 +100,9 @@
     },
     "root": {
       "inputs": {
+        "entrablau": "entrablau",
         "nixling": "nixling",
-        "nixos-entra-id": "nixos-entra-id",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "spectrum": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1778940603,
-        "narHash": "sha256-voSM8dZNlaOWN3kbYFky+FNY6fFQOEw0xF+ZMpZKkCQ=",
-        "ref": "refs/heads/main",
-        "rev": "367dd227f539267eae2b62770b4c17b88ac8c1f1",
-        "revCount": 1265,
-        "type": "git",
-        "url": "https://spectrum-os.org/git/spectrum"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://spectrum-os.org/git/spectrum"
       }
     }
   },

--- a/examples/with-entra-id/flake.nix
+++ b/examples/with-entra-id/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "nixling + nixos-entra-id composition example (Entra-joined work VM)";
+  description = "nixling + entrablau composition example (Entra-joined work VM)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -7,8 +7,8 @@
     # Local path during the in-flight refactor. Once both flakes
     # are tagged, downstream consumers should pin GitHub refs:
     #
-    #   nixling.url        = "github:vicondoa/nixling/v0.1.0";
-    #   nixos-entra-id.url = "github:vicondoa/nixos-entra-id/v0.1.0";
+    #   nixling.url   = "github:vicondoa/nixling";
+    #   entrablau.url = "github:vicondoa/entrablau.nix/v1.0.0";
     #
     # The relative path here exists so `nix flake check` in this
     # subdirectory exercises the in-tree nixling sources without
@@ -16,11 +16,11 @@
     nixling.url = "path:../..";
     nixling.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixos-entra-id.url = "github:vicondoa/nixos-entra-id";
-    nixos-entra-id.inputs.nixpkgs.follows = "nixpkgs";
+    entrablau.url = "github:vicondoa/entrablau.nix/v1.0.0";
+    entrablau.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, nixling, nixos-entra-id, ... }@inputs: {
+  outputs = { self, nixpkgs, nixling, entrablau, ... }@inputs: {
     nixosConfigurations.demo = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
@@ -28,7 +28,7 @@
         ./configuration.nix
 
         # Per-VM glue: register `work-entra` with nixling, hand its
-        # NixOS config (including the nixos-entra-id module) to
+        # NixOS config (including the entrablau module) to
         # the framework via `config.imports`. The two flakes know
         # nothing about each other; this attrset is where they meet.
         {
@@ -41,7 +41,7 @@
 
             config = {
               imports = [
-                nixos-entra-id.nixosModules.default
+                entrablau.nixosModules.default
                 ./work-entra.nix
               ];
             };

--- a/examples/with-entra-id/work-entra.nix
+++ b/examples/with-entra-id/work-entra.nix
@@ -1,6 +1,6 @@
 # Guest-side NixOS configuration for the `work-entra` Entra workspace.
 # This module is merged into the VM's `config.imports` from
-# `flake.nix` alongside `nixos-entra-id.nixosModules.default`, so
+# `flake.nix` alongside `entrablau.nixosModules.default`, so
 # every option here is set INSIDE the VM, not on the host.
 #
 # The split of responsibility is:
@@ -8,7 +8,7 @@
 #   nixling.vms.work-entra.tpm.enable = true   (in flake.nix)
 #     -> wires swtpm on the host, exposes /dev/tpmrm0 in the guest
 #
-#   nixosEntraId.* (here)
+#   entrablau.* (here)
 #     -> Himmelblau daemon, PAM/NSS, Intune compliance shimming
 #
 # Both halves are needed: Entra Conditional Access requires a
@@ -48,13 +48,13 @@
     extraGroups = [ "wheel" ];
   };
 
-  # The Entra-ID configuration. Everything under `nixosEntraId.*`
-  # is owned by the sibling `vicondoa/nixos-entra-id` flake — see
+  # The Entra-ID configuration. Everything under `entrablau.*`
+  # is owned by the sibling `vicondoa/entrablau.nix` flake — see
   # its README for the full schema and per-option semantics. The
   # generic placeholders below MUST be replaced with your tenant
   # values before this VM will actually authenticate against
   # Entra.
-  nixosEntraId = {
+  entrablau = {
     enable = true;
 
     # TODO: replace with your tenant domain.
@@ -84,11 +84,11 @@
       #
       # GENERIC PLACEHOLDERS. In a real deployment you crib these
       # from a `dmidecode -t system,baseboard` dump on a real
-      # device of a supported make/model. See the nixos-entra-id
+      # device of a supported make/model. See the entrablau
       # README for guidance on what counts as "supported" and the
       # Intune compliance disclaimer below in this example's
       # README for the rules of the road.
-      fakeDmi = {
+      dmiOverride = {
         sys_vendor = "Example Corp";
         product_name = "Example Workstation";
         board_vendor = "Example Corp";

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
       # — which is what we want from a `nix flake check` gate.
       #
       # `with-entra-id` is intentionally absent: it imports
-      # `nixos-entra-id.nixosModules.default` from a separate sibling
+      # `entrablau.nixosModules.default` from a separate sibling
       # flake, and the root flake doesn't (and shouldn't) pull that
       # in as an input. The example's own `flake.nix` still gates
       # eval via `nix flake check` in its own directory; the

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -298,27 +298,26 @@ let
           nixling.vms.${name}.entra-id.* was removed.
           Himmelblau / Microsoft Entra ID support has moved out of
           the nixling framework into the sibling
-          `vicondoa/nixos-entra-id` flake. To migrate:
+          `vicondoa/entrablau.nix` flake. To migrate:
 
-            inputs.nixos-entra-id.url =
-              "github:vicondoa/nixos-entra-id";
+            inputs.entrablau.url =
+              "github:vicondoa/entrablau.nix";
 
             nixling.vms.${name}.config.imports = [
-              inputs.nixos-entra-id.nixosModules.default
+              inputs.entrablau.nixosModules.default
             ];
 
             # Move each `nixling.vms.${name}.entra-id.<key>` setting
             # into the VM's guest config under the sibling module's
-            # `services.entra-id.<key>` (or whatever attribute path
-            # the sibling module declares — see its README).
-            nixling.vms.${name}.config.services.entra-id = {
+            # `entrablau.<key>` option tree.
+            nixling.vms.${name}.config.entrablau = {
               enable    = true;
               domain    = [ "contoso.com" ];
               # ...
             };
 
           See CHANGELOG.md and the
-          nixos-entra-id README for the full migration recipe.
+          entrablau README for the full migration recipe.
         '';
       }
       {

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -65,11 +65,11 @@
   ];
 
   # Entra ID / Himmelblau is NOT auto-imported here — it lives in
-  # the sibling `vicondoa/nixos-entra-id` flake. Consumers bring
+  # the sibling `vicondoa/entrablau.nix` flake. Consumers bring
   # it in per-VM
   #
   #   nixling.vms.<vm>.config.imports = [
-  #     inputs.nixos-entra-id.nixosModules.default
+  #     inputs.entrablau.nixosModules.default
   #   ];
   #
   # That keeps the himmelblau NixOS module out of nixling's eval

--- a/nixos-modules/options-site.nix
+++ b/nixos-modules/options-site.nix
@@ -339,7 +339,7 @@
         nixling FLAKE's inputs). Consumer keys take precedence on
         collision — set `inputs = consumerInputs;` here if your
         per-VM modules need `inputs.<your-flake>` visibility (e.g.
-        `inputs.nixos-entra-id`, `inputs.llm-agents`).
+        `inputs.entrablau`, `inputs.llm-agents`).
 
         Use this when:
         - A per-VM module file (e.g. `vms/work.nix`) takes

--- a/nixos-modules/options-vms.nix
+++ b/nixos-modules/options-vms.nix
@@ -490,7 +490,7 @@
         # appear in generated docs.
         #
         # Migration: see CHANGELOG.md and the
-        # `vicondoa/nixos-entra-id` flake README for the new
+        # `vicondoa/entrablau.nix` flake README for the new
         # composition pattern (per-VM config.imports of the sibling
         # flake's nixosModules.default).
         entra-id = lib.mkOption {
@@ -499,7 +499,7 @@
           internal = true;
           visible = false;
           description = ''
-            REMOVED. Use `vicondoa/nixos-entra-id`'s
+            REMOVED. Use `vicondoa/entrablau.nix`'s
             module per-VM via `nixling.vms.<vm>.config.imports`.
           '';
         };

--- a/scripts/MIGRATION-PRE-V0.1.0.md
+++ b/scripts/MIGRATION-PRE-V0.1.0.md
@@ -278,7 +278,7 @@ The script **does not** run `nixos-rebuild`. That's the user's next step:
    - `flake.nix`: replace `./modules/nixling` import with
      `inputs.nixling.nixosModules.default`
    - Add `modules/nixling-site.nix` with `nixling.site.*` options
-   - Add `modules/nixos-entra-id-site.nix` for the work VM
+   - Add `modules/entrablau-site.nix` for the work VM
    - Move sbctl backup activation out of `host.nix`
    - Delete `/etc/nixos/modules/nixling/`
 2. ```bash

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -158,7 +158,7 @@ for the full semantics.
 - **Graphics / audio**: flip `graphics.enable = true` (and/or
   `audio.enable = true`) on a VM. Requires `nixling.site.waylandUser`
   set. See [`examples/graphics-workstation`][gfx-example].
-- **Microsoft Entra ID**: compose [`vicondoa/nixos-entra-id`][nixos-entra-id]
+- **Microsoft Entra ID**: compose [`vicondoa/entrablau.nix`][entrablau]
   per-VM via `nixling.vms.<vm>.config.imports`. See
   [`examples/with-entra-id`][entra-example].
 - **Two-env isolation**: see [`examples/multi-env`][multi-env-example].
@@ -166,7 +166,7 @@ for the full semantics.
 [gfx-example]: https://github.com/vicondoa/nixling/tree/main/examples/graphics-workstation
 [entra-example]: https://github.com/vicondoa/nixling/tree/main/examples/with-entra-id
 [multi-env-example]: https://github.com/vicondoa/nixling/tree/main/examples/multi-env
-[nixos-entra-id]: https://github.com/vicondoa/nixos-entra-id
+[entrablau]: https://github.com/vicondoa/entrablau.nix
 
 ## Common gotchas
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -293,7 +293,7 @@ isolated even after a workload spoofs a peer-style MAC.
 > `tests/static.sh` iterates every `examples/*/flake.nix` and runs
 > `nix flake check --no-build --all-systems` against each. The
 > `with-entra-id` example reaches a sibling flake
-> (`vicondoa/nixos-entra-id`), so its iteration step is not fully
+> (`vicondoa/entrablau.nix`), so its iteration step is not fully
 > hermetic — it eval-tests through the example's pinned
 > `flake.lock`. That hermeticity gap is the only remaining
 > example-iteration follow-up; see CHANGELOG "Known gaps".

--- a/tests/static.sh
+++ b/tests/static.sh
@@ -400,7 +400,7 @@ cd "$ROOT"
 #   * vms.nix is NOT lifted into the public flake (consumers declare
 #     their own nixling.vms.<name> bindings).
 #   * audio.nix split into components/audio/{guest,host}.nix.
-#   * entra-id.nix moved to the sibling nixos-entra-id flake.
+#   * entra-id.nix moved to the sibling entrablau flake.
 # Consumer-specific `vms/<name>.nix` paths are excluded — they only
 # exist on the maintainer's host. The loop below skips any entry that
 # isn't present on disk so the gate stays useful for the public flake
@@ -1312,7 +1312,7 @@ nl_static_gate_end "W2 control-plane skeleton gates"
 #
 # Carve-out: the `with-entra-id` example-flake check can fail with a
 # transient/external crates.io 403 against a `libhimmelblau`-/`kanidm-hsm-
-# crypto`-pinned vicondoa/nixos-entra-id revision. Set
+# crypto`-pinned vicondoa/entrablau.nix revision. Set
 # `NL_SKIP_WITH_ENTRA_ID=1` to skip the per-example check for that one
 # example (the per-example loop honors the knob in the per-example block
 # below). Use only after one in-band retry; this is an explicit carve-out
@@ -1411,7 +1411,7 @@ nl_static_gate_end "tests/harness-ubuntu-eval.sh"
 nl_static_gate_begin "per-example/template flake check" "per-example/template flake check"
 if [ -d "$ROOT/examples/with-entra-id" ] && [ -f "$ROOT/examples/with-entra-id/flake.lock" ] && [ -z "${NL_SKIP_WITH_ENTRA_ID:-}" ]; then
   nl_time_begin "with-entra-id input prewarm"
-  _WITH_ENTRA_ID_REF=$(jq -er '.nodes["nixos-entra-id"].locked | "github:\(.owner)/\(.repo)/\(.rev)"' "$ROOT/examples/with-entra-id/flake.lock")
+  _WITH_ENTRA_ID_REF=$(jq -er '.nodes["entrablau"].locked | "github:\(.owner)/\(.repo)/\(.rev)"' "$ROOT/examples/with-entra-id/flake.lock")
   nix build --no-link "$_WITH_ENTRA_ID_REF#checks.x86_64-linux.himmelblau-tpm-drv" >/dev/null
   nl_time_end "with-entra-id input prewarm"
 fi
@@ -1433,7 +1433,7 @@ nl_static_parallel_wait_all
 if [ -f "$ROOT/examples/with-entra-id/flake.nix" ]; then
   if [ -n "${NL_SKIP_WITH_ENTRA_ID:-}" ]; then
     # Carve-out: explicit operator opt-in to skip the with-entra-id
-    # per-example check when its pinned vicondoa/nixos-entra-id input
+    # per-example check when its pinned vicondoa/entrablau.nix input
     # fails the cargo fetch with a crates.io 403 against the
     # `libhimmelblau` / `kanidm-hsm-crypto` versions in its lockfile.
     # Used only after the in-band retry below failed.


### PR DESCRIPTION
## Summary

- Update nixling's Entra composition docs/example from `nixos-entra-id` to `entrablau.nix`.
- Switch the checked `examples/with-entra-id` flake to `inputs.entrablau` pinned at `v1.0.0`.
- Rename guest config from `nixosEntraId.*` to `entrablau.*` and `fakeDmi` to `dmiOverride`.
- Update the static gate's with-entra-id prewarm to read the `entrablau` lock node.

## Validation

- `nix build --no-link github:vicondoa/entrablau.nix/bbefb679a5d92fd4eb939b0a6e289b22380dd4b1#checks.x86_64-linux.himmelblau-tpm-drv`
- `cd examples/with-entra-id && nix flake check --no-build --all-systems --no-write-lock-file`
- `bash tests/static-fast-tier0.sh`
- `bash tests/ci-coverage.sh`
- `bash tests/adr-index-coverage.sh`
- `bash tests/agents-md-rewrite-eval.sh`
- `nix flake check --no-build --all-systems`
