### PR TITLE
vms: inherit host overlays during eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+### Fixed
+
+- Per-VM NixOS evaluations now inherit the host's `nixpkgs.overlays` in
+  addition to `nixpkgs.config`, so consumer security overlays patch VM
+  closures as well as host closures.
+
 ### Changed
 
 - CI: the `pr-l1-static-fast` x86_64 flake check is now sharded one job per

--- a/nixos-modules/vm-evaluator.nix
+++ b/nixos-modules/vm-evaluator.nix
@@ -49,11 +49,13 @@ let
         ./vm-options.nix
         ./vm-guest-base.nix
         ./guest-control.nix
-        # inherit the host's nixpkgs.config so per-VM evals
-        # honor the consumer's allowUnfree / allowUnfreePredicate /
-        # permittedInsecurePackages settings without re-stating them
-        # in each per-VM module.
-        { nixpkgs.config = config.nixpkgs.config; }
+        # Inherit host nixpkgs policy so per-VM evals honor the consumer's
+        # allowUnfree / overlays / security fixes without re-stating them in
+        # each per-VM module.
+        {
+          nixpkgs.config = config.nixpkgs.config;
+          nixpkgs.overlays = config.nixpkgs.overlays;
+        }
         { _module.args.name = name; }
       ] ++ composedModules;
       specialArgs =

--- a/tests/unit/nix/cases/vm-eval-overlays.nix
+++ b/tests/unit/nix/cases/vm-eval-overlays.nix
@@ -1,0 +1,50 @@
+# Per-VM evaluations must inherit the host's nixpkgs overlays. Security-fix
+# overlays are declared once on the host but must affect every VM closure too.
+{ mkEval, ... }:
+
+let
+  fixture = { lib, ... }: {
+    boot.loader.grub.enable = false;
+    boot.loader.systemd-boot.enable = false;
+    boot.initrd.includeDefaultModules = false;
+    fileSystems."/" = { device = "tmpfs"; fsType = "tmpfs"; };
+    environment.etc."machine-id".text = "00000000000000000000000000000000";
+    system.stateVersion = "25.11";
+    users.users.alice = { isNormalUser = true; uid = 1000; };
+
+    nixpkgs.overlays = [
+      (_final: _prev: {
+        overlayProbeText = "guest-overlay-visible";
+      })
+    ];
+
+    nixling.site = {
+      waylandUser = "alice";
+      launcherUsers = [ "alice" ];
+      yubikey.enable = false;
+    };
+    nixling.envs.work = {
+      lanSubnet = "10.20.0.0/24";
+      uplinkSubnet = "192.0.2.0/30";
+    };
+    nixling.vms.demo = {
+      enable = true;
+      env = "work";
+      index = 10;
+      ssh.user = "alice";
+      config = { lib, pkgs, ... }: {
+        networking.hostName = lib.mkDefault "demo";
+        users.users.alice = { isNormalUser = true; uid = 1000; };
+        environment.etc."overlay-probe".text = pkgs.overlayProbeText;
+      };
+    };
+  };
+
+  cfg = (mkEval [ fixture ]).config;
+in
+{
+  "vm-eval-overlays/guest-inherits-host-overlays" = {
+    expr = cfg.nixling._computed.demo.config.environment.etc."overlay-probe".text;
+    expected = "guest-overlay-visible";
+  };
+}

--- a/tests/unit/nix/eval-cases/shared.nix
+++ b/tests/unit/nix/eval-cases/shared.nix
@@ -143,14 +143,17 @@ let
       };
     };
 
-  # `nixpkgs` is read by vm-evaluator.nix (`config.nixpkgs.config`), so
-  # its sink seeds a `.config` attr.
+  # `nixpkgs` is read by vm-evaluator.nix (`config.nixpkgs.config` and
+  # `config.nixpkgs.overlays`), so its sink seeds both attrs.
   nixpkgsSink =
     { lib, ... }:
     {
       options.nixpkgs = lib.mkOption {
         type = lib.types.anything;
-        default = { config = { }; };
+        default = {
+          config = { };
+          overlays = [ ];
+        };
       };
     };
 

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -396,6 +396,7 @@ usbip-gating/vm-enabled-site-disabled-kernel-module-absent
 usbip-gating/vm-enabled-site-disabled-proxy-absent
 usbip-gating/vm-enabled-site-disabled-proxy-firewall-rule-absent
 usbip-gating/vm-enabled-site-disabled-socket-absent
+vm-eval-overlays/guest-inherits-host-overlays
 volume-mounts/disk-init-absolute
 volume-mounts/disk-init-non-ext4
 volume-mounts/disk-init-non-raw


### PR DESCRIPTION
## Summary
- inherit host nixpkgs.overlays in per-VM NixOS evals alongside nixpkgs.config
- add a nix-unit regression proving guest pkgs sees host overlays
- document the fix in the changelog

## Validation
- nix flake check --no-build --all-systems
- nix-unit pin regenerated with make nix-unit-pin
- review panel signoff: product, observability, kernel, nixos, rust, test/software, docs, networking, security

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>