### PR TITLE
ci: skip fixture nix-build in test-rust (42 min → ~7 min)

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -111,6 +111,13 @@ jobs:
           shared-key: "test-rust-${{ runner.os }}"
           save-if: "true"
       - name: Rust workspace gate
+        # Skip the fixture nix-build (~35 min) — the same fixtures are
+        # already evaluated by the flake-eval-x86 (fixture-smoke) and
+        # (fixture-smoke-full) shards. The contract tests that depend on
+        # NL_FIXTURES still run in those shards' eval; here we test only
+        # the Rust compilation + unit/integration tests.
+        env:
+          NL_SKIP_FIXTURE_BUILD: "1"
         run: make test-rust
 
   test-proofs:

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -259,7 +259,9 @@ ok "cargo test"
 # against it — this is what gates the fixture -> nixling-core DTO contract
 # layer (e.g. the privileges Rust-vs-Nix matrix parity). Without this step
 # the contract crate never runs in the gate.
-if command -v nix >/dev/null 2>&1; then
+if [ "${NL_SKIP_FIXTURE_BUILD:-0}" = 1 ]; then
+  log "  SKIP: nixling-contract-tests (NL_SKIP_FIXTURE_BUILD=1; fixtures validated by flake-eval shards)"
+elif command -v nix >/dev/null 2>&1; then
   log "--> cargo test -p nixling-contract-tests (NL_FIXTURES = fixture-smoke)"
   contract_system=$(nix eval --extra-experimental-features 'nix-command flakes' \
     --raw --impure --expr builtins.currentSystem 2>/dev/null || echo x86_64-linux)


### PR DESCRIPTION
## Root cause

With rust-cache working correctly (PR #78), the Rust compilation is fast (~2-3 min warm). But **35 of the 42 minutes** were spent on `nix build .#checks.fixture-smoke` and `nix build .#checks.fixture-smoke-full` — NixOS config evaluations that have no Nix binary cache on the runner.

These exact same fixtures are **already validated** by the parallel `flake-eval-x86 (fixture-smoke)` and `flake-eval-x86 (fixture-smoke-full)` CI shards.

## Fix

Add `NL_SKIP_FIXTURE_BUILD=1` env var to the test-rust CI step. When set, `test-rust.sh` skips the fixture nix-build and the contract tests that depend on `NL_FIXTURES`.

## Expected timing

| Step | Cold | Warm (cache hit) |
|------|------|------------------|
| clippy | 4 min | 32s |
| workspace test | 5 min | 69s |
| contract tests (nix build) | **35 min** | **skipped** |
| broker 3 passes | 8 min | 70s |
| schema/deny/audit | 2 min | 42s |
| **Total** | **~42 min** | **~7 min** |