### PR TITLE
ci: fix cargo-ubuntu + static-fast gates on ubuntu runners

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -30,5 +30,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Static fast regression gate
         run: bash tests/static-fast.sh

--- a/packages/nixling-priv-broker/src/live_handlers.rs
+++ b/packages/nixling-priv-broker/src/live_handlers.rs
@@ -3824,11 +3824,13 @@ mod tests {
             Ok(false),
             "absent socket must report not-ready",
         );
-        // Traversal over the world-traversable TestDir ancestors is a
-        // no-op (no non-world-x component needs an explicit grant).
-        grant_guest_control_traversal_acls(&dir.path)
-            .expect("traversal over world-x ancestors is a no-op");
-        // Revoke against an absent socket is a no-op.
+        // Revoke against an absent socket is a no-op (short-circuits on
+        // the absent inode before any setfacl). The traversal-skip
+        // behaviour (no setfacl on world-traversable ancestors) is
+        // covered hermetically by `dir_traverse_classification_world_x_vs_private`
+        // without invoking the host setfacl binary on real ancestors —
+        // which a TestDir rooted under a non-world-x CI path (e.g.
+        // `/home/runner`, mode 0750) would otherwise trigger.
         revoke_guest_control_vsock_acl(&socket).expect("revoke of absent socket is a no-op");
     }
 


### PR DESCRIPTION
## Summary

Fixes the two CI gates that were failing on PR #50/#51 (pre-existing, ubuntu-runner-specific):

1. **`cargo-ubuntu`** — `guest_control_acl_grant_not_ready_for_absent_socket` panicked because its `grant_guest_control_traversal_acls` no-op assertion only holds when every TestDir ancestor is world-traversable. The TestDir roots under `current_dir()/target`, so on the GitHub runner the chain includes `/home/runner` (0750), triggering a setfacl call at the NixOS-only path `/run/current-system/sw/bin/setfacl` (absent on ubuntu). Dropped the environment-dependent assertion; the core contract is retained and the traversal-skip mechanism is already covered hermetically by `dir_traverse_classification_world_x_vs_private`.

2. **`static-fast`** — `tests/guest-proto-bindings.sh` hard-requires `rg`, which the ubuntu runner image doesn't ship. Install ripgrep before the gate runs.

## Validation
- Broker: the fixed test + full suite pass; clippy `-D warnings` clean.
- `tests/guest-proto-bindings.sh` passes locally.
- CI on this PR exercises both fixed gates.
