### PR TITLE
ci: add Nix store cache + fix sccache wrapper error

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -84,6 +84,18 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
+      - name: Nix store cache (fixture builds + nixpkgs eval)
+        # Caches /nix (the Nix store) using the GitHub Actions cache API.
+        # This avoids rebuilding fixture-smoke / fixture-smoke-full / sccache
+        # derivations on every run (~10-15 min of Nix eval+build saved).
+        # The action runs in its own JavaScript process — no tokens are
+        # exposed to `run:` steps.
+        uses: nix-community/cache-nix-action@8351fb9f51c580c96c509987ebb99e38aed956ce
+        with:
+          primary-key: nix-test-rust-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: |
+            nix-test-rust-${{ runner.os }}-
+          gc-max-store-size-linux: 4G
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action


### PR DESCRIPTION
Follow-up to #72. Two fixes:

1. **Nix store cache** (`nix-community/cache-nix-action`): caches `/nix` between runs so `nix build .#checks.fixture-smoke` and `fixture-smoke-full` are instant cache hits instead of ~10-15 min rebuilds.

2. **CARGO_BUILD_RUSTC_WRAPPER=''**: fixes the cosmetic `could not execute process sccache` error in rust-cache's post-step `cargo metadata` (the repo's `.cargo/config.toml` references sccache which isn't installed in CI anymore).

**Security**: `cache-nix-action` uses the same `@actions/cache` API as `actions/cache` and `Swatinem/rust-cache`. All cache I/O happens in the action's JavaScript pre/post steps — no `ACTIONS_RUNTIME_TOKEN` is exposed to `run:` steps. Purge is disabled so no `actions: write` permission needed.

**Expected total warm time** (rust-cache + nix store cache): ~8-12 min (down from 41 min).