### PR TITLE
exec: fix detached exec live failures (slice nesting, nested-runtime panic, ExecStart identity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,22 @@ deprecations ship one minor release before removal.
   exhaustion from breaking TPM-bound credentials while preserving NVRAM
   and persistent handles.
 
+- Detached exec (`nixling vm exec -d`) now works end-to-end. Three faults in
+  its initial implementation are fixed: the per-VM exec runner verified the
+  workload's cgroup placement against a top-level `nixling-exec.slice` path
+  even though systemd nests it under `nixling.slice`, so every detached
+  command was killed at spawn; the daemon panicked (taking down `nixlingd`)
+  when a detached management verb (`list`/`logs`/`status`/`kill`) was
+  dispatched, because it built a nested async runtime on the request thread;
+  and the guest reconciler matched a running workload's command against
+  `systemctl show` output using exact, quote-aware argv tokens, but systemd
+  renders `ExecStart` argv as a literal, unescaped, space-joined string — so
+  live jobs (and any command containing a space, quote, backslash, or
+  semicolon) were misclassified as foreign and reaped as `lost-guestd`
+  shortly after starting. Workload identity is now matched against systemd's
+  raw rendering, and a failed runner-side spawn verification logs an
+  actionable guest-journal diagnostic.
+
 ### Added
 
 - `nixling vm exec <vm> -- <cmd…>` (and `-it` for an interactive TTY):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,10 @@ deprecations ship one minor release before removal.
   semicolon) were misclassified as foreign and reaped as `lost-guestd`
   shortly after starting. Workload identity is now matched against systemd's
   raw rendering, and a failed runner-side spawn verification logs an
-  actionable guest-journal diagnostic.
+  actionable guest-journal diagnostic. (Detached command arguments may not
+  contain a newline or carriage return, which `systemctl show` cannot render
+  on one line; such commands are now rejected at create with a clear error
+  rather than starting and then vanishing.)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,8 +147,8 @@ deprecations ship one minor release before removal.
   raw rendering, and a failed runner-side spawn verification logs an
   actionable guest-journal diagnostic. (Detached command arguments may not
   contain a newline or carriage return, which `systemctl show` cannot render
-  on one line; such commands are now rejected at create with a clear error
-  rather than starting and then vanishing.)
+  on one line; such commands are now rejected at create as an invalid argument
+  rather than starting and then being reaped.)
 
 ### Added
 

--- a/packages/nixling-exec-runner/src/service_mode.rs
+++ b/packages/nixling-exec-runner/src/service_mode.rs
@@ -861,14 +861,17 @@ mod production {
                 if slice != Some("nixling-exec.slice") {
                     return SliceCheck::Unsafe;
                 }
+                // systemd nests `nixling-exec.slice` under `nixling.slice`
+                // (a `-`-keyed slice name denotes cgroup hierarchy), so the
+                // live `ControlGroup` is `/nixling.slice/nixling-exec.slice/
+                // <unit>`, NOT a top-level `/nixling-exec.slice/<unit>`. Verify
+                // the IMMEDIATE parent slice segment is `nixling-exec.slice`
+                // regardless of ancestor slices; the authoritative `Slice=`
+                // property above already pins the slice unit assignment.
+                let expected_suffix = format!("/nixling-exec.slice/{unit_name}");
                 return match cgroup {
                     Some("") => SliceCheck::NotObserved,
-                    Some(value)
-                        if value.starts_with("/nixling-exec.slice/")
-                            && value.ends_with(unit_name) =>
-                    {
-                        SliceCheck::Verified
-                    }
+                    Some(value) if value.ends_with(&expected_suffix) => SliceCheck::Verified,
                     Some(_) => SliceCheck::Unsafe,
                     None => SliceCheck::NotObserved,
                 };
@@ -1113,7 +1116,28 @@ mod tests {
 
     #[test]
     fn slice_verification_requires_runner_and_workload_in_exec_slice() {
+        // Production reality: systemd nests `nixling-exec.slice` under
+        // `nixling.slice`, so the live `ControlGroup` paths carry the
+        // `/nixling.slice/nixling-exec.slice/<unit>` prefix.
         let ok = "\
+Id=nixling-exec-03.service
+Slice=nixling-exec.slice
+ControlGroup=/nixling.slice/nixling-exec.slice/nixling-exec-03.service
+
+Id=nixling-exec-03-w.service
+Slice=nixling-exec.slice
+ControlGroup=/nixling.slice/nixling-exec.slice/nixling-exec-03-w.service
+";
+        assert!(production::units_in_expected_slice(
+            ok,
+            "nixling-exec-03.service",
+            "nixling-exec-03-w.service"
+        ));
+
+        // A flat (top-level) slice placement must also verify — the check
+        // anchors on the immediate parent slice segment, not on a fixed
+        // ancestor prefix.
+        let flat = "\
 Id=nixling-exec-03.service
 Slice=nixling-exec.slice
 ControlGroup=/nixling-exec.slice/nixling-exec-03.service
@@ -1123,13 +1147,13 @@ Slice=nixling-exec.slice
 ControlGroup=/nixling-exec.slice/nixling-exec-03-w.service
 ";
         assert!(production::units_in_expected_slice(
-            ok,
+            flat,
             "nixling-exec-03.service",
             "nixling-exec-03-w.service"
         ));
 
         let bad_workload_slice = ok.replace(
-            "Slice=nixling-exec.slice\nControlGroup=/nixling-exec.slice/nixling-exec-03-w.service",
+            "Slice=nixling-exec.slice\nControlGroup=/nixling.slice/nixling-exec.slice/nixling-exec-03-w.service",
             "Slice=user-1000.slice\nControlGroup=/user.slice/user-1000.slice/session-2.scope",
         );
         assert!(!production::units_in_expected_slice(
@@ -1138,10 +1162,28 @@ ControlGroup=/nixling-exec.slice/nixling-exec-03-w.service
             "nixling-exec-03-w.service"
         ));
 
+        // A workload whose immediate parent slice is NOT `nixling-exec.slice`
+        // (even if `nixling-exec.slice` appears as a non-adjacent ancestor)
+        // must fail closed.
+        let wrong_parent = "\
+Id=nixling-exec-03.service
+Slice=nixling-exec.slice
+ControlGroup=/nixling.slice/nixling-exec.slice/nixling-exec-03.service
+
+Id=nixling-exec-03-w.service
+Slice=nixling-exec.slice
+ControlGroup=/nixling.slice/nixling-exec.slice/evil.slice/nixling-exec-03-w.service
+";
+        assert!(!production::units_in_expected_slice(
+            wrong_parent,
+            "nixling-exec-03.service",
+            "nixling-exec-03-w.service"
+        ));
+
         let missing_workload = "\
 Id=nixling-exec-03.service
 Slice=nixling-exec.slice
-ControlGroup=/nixling-exec.slice/nixling-exec-03.service
+ControlGroup=/nixling.slice/nixling-exec.slice/nixling-exec-03.service
 ";
         assert!(!production::units_in_expected_slice(
             missing_workload,

--- a/packages/nixling-guestd/src/detached.rs
+++ b/packages/nixling-guestd/src/detached.rs
@@ -224,6 +224,38 @@ pub fn parse_exec_start(value: &str) -> Option<ParsedExecStart> {
     })
 }
 
+/// Extract the RAW `path=` and `argv[]=` field values from a systemd-rendered
+/// `ExecStart` (`{ path=<exe> ; argv[]=<args> ; ignore_errors=... ; ... }`)
+/// WITHOUT tokenizing the argv.
+///
+/// `systemctl show -p ExecStart` renders `argv[]` as a literal single-space
+/// join of the argument vector with NO escaping of embedded spaces, quotes, or
+/// backslashes. The token parser (`parse_exec_start`) is therefore the wrong
+/// tool for the workload-identity check: `validate_command` permits argv bytes
+/// the tokenizer rejects (an unmatched `"`, a trailing `\`) or mis-splits (a
+/// `;`, which `parse_exec_start` treats as a field delimiter — a fail-OPEN
+/// truncation that would compare only a shared prefix). The caller compares
+/// this raw `argv[]=` value byte-for-byte against the expected argv rendered the
+/// same lossy way, so the match is symmetric, never tokenizes user bytes, and
+/// cannot truncate at a user `;`.
+///
+/// The `argv[]=` value is delimited by the fixed ` ; ignore_errors=` field that
+/// systemd always emits immediately after it, so a `;` inside a user argument
+/// (e.g. `sh -c 'a ; b'`) is preserved rather than treated as a field break.
+/// Returns `None` if either field is absent (treated as a mismatch, never a
+/// match).
+pub fn exec_start_raw_fields(value: &str) -> Option<(String, String)> {
+    let path = {
+        let after = value.split_once("path=")?.1;
+        after.split_once(" ; ")?.0.trim().to_owned()
+    };
+    let argv = {
+        let after = value.split_once("argv[]=")?.1;
+        after.split_once(" ; ignore_errors=")?.0.trim().to_owned()
+    };
+    Some((path, argv))
+}
+
 /// Absolute, controlled paths the manager needs to launch a runner unit. All
 /// values are host-supplied constants (never caller-derived).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/nixling-guestd/src/detached.rs
+++ b/packages/nixling-guestd/src/detached.rs
@@ -236,23 +236,30 @@ pub fn parse_exec_start(value: &str) -> Option<ParsedExecStart> {
 /// `;`, which `parse_exec_start` treats as a field delimiter — a fail-OPEN
 /// truncation that would compare only a shared prefix). The caller compares
 /// this raw `argv[]=` value byte-for-byte against the expected argv rendered the
-/// same lossy way, so the match is symmetric, never tokenizes user bytes, and
-/// cannot truncate at a user `;`.
+/// same lossy way, so the match is symmetric and never tokenizes user bytes.
 ///
 /// The `argv[]=` value is delimited by the fixed ` ; ignore_errors=` field that
-/// systemd always emits immediately after it, so a `;` inside a user argument
-/// (e.g. `sh -c 'a ; b'`) is preserved rather than treated as a field break.
-/// Returns `None` if either field is absent (treated as a mismatch, never a
-/// match).
+/// systemd always emits immediately after it. We bound on the LAST occurrence
+/// (`rsplit_once`): systemd's `ignore_errors` field is the last
+/// ` ; ignore_errors=` in the line (no later field — `start_time`, `pid`, … —
+/// contains that substring), so a user argument that itself contains the literal
+/// ` ; ignore_errors=` substring is preserved in full rather than truncating the
+/// recovered argv at the user's copy (a fail-OPEN that could match a shorter
+/// persisted argv). The recovered argv is NOT trimmed: every argv byte is
+/// significant, including a final argument's trailing whitespace.
+///
+/// Newline bytes in an argument are rejected at detached create
+/// (`validate_detached_command`) because `systemctl show` would split the
+/// single-line property; they cannot reach this matcher. Returns `None` if
+/// either field is absent (treated as a mismatch, never a match).
 pub fn exec_start_raw_fields(value: &str) -> Option<(String, String)> {
-    let path = {
-        let after = value.split_once("path=")?.1;
-        after.split_once(" ; ")?.0.trim().to_owned()
-    };
-    let argv = {
-        let after = value.split_once("argv[]=")?.1;
-        after.split_once(" ; ignore_errors=")?.0.trim().to_owned()
-    };
+    let path = value.split_once("path=")?.1.split_once(" ; ")?.0.to_owned();
+    let argv = value
+        .split_once("argv[]=")?
+        .1
+        .rsplit_once(" ; ignore_errors=")?
+        .0
+        .to_owned();
     Some((path, argv))
 }
 

--- a/packages/nixling-guestd/src/detached.rs
+++ b/packages/nixling-guestd/src/detached.rs
@@ -250,11 +250,17 @@ pub fn parse_exec_start(value: &str) -> Option<ParsedExecStart> {
 ///
 /// Newline bytes in an argument are rejected at detached create
 /// (`validate_detached_command`) because `systemctl show` would split the
-/// single-line property; they cannot reach this matcher. Returns `None` if
-/// either field is absent (treated as a mismatch, never a match).
+/// single-line property; they cannot reach this matcher for our own units. The
+/// value MUST be a complete `{ ... }` block: if a foreign unit's argv contained
+/// a newline, `systemctl show` would split its `ExecStart` across lines and the
+/// captured value would be truncated (no closing `}`), so requiring both braces
+/// fails closed on such malformed/foreign input rather than matching a
+/// recovered prefix. Returns `None` if the block is malformed or either field
+/// is absent (treated as a mismatch, never a match).
 pub fn exec_start_raw_fields(value: &str) -> Option<(String, String)> {
-    let path = value.split_once("path=")?.1.split_once(" ; ")?.0.to_owned();
-    let argv = value
+    let inner = value.trim().strip_prefix('{')?.strip_suffix('}')?;
+    let path = inner.split_once("path=")?.1.split_once(" ; ")?.0.to_owned();
+    let argv = inner
         .split_once("argv[]=")?
         .1
         .rsplit_once(" ; ignore_errors=")?

--- a/packages/nixling-guestd/src/detached.rs
+++ b/packages/nixling-guestd/src/detached.rs
@@ -450,13 +450,20 @@ impl TransientUnitManager for SystemdRunUnitManager {
                 for unit in &mut units {
                     let name = unit.name();
                     if let Some(block) = blocks.iter().find(|b| b.id == name) {
-                        unit.identity = UnitIdentity::Queried {
-                            slice: block.slice.clone(),
-                            exec_start: block.exec_start.clone(),
-                            binds_to: block.binds_to.clone(),
-                            part_of: block.part_of.clone(),
-                            after: block.after.clone(),
-                        };
+                        // A malformed block (a multi-line/continuation property
+                        // value — only possible for a foreign or crafted unit,
+                        // since our own argv is newline-free) is left Unqueried
+                        // so the active unit classifies Unknown (retry), never a
+                        // confident identity match against a truncated value.
+                        if !block.malformed {
+                            unit.identity = UnitIdentity::Queried {
+                                slice: block.slice.clone(),
+                                exec_start: block.exec_start.clone(),
+                                binds_to: block.binds_to.clone(),
+                                part_of: block.part_of.clone(),
+                                after: block.after.clone(),
+                            };
+                        }
                     }
                 }
             }
@@ -474,6 +481,11 @@ struct ShowEntry {
     binds_to: Option<String>,
     part_of: Option<String>,
     after: Option<String>,
+    /// Set when the block contained a non-empty line matching no known property
+    /// prefix — i.e. a continuation of a multi-line property value (e.g. a
+    /// newline inside a unit's argv split its `ExecStart` across `systemctl
+    /// show` lines). The block is then untrustworthy for identity verification.
+    malformed: bool,
 }
 
 impl fmt::Debug for ShowEntry {
@@ -485,6 +497,7 @@ impl fmt::Debug for ShowEntry {
             .field("has_binds_to", &self.binds_to.is_some())
             .field("has_part_of", &self.part_of.is_some())
             .field("has_after", &self.after.is_some())
+            .field("malformed", &self.malformed)
             .finish()
     }
 }
@@ -527,6 +540,17 @@ fn parse_show_blocks(text: &str) -> Vec<ShowEntry> {
                 if !v.is_empty() {
                     entry.after = Some(v.to_owned());
                 }
+            } else if !line.trim().is_empty() {
+                // A non-empty line matching no known property prefix is a
+                // continuation of a multi-line property value: systemd's
+                // `systemctl show` renders one `Key=Value` per line, and our
+                // own units' properties are all single-line (detached argv with
+                // a newline is rejected at create). A continuation therefore
+                // means a foreign/malformed block (e.g. a newline-bearing argv
+                // split across lines); mark it so the unit's identity stays
+                // Unqueried (-> Unknown/retry) rather than trusting a truncated
+                // first line.
+                entry.malformed = true;
             }
         }
         if !entry.id.is_empty() {
@@ -853,6 +877,43 @@ ExecStart=
         assert_eq!(blocks[0].id, "nixling-exec-00.service");
         assert_eq!(blocks[0].slice, None);
         assert_eq!(blocks[0].exec_start, None);
+        assert!(!blocks[0].malformed);
+    }
+
+    #[test]
+    fn parse_show_blocks_flags_multiline_continuation_as_malformed() {
+        // A foreign/crafted unit whose argv contained a newline splits its
+        // ExecStart across `systemctl show` lines. The continuation line matches
+        // no `Key=` prefix, so the block is flagged malformed even though its
+        // truncated first ExecStart line carries a fake closing brace — so the
+        // unit's identity is left Unqueried (-> Unknown/retry), never a
+        // confident match against the truncated value.
+        let text = "\
+Id=nixling-exec-03-w.service
+Slice=nixling-exec.slice
+ExecStart={ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec \"$@\" nl-exec sh -c echo a ; ignore_errors=evil }
+echo b ; ignore_errors=no ; start_time=[n/a] }
+BindsTo=nixling-exec-03.service
+PartOf=nixling-exec-03.service
+After=nixling-exec-03.service
+";
+        let blocks = parse_show_blocks(text);
+        assert_eq!(blocks.len(), 1);
+        assert!(
+            blocks[0].malformed,
+            "a non-property continuation line must flag the block malformed"
+        );
+
+        // A well-formed single-line block is NOT malformed.
+        let ok = "\
+Id=nixling-exec-03-w.service
+Slice=nixling-exec.slice
+ExecStart={ path=/bin/bash ; argv[]=/bin/bash -l -c exec \"$@\" nl-exec id ; ignore_errors=no }
+BindsTo=nixling-exec-03.service
+";
+        let blocks = parse_show_blocks(ok);
+        assert_eq!(blocks.len(), 1);
+        assert!(!blocks[0].malformed);
     }
 
     #[test]
@@ -936,6 +997,7 @@ ExecStart=
             binds_to: Some("nixling-exec-03.service".to_owned()),
             part_of: Some("nixling-exec-03.service".to_owned()),
             after: Some("nixling-exec-03.service".to_owned()),
+            malformed: false,
         };
         for rendered in [
             format!("{identity:?}"),

--- a/packages/nixling-guestd/src/detached_registry.rs
+++ b/packages/nixling-guestd/src/detached_registry.rs
@@ -23,8 +23,7 @@ use sha2::{Digest, Sha256};
 
 use crate::detached::{
     exec_start_raw_fields, parse_exec_start, unit_name, workload_unit_name, ManagedUnit,
-    ManagedUnitKind, RunnerUnitPaths,
-    TransientUnitManager, UnitIdentity,
+    ManagedUnitKind, RunnerUnitPaths, TransientUnitManager, UnitIdentity,
 };
 use crate::exec::{
     ExecError, ExecIdSource, ExecSnapshot, ExecState, ExitOutcome, Stream as RtStream,

--- a/packages/nixling-guestd/src/detached_registry.rs
+++ b/packages/nixling-guestd/src/detached_registry.rs
@@ -3411,6 +3411,21 @@ mod tests {
         assert!(exec_start_raw_fields("{ argv[]=x ; ignore_errors=no }").is_none());
         assert!(exec_start_raw_fields("{ path=/x ; argv[]=/x ; }").is_none());
         assert!(exec_start_raw_fields("{ path=/x ; ignore_errors=no }").is_none());
+
+        // A truncated / line-split ExecStart (no closing `}`, e.g. a foreign
+        // unit whose argv newline split the `systemctl show` property across
+        // lines) MUST fail closed — even though it carries a `; ignore_errors=`
+        // tail that would otherwise let a recovered prefix match a shorter
+        // persisted argv.
+        assert!(exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec sh -c echo a ; ignore_errors=evil"#,
+        )
+        .is_none());
+        // No leading brace (e.g. a captured continuation line) also fails closed.
+        assert!(exec_start_raw_fields(
+            "path=/x ; argv[]=/x -l -c exec \"$@\" nl-exec id ; ignore_errors=no }"
+        )
+        .is_none());
     }
 
     #[tokio::test]

--- a/packages/nixling-guestd/src/detached_registry.rs
+++ b/packages/nixling-guestd/src/detached_registry.rs
@@ -3366,16 +3366,51 @@ mod tests {
         .expect("extract raw fields");
         assert_eq!(argv, expected_raw(exe, &["sh", "-c", "echo a ; echo b"]));
 
-        // Distinct semicolon suffixes are NOT conflated (no prefix-truncation
-        // fail-open): `echo a ; echo b` and `echo a ; echo c` differ.
+        // A user argument containing the EXACT field delimiter ` ; ignore_errors=`
+        // is preserved in full: we bound on the LAST occurrence (systemd's real
+        // field), so the user's copy stays in the recovered argv and matches a
+        // persisted spec that carries it.
+        let (_, argv) = exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec sh -c echo a ; ignore_errors=evil ; ignore_errors=no ; start_time=[n/a] }"#,
+        )
+        .expect("extract raw fields");
+        assert_eq!(
+            argv,
+            expected_raw(exe, &["sh", "-c", "echo a ; ignore_errors=evil"])
+        );
+        // ...and a DIFFERENT persisted command must NOT match it (fail closed):
+        // a spec for just `echo a` does not equal the recovered, full argv.
+        assert_ne!(argv, expected_raw(exe, &["sh", "-c", "echo a"]));
+
+        // A final argument's trailing whitespace is significant and preserved
+        // (the recovered argv is not trimmed).
+        let (_, argv) = exec_start_raw_fields(
+            "{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec \"$@\" nl-exec echo hi  ; ignore_errors=no }",
+        )
+        .expect("extract raw fields");
+        assert_eq!(argv, expected_raw(exe, &["echo", "hi "]));
+
+        // Distinct semicolon suffixes are NOT conflated, both at the rendering
+        // layer and when driven through real extraction.
         assert_ne!(
             expected_raw(exe, &["sh", "-c", "echo a ; echo b"]),
             expected_raw(exe, &["sh", "-c", "echo a ; echo c"]),
         );
+        let (_, argv_b) = exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec sh -c echo a ; echo b ; ignore_errors=no }"#,
+        )
+        .expect("extract raw fields");
+        let (_, argv_c) = exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec sh -c echo a ; echo c ; ignore_errors=no }"#,
+        )
+        .expect("extract raw fields");
+        assert_ne!(argv_b, argv_c);
 
-        // Missing fields => None (treated as a mismatch, never a match).
+        // Missing fields => None (treated as a mismatch, never a match):
+        // no path, no argv[], and path-present-but-argv-absent.
         assert!(exec_start_raw_fields("{ argv[]=x ; ignore_errors=no }").is_none());
         assert!(exec_start_raw_fields("{ path=/x ; argv[]=/x ; }").is_none());
+        assert!(exec_start_raw_fields("{ path=/x ; ignore_errors=no }").is_none());
     }
 
     #[tokio::test]

--- a/packages/nixling-guestd/src/detached_registry.rs
+++ b/packages/nixling-guestd/src/detached_registry.rs
@@ -22,7 +22,8 @@ use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 
 use crate::detached::{
-    parse_exec_start, unit_name, workload_unit_name, ManagedUnit, ManagedUnitKind, RunnerUnitPaths,
+    exec_start_raw_fields, parse_exec_start, unit_name, workload_unit_name, ManagedUnit,
+    ManagedUnitKind, RunnerUnitPaths,
     TransientUnitManager, UnitIdentity,
 };
 use crate::exec::{
@@ -552,6 +553,19 @@ impl DetachedRegistry {
                     return Ok((exec_id.to_owned(), self.snapshot_for(slot)?));
                 }
                 Some(StatusPhase::InfraFailed) => {
+                    // The runner spawned the workload but its post-spawn safety
+                    // verification failed (slice placement, the never-root
+                    // re-guard, or a unit-setup fault) and refused to publish
+                    // `Started`. The operator-facing wire error is intentionally
+                    // coarse and carries no argv, so emit a guest-journal
+                    // diagnostic naming the failure class and what to inspect.
+                    eprintln!(
+                        "nixling-guestd: detached exec create aborted (slot {slot:02}): the exec \
+                         runner reported an infrastructure failure — post-spawn verification \
+                         failed. Inspect the nixling-exec.slice placement and status of \
+                         nixling-exec-{slot:02}.service and nixling-exec-{slot:02}-w.service in \
+                         the guest journal."
+                    );
                     self.abort_create(slot).await;
                     return Err(ExecError::RetainedLogPathUnsafe);
                 }
@@ -772,10 +786,16 @@ impl DetachedRegistry {
         let Some(exec_start) = identity.exec_start else {
             return false;
         };
-        let Some(parsed) = parse_exec_start(exec_start) else {
+        // Match against the RAW `path=`/`argv[]=` fields, never the quote-aware
+        // token parser: `systemctl show` renders argv[] losslessly space-joined
+        // and UNescaped, and `validate_command` permits argv bytes the parser
+        // would reject (literal `"`, trailing `\`) or fail-OPEN truncate at (a
+        // user `;`). Render the expected argv the same lossy way and compare the
+        // raw strings byte-for-byte.
+        let Some((raw_path, raw_argv)) = exec_start_raw_fields(exec_start) else {
             return false;
         };
-        if parsed.exe != spec.login_shell_path {
+        if raw_path != spec.login_shell_path {
             return false;
         }
         let mut expected = Vec::with_capacity(5 + spec.argv.len());
@@ -785,7 +805,7 @@ impl DetachedRegistry {
         expected.push(r#"exec "$@""#.to_owned());
         expected.push("nl-exec".to_owned());
         expected.extend(spec.argv.iter().cloned());
-        workload_argv_matches_rendered(&parsed.argv, &spec.login_shell_path, &expected)
+        raw_argv == expected.join(" ")
     }
 
     // ---- read-side ops ---------------------------------------------------
@@ -1643,40 +1663,6 @@ fn property_contains_unit(value: Option<&str>, unit: &str) -> bool {
     value
         .map(|v| v.split_whitespace().any(|token| token == unit))
         .unwrap_or(false)
-}
-
-/// Compare a workload unit's parsed `argv[]` against the expected login-session
-/// argv, accounting for systemd's lossy `ExecStart` rendering.
-///
-/// `systemctl show -p ExecStart` joins `argv[]` with single spaces and does NOT
-/// escape embedded spaces or quotes — the `-c` value `exec "$@"` renders
-/// literally as `exec "$@"`, NOT as the escaped `"exec \"$@\""`. So the rendered
-/// `argv[]=` does not round-trip an argv whose elements contain spaces: neither
-/// the fixed `exec "$@"` login preamble nor any user argument that contains a
-/// space. (An earlier byte-exact comparison assumed systemd escapes such
-/// elements; against real systemd it instead reaps our OWN live workloads as
-/// "foreign".)
-///
-/// Re-render the EXPECTED argv through the same space-join and re-parse it with
-/// the same quote-aware tokenizer, so the comparison is symmetric with whatever
-/// systemd produced. The rendering is inherently lossy (a single arg
-/// `foo bar` is indistinguishable from two args `foo` `bar`), but the workload
-/// unit's `nixling-exec.slice` placement plus its `BindsTo`/`PartOf`/`After`
-/// pinning to THIS slot's runner unit already establish that the unit is ours;
-/// the argv comparison is a consistency check on top of that structural
-/// identity, not the trust boundary. A genuine mismatch (different exe, program,
-/// or argument count/content beyond systemd's space-flattening) still fails
-/// closed.
-fn workload_argv_matches_rendered(actual: &[String], exe: &str, expected: &[String]) -> bool {
-    let rendered = format!(
-        "{{ path={} ; argv[]={} ; ignore_errors=no }}",
-        exe,
-        expected.join(" ")
-    );
-    match parse_exec_start(&rendered) {
-        Some(reparsed) => actual == reparsed.argv.as_slice(),
-        None => false,
-    }
 }
 
 fn build_spec(
@@ -3324,60 +3310,72 @@ mod tests {
     }
 
     #[test]
-    fn workload_argv_matches_real_unescaped_systemd_rendering() {
+    fn exec_start_raw_fields_handles_lossy_systemd_argv_bytes() {
+        use crate::detached::exec_start_raw_fields;
+
+        // Helper: build the expected raw argv[] string the same lossy way systemd
+        // renders it (literal single-space join, no escaping).
+        fn expected_raw(exe: &str, user_argv: &[&str]) -> String {
+            let mut v = vec![
+                exe.to_owned(),
+                "-l".to_owned(),
+                "-c".to_owned(),
+                r#"exec "$@""#.to_owned(),
+                "nl-exec".to_owned(),
+            ];
+            v.extend(user_argv.iter().map(|s| (*s).to_owned()));
+            v.join(" ")
+        }
+
         let exe = "/run/current-system/sw/bin/bash";
-        let expected = vec![
-            exe.to_owned(),
-            "-l".to_owned(),
-            "-c".to_owned(),
-            r#"exec "$@""#.to_owned(),
-            "nl-exec".to_owned(),
-            "/bin/id".to_owned(),
-        ];
 
-        // Real systemd renders argv[] with a literal space-join and NO escaping
-        // of the `-c` value's inner quotes/space: `... -c exec "$@" nl-exec ...`.
-        // The quote-aware parser splits that into [`exec`, `$@`]. The matcher
-        // must accept this (it reaped our own live workloads before the fix).
-        let real = parse_exec_start(
-            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec /bin/id ; ignore_errors=no }"#,
+        // Real systemd renders the `-c` value `exec "$@"` UNescaped and
+        // space-joined: `... -c exec "$@" nl-exec ...`. Raw extraction must
+        // recover it verbatim (this is what was reaping our own live workloads).
+        let (path, argv) = exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec /bin/id ; ignore_errors=no ; start_time=[n/a] }"#,
         )
-        .expect("parse systemd ExecStart");
-        assert!(
-            workload_argv_matches_rendered(&real.argv, exe, &expected),
-            "real unescaped systemd argv[] must match the expected login-session argv"
+        .expect("extract raw fields");
+        assert_eq!(path, exe);
+        assert_eq!(argv, expected_raw(exe, &["/bin/id"]));
+
+        // A user argument containing a literal double quote (which the token
+        // parser would reject as an unmatched quote, reaping a valid job) is
+        // preserved byte-for-byte by raw extraction.
+        let (_, argv) = exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec grep " /etc/hosts ; ignore_errors=no }"#,
+        )
+        .expect("extract raw fields");
+        assert_eq!(argv, expected_raw(exe, &["grep", "\"", "/etc/hosts"]));
+
+        // A user argument ending in a backslash (rejected by the token parser as
+        // a dangling escape) is preserved.
+        let (_, argv) = exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec echo back\ ; ignore_errors=no }"#,
+        )
+        .expect("extract raw fields");
+        assert_eq!(argv, expected_raw(exe, &["echo", "back\\"]));
+
+        // A user argument containing a semicolon (the common `sh -c 'a ; b'`
+        // pattern) must NOT truncate at the `;`: extraction is bounded by the
+        // fixed ` ; ignore_errors=` field, so the whole `a ; b` is preserved.
+        // (A bare `;` split would fail-OPEN by comparing only the prefix `a`.)
+        let (_, argv) = exec_start_raw_fields(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec sh -c echo a ; echo b ; ignore_errors=no }"#,
+        )
+        .expect("extract raw fields");
+        assert_eq!(argv, expected_raw(exe, &["sh", "-c", "echo a ; echo b"]));
+
+        // Distinct semicolon suffixes are NOT conflated (no prefix-truncation
+        // fail-open): `echo a ; echo b` and `echo a ; echo c` differ.
+        assert_ne!(
+            expected_raw(exe, &["sh", "-c", "echo a ; echo b"]),
+            expected_raw(exe, &["sh", "-c", "echo a ; echo c"]),
         );
 
-        // A genuinely different program (same login preamble) must NOT match.
-        let wrong_prog = parse_exec_start(
-            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec /bin/evil ; ignore_errors=no }"#,
-        )
-        .expect("parse systemd ExecStart");
-        assert!(
-            !workload_argv_matches_rendered(&wrong_prog.argv, exe, &expected),
-            "a different program must fail the workload argv match"
-        );
-
-        // A user argument that itself contains a space round-trips through the
-        // same lossy rendering on both sides, so it matches.
-        let expected_spacey = vec![
-            exe.to_owned(),
-            "-l".to_owned(),
-            "-c".to_owned(),
-            r#"exec "$@""#.to_owned(),
-            "nl-exec".to_owned(),
-            "/bin/sh".to_owned(),
-            "-c".to_owned(),
-            "echo hi there".to_owned(),
-        ];
-        let real_spacey = parse_exec_start(
-            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec /bin/sh -c echo hi there ; ignore_errors=no }"#,
-        )
-        .expect("parse systemd ExecStart");
-        assert!(
-            workload_argv_matches_rendered(&real_spacey.argv, exe, &expected_spacey),
-            "a user arg containing spaces matches via symmetric lossy rendering"
-        );
+        // Missing fields => None (treated as a mismatch, never a match).
+        assert!(exec_start_raw_fields("{ argv[]=x ; ignore_errors=no }").is_none());
+        assert!(exec_start_raw_fields("{ path=/x ; argv[]=/x ; }").is_none());
     }
 
     #[tokio::test]

--- a/packages/nixling-guestd/src/detached_registry.rs
+++ b/packages/nixling-guestd/src/detached_registry.rs
@@ -785,7 +785,7 @@ impl DetachedRegistry {
         expected.push(r#"exec "$@""#.to_owned());
         expected.push("nl-exec".to_owned());
         expected.extend(spec.argv.iter().cloned());
-        argv_matches_expected(&parsed.argv, &expected)
+        workload_argv_matches_rendered(&parsed.argv, &spec.login_shell_path, &expected)
     }
 
     // ---- read-side ops ---------------------------------------------------
@@ -1645,16 +1645,38 @@ fn property_contains_unit(value: Option<&str>, unit: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Exact argv equality for workload-unit identity. `parse_exec_start`'s
-/// `parse_exec_argv` is quote-aware (honours `'`/`"`/`\`), so a systemd-rendered
-/// `argv[]=` round-trips to the persisted argv exactly — including the
-/// space-bearing `exec "$@"` element. We therefore require BYTE-EXACT argv
-/// equality: a whitespace-flattened comparison would let a foreign unit whose
-/// argument boundaries differ (e.g. `["hello", "world"]` vs a persisted
-/// `["hello world"]`) classify as the expected workload. A genuine mismatch
-/// fails closed (the slot is not adopted) rather than adopting a foreign unit.
-fn argv_matches_expected(actual: &[String], expected: &[String]) -> bool {
-    actual == expected
+/// Compare a workload unit's parsed `argv[]` against the expected login-session
+/// argv, accounting for systemd's lossy `ExecStart` rendering.
+///
+/// `systemctl show -p ExecStart` joins `argv[]` with single spaces and does NOT
+/// escape embedded spaces or quotes — the `-c` value `exec "$@"` renders
+/// literally as `exec "$@"`, NOT as the escaped `"exec \"$@\""`. So the rendered
+/// `argv[]=` does not round-trip an argv whose elements contain spaces: neither
+/// the fixed `exec "$@"` login preamble nor any user argument that contains a
+/// space. (An earlier byte-exact comparison assumed systemd escapes such
+/// elements; against real systemd it instead reaps our OWN live workloads as
+/// "foreign".)
+///
+/// Re-render the EXPECTED argv through the same space-join and re-parse it with
+/// the same quote-aware tokenizer, so the comparison is symmetric with whatever
+/// systemd produced. The rendering is inherently lossy (a single arg
+/// `foo bar` is indistinguishable from two args `foo` `bar`), but the workload
+/// unit's `nixling-exec.slice` placement plus its `BindsTo`/`PartOf`/`After`
+/// pinning to THIS slot's runner unit already establish that the unit is ours;
+/// the argv comparison is a consistency check on top of that structural
+/// identity, not the trust boundary. A genuine mismatch (different exe, program,
+/// or argument count/content beyond systemd's space-flattening) still fails
+/// closed.
+fn workload_argv_matches_rendered(actual: &[String], exe: &str, expected: &[String]) -> bool {
+    let rendered = format!(
+        "{{ path={} ; argv[]={} ; ignore_errors=no }}",
+        exe,
+        expected.join(" ")
+    );
+    match parse_exec_start(&rendered) {
+        Some(reparsed) => actual == reparsed.argv.as_slice(),
+        None => false,
+    }
 }
 
 fn build_spec(
@@ -2714,27 +2736,16 @@ mod tests {
         rendered.push(r#"exec "$@""#.to_owned());
         rendered.push("nl-exec".to_owned());
         rendered.extend(spec.argv);
-        let argv = rendered
-            .iter()
-            .map(|arg| quote_exec_start_arg(arg))
-            .collect::<Vec<_>>()
-            .join(" ");
+        // Render argv[] the way real systemd does: a literal single-space join
+        // with NO escaping of embedded spaces/quotes (so the `-c` value
+        // `exec "$@"` appears verbatim as `... -c exec "$@" nl-exec ...`). This
+        // mirrors `systemctl show -p ExecStart` output so the identity tests
+        // exercise the real, lossy rendering rather than an idealized escaped one.
+        let argv = rendered.join(" ");
         format!(
             "{{ path={} ; argv[]={argv} ; ignore_errors=no }}",
             spec.login_shell_path
         )
-    }
-
-    fn quote_exec_start_arg(arg: &str) -> String {
-        if !arg.is_empty()
-            && arg
-                .chars()
-                .all(|ch| !ch.is_whitespace() && ch != '"' && ch != '\'' && ch != '\\')
-        {
-            return arg.to_owned();
-        }
-        let escaped = arg.replace('\\', r"\\").replace('"', r#"\""#);
-        format!("\"{escaped}\"")
     }
 
     fn test_registry_config() -> RegistryConfig {
@@ -3313,33 +3324,60 @@ mod tests {
     }
 
     #[test]
-    fn argv_matches_expected_requires_byte_exact_argv() {
+    fn workload_argv_matches_real_unescaped_systemd_rendering() {
+        let exe = "/run/current-system/sw/bin/bash";
         let expected = vec![
-            "/run/current-system/sw/bin/bash".to_owned(),
+            exe.to_owned(),
             "-l".to_owned(),
             "-c".to_owned(),
             r#"exec "$@""#.to_owned(),
             "nl-exec".to_owned(),
             "/bin/id".to_owned(),
         ];
-        assert!(argv_matches_expected(&expected, &expected));
 
-        // A whitespace-flattened variant MUST NOT match: a persisted single arg
-        // with an embedded space must not be satisfied by two separate args
-        // (the foreign-unit adoption hole the flatten fallback opened).
-        let persisted = vec!["hello world".to_owned()];
-        let two_args = vec!["hello".to_owned(), "world".to_owned()];
-        assert!(!argv_matches_expected(&two_args, &persisted));
-        assert!(!argv_matches_expected(&persisted, &two_args));
-
-        // The space-bearing `exec "$@"` element round-trips exactly through the
-        // quote-aware ExecStart parser, so byte-exact comparison still matches a
-        // real systemd `argv[]=` rendering.
-        let parsed = parse_exec_start(
-            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c "exec \"$@\"" nl-exec /bin/id ; ignore_errors=no }"#,
+        // Real systemd renders argv[] with a literal space-join and NO escaping
+        // of the `-c` value's inner quotes/space: `... -c exec "$@" nl-exec ...`.
+        // The quote-aware parser splits that into [`exec`, `$@`]. The matcher
+        // must accept this (it reaped our own live workloads before the fix).
+        let real = parse_exec_start(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec /bin/id ; ignore_errors=no }"#,
         )
         .expect("parse systemd ExecStart");
-        assert!(argv_matches_expected(&parsed.argv, &expected));
+        assert!(
+            workload_argv_matches_rendered(&real.argv, exe, &expected),
+            "real unescaped systemd argv[] must match the expected login-session argv"
+        );
+
+        // A genuinely different program (same login preamble) must NOT match.
+        let wrong_prog = parse_exec_start(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec /bin/evil ; ignore_errors=no }"#,
+        )
+        .expect("parse systemd ExecStart");
+        assert!(
+            !workload_argv_matches_rendered(&wrong_prog.argv, exe, &expected),
+            "a different program must fail the workload argv match"
+        );
+
+        // A user argument that itself contains a space round-trips through the
+        // same lossy rendering on both sides, so it matches.
+        let expected_spacey = vec![
+            exe.to_owned(),
+            "-l".to_owned(),
+            "-c".to_owned(),
+            r#"exec "$@""#.to_owned(),
+            "nl-exec".to_owned(),
+            "/bin/sh".to_owned(),
+            "-c".to_owned(),
+            "echo hi there".to_owned(),
+        ];
+        let real_spacey = parse_exec_start(
+            r#"{ path=/run/current-system/sw/bin/bash ; argv[]=/run/current-system/sw/bin/bash -l -c exec "$@" nl-exec /bin/sh -c echo hi there ; ignore_errors=no }"#,
+        )
+        .expect("parse systemd ExecStart");
+        assert!(
+            workload_argv_matches_rendered(&real_spacey.argv, exe, &expected_spacey),
+            "a user arg containing spaces matches via symmetric lossy rendering"
+        );
     }
 
     #[tokio::test]

--- a/packages/nixling-guestd/src/detached_registry.rs
+++ b/packages/nixling-guestd/src/detached_registry.rs
@@ -773,6 +773,18 @@ impl DetachedRegistry {
         slot: u32,
         spec: &ExecSpec,
     ) -> bool {
+        // The workload's TRUST identity is structural and systemd-/root-enforced:
+        // membership in `nixling-exec.slice` plus `BindsTo`/`PartOf`/`After`
+        // pinned to THIS slot's runner unit, both checked below. Only the
+        // framework (running as root in the guest) creates `nixling-exec-*` units
+        // with those properties, so a non-root caller cannot place an impostor at
+        // our slot. The `argv[]` comparison that follows is a best-effort
+        // CONSISTENCY check (does the live command match the persisted spec?)
+        // recovered from systemd's lossy single-line `systemctl show` rendering;
+        // it is hardened against the realistic argv bytes our own well-formed
+        // units carry, but it is not — and need not be — a defense against a
+        // guest-root attacker crafting a multi-line/forged ExecStart, which is a
+        // total compromise the structural boundary cannot help with either.
         if identity.slice != Some("nixling-exec.slice") {
             return false;
         }

--- a/packages/nixling-guestd/src/service.rs
+++ b/packages/nixling-guestd/src/service.rs
@@ -1818,8 +1818,9 @@ fn validate_detached_command(
         // recovers the running command from `systemctl show -p ExecStart`, whose
         // `argv[]` is a single line, so a `\n`/`\r` byte would split the property
         // and make the live workload unmatchable (silently reaped). Reject at
-        // create so the operator gets a clear error instead of a detached job
-        // that starts and then vanishes on the first reconcile.
+        // create — as an invalid argument — so a detached job is not started
+        // only to be reaped on the first reconcile. (The create error reuses the
+        // existing InvalidArgv kind; its operator message is generic.)
         if arg.len() > MAX_ARG_BYTES
             || arg
                 .as_bytes()

--- a/packages/nixling-guestd/src/service.rs
+++ b/packages/nixling-guestd/src/service.rs
@@ -1813,7 +1813,19 @@ fn validate_detached_command(
         return Err(ExecError::InvalidArgv);
     }
     for arg in &input.argv {
-        if arg.len() > MAX_ARG_BYTES || arg.as_bytes().contains(&0) {
+        // NUL is rejected for every exec. Detached argv additionally must not
+        // contain a newline or carriage return: the workload-identity reconciler
+        // recovers the running command from `systemctl show -p ExecStart`, whose
+        // `argv[]` is a single line, so a `\n`/`\r` byte would split the property
+        // and make the live workload unmatchable (silently reaped). Reject at
+        // create so the operator gets a clear error instead of a detached job
+        // that starts and then vanishes on the first reconcile.
+        if arg.len() > MAX_ARG_BYTES
+            || arg
+                .as_bytes()
+                .iter()
+                .any(|&b| b == 0 || b == b'\n' || b == b'\r')
+        {
             return Err(ExecError::InvalidArgv);
         }
     }
@@ -2227,6 +2239,30 @@ mod tests {
     fn detached_command_validation_rejects_empty_argv0_as_invalid_program() {
         let err = validate_detached_command(&detached_input(""), &exec_policy()).unwrap_err();
         assert_eq!(err, ExecError::InvalidProgram);
+    }
+
+    #[test]
+    fn detached_command_validation_rejects_newline_or_cr_in_argv() {
+        // A detached argv byte that would split the single-line `systemctl show
+        // -p ExecStart` property (newline / carriage return) is rejected at
+        // create — otherwise the running workload becomes unmatchable by the
+        // identity reconciler and is silently reaped. Reject up front instead.
+        for bad in ["a\nb", "a\rb", "trailing\n"] {
+            let mut input = detached_input("/bin/sh");
+            input.argv = vec!["/bin/sh".to_owned(), "-c".to_owned(), bad.to_owned()];
+            let err = validate_detached_command(&input, &exec_policy()).unwrap_err();
+            assert_eq!(err, ExecError::InvalidArgv, "argv {bad:?} must be rejected");
+        }
+        // A semicolon argument (now handled by raw identity matching) is still
+        // accepted — the newline guard must not over-restrict the common
+        // `sh -c 'a ; b'` pattern.
+        let mut ok = detached_input("/bin/sh");
+        ok.argv = vec![
+            "/bin/sh".to_owned(),
+            "-c".to_owned(),
+            "echo a ; echo b".to_owned(),
+        ];
+        assert!(validate_detached_command(&ok, &exec_policy()).is_ok());
     }
 
     #[test]

--- a/packages/nixlingd/src/exec_detached.rs
+++ b/packages/nixlingd/src/exec_detached.rs
@@ -310,45 +310,45 @@ fn run_real(
     let params = resolve_guest_control_probe_params(state, &resolver, vm)
         .map_err(|_| exec_typed_error(ExecOpError::OldGeneration))?;
     let broker_socket = broker_socket_path(state);
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|err| TypedError::InternalIo {
-            context: "build detached exec runtime".to_owned(),
-            detail: err.to_string(),
-        })?;
 
-    runtime
-        .block_on(async move {
-            let client = DetachedClient::connect(params, broker_socket).await?;
-            match request {
-                DetachedRealRequest::Create(spec) => client
-                    .exec_create(&spec)
-                    .await
-                    .map(DetachedRealResponse::Create),
-                DetachedRealRequest::List => {
-                    client.exec_list().await.map(DetachedRealResponse::List)
-                }
-                DetachedRealRequest::Status { exec_id } => client
-                    .exec_status(&exec_id)
-                    .await
-                    .map(DetachedRealResponse::Status),
-                DetachedRealRequest::Logs {
-                    exec_id,
-                    stdout_offset,
-                    stderr_offset,
-                    max_len,
-                } => client
-                    .exec_logs(&exec_id, stdout_offset, stderr_offset, max_len)
-                    .await
-                    .map(DetachedRealResponse::Logs),
-                DetachedRealRequest::Kill { exec_id } => client
-                    .exec_kill(&exec_id)
-                    .await
-                    .map(DetachedRealResponse::Kill),
+    // Detached ops dispatch from two distinct contexts: detached *create* runs on
+    // a dedicated `std::thread` (the exec owner, no ambient runtime), while the
+    // management verbs (list/logs/status/kill) dispatch INLINE on the
+    // multi-threaded runtime's request thread. A raw nested `Runtime::block_on`
+    // panics ("Cannot start a runtime from within a runtime") in the latter case
+    // and crashes the whole daemon, so reuse the shared `block_on_future` helper:
+    // it uses `block_in_place` + the ambient `Handle` when already inside the
+    // runtime and only builds a temporary runtime when none is present.
+    crate::block_on_future(async move {
+        let client = DetachedClient::connect(params, broker_socket).await?;
+        match request {
+            DetachedRealRequest::Create(spec) => client
+                .exec_create(&spec)
+                .await
+                .map(DetachedRealResponse::Create),
+            DetachedRealRequest::List => {
+                client.exec_list().await.map(DetachedRealResponse::List)
             }
-        })
-        .map_err(exec_typed_error)
+            DetachedRealRequest::Status { exec_id } => client
+                .exec_status(&exec_id)
+                .await
+                .map(DetachedRealResponse::Status),
+            DetachedRealRequest::Logs {
+                exec_id,
+                stdout_offset,
+                stderr_offset,
+                max_len,
+            } => client
+                .exec_logs(&exec_id, stdout_offset, stderr_offset, max_len)
+                .await
+                .map(DetachedRealResponse::Logs),
+            DetachedRealRequest::Kill { exec_id } => client
+                .exec_kill(&exec_id)
+                .await
+                .map(DetachedRealResponse::Kill),
+        }
+    })
+    .map_err(exec_typed_error)
 }
 
 fn exec_typed_error(error: ExecOpError) -> TypedError {

--- a/packages/nixlingd/src/exec_detached.rs
+++ b/packages/nixlingd/src/exec_detached.rs
@@ -310,15 +310,26 @@ fn run_real(
     let params = resolve_guest_control_probe_params(state, &resolver, vm)
         .map_err(|_| exec_typed_error(ExecOpError::OldGeneration))?;
     let broker_socket = broker_socket_path(state);
+    run_detached_request(params, broker_socket, request)
+}
 
-    // Detached ops dispatch from two distinct contexts: detached *create* runs on
-    // a dedicated `std::thread` (the exec owner, no ambient runtime), while the
-    // management verbs (list/logs/status/kill) dispatch INLINE on the
-    // multi-threaded runtime's request thread. A raw nested `Runtime::block_on`
-    // panics ("Cannot start a runtime from within a runtime") in the latter case
-    // and crashes the whole daemon, so reuse the shared `block_on_future` helper:
-    // it uses `block_in_place` + the ambient `Handle` when already inside the
-    // runtime and only builds a temporary runtime when none is present.
+/// Drive a detached guest-control request to completion over the guest-control
+/// bridge. Extracted from `run_real` so the runtime-bridging boundary is
+/// unit-testable independently of bundle/owner resolution.
+///
+/// Detached ops dispatch from two distinct contexts: detached *create* runs on a
+/// dedicated `std::thread` (the exec owner, no ambient runtime), while the
+/// management verbs (list/logs/status/kill) dispatch INLINE on the
+/// multi-threaded runtime's request thread. A raw nested `Runtime::block_on`
+/// panics ("Cannot start a runtime from within a runtime") in the latter case
+/// and crashes the whole daemon, so this MUST use the shared `block_on_future`
+/// helper: it uses `block_in_place` + the ambient `Handle` when already inside
+/// the runtime and only builds a temporary runtime when none is present.
+fn run_detached_request(
+    params: ProbeParams,
+    broker_socket: PathBuf,
+    request: DetachedRealRequest,
+) -> Result<DetachedRealResponse, TypedError> {
     crate::block_on_future(async move {
         let client = DetachedClient::connect(params, broker_socket).await?;
         match request {
@@ -1019,6 +1030,45 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+
+    // Regression guard for the detached-management nested-runtime panic.
+    //
+    // Management verbs (list/logs/status/kill) dispatch INLINE on nixlingd's
+    // multi-threaded runtime request thread. `run_detached_request` MUST bridge
+    // through `block_on_future` (block_in_place + the ambient `Handle`), NOT
+    // build a fresh `Runtime` and `block_on` it — the latter panics ("Cannot
+    // start a runtime from within a runtime") and took down the whole daemon
+    // (status=101) on every management call. The hook-based routing tests below
+    // short-circuit before `run_real`/`run_detached_request`, so only this test
+    // exercises the bridge: reverting it to a nested runtime makes this PANIC
+    // (a test failure) instead of merely returning `Err`.
+    //
+    // It runs on a multi-threaded runtime worker (Handle::current is Some,
+    // exactly like the inline dispatch). With a non-existent broker socket and
+    // guest-control endpoint, the connect fails fast and the call returns a
+    // transport error; reaching that error proves the bridge ran without
+    // panicking.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_detached_request_bridges_runtime_without_panicking() {
+        let params = ProbeParams {
+            vm_id: "vm-a".to_owned(),
+            socket_path: PathBuf::from("/nonexistent/nixling/vm-a/vsock.sock"),
+            state_root: PathBuf::from("/nonexistent/nixling/vm-a"),
+            expected_state_root_uid: 0,
+            expected_state_root_gid: 0,
+            expected_peer_uid: 0,
+            expected_peer_gid: 0,
+        };
+        let result = run_detached_request(
+            params,
+            PathBuf::from("/nonexistent/nixling/broker.sock"),
+            DetachedRealRequest::List,
+        );
+        assert!(
+            result.is_err(),
+            "detached request with no reachable guest must return an error, not panic: {result:?}"
+        );
+    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct RecordedCall {

--- a/packages/nixlingd/src/exec_detached.rs
+++ b/packages/nixlingd/src/exec_detached.rs
@@ -337,9 +337,7 @@ fn run_detached_request(
                 .exec_create(&spec)
                 .await
                 .map(DetachedRealResponse::Create),
-            DetachedRealRequest::List => {
-                client.exec_list().await.map(DetachedRealResponse::List)
-            }
+            DetachedRealRequest::List => client.exec_list().await.map(DetachedRealResponse::List),
             DetachedRealRequest::Status { exec_id } => client
                 .exec_status(&exec_id)
                 .await


### PR DESCRIPTION
## Summary

`nixling vm exec -d` (detached exec) was merged in #57 but had never been
live-validated. On a real host it failed three different ways; all three are
fixed here and validated end-to-end on a live VM (workload user `john`, uid
1000). Each bug was the same class — a unit test used a mock/fixture that did
not match real runtime behaviour, so the test passed while production failed.

### The three live bugs

1. **Runner reaped its own workload at spawn.** The exec runner verified the
   workload unit's cgroup against a top-level `/nixling-exec.slice/` path, but
   systemd nests `nixling-exec.slice` under `nixling.slice` (dash-keyed slice
   hierarchy), so the real path is `/nixling.slice/nixling-exec.slice/<unit>`.
   The check failed → the workload was SIGKILLed at spawn → every detached
   create failed. Fixed by anchoring on the immediate parent slice segment.

2. **Daemon crashed on every management verb.** `list`/`logs`/`status`/`kill`
   dispatch inline on `nixlingd`'s multi-threaded runtime thread, but the
   detached path built a nested current-thread runtime and `block_on`'d it,
   which panics ("Cannot start a runtime from within a runtime") and took down
   the whole daemon (status=101). Fixed by using the shared `block_on_future`
   bridge (the same one vm-start uses).

3. **Guest reaped its own live workloads as `lost-guestd`.** The reconciler
   matched the running command against `systemctl show -p ExecStart` using
   exact quote-aware argv tokens, but systemd renders `argv[]` as a literal,
   unescaped, single-space-joined string. The login wrapper `exec "$@"` (and
   any command with a space/quote/backslash/semicolon) never matched → live
   jobs were classified foreign and reaped shortly after starting. Fixed by
   comparing against systemd's raw rendering (bounded by the fixed
   ` ; ignore_errors=` field), rejecting argv bytes that cannot survive
   single-line rendering (newline/CR) at create, and failing closed on any
   malformed/multi-line `systemctl show` block.

### Also

- Hermetic regression test for the nested-runtime panic (a seam +
  `#[tokio::test(multi_thread)]` that panics if reverted).
- A guest-journal diagnostic when a runner-side spawn verification fails.
- Test fixtures updated to the real systemd rendering (so the existing
  reconcile/identity tests exercise it), plus quote/backslash/semicolon/
  trailing-whitespace/line-split/non-conflation coverage.
- CHANGELOG `[Unreleased]` Fixed entry.

## Validation

- `cargo clippy -p nixlingd -p nixling-guestd -p nixling-exec-runner
  --all-targets`: 0 warnings.
- Tests: nixlingd 427, nixling-guestd 199, nixling-exec-runner 56.
- `xtask gen-*` + `git diff`: no drift.
- **Live** (real host): detached create → `running`; stays running across the
  30s reaper, on-access reconciles, and a `nixlingd` restart; never-root
  (recorded uid=1000); `list`/`status`/`logs`/`cancel` work; a semicolon
  command (`sh -c 'echo a ; echo b ; sleep 300'`) stays running with correct
  logs; a newline-argument command is rejected at create.
- Panel review: 10/10 sign-off (default roster) after iterating findings on
  argv robustness, the hermetic panic test, and the workload-identity trust
  model.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
