### PR TITLE
ci: set CARGO_BUILD_RUSTC_WRAPPER='' to disable sccache in rust-cache steps

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -51,9 +51,13 @@ jobs:
       # caching) instead, which caches ALL compiled artifacts including
       # proc-macros and bin/lib crates that sccache cannot cache (~60% of
       # compilations are "non-cacheable" by sccache due to crate-type).
+      # CARGO_BUILD_RUSTC_WRAPPER="" overrides packages/.cargo/config.toml's
+      # `rustc-wrapper = "sccache"` for ALL steps (including rust-cache's
+      # own `cargo metadata` pre/post steps where sccache is unavailable).
       # CARGO_INCREMENTAL=0 is still set: incremental compilation artifacts
       # are non-deterministic and bloat the cache without benefit for CI
       # (each PR run starts from a different commit).
+      CARGO_BUILD_RUSTC_WRAPPER: ""
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5


### PR DESCRIPTION
## Problem

The `Swatinem/rust-cache` action runs `cargo metadata --all-features` in its own pre/post JavaScript steps. Those steps inherit the job `env:` block but not Makefile-internal overrides from `make test-rust`.

`packages/.cargo/config.toml` sets `rustc-wrapper = "sccache"`, which cargo resolves when running `rustc -vV` during metadata. Since `sccache` is not installed on the CI runner, this fails:

```
error: could not execute process `sccache .../rustc -vV` (never executed)
Caused by: No such file or directory (os error 2)
```

## Fix

Add `CARGO_BUILD_RUSTC_WRAPPER: ""` to the job-level `env:` block. This env var overrides the config file setting for ALL steps, including rust-cache's own `cargo metadata` invocations.

Fixes: https://github.com/vicondoa/nixling/actions/runs/27805970121/job/82285819398