### PR TITLE
broker: self-heal OtelHostBridge across obs-VM restarts (stale host-egress.sock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,19 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- The OTel host-bridge runner (`socat UNIX-LISTEN:host-egress.sock,...`)
+  now self-heals across obs-VM restarts. `socat` does not unlink a
+  pre-existing socket path before binding, so a stale `host-egress.sock`
+  left by a previously-drained bridge made the freshly-spawned bridge
+  exit immediately ("address in use"); the readiness probe only checks
+  the socket *file* exists, so the failure was masked and host telemetry
+  silently stopped reaching `sys-obs`. The broker now drops a
+  provably-stale (non-listening) `host-egress.sock` before each
+  `OtelHostBridge` spawn — mirroring the existing cloud-hypervisor / video
+  socket preflight — so restarting the obs VM no longer wedges the host
+  telemetry path. A live listener is never removed, and only sockets under
+  `/run/nixling/otel/` are eligible.
+
 - The privileged broker now compiles under the `layer1-bootstrap`
   feature (and thus `--all-features`): the guest-control `GuestControlSign`
   audit-redaction arm in `request_fields_value` is gated to the real-wire

--- a/packages/nixling-priv-broker/src/runtime.rs
+++ b/packages/nixling-priv-broker/src/runtime.rs
@@ -1765,6 +1765,7 @@ fn dispatch_request_with_backend<B: DispatchBackend>(
             )?;
             cleanup_cloud_hypervisor_stale_sockets(&req.role, &intent.argv)?;
             cleanup_video_stale_socket(&req.role, &intent.argv)?;
+            cleanup_otel_host_bridge_stale_socket(&req.role, &intent.argv)?;
             let plan_input = crate::ops::spawn_runner::SpawnRunnerPlanInput {
                 binary_path: intent.binary_path.clone(),
                 argv: intent.argv.clone(),
@@ -4841,6 +4842,49 @@ fn video_socket_path(argv: &[String]) -> Result<PathBuf, BrokerError> {
     }
     Err(BrokerError::LiveHandler(
         "video socket preflight could not find --socket-path in runner argv".to_owned(),
+    ))
+}
+
+// The OtelHostBridge runner is `socat UNIX-LISTEN:<host-egress.sock>,...`.
+// socat does not unlink a pre-existing socket path before binding, so a
+// stale `host-egress.sock` left behind by a prior bridge instance (e.g.
+// after the obs VM is restarted, draining and respawning the bridge)
+// makes the fresh socat exit immediately with "address in use". The
+// readiness probe only checks the socket *file* exists, so the stale
+// socket masks the failure and host telemetry silently stops flowing.
+// Mirror the cloud-hypervisor / video preflight: drop a provably-stale
+// (non-listening) socket before spawn so obs-VM restarts self-heal.
+#[cfg(not(feature = "layer1-bootstrap"))]
+fn cleanup_otel_host_bridge_stale_socket(
+    role: &nixling_ipc::broker_wire::RunnerRole,
+    argv: &[String],
+) -> Result<(), BrokerError> {
+    if !matches!(role, nixling_ipc::broker_wire::RunnerRole::OtelHostBridge) {
+        return Ok(());
+    }
+    let path = otel_host_bridge_socket_path(argv)?;
+    if !path.starts_with("/run/nixling/otel/") {
+        return Err(BrokerError::LiveHandler(format!(
+            "otel-host-bridge socket preflight refusing non-nixling socket path {}",
+            path.display()
+        )));
+    }
+    cleanup_stale_unix_socket_without_probe(&path, "otel-host-bridge socket preflight")
+}
+
+#[cfg(not(feature = "layer1-bootstrap"))]
+fn otel_host_bridge_socket_path(argv: &[String]) -> Result<PathBuf, BrokerError> {
+    for arg in argv {
+        if let Some(rest) = arg.strip_prefix("UNIX-LISTEN:") {
+            let path = rest.split(',').next().unwrap_or(rest);
+            if !path.is_empty() {
+                return Ok(PathBuf::from(path));
+            }
+        }
+    }
+    Err(BrokerError::LiveHandler(
+        "otel-host-bridge socket preflight could not find UNIX-LISTEN socket in runner argv"
+            .to_owned(),
     ))
 }
 
@@ -8676,6 +8720,64 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(not(feature = "layer1-bootstrap"))]
+    #[test]
+    fn otel_host_bridge_socket_path_extracts_unix_listen_target() {
+        let argv = vec![
+            "/run/current-system/sw/bin/socat".to_owned(),
+            "-d".to_owned(),
+            "-d".to_owned(),
+            "UNIX-LISTEN:/run/nixling/otel/host-egress.sock,fork,reuseaddr,mode=0660".to_owned(),
+            "EXEC:\"/run/current-system/sw/bin/nixling-ch-vsock-connect \
+             /var/lib/nixling/vms/sys-obs/vsock.sock 14317\""
+                .to_owned(),
+        ];
+        let path = otel_host_bridge_socket_path(&argv).expect("extract UNIX-LISTEN target");
+        assert_eq!(
+            path,
+            PathBuf::from("/run/nixling/otel/host-egress.sock"),
+            "the socket path is the UNIX-LISTEN target stripped of socat options"
+        );
+    }
+
+    #[cfg(not(feature = "layer1-bootstrap"))]
+    #[test]
+    fn otel_host_bridge_socket_path_errors_without_unix_listen() {
+        let argv = vec![
+            "/run/current-system/sw/bin/socat".to_owned(),
+            "-d".to_owned(),
+        ];
+        assert!(
+            otel_host_bridge_socket_path(&argv).is_err(),
+            "argv without a UNIX-LISTEN address must be rejected"
+        );
+    }
+
+    #[cfg(not(feature = "layer1-bootstrap"))]
+    #[test]
+    fn cleanup_otel_host_bridge_stale_socket_noop_for_other_role() {
+        use nixling_ipc::broker_wire::RunnerRole;
+        // A non-bridge role must short-circuit Ok before touching argv or
+        // the filesystem, even with an otherwise-dangerous argv.
+        let argv = vec!["UNIX-LISTEN:/etc/shadow,fork".to_owned()];
+        cleanup_otel_host_bridge_stale_socket(&RunnerRole::CloudHypervisor, &argv)
+            .expect("non-bridge role is a no-op");
+    }
+
+    #[cfg(not(feature = "layer1-bootstrap"))]
+    #[test]
+    fn cleanup_otel_host_bridge_stale_socket_rejects_path_outside_otel_runtime_dir() {
+        use nixling_ipc::broker_wire::RunnerRole;
+        // The prefix guard must refuse any socket outside the nixling OTel
+        // runtime dir so a malformed bundle can never unlink an arbitrary
+        // path before the guarded `cleanup_stale_unix_socket_without_probe`.
+        let argv = vec!["UNIX-LISTEN:/tmp/evil.sock,fork".to_owned()];
+        assert!(
+            cleanup_otel_host_bridge_stale_socket(&RunnerRole::OtelHostBridge, &argv).is_err(),
+            "socket path outside /run/nixling/otel/ must be refused"
+        );
     }
 
     #[cfg(not(feature = "layer1-bootstrap"))]


### PR DESCRIPTION
## Problem

The OTel host-bridge runner is `socat UNIX-LISTEN:/run/nixling/otel/host-egress.sock,fork,reuseaddr,mode=0660 EXEC:"nixling-ch-vsock-connect …"`. `socat`'s `reuseaddr` (SO_REUSEADDR) does **not** unlink a pre-existing `AF_UNIX` socket path before binding.

When the obs VM (`sys-obs`) is restarted, the broker drains and respawns the bridge. The drained `socat` leaves its `host-egress.sock` file behind, so the freshly-spawned `socat` hits the stale path and exits immediately with "address already in use". It is reaped and not retried.

The runner readiness check is `unix-socket-exists:/run/nixling/otel/host-egress.sock` — it only verifies the **file** exists, which the stale socket satisfies — so the failure is masked. The host edge collector then loops on `dial unix …/host-egress.sock: connect: connection refused` and **host telemetry silently stops reaching `sys-obs`** until the socket is manually removed and the bridge respawned.

(The per-VM guest collectors use the same `socat UNIX-LISTEN` shape but run *inside* the guest where `/run` is wiped on every VM boot, so they never hit a cross-restart stale socket. Only the host bridge, whose `/run/nixling/otel` persists across the bridge's lifecycle, is affected.)

## Fix

Add `cleanup_otel_host_bridge_stale_socket` to the broker's `SpawnRunner` preflight, mirroring the existing `cleanup_cloud_hypervisor_stale_sockets` / `cleanup_video_stale_socket` pattern. Before spawning an `OtelHostBridge` runner, the broker drops a **provably-stale** (non-listening) `host-egress.sock`. This runs in the broker context (no jail/seccomp/argv changes), so:

- A **live** listener is never removed (`cleanup_stale_unix_socket_without_probe` refuses if `/proc/net/unix` shows it listening).
- Only sockets under `/run/nixling/otel/` are eligible (prefix guard).
- The socat argv and its byte-parity golden oracle are unchanged.

Restarting the obs VM now self-heals the host telemetry path.

## Tests

New unit tests in `nixling-priv-broker`:
- `otel_host_bridge_socket_path_extracts_unix_listen_target`
- `otel_host_bridge_socket_path_errors_without_unix_listen`
- `cleanup_otel_host_bridge_stale_socket_noop_for_other_role`
- `cleanup_otel_host_bridge_stale_socket_rejects_path_outside_otel_runtime_dir`

`cargo test -p nixling-priv-broker` green; `cargo clippy --all-targets` clean.

## Verified on host

Reproduced on `ddbus`: after a `sys-obs` restart the bridge was reaped (stale socket) and the host collector logged `connection refused`; removing the stale socket + restarting `sys-obs` restored flow. This change makes that recovery automatic on the next bridge spawn.

Follow-up to #62 / #63 (ADR 0033 host collector parity).