### PR TITLE
observability: ADR 0033 follow-ups — host OTLP ingest namespace fix + deployment.environment scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ deprecations ship one minor release before removal.
 
 ### Changed
 
+- `deployment.environment` is now machine-and-env aware: the central
+  collector stamps it `<hostName>` for host telemetry and
+  `<hostName>-<env>` for workload VMs (e.g. `ddbus`, `ddbus-work`,
+  `ddbus-personal`), instead of the bare host name for everything.
+  `host.name` remains the per-source name (the host's name for host
+  telemetry, the VM's name for workloads). See
+  [ADR 0033](docs/adr/0033-host-collector-parity.md).
+
 - Host-origin telemetry now carries the **hostname** as `vm.name` /
   `host.name` (via `nixling.observability.host.identityName`, default
   `networking.hostName`), assigned at the trusted ingress boundary, rather

--- a/docs/reference/components-observability.md
+++ b/docs/reference/components-observability.md
@@ -44,9 +44,13 @@ cursor lets a collector restart resume where it left off rather than
 dropping entries written during downtime.
 
 The central SigNoz collector stamps these resource attributes on every
-ingested source: `vm.name` (the VM), `vm.env` / `service.namespace`
-(the env), `vm.role`, and `deployment.environment` (the physical host
-machine the guests run on, from the host's `networking.hostName`).
+ingested source: `vm.name` (the source's nixling name — the host or the
+VM), `host.name` (the same per-source name, i.e. the hostname telemetry
+is collected from: `ddbus` for the host, `work-aad` for a VM), `vm.env` /
+`service.namespace` (the env), `vm.role` (`host` or `workload`), and
+`deployment.environment` — the physical host for host telemetry
+(`<hostName>`, e.g. `ddbus`) and `<hostName>-<env>` for workload VMs
+(e.g. `ddbus-work`, `ddbus-personal`).
 
 > The systemd journal can contain sensitive data (auth failures,
 > command lines, service-logged secrets). Guest journal logs are

--- a/nixos-modules/components/observability/host.nix
+++ b/nixos-modules/components/observability/host.nix
@@ -274,7 +274,13 @@ lib.mkIf cfg.enable {
   systemd.tmpfiles.rules = [
     "d ${otelRuntimeDir} 0750 nixlingd nixling -"
     "L+ /run/nixling/host-egress.sock - - - - ${hostEgressSocket}"
-  ];
+  ] ++ lib.optional otlpIngest
+    # The OTLP ingest subdir MUST exist before the unit's mount namespace
+    # is constructed: systemd builds the ReadWritePaths bind mount for it
+    # at start, and a missing path fails the unit at the NAMESPACE step
+    # (226/NAMESPACE) before any ExecStartPre runs. tmpfiles creates it
+    # ahead of the unit; runtimePrep then refines perms/ACLs.
+    "d ${otelIngestDir} ${ingestDirMode} nixling-host-otel-collector ${ingestGroup} -";
 
   systemd.services.nixling-host-otel-collector = {
     description = "nixling host OpenTelemetry collector";

--- a/nixos-modules/components/observability/stack.nix
+++ b/nixos-modules/components/observability/stack.nix
@@ -76,13 +76,23 @@ let
         { key = "vm.name"; value = source.vmName; action = "upsert"; }
         { key = "vm.env"; value = source.envName; action = "upsert"; }
         { key = "vm.role"; value = source.role; action = "upsert"; }
+        # host.name is the per-source name: the host's name (cfg.hostName,
+        # via the host source's vmName) for host telemetry, or the VM's name
+        # for workload VMs.
         { key = "host.name"; value = source.vmName; action = "upsert"; }
         { key = "service.namespace"; value = source.envName; action = "upsert"; }
-        # deployment.environment is the physical host the guests run on
-        # (cfg.hostName), so SigNoz's environment dimension groups all
-        # VMs by their host machine. The per-VM env still lives in
+        # deployment.environment encodes the machine, plus the env for VMs:
+        # "<host>" for host telemetry, "<host>-<env>" for workload VMs (e.g.
+        # ddbus, ddbus-work, ddbus-personal). The per-VM env still lives in
         # service.namespace / vm.env and the VM identity in vm.name.
-        { key = "deployment.environment"; value = cfg.hostName; action = "upsert"; }
+        {
+          key = "deployment.environment";
+          value =
+            if source.role == "host"
+            then cfg.hostName
+            else "${cfg.hostName}-${source.envName}";
+          action = "upsert";
+        }
       ];
     }
   ) ingressSources) // {

--- a/packages/nixling-contract-tests/tests/policy_observability.rs
+++ b/packages/nixling-contract-tests/tests/policy_observability.rs
@@ -229,6 +229,44 @@ fn tempo_stack_signoz_backend_and_collector() {
 }
 
 // ===========================================================================
+// ADR 0033 follow-up: host.name / deployment.environment identity scheme.
+//
+// The central collector stamps `host.name` with the per-source name (the
+// host's name for host telemetry, the VM's name for workloads), and encodes
+// `deployment.environment` as "<host>" for host telemetry and "<host>-<env>"
+// for workload VMs (e.g. ddbus, ddbus-work, ddbus-personal).
+// ===========================================================================
+#[test]
+fn signoz_resource_identity_scheme() {
+    assert!(
+        repo_path_exists(OBS_STACK),
+        "identity-scheme: missing file: {OBS_STACK}"
+    );
+    let stack = read_repo_file(OBS_STACK);
+
+    // host.name is the per-source name (host's name or the VM's name).
+    assert!(
+        any_line_matches(
+            &stack,
+            r#"key[[:space:]]*=[[:space:]]*"host.name";[[:space:]]*value[[:space:]]*=[[:space:]]*source\.vmName"#
+        ),
+        "identity-scheme: host.name must be the per-source name (source.vmName)"
+    );
+
+    // deployment.environment: "<host>" for host, "<host>-<env>" for VMs.
+    for pat in [
+        r#"if source\.role == "host""#,
+        r#"then cfg\.hostName"#,
+        r#"else "\$\{cfg\.hostName\}-\$\{source\.envName\}""#,
+    ] {
+        assert!(
+            any_line_matches(&stack, pat),
+            "identity-scheme: deployment.environment must be host-aware (missing /{pat}/)"
+        );
+    }
+}
+
+// ===========================================================================
 // Migrated from tests/tempo-budget-eval.sh (part 2 of 3): the guest collector
 // shape.
 //

--- a/packages/nixling-contract-tests/tests/policy_state.rs
+++ b/packages/nixling-contract-tests/tests/policy_state.rs
@@ -479,6 +479,10 @@ fn host_otlp_ingest_socket_isolation() {
             "deterministic ingest socket mode via UMask",
             r#"UMask[[:space:]]*=[[:space:]]*ingestUmask"#,
         ),
+        (
+            "the ingest dir is pre-created via tmpfiles before the unit namespace is built",
+            r#"d \$\{otelIngestDir\} \$\{ingestDirMode\} nixling-host-otel-collector \$\{ingestGroup\}"#,
+        ),
     ];
 
     let denies: &[(&str, &str)] = &[

--- a/tests/unit/nix/cases/observability.nix
+++ b/tests/unit/nix/cases/observability.nix
@@ -697,6 +697,7 @@ let
           readWritePaths = svc.serviceConfig.ReadWritePaths or null;
           umask = svc.serviceConfig.UMask or null;
           suppGroups = svc.serviceConfig.SupplementaryGroups or null;
+          tmpfilesHasIngest = builtins.any (r: lib.hasInfix "/run/nixling/otel/ingest" r) nixos.config.systemd.tmpfiles.rules;
         };
       expectedExtract = {
         receiverNames = [ "filelog/store_sync_audit" "hostmetrics" "prometheus" ];
@@ -706,6 +707,7 @@ let
         readWritePaths = null;
         umask = null;
         suppGroups = null;
+        tmpfilesHasIngest = false;
       };
     };
 
@@ -764,6 +766,7 @@ let
           readWritePaths = svc.serviceConfig.ReadWritePaths or null;
           umask = svc.serviceConfig.UMask or null;
           endpointIsolatedFromEgress = endpoint != "/run/nixling/otel/host-egress.sock";
+          tmpfilesHasIngest = builtins.any (r: lib.hasInfix "/run/nixling/otel/ingest" r) nixos.config.systemd.tmpfiles.rules;
         };
       expectedExtract = {
         hasOtlp = true;
@@ -777,6 +780,7 @@ let
         readWritePaths = [ "/run/nixling/otel/ingest" ];
         umask = "0177";
         endpointIsolatedFromEgress = true;
+        tmpfilesHasIngest = true;
       };
     };
 


### PR DESCRIPTION
## Summary

Fixes a `226/NAMESPACE` activation failure introduced by ADR 0033's host
OTLP ingest path.

When `nixling.observability.host.otlpIngest.enable = true`, the collector
unit sets `ReadWritePaths = [ "/run/nixling/otel/ingest" ]`, but the ingest
dir was only created in the collector's `ExecStartPre` — which runs *inside*
the unit's mount namespace. systemd builds the `ReadWritePaths` bind mount at
namespace-construction time, **before any `ExecStartPre`**, so the missing
dir fails the unit:

```
nixling-host-otel-collector.service: Failed to set up mount namespacing:
/run/nixling/otel/ingest: No such file or directory
Failed at step NAMESPACE ... status=226/NAMESPACE
```

### Fix

Create `/run/nixling/otel/ingest` via `systemd.tmpfiles.rules` (gated on
`otlpIngest`) so it exists before the unit's namespace is built; `runtimePrep`
still refines its perms/ACLs and unlinks a stale socket. `host-egress.sock`
isolation is unchanged.

### Validation

- Reproduced and confirmed the fix live on a host: with the ingest dir
  pre-created the collector reaches "Everything is ready. Begin running and
  processing data." with `prometheus` + `journald` + `filelog` receivers up.
- New regression coverage: eval cases assert `tmpfilesHasIngest`
  (true with `otlpIngest`, false by default); `policy_state.rs`
  `host_otlp_ingest_socket_isolation` gains a source `want` for the tmpfiles
  rule. `cargo test -p nixling-contract-tests --test policy_state` passes (6).

Hotfix for an activation regression in already-merged ADR 0033 work.
