### PR TITLE
wlproxy: repin wl-proxy to master with the server-id-reuse fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -287,7 +287,7 @@
           sourceRoot = "nixling-rust-src/packages";
           cargoLock = {
             lockFile = ./packages/Cargo.lock;
-            outputHashes."wl-proxy-0.1.2" = "sha256-5hnfZksxKQIWVEKYnqwyJGWKrBX1FOMGG+3k/FASoBg=";
+            outputHashes."wl-proxy-0.1.2" = "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
           };
           # Repo-local .cargo/config.toml files set
           # `rustc-wrapper = "sccache"`, but the Nix sandbox doesn't
@@ -463,7 +463,7 @@
         rust-deny = let
           mainVendor = pkgs.rustPlatform.importCargoLock {
             lockFile = ./packages/Cargo.lock;
-            outputHashes."wl-proxy-0.1.2" = "sha256-5hnfZksxKQIWVEKYnqwyJGWKrBX1FOMGG+3k/FASoBg=";
+            outputHashes."wl-proxy-0.1.2" = "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
           };
           brokerVendor = pkgs.rustPlatform.importCargoLock {
             lockFile = ./packages/nixling-priv-broker/Cargo.lock;
@@ -471,9 +471,9 @@
           cargoConfig = vendorDir: ''
             [source.crates-io]
             replace-with = "vendored-sources"
-            [source."git+https://github.com/vicondoa/wl-proxy.git?rev=83b0001ce6c1f8d379609b07b7bcb8528bd044cd#83b0001ce6c1f8d379609b07b7bcb8528bd044cd"]
+            [source."git+https://github.com/vicondoa/wl-proxy.git?rev=072945b59fef21a2a8166460454280d543f48772#072945b59fef21a2a8166460454280d543f48772"]
             git = "https://github.com/vicondoa/wl-proxy.git"
-            rev = "83b0001ce6c1f8d379609b07b7bcb8528bd044cd"
+            rev = "072945b59fef21a2a8166460454280d543f48772"
             replace-with = "vendored-sources"
             [source.vendored-sources]
             directory = "${vendorDir}"

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "wl-proxy"
 version = "0.1.2"
-source = "git+https://github.com/vicondoa/wl-proxy.git?rev=83b0001ce6c1f8d379609b07b7bcb8528bd044cd#83b0001ce6c1f8d379609b07b7bcb8528bd044cd"
+source = "git+https://github.com/vicondoa/wl-proxy.git?rev=072945b59fef21a2a8166460454280d543f48772#072945b59fef21a2a8166460454280d543f48772"
 dependencies = [
  "debug-fn",
  "error_reporter",

--- a/packages/nixling-wayland-filter/Cargo.toml
+++ b/packages/nixling-wayland-filter/Cargo.toml
@@ -13,7 +13,7 @@ env_logger = "0.11"
 nix = { version = "0.29", default-features = false, features = ["fs", "uio"] }
 thiserror = "2"
 uapi = "0.2"
-wl-proxy = { version = "=0.1.2", git = "https://github.com/vicondoa/wl-proxy.git", rev = "83b0001ce6c1f8d379609b07b7bcb8528bd044cd", package = "wl-proxy", features = [
+wl-proxy = { version = "=0.1.2", git = "https://github.com/vicondoa/wl-proxy.git", rev = "072945b59fef21a2a8166460454280d543f48772", package = "wl-proxy", features = [
     "protocol-drm",
     "protocol-stream",
     "protocol-wl_eglstream_controller",


### PR DESCRIPTION
Bumps the `wl-proxy` git dependency from `83b0001` (old nixling fork tip) to `master` `072945b`, which now carries the fork's commits plus the server-allocated-id reuse fix (vicondoa/wl-proxy#1).

That bug made the proxy abort a client connection with `ServerIdInUse(0xff000000)` when the compositor reused a server id for a new `wl_data_offer` (clipboard, on focus change) or dmabuf `wl_buffer` (Firefox video) after the client destroyed the previous one — unmapping the guest window on the host compositor while the guest kept rendering. Reproduced and fixed against niri; Firefox (video+clipboard) and foot survived 40–60 focus cycles with the fix vs the client vanishing within ~35 before.

Updates the rev in `Cargo.toml`, `Cargo.lock`, and the flake's vendored-source config, plus the `importCargoLock` `outputHashes` FOD hash. Locally validated: `nix build` of the `rust-build`, `rust-tests`, and `rust-deny` checks pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>