### PR TITLE
tpm: flush stale sessions before SRK provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+### Fixed
+
+- TPM-enabled guests now flush stale loaded/saved TPM sessions during
+  early boot before SRK provisioning. This prevents swtpm session-handle
+  exhaustion from breaking TPM-bound credentials while preserving NVRAM
+  and persistent handles.
+
 ### Added
 
 - `nixling.site.niriVmBorders.{enable,outputPath}` — opt-in niri KDL

--- a/docs/reference/components-tpm.md
+++ b/docs/reference/components-tpm.md
@@ -103,11 +103,17 @@ together so the TPM socket survives the round-trip). See
   `fed40000-fed40fff`.
 - `environment.systemPackages = [ pkgs.tpm2-tools ]` for in-guest
   diagnostics (`tpm2_getcap properties-fixed`, `tpm2_getrandom 16`).
+- `systemd.services.tpm2-flush-sessions` — early oneshot, wanted by
+  `sysinit.target`, that flushes only loaded/saved TPM sessions via
+  `/dev/tpmrm0`. This prevents stale swtpm saved sessions from filling
+  the TPM active-session table after guest reboots while preserving NV
+  indices and persistent handles.
 - `systemd.services.tpm2-srk-provision` — oneshot, `RemainAfterExit`,
   `wantedBy = [ "multi-user.target" ]`. Idempotently provisions the
   SRK at `0x81000001`. Pins `TPM2TOOLS_TCTI = "device:/dev/tpmrm0"`
-  to skip the tabrmd D-Bus probe. Services that need the SRK in
-  place should add `after = [ "tpm2-srk-provision.service" ]`.
+  to skip the tabrmd D-Bus probe and orders after
+  `tpm2-flush-sessions.service`. Services that need the SRK in place
+  should add `after = [ "tpm2-srk-provision.service" ]`.
 
 ## Runtime invariants
 

--- a/nixos-modules/components/tpm.nix
+++ b/nixos-modules/components/tpm.nix
@@ -41,6 +41,44 @@
   #   sudo tpm2_getrandom 16 | xxd            -> non-zero bytes
   environment.systemPackages = [ pkgs.tpm2-tools ];
 
+  # swtpm can retain saved sessions across guest reboots while keeping
+  # persistent handles and NVRAM intact. systemd-creds/libtss then fails
+  # with TPM_RC_SESSION_HANDLES once the active session table fills. Clear
+  # session handles only; never clear transient objects, NV indices, or the
+  # persistent SRK.
+  systemd.services.tpm2-flush-sessions = {
+    description = "Flush stale TPM2 saved sessions";
+    wantedBy = [ "sysinit.target" ];
+    before = [
+      "sysinit.target"
+      "tpm2-srk-provision.service"
+    ];
+    after = [ "systemd-modules-load.service" ];
+    path = with pkgs; [ coreutils tpm2-tools ];
+    unitConfig.DefaultDependencies = false;
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    environment.TPM2TOOLS_TCTI = "device:/dev/tpmrm0";
+    script = ''
+      set -e
+
+      for _ in $(seq 1 50); do
+        [ -e /dev/tpmrm0 ] && break
+        sleep 0.1
+      done
+
+      if [ ! -e /dev/tpmrm0 ]; then
+        echo "TPM resource manager device /dev/tpmrm0 is unavailable; skipping stale-session flush."
+        exit 0
+      fi
+
+      tpm2_flushcontext --loaded-session || true
+      tpm2_flushcontext --saved-session || true
+    '';
+  };
+
   # Provision the TPM2 Storage Root Key (SRK) at the standard
   # persistent handle 0x81000001 before any service that wants to
   # bind keys tries to use it. ECC P-256 first (matches
@@ -52,7 +90,10 @@
   systemd.services.tpm2-srk-provision = {
     description = "Provision TPM2 SRK at 0x81000001";
     wantedBy = [ "multi-user.target" ];
-    after = [ "systemd-modules-load.service" ];
+    after = [
+      "systemd-modules-load.service"
+      "tpm2-flush-sessions.service"
+    ];
     path = with pkgs; [ tpm2-tools coreutils ];
     serviceConfig = {
       Type = "oneshot";

--- a/tests/smoke-eval-tpm.nix
+++ b/tests/smoke-eval-tpm.nix
@@ -114,6 +114,16 @@ let
   hasMigrationScript =
     builtins.hasAttr "nixlingMigrateOwnership"
       nixos.config.system.activationScripts;
+  tpmGuest = nixos.config.nixling._computed."tpm-vm".config;
+  plainGuest = nixos.config.nixling._computed."plain-vm".config;
+  hasTpmFlushService =
+    builtins.hasAttr "tpm2-flush-sessions"
+      tpmGuest.systemd.services;
+  plainHasTpmFlushService =
+    builtins.hasAttr "tpm2-flush-sessions"
+      plainGuest.systemd.services;
+  tpmFlushService = tpmGuest.systemd.services."tpm2-flush-sessions";
+  tpmSrkService = tpmGuest.systemd.services.tpm2-srk-provision;
 
   # The per-VM
   # `nixling-<vm>-swtpm.service` units were deleted along with
@@ -140,6 +150,20 @@ let
       throw "smoke-eval-tpm: system.activationScripts.nixlingTpmStatePerms is missing")
     (if hasMigrationScript then null else
       throw "smoke-eval-tpm: system.activationScripts.nixlingMigrateOwnership is missing")
+    (if hasTpmFlushService then null else
+      throw "smoke-eval-tpm: TPM guest is missing tpm2-flush-sessions.service")
+    (if ! plainHasTpmFlushService then null else
+      throw "smoke-eval-tpm: non-TPM guest unexpectedly has tpm2-flush-sessions.service")
+    (if tpmFlushService.environment.TPM2TOOLS_TCTI == "device:/dev/tpmrm0" then null else
+      throw "smoke-eval-tpm: tpm2-flush-sessions must pin TPM2TOOLS_TCTI to /dev/tpmrm0")
+    (if lib.elem "sysinit.target" tpmFlushService.wantedBy then null else
+      throw "smoke-eval-tpm: tpm2-flush-sessions must be wanted by sysinit.target")
+    (if (tpmFlushService.unitConfig.DefaultDependencies or null) == false then null else
+      throw "smoke-eval-tpm: tpm2-flush-sessions must disable default dependencies")
+    (if lib.elem "tpm2-srk-provision.service" tpmFlushService.before then null else
+      throw "smoke-eval-tpm: tpm2-flush-sessions must run before SRK provisioning")
+    (if lib.elem "tpm2-flush-sessions.service" tpmSrkService.after then null else
+      throw "smoke-eval-tpm: tpm2-srk-provision must order after tpm2-flush-sessions")
   ];
 in
   builtins.deepSeq checks


### PR DESCRIPTION
## Summary
- add an early TPM guest oneshot that flushes loaded/saved sessions before SRK provisioning
- document the guest-side session flush behavior
- extend the TPM smoke eval to assert service gating and ordering

## Validation
- `bash tests/static-fast-tier0.sh`
- `nix-instantiate --eval --strict -E 'let f = import ./tests/smoke-eval-tpm.nix; r = f {}; in r.drvPath' >/dev/null`