### PR TITLE
wlproxy: log full source chain on server-event dispatch error

### DIFF
--- a/packages/nixling-wayland-filter/src/main.rs
+++ b/packages/nixling-wayland-filter/src/main.rs
@@ -255,7 +255,18 @@ fn run_client(client_id: u64, fd: OwnedFd, upstream: &str, policy: FilterPolicy)
         match state.dispatch(Some(Duration::from_millis(10))) {
             Ok(_) => {}
             Err(e) => {
-                log::warn!("[nixling-wlproxy] vm={vm} client={client_id} dispatch error: {e}");
+                // Log the full source chain, not just the top-level
+                // `StateError` message. A server-event dispatch failure renders
+                // as the generic "could not dispatch server events"; the
+                // `#[source]` `EndpointError`/`MessageError` underneath names the
+                // actual failing object/interface/event (e.g. `NoReceiver`, the
+                // destroy-vs-event race), which is what's needed to diagnose a
+                // window that vanishes from the host compositor while the guest
+                // keeps rendering.
+                log::warn!(
+                    "[nixling-wlproxy] vm={vm} client={client_id} dispatch error: {}",
+                    error_source_chain(&e)
+                );
                 break;
             }
         }
@@ -275,6 +286,21 @@ fn is_recoverable_accept_error(error: &io::Error) -> bool {
     }
 
     matches!(error.raw_os_error(), Some(libc::ECONNABORTED | libc::EINTR))
+}
+
+/// Renders an error together with its full `source()` chain on one line, e.g.
+/// `could not dispatch server events: receiver object 4278190081 does not exist`.
+/// `thiserror`'s `Display` only prints the top-level message, so without walking
+/// the chain the `#[source]` detail that pinpoints the failing message is lost.
+fn error_source_chain(error: &dyn std::error::Error) -> String {
+    let mut out = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        out.push_str(": ");
+        out.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    out
 }
 
 #[cfg(test)]
@@ -297,5 +323,38 @@ mod tests {
     fn permission_denied_accept_is_fatal() {
         let err = io::Error::from_raw_os_error(libc::EACCES);
         assert!(!is_recoverable_accept_error(&err));
+    }
+
+    #[test]
+    fn error_source_chain_includes_nested_causes() {
+        use std::error::Error;
+        use std::fmt;
+
+        #[derive(Debug)]
+        struct Inner;
+        impl fmt::Display for Inner {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "receiver object 42 does not exist")
+            }
+        }
+        impl Error for Inner {}
+
+        #[derive(Debug)]
+        struct Outer(Inner);
+        impl fmt::Display for Outer {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "could not dispatch server events")
+            }
+        }
+        impl Error for Outer {
+            fn source(&self) -> Option<&(dyn Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        assert_eq!(
+            error_source_chain(&Outer(Inner)),
+            "could not dispatch server events: receiver object 42 does not exist"
+        );
     }
 }


### PR DESCRIPTION
## Why

Investigating an openterface-rs (Wayland/wgpu) GUI on **work-ssd/niri** that **vanishes from the host compositor while the guest process keeps rendering** after a focus/visibility change (workspace switch + return). Intermittent (~1 in 6 returns), and any logging slowdown masks it (a fast timing race).

Root cause traced to the wlproxy: at the exact break moments it logs

```
WARN nixling_wayland_filter] vm=work-ssd client=21 dispatch error: could not dispatch server events
```

`run_client` treats a `state.dispatch()` failure as fatal and tears the connection down (`wl-proxy`'s `dispatch()` already `destroy()`s the state on error), which **unmaps the toplevel on niri** even though the guest's local render loop keeps committing buffers (confirmed via `WAYLAND_DEBUG` on the guest — Mesa keeps `attach`/`commit`-ing to the raw `wl_surface` after the window is gone).

The failure is in `wl-proxy`'s server-endpoint `read_messages` (`endpoint.rs` `EndpointError::NoReceiver` / `HandleMessage`), most likely a **destroy-vs-event race**: niri sends an in-flight event for an object the client just destroyed (this app churns `wl_callback`/`wl_buffer`/`wp_presentation_feedback` every frame), which a libwayland client would silently drop as a zombie.

## What this PR does

**Diagnostic only — no behavior change.** The old log printed only the top-level `StateError` `Display` ("could not dispatch server events"), discarding the `#[source]` `EndpointError`/`MessageError` that names the **actual failing object/interface/event**. This walks the full `source()` chain so the log becomes e.g.:

```
dispatch error: could not dispatch server events: receiver object 4278190081 does not exist
```

or

```
dispatch error: could not dispatch server events: could not handle a wp_presentation_feedback#N.discarded message: ...
```

That single detail distinguishes the candidate causes (`NoReceiver` destroy/event race → fix belongs in wl-proxy zombie handling; vs a version/`HandleMessage` decode error → addressable via `graphics.waylandFilter.maxVersions`) and unblocks the real fix.

Adds `error_source_chain()` + a unit test. `cargo test/clippy/fmt -p nixling-wayland-filter` pass.

## Not included / next step

The behavioral fix (don't unmap the window on a single recoverable server-event error — handle in-flight events for destroyed objects like libwayland's zombie semantics) lives in `vicondoa/wl-proxy` and/or a wlproxy robustness change. This PR is the diagnostic that confirms which. It has **not** been deployed to the running host yet (nixling is mid-transition).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>