### PR TITLE
wlproxy: fix wl-proxy FOD hash in nixos-modules too (#55 follow-up)

### DIFF
--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -51,7 +51,7 @@ let
   };
   cargoLock = {
     lockFile = ../packages/Cargo.lock;
-    outputHashes."wl-proxy-0.1.2" = "sha256-5hnfZksxKQIWVEKYnqwyJGWKrBX1FOMGG+3k/FASoBg=";
+    outputHashes."wl-proxy-0.1.2" = "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
   };
   activationHelperPackage = pkgs.rustPlatform.buildRustPackage {
     pname = "nixling-activation-helper";

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -13,7 +13,7 @@ let
   };
   cargoLock = {
     lockFile = ../packages/Cargo.lock;
-    outputHashes."wl-proxy-0.1.2" = "sha256-5hnfZksxKQIWVEKYnqwyJGWKrBX1FOMGG+3k/FASoBg=";
+    outputHashes."wl-proxy-0.1.2" = "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
   };
 
   nixlingdPackage = pkgs.rustPlatform.buildRustPackage {

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -49,7 +49,7 @@ let
     src = packagesSrc;
     cargoLock = {
       lockFile = ../packages/Cargo.lock;
-      outputHashes."wl-proxy-0.1.2" = "sha256-5hnfZksxKQIWVEKYnqwyJGWKrBX1FOMGG+3k/FASoBg=";
+      outputHashes."wl-proxy-0.1.2" = "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
     };
     cargoBuildFlags = [ "--package" "nixling-wayland-filter" ];
     doCheck = false;


### PR DESCRIPTION
PR #55 updated the `wl-proxy` `outputHashes` in `flake.nix` but missed the **same** `outputHashes` in the nixos-module build paths that consumers actually build:

- `nixos-modules/host-daemon.nix`
- `nixos-modules/processes-json.nix`
- `nixos-modules/host-activation.nix`

The flake checks (`rust-build`/`rust-tests`/`rust-deny`) passed because they use `flake.nix`'s hash, but a **host rebuild** that builds `nixlingd` / the wayland-filter via the modules fails with:

```
hash mismatch in fixed-output derivation '…-wl-proxy-072945b.drv':
  specified: sha256-5hnfZksxKQIWVEKYnqwyJGWKrBX1FOMGG+3k/FASoBg=   (old)
       got: sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=   (correct)
```

Updates all three to the correct rev-`072945b` hash (same value — the source is content-addressed). The rev itself is already correct in these modules via the shared `../packages/Cargo.lock`.

**Validated:** built the full host closure (`nixos-rebuild`-equivalent `nixosConfigurations.desktop…toplevel`) with this fix — succeeds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>