### PR TITLE
observability: readable journal severity + host-named deployment.environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ deprecations ship one minor release before removal.
   collector now tails the guest journal through the contrib `journald`
   receiver and forwards it to SigNoz as logs tagged with the VM's
   `vm.name` / `vm.env` resource attributes, with the journal `PRIORITY`
-  mapped to OTel severity and a `file_storage` cursor so a collector
-  restart resumes without dropping entries.
-  `nixling.vms.<vm>.observability.scrapeJournal` now defaults to `true`
-  (previously a reserved no-op) and the guest collector user is granted
-  `systemd-journal` read access plus `journalctl` on its unit PATH.
+  mapped to a readable OTel severity (`INFO`/`WARN`/`ERROR`/…) and a
+  `file_storage` cursor so a collector restart resumes without dropping
+  entries. `nixling.vms.<vm>.observability.scrapeJournal` now defaults
+  to `true` (previously a reserved no-op) and the guest collector user
+  is granted `systemd-journal` read access plus `journalctl` on its
+  unit PATH. Ingested telemetry's `deployment.environment` resource
+  attribute is the physical host machine name (from the host's
+  `networking.hostName`, settable via `nixling.observability.hostName`)
+  so SigNoz groups VMs by the host they run on; the per-VM env stays on
+  `vm.env` / `service.namespace`.
 
 - Native, container-free SigNoz observability backend packages and ADR.
   The bundled observability path now targets SigNoz, the SigNoz OTel

--- a/docs/reference/components-observability.md
+++ b/docs/reference/components-observability.md
@@ -38,9 +38,15 @@ forwards OTLP (metrics, traces, logs) over the guest→host vsock relay.
 The guest collector also tails the VM's systemd journal through the
 contrib `journald` receiver (`scrapeJournal`, default on) so guest
 service logs land in SigNoz tagged with the VM's `vm.name` / `vm.env`
-resource attributes. The journal `PRIORITY` field is mapped to OTel
-severity, and a `file_storage` cursor lets a collector restart resume
-where it left off rather than dropping entries written during downtime.
+resource attributes. The journal `PRIORITY` field is mapped to a
+readable OTel severity (`INFO`/`WARN`/`ERROR`/…), and a `file_storage`
+cursor lets a collector restart resume where it left off rather than
+dropping entries written during downtime.
+
+The central SigNoz collector stamps these resource attributes on every
+ingested source: `vm.name` (the VM), `vm.env` / `service.namespace`
+(the env), `vm.role`, and `deployment.environment` (the physical host
+machine the guests run on, from the host's `networking.hostName`).
 
 > The systemd journal can contain sensitive data (auth failures,
 > command lines, service-logged secrets). Guest journal logs are
@@ -80,6 +86,7 @@ LAN routing.
 | `nixling.observability.enable` | bool | `false` | Enable the bundled observability stack. |
 | `nixling.observability.env` | str | `"obs"` | Auto-declared observability env name. |
 | `nixling.observability.vmName` | str | `"sys-obs"` | Auto-declared observability VM name. |
+| `nixling.observability.hostName` | str | host `networking.hostName` | Physical host name stamped as the `deployment.environment` resource attribute on all ingested telemetry. |
 | `nixling.observability.index` | int | `10` | LAN index for `sys-obs`. |
 | `nixling.observability.lanSubnet` | str | `"10.40.0.0/24"` | Observability LAN CIDR. |
 | `nixling.observability.uplinkSubnet` | str | `"203.0.113.0/30"` | Host↔obs point-to-point CIDR. |

--- a/nixos-modules/components/observability/guest.nix
+++ b/nixos-modules/components/observability/guest.nix
@@ -59,6 +59,10 @@ let
             {
               type = "severity_parser";
               parse_from = "body.PRIORITY";
+              # overwrite_text replaces the raw PRIORITY digit with the
+              # canonical OTel severity text (INFO/WARN/ERROR/…) so SigNoz
+              # shows a readable level instead of "3"/"4"/"6".
+              overwrite_text = true;
               mapping = {
                 fatal = [ "0" "1" "2" ];
                 error = "3";

--- a/nixos-modules/components/observability/stack.nix
+++ b/nixos-modules/components/observability/stack.nix
@@ -72,7 +72,11 @@ let
         { key = "vm.role"; value = source.role; action = "upsert"; }
         { key = "host.name"; value = source.vmName; action = "upsert"; }
         { key = "service.namespace"; value = source.envName; action = "upsert"; }
-        { key = "deployment.environment"; value = source.envName; action = "upsert"; }
+        # deployment.environment is the physical host the guests run on
+        # (cfg.hostName), so SigNoz's environment dimension groups all
+        # VMs by their host machine. The per-VM env still lives in
+        # service.namespace / vm.env and the VM identity in vm.name.
+        { key = "deployment.environment"; value = cfg.hostName; action = "upsert"; }
       ];
     }
   ) ingressSources) // {
@@ -395,6 +399,17 @@ in
       type = lib.types.str;
       default = "sys-obs";
       description = "VM name of the auto-declared observability VM.";
+    };
+
+    hostName = lib.mkOption {
+      type = lib.types.str;
+      default = "nixling-host";
+      description = ''
+        Name of the physical host the guests run on. Stamped as the
+        `deployment.environment` resource attribute on all ingested
+        telemetry so SigNoz groups VMs by their host machine. The host
+        module defaults this to the host's `networking.hostName`.
+      '';
     };
 
     retention = lib.mkOption {

--- a/nixos-modules/observability-vm.nix
+++ b/nixos-modules/observability-vm.nix
@@ -74,6 +74,11 @@ in
           transport.relayPackage = lib.mkDefault cfg.transport.relayPackage;
           ingress.sources = lib.mkDefault obsIngressSources;
           alerts = lib.mkDefault cfg.alerts;
+          # Physical host the guests run on; stamped as
+          # deployment.environment on ingested telemetry. Resolved from
+          # the host's networking.hostName (this module evaluates in the
+          # host config context).
+          hostName = lib.mkDefault config.networking.hostName;
         };
 
         # SigNoz + ClickHouse is materially heavier than the retired

--- a/tests/tempo-budget-eval.sh
+++ b/tests/tempo-budget-eval.sh
@@ -120,15 +120,23 @@ fi
 
 if grep -q 'type = "severity_parser"' "$GUEST" \
   && grep -q 'parse_from = "body.PRIORITY"' "$GUEST" \
+  && grep -q 'overwrite_text = true' "$GUEST" \
   && grep -q 'error = "3"' "$GUEST" \
   && grep -q 'storage = "file_storage/journald"' "$GUEST" \
   && grep -q '"file_storage/journald" = {' "$GUEST" \
   && grep -q 'directory = "/var/lib/otel/journald"' "$GUEST" \
   && grep -q 'create_directory = true' "$GUEST" \
   && grep -q 'extensions = lib.optional cfg\.scrapeJournal "file_storage/journald"' "$GUEST"; then
-  ok "guest journald logs carry severity and persist a restart-safe read cursor"
+  ok "guest journald logs carry readable severity and persist a restart-safe read cursor"
 else
-  fail "guest journald receiver must map PRIORITY->severity and bind+enable a file_storage cursor"
+  fail "guest journald receiver must map PRIORITY->severity (overwrite_text) and bind+enable a file_storage cursor"
+fi
+
+if grep -q 'key = "deployment.environment"; value = cfg.hostName' "$STACK" \
+  && grep -q 'hostName = lib.mkDefault config.networking.hostName' "$ROOT/nixos-modules/observability-vm.nix"; then
+  ok "central collector stamps deployment.environment with the physical host name"
+else
+  fail "deployment.environment must be the physical host name (cfg.hostName threaded from networking.hostName)"
 fi
 
 if grep -q 'pipelines = sourcePipelines' "$STACK" && ! grep -q 'receivers = \[ "otlp" \]' "$STACK"; then


### PR DESCRIPTION
## Summary

Two operator-facing telemetry refinements on top of the merged
guest-journald collection (PR #48):

1. **Readable severity** — the guest journald `severity_parser` now sets
   `overwrite_text = true`, so SigNoz shows canonical OTel severity text
   (`INFO`/`WARN`/`ERROR`/…) instead of the raw journal `PRIORITY` digit
   (e.g. `"3"`). The numeric severity mapping is unchanged, so level
   filtering still works.

2. **`deployment.environment` = physical host** — the central SigNoz
   collector now stamps `deployment.environment` with the physical host
   machine name instead of the per-VM env, so SigNoz's environment
   dimension groups VMs by the host they run on. Threaded via a new
   `nixling.observability.hostName` option, defaulted from the host's
   `networking.hostName`. The per-VM env stays on `vm.env` /
   `service.namespace`; VM identity stays on `vm.name`.

## Validation
- `otelcol-contrib 0.151 validate` rc=0 with `overwrite_text`.
- Full `nixosSystem` eval: `nixling.observability.hostName` resolves to
  the host `networking.hostName`; sys-obs closure builds; toYAML render
  shows `deployment.environment` = host name.
- `tests/tempo-budget-eval.sh` PASS=50 (gates pin `overwrite_text`,
  `deployment.environment = cfg.hostName`, and the host→option
  threading; mutation-verified).
- `tests/static-fast-tier0.sh` PASS.

## Review
6-engineer panel (Opus 4.8, diff-review only): unanimous sign-off.
Test (threading-coverage gap) and docs (CHANGELOG grouping + missing
option-table row) findings were addressed and re-reviewed.