### PR TITLE
ci: set CARGO_BUILD_RUSTC_WRAPPER='' to fix rust-cache post-step

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -55,6 +55,10 @@ jobs:
       # are non-deterministic and bloat the cache without benefit for CI
       # (each PR run starts from a different commit).
       CARGO_INCREMENTAL: "0"
+      # Override the repo .cargo/config.toml rustc-wrapper (sccache) so
+      # rust-cache's post-step `cargo metadata` doesn't fail looking for
+      # an sccache binary that isn't installed.
+      CARGO_BUILD_RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:


### PR DESCRIPTION
Follow-up to #72. The repo's `.cargo/config.toml` sets `rustc-wrapper = "sccache"`, which causes rust-cache's post-step `cargo metadata` to fail with "could not execute process sccache" since sccache isn't installed in CI anymore. Setting `CARGO_BUILD_RUSTC_WRAPPER=''` in the job env overrides the config file and silences the cosmetic error. The cache save succeeded regardless (652 MiB saved on main), but this eliminates the error noise.