### PR TITLE
broker: make USBIP lock acquire idempotent for same-VM re-bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-06-18
+
+### Fixed
+
+- USBIP lock acquire is now idempotent for the same VM: when a VM is
+  restarted (`nixling down` + `nixling up`), the broker no longer
+  refuses to re-bind a busid that the same VM already owns. Previously,
+  every VM restart required a manual `nixling usb detach` + `nixling usb
+  attach` cycle because the lock file persisted across the stop/start.
+
 ## [1.3.0] - 2026-06-18
 
 ### Fixed

--- a/packages/nixling-priv-broker/src/ops/usbip_lock.rs
+++ b/packages/nixling-priv-broker/src/ops/usbip_lock.rs
@@ -11,9 +11,13 @@
 //! Lock semantics:
 //!
 //! - Acquire: `O_CREAT | O_EXCL | O_WRONLY`, file body is the owning
-//!   VM name + newline. Returns `LockAlreadyHeld` if another VM
+//!   VM name + newline. Returns `LockAlreadyHeld` if a *different* VM
 //!   already owns the busid; the daemon must surface a typed refusal
 //!   to the operator (USBIP single-owner is a v0.4.0 invariant).
+//!   **Idempotent for the same VM**: if the lock already exists and
+//!   the recorded owner matches the requesting VM, the acquire
+//!   succeeds without modification. This covers VM restarts where
+//!   `nixling down` does not release USBIP locks.
 //! - Release: read the file, verify the recorded owner matches the
 //!   expected vm name (defence-in-depth against a stale unbind),
 //!   then unlink. Missing file is treated as success (idempotent
@@ -228,6 +232,12 @@ pub fn acquire_lock(
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
             let existing =
                 read_owner(&full_lock_path).unwrap_or_else(|_| "<unreadable>".to_owned());
+            // Idempotent: if the same VM already owns the lock (e.g.
+            // after a VM restart without an explicit detach), treat the
+            // acquire as a success rather than refusing.
+            if existing.trim() == owner_vm {
+                return Ok(());
+            }
             Err(UsbipLockError::LockAlreadyHeld {
                 path: full_lock_path,
                 existing_owner: existing,
@@ -475,6 +485,18 @@ mod tests {
         let gid = nix::unistd::Gid::current().as_raw();
         let err = acquire_lock(&link.join("5-5"), "vm-z", uid, gid).unwrap_err();
         assert!(matches!(err, UsbipLockError::Io { .. }));
+    }
+
+    #[test]
+    fn acquire_idempotent_when_same_vm_owns_lock() {
+        let tmp = temp_lock_dir();
+        let lock = tmp.path().join("6-1");
+        let uid = nix::unistd::Uid::current().as_raw();
+        let gid = nix::unistd::Gid::current().as_raw();
+        acquire_lock(&lock, "work-aad", uid, gid).unwrap();
+        // Re-acquire by the same VM succeeds (e.g. after VM restart).
+        acquire_lock(&lock, "work-aad", uid, gid).unwrap();
+        assert_eq!(peek_owner(&lock).unwrap(), "work-aad");
     }
 
     #[test]


### PR DESCRIPTION
When a VM is restarted (`nixling down` + `nixling up`), the USBIP lock file at
`/run/nixling/locks/usbip/<busid>` persists because vm stop does not release USBIP locks.
On restart, the live handler's UsbipBind attempt fails with 'already held by <vm>' even
though the owning VM is the same one requesting the bind.

**Fix:** treat `acquire_lock` as a success when the existing lock owner matches the
requesting VM. This makes the bind path idempotent across VM restarts without requiring
an explicit detach/re-attach cycle.

**Testing:**
- `cargo test --lib ops::usbip_lock` — 7/7 pass (including new `acquire_idempotent_when_same_vm_owns_lock`)
- Panel review: 8/8 sign-off (rust, security, test, software, kernel, product, docs, networking)
- Live validated: stale lock was the root cause of repeated USB attach failures after VM restart