### PR TITLE
observability: collect guest journald logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Guest systemd-journal log collection. The per-VM OpenTelemetry
+  collector now tails the guest journal through the contrib `journald`
+  receiver and forwards it to SigNoz as logs tagged with the VM's
+  `vm.name` / `vm.env` resource attributes, with the journal `PRIORITY`
+  mapped to OTel severity and a `file_storage` cursor so a collector
+  restart resumes without dropping entries.
+  `nixling.vms.<vm>.observability.scrapeJournal` now defaults to `true`
+  (previously a reserved no-op) and the guest collector user is granted
+  `systemd-journal` read access plus `journalctl` on its unit PATH.
+
 - Native, container-free SigNoz observability backend packages and ADR.
   The bundled observability path now targets SigNoz, the SigNoz OTel
   Collector, schema migrator, ClickHouse, and ClickHouse Keeper as native

--- a/docs/reference/components-observability.md
+++ b/docs/reference/components-observability.md
@@ -33,6 +33,22 @@ The collector runs from nixling's static generated config; SigNoz OpAMP
 manager mode is intentionally not enabled so it cannot rewrite the
 source-specific receivers.
 
+Each opted-in workload VM runs a guest OpenTelemetry collector that
+forwards OTLP (metrics, traces, logs) over the guest→host vsock relay.
+The guest collector also tails the VM's systemd journal through the
+contrib `journald` receiver (`scrapeJournal`, default on) so guest
+service logs land in SigNoz tagged with the VM's `vm.name` / `vm.env`
+resource attributes. The journal `PRIORITY` field is mapped to OTel
+severity, and a `file_storage` cursor lets a collector restart resume
+where it left off rather than dropping entries written during downtime.
+
+> The systemd journal can contain sensitive data (auth failures,
+> command lines, service-logged secrets). Guest journal logs are
+> forwarded only over the in-guest → vsock → `sys-obs` path (never the
+> workload env LAN) into the operator's own observability VM. Set
+> `nixling.vms.<vm>.observability.scrapeJournal = false` to disable
+> guest log collection for a VM.
+
 ## Data path
 
 ```text
@@ -87,7 +103,7 @@ configure SigNoz/ClickHouse TTL.
 | Option | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `nixling.vms.<vm>.observability.enable` | bool | `false` | Enable telemetry collection for this VM. |
-| `nixling.vms.<vm>.observability.scrapeJournal` | bool | `false` | Compatibility toggle reserved for future guest journald collection. |
+| `nixling.vms.<vm>.observability.scrapeJournal` | bool | `true` | Tail the guest systemd journal (journald receiver) and forward it to SigNoz as logs. |
 | `nixling.vms.<vm>.observability.scrapeNodeMetrics` | bool | `true` | Enable guest hostmetrics collection. |
 
 ## Runtime services

--- a/nixos-modules/components/observability/guest.nix
+++ b/nixos-modules/components/observability/guest.nix
@@ -44,6 +44,31 @@ let
             processes = { };
           };
         };
+      } // lib.optionalAttrs cfg.scrapeJournal {
+        # Tail the guest's systemd journal via the contrib journald
+        # receiver (which execs `journalctl`). `start_at = "end"` keeps
+        # boot-time backlog out of the pipeline; the file_storage cursor
+        # below means a collector restart resumes where it left off
+        # instead of silently dropping entries written during downtime.
+        # The severity_parser maps the journal PRIORITY field onto OTel
+        # severity so logs are filterable by level in SigNoz.
+        journald = {
+          start_at = "end";
+          storage = "file_storage/journald";
+          operators = [
+            {
+              type = "severity_parser";
+              parse_from = "body.PRIORITY";
+              mapping = {
+                fatal = [ "0" "1" "2" ];
+                error = "3";
+                warn = "4";
+                info = [ "5" "6" ];
+                debug = "7";
+              };
+            }
+          ];
+        };
       };
       processors = {
         memory_limiter = {
@@ -74,7 +99,18 @@ let
         sending_queue.enabled = true;
         retry_on_failure.enabled = true;
       };
+      extensions = lib.optionalAttrs cfg.scrapeJournal {
+        # Persist the journald read cursor so a collector restart
+        # (OOM/crash → Restart=on-failure) resumes from the last read
+        # entry instead of jumping back to the journal tail and dropping
+        # everything written during the downtime window.
+        "file_storage/journald" = {
+          directory = "/var/lib/otel/journald";
+          create_directory = true;
+        };
+      };
       service = {
+        extensions = lib.optional cfg.scrapeJournal "file_storage/journald";
         telemetry.metrics.readers = [
           {
             pull.exporter.prometheus = {
@@ -99,7 +135,7 @@ let
           exporters = [ "otlp" ];
         };
         pipelines.logs = {
-          receivers = [ "otlp" ];
+          receivers = [ "otlp" ] ++ lib.optional cfg.scrapeJournal "journald";
           processors = [ "memory_limiter" "resource" "batch" ];
           exporters = [ "otlp" ];
         };
@@ -111,8 +147,8 @@ in
   options.nixling.observability = {
     scrapeJournal = lib.mkOption {
       type = lib.types.bool;
-      default = false;
-      description = "Compatibility toggle reserved for future journald collection; native OTel guest logs are not yet scraped from journald.";
+      default = true;
+      description = "Whether the guest OTel collector tails this VM's systemd journal (journald receiver) and forwards it to SigNoz as logs.";
     };
 
     scrapeNodeMetrics = lib.mkOption {
@@ -143,11 +179,7 @@ in
   };
 
   config = {
-    warnings = lib.optional cfg.scrapeJournal ''
-      nixling.vms.<vm>.observability.scrapeJournal is currently a
-      compatibility no-op in the native SigNoz path; journald/audit log
-      ingestion is not wired yet.
-    '';
+    warnings = [ ];
 
     microvm.hypervisor = lib.mkDefault "cloud-hypervisor";
 
@@ -157,6 +189,10 @@ in
       home = "/var/lib/otel";
       createHome = false;
       description = "Guest OpenTelemetry collector user";
+      # The journald receiver execs `journalctl`, which needs read
+      # access to the system journal. Membership in `systemd-journal`
+      # grants that without any extra capabilities.
+      extraGroups = lib.optional cfg.scrapeJournal "systemd-journal";
     };
     users.groups.otel = { };
 
@@ -170,10 +206,17 @@ in
       description = "nixling guest OpenTelemetry collector";
       wantedBy = [ "multi-user.target" ];
       restartIfChanged = false;
+      # The journald receiver shells out to `journalctl`; expose it (and
+      # its systemd runtime deps) on the unit PATH.
+      path = lib.optional cfg.scrapeJournal pkgs.systemd;
       serviceConfig = {
         Type = "exec";
         User = "otel";
         Group = "otel";
+        # Supplementary group is granted via users.users.otel.extraGroups;
+        # SupplementaryGroups here keeps it explicit for the unit even if
+        # the static user definition is overridden.
+        SupplementaryGroups = lib.optional cfg.scrapeJournal "systemd-journal";
         ExecStart = "${pkgs.opentelemetry-collector-contrib}/bin/otelcol-contrib --config=file:${collectorConfig}";
         Restart = "on-failure";
         RestartSec = "3s";

--- a/nixos-modules/options-vms.nix
+++ b/nixos-modules/options-vms.nix
@@ -463,11 +463,12 @@
 
         observability.scrapeJournal = lib.mkOption {
           type = lib.types.bool;
-          default = false;
+          default = true;
           description = ''
-            Reserved compatibility toggle for guest journald/audit log
-            collection. The native SigNoz path does not scrape journald
-            yet; setting this to true currently emits a warning.
+            Whether the guest OpenTelemetry collector tails this VM's
+            systemd journal (journald receiver) and forwards it to the
+            SigNoz backend as logs. Default on for observed VMs; set to
+            false to suppress guest log collection.
           '';
         };
 

--- a/tests/eval-cases/observability.nix
+++ b/tests/eval-cases/observability.nix
@@ -390,6 +390,26 @@ in
     expectedExtract = false;
   };
 
+  obs-journal-default-on = mkCase {
+    override = { ... }: {
+      nixling.observability.enable = true;
+      nixling.vms.corp-vm.observability.enable = true;
+    };
+    extract = nixos:
+      let
+        workGuest = nixos.config.microvm.vms.corp-vm.config.config;
+      in
+      {
+        scrapeJournalResolved = workGuest.nixling.observability.scrapeJournal;
+        otelUserInJournalGroup =
+          builtins.elem "systemd-journal" (workGuest.users.users.otel.extraGroups or [ ]);
+      };
+    expectedExtract = {
+      scrapeJournalResolved = true;
+      otelUserInJournalGroup = true;
+    };
+  };
+
   obs-audit-surface = mkCase {
     override = { ... }: {
       nixling.observability.enable = true;

--- a/tests/tempo-budget-eval.sh
+++ b/tests/tempo-budget-eval.sh
@@ -102,6 +102,35 @@ else
   ok "guest workload resource processor preserves application service.name"
 fi
 
+GUEST="$ROOT/nixos-modules/components/observability/guest.nix"
+if grep -q 'lib.optionalAttrs cfg\.scrapeJournal {' "$GUEST" \
+  && grep -q 'journald = {' "$GUEST" \
+  && grep -q 'lib.optional cfg\.scrapeJournal "journald"' "$GUEST"; then
+  ok "guest collector wires the journald receiver into the logs pipeline when scrapeJournal is on"
+else
+  fail "guest collector must add the journald receiver to the logs pipeline under scrapeJournal"
+fi
+
+if grep -q 'extraGroups = lib.optional cfg\.scrapeJournal "systemd-journal"' "$GUEST" \
+  && grep -q 'path = lib.optional cfg\.scrapeJournal pkgs\.systemd' "$GUEST"; then
+  ok "guest journald collection grants journal read access and journalctl on PATH"
+else
+  fail "guest journald collection must grant systemd-journal access and journalctl on PATH"
+fi
+
+if grep -q 'type = "severity_parser"' "$GUEST" \
+  && grep -q 'parse_from = "body.PRIORITY"' "$GUEST" \
+  && grep -q 'error = "3"' "$GUEST" \
+  && grep -q 'storage = "file_storage/journald"' "$GUEST" \
+  && grep -q '"file_storage/journald" = {' "$GUEST" \
+  && grep -q 'directory = "/var/lib/otel/journald"' "$GUEST" \
+  && grep -q 'create_directory = true' "$GUEST" \
+  && grep -q 'extensions = lib.optional cfg\.scrapeJournal "file_storage/journald"' "$GUEST"; then
+  ok "guest journald logs carry severity and persist a restart-safe read cursor"
+else
+  fail "guest journald receiver must map PRIORITY->severity and bind+enable a file_storage cursor"
+fi
+
 if grep -q 'pipelines = sourcePipelines' "$STACK" && ! grep -q 'receivers = \[ "otlp" \]' "$STACK"; then
   ok "collector pipelines are source-specific, not a shared otlp receiver"
 else


### PR DESCRIPTION
## Summary

Wire the OpenTelemetry contrib `journald` receiver into the per-VM guest
OTel collector so guest systemd-journal logs flow to SigNoz, tagged with
the VM's `vm.name` / `vm.env` resource attributes.

- `nixling.vms.<vm>.observability.scrapeJournal` becomes a real feature
  and defaults to `true` (previously a reserved no-op). This restores the
  guest journal collection that shipped through v1.2 (Alloy), now over the
  native SigNoz path.
- The guest `otel` collector user is granted `systemd-journal` read access
  and `journalctl` on its unit PATH.
- Journal `PRIORITY` is mapped to OTel severity via a `severity_parser`.
- A `file_storage` cursor (under the unit StateDirectory) makes a collector
  restart resume instead of dropping entries written during downtime;
  `start_at = "end"` still skips boot backlog on first start.
- Logs ride the existing in-guest → vsock → `sys-obs` path (never the
  workload LAN). Per-VM `scrapeJournal = false` disables collection.

## Validation
- `otelcol-contrib 0.151 validate` on the full guest config: OK
- Full `nixosSystem` eval with observability enabled: guest closure builds;
  `scrapeJournal=true`, otel ∈ `systemd-journal`, `journalctl` on PATH.
- `tests/tempo-budget-eval.sh`: PASS=49 FAIL=0 (new gates pin the journald
  receiver, severity mapping, and all three file_storage cursor legs;
  mutation-tested).
- `tests/static-fast-tier0.sh`: PASS

## Review
Reviewed by the full 10-engineer panel (Opus 4.8), unanimous sign-off.
Security (default-on exposure parity with shipped v1.2 + documented
off-switch/egress) and observability (cursor persistence + severity
mapping) blockers were addressed; the test reviewer's coverage findings
on the cursor wiring were closed with mutation-verified gates.