### PR TITLE
nix: keep target.rs in packaged Rust sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Nix packaging now keeps legitimate source files whose names contain
+  `target` (for example `nixling-constellation-core/src/target.rs`) while
+  still filtering Cargo `target/` build directories out of package sources.
 - USBIP lock acquire is now idempotent for the same VM: when a VM is
   restarted (`nixling down` + `nixling up`), the broker no longer
   refuses to re-bind a busid that the same VM already owns. Previously,

--- a/nixos-modules/gateway-vm.nix
+++ b/nixos-modules/gateway-vm.nix
@@ -7,8 +7,10 @@ let
   packagesSrc = lib.cleanSourceWith {
     src = ../packages;
     filter = path: type:
-      let rel = lib.removePrefix (toString ../packages + "/") (toString path);
-      in !(lib.hasInfix "target" rel || lib.hasInfix ".cargo/registry" rel);
+      let
+        rel = lib.removePrefix (toString ../packages + "/") (toString path);
+        parts = lib.splitString "/" rel;
+      in !(builtins.elem "target" parts || lib.hasPrefix ".cargo/registry/" rel || lib.hasInfix "/.cargo/registry/" rel);
   };
   cargoLock = {
     lockFile = ../packages/Cargo.lock;

--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -46,8 +46,10 @@ let
   packagesSrc = lib.cleanSourceWith {
     src = ../packages;
     filter = path: type:
-      let rel = lib.removePrefix (toString ../packages + "/") (toString path);
-      in !(lib.hasInfix "target" rel || lib.hasInfix ".cargo/registry" rel);
+      let
+        rel = lib.removePrefix (toString ../packages + "/") (toString path);
+        parts = lib.splitString "/" rel;
+      in !(builtins.elem "target" parts || lib.hasPrefix ".cargo/registry/" rel || lib.hasInfix "/.cargo/registry/" rel);
   };
   cargoLock = {
     lockFile = ../packages/Cargo.lock;

--- a/nixos-modules/host-broker.nix
+++ b/nixos-modules/host-broker.nix
@@ -22,8 +22,10 @@ let
   packagesSrc = lib.cleanSourceWith {
     src = ../packages;
     filter = path: type:
-      let rel = lib.removePrefix (toString ../packages + "/") (toString path);
-      in !(lib.hasInfix "target" rel || lib.hasInfix ".cargo/registry" rel);
+      let
+        rel = lib.removePrefix (toString ../packages + "/") (toString path);
+        parts = lib.splitString "/" rel;
+      in !(builtins.elem "target" parts || lib.hasPrefix ".cargo/registry/" rel || lib.hasInfix "/.cargo/registry/" rel);
   };
 
   brokerPackage = pkgs.rustPlatform.buildRustPackage {

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -8,8 +8,10 @@ let
   packagesSrc = lib.cleanSourceWith {
     src = ../packages;
     filter = path: type:
-      let rel = lib.removePrefix (toString ../packages + "/") (toString path);
-      in !(lib.hasInfix "target" rel || lib.hasInfix ".cargo/registry" rel);
+      let
+        rel = lib.removePrefix (toString ../packages + "/") (toString path);
+        parts = lib.splitString "/" rel;
+      in !(builtins.elem "target" parts || lib.hasPrefix ".cargo/registry/" rel || lib.hasInfix "/.cargo/registry/" rel);
   };
   cargoLock = {
     lockFile = ../packages/Cargo.lock;

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -40,8 +40,10 @@ let
   packagesSrc = lib.cleanSourceWith {
     src = ../packages;
     filter = path: type:
-      let rel = lib.removePrefix (toString ../packages + "/") (toString path);
-      in !(lib.hasInfix "target" rel || lib.hasInfix ".cargo/registry" rel);
+      let
+        rel = lib.removePrefix (toString ../packages + "/") (toString path);
+        parts = lib.splitString "/" rel;
+      in !(builtins.elem "target" parts || lib.hasPrefix ".cargo/registry/" rel || lib.hasInfix "/.cargo/registry/" rel);
   };
   nixlingWaylandFilterPackage = pkgs.rustPlatform.buildRustPackage {
     pname = "nixling-wayland-filter";

--- a/packages/nixling-contract-tests/tests/policy_source.rs
+++ b/packages/nixling-contract-tests/tests/policy_source.rs
@@ -91,6 +91,31 @@ fn is_excluded_dir(rel: &str) -> bool {
         .any(|c| matches!(*c, "target" | "tests" | ".git"))
 }
 
+#[test]
+fn nix_package_source_filters_are_path_segment_based() {
+    let files = [
+        "nixos-modules/host-daemon.nix",
+        "nixos-modules/host-broker.nix",
+        "nixos-modules/host-activation.nix",
+        "nixos-modules/processes-json.nix",
+        "nixos-modules/gateway-vm.nix",
+    ];
+
+    for rel in files {
+        let content = read_repo_file(rel);
+        assert!(
+            !content.contains("hasInfix \"target\" rel"),
+            "{rel}: package source filters must not substring-match `target`; \
+             that excludes legitimate files like \
+             packages/nixling-constellation-core/src/target.rs"
+        );
+        assert!(
+            content.contains("builtins.elem \"target\" parts"),
+            "{rel}: package source filter must exclude only a path segment named `target`"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Migrated from tests/no-bash-exec-eval.sh (v1.1 / ADR 0017: "the Rust CLI
 // never executes bash").


### PR DESCRIPTION
## Summary
- make Rust package source filters path-segment based so `src/target.rs` is not excluded
- add a source policy regression test for the filter shape

## Validation
- cargo test -p nixling-contract-tests nix_package_source_filters_are_path_segment_based --test policy_source --quiet
- bash tests/test-policy.sh
- make test-nix-unit
- nix eval cleanSource target.rs presence