### PR TITLE
bundle: add storage and sync contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Bundle: the private manifest bundle now emits `storage.json` and
+  `sync.json` contracts for managed paths, process restart/adoption
+  policies, degraded-state taxonomy, and lock/lease synchronization
+  policy.
 - Documentation: ADR 0034 and the storage lifecycle explanation now
   define the planned generated contracts for managed paths, process
   restart/adoption, synchronization, lock ownership, degraded-state
@@ -35,6 +39,8 @@ deprecations ship one minor release before removal.
 
 ### Changed
 
+- `bundleVersion` 5 → 6: adds the private storage lifecycle and
+  synchronization artifacts to the trusted bundle.
 - CI: pull requests now fail closed when Rust/Nix/Cargo changes do not
   update `CHANGELOG.md`, or when the changelog is missing
   `## [Unreleased]`, uses duplicate/out-of-order version headers, or

--- a/docs/reference/manifest-bundle.md
+++ b/docs/reference/manifest-bundle.md
@@ -16,6 +16,8 @@ world-readable system profile.
 | `bundle.json` | private bundle index | root:`nixlingd` `0640` | Bundle version, artifact paths, hashes, and compatibility policy. |
 | `host.json` | private host intent | root:`nixlingd` `0640` | Host requirements, network intent, kernel/device/fd requirements, and support tier. |
 | `processes.json` | private supervisor intent | root:`nixlingd` `0640` | Per-VM process DAG, readiness predicates, cgroup placement, and minijail profile IDs. |
+| `storage.json` | private storage lifecycle contract | root:`nixlingd` `0640` | Managed path inventory, restart/adoption policy, degraded-state taxonomy, cleanup/repair policy, and remediation IDs. |
+| `sync.json` | private synchronization contract | root:`nixlingd` `0640` | Lock inventory, OFD/fd-transfer policy, acquisition order, stale-owner policy, and lock degraded-state handling. |
 | `privileges.json` | private authorization policy | root:`nixlingd` `0640` | Public API/CLI authorization matrix and private broker operation matrix. |
 | `closures/<vm>.json` | private closure metadata | root:`nixlingd` `0640` | Per-VM toplevel, closure paths, declared-runner parity data, and generation metadata. |
 | `minijail-profile.json` | private sandbox profile catalog | root:`nixlingd` `0640` | Typed minijail profile fields, mount policy, and bounded start-as-root exceptions. |
@@ -37,8 +39,9 @@ The policy is defined by
 schema directory is `docs/reference/schemas/v2/`; the bundle and
 per-artifact schemas were bumped from `v1` to `v2` to land the
 host-prepare additions; the current emitted
-bundle keeps `schemaVersion = "v2"` and bumps `bundleVersion = 5`
-for the swtpm first-run hardening additions (issue #64)). Each artifact now carries a
+bundle keeps `schemaVersion = "v2"` and bumps `bundleVersion = 6`
+for the storage/restart/synchronization contract additions (ADR 0034).
+Each artifact now carries a
 matching v2 markdown companion beside the committed JSON schema.
 `cargo xtask gen-schemas` regenerates the JSON files under
 `schemas/v2/` from the Rust DTOs in `nixling-core` and
@@ -85,6 +88,8 @@ references below.
 | `bundle.json` | [`schemas/v2/bundle.md`](./schemas/v2/bundle.md) | `schemas/v2/bundle.json` |
 | `host.json` | [`schemas/v2/host.md`](./schemas/v2/host.md) | `schemas/v2/host.json` |
 | `processes.json` | [`schemas/v2/processes.md`](./schemas/v2/processes.md) | `schemas/v2/processes.json` |
+| `storage.json` | [`schemas/v2/storage.md`](./schemas/v2/storage.md) | `schemas/v2/storage.json` |
+| `sync.json` | [`schemas/v2/sync.md`](./schemas/v2/sync.md) | `schemas/v2/sync.json` |
 | `privileges.json` | [`schemas/v2/privileges.md`](./schemas/v2/privileges.md) | `schemas/v2/privileges.json` |
 | `closures/<vm>.json` | [`schemas/v2/closures.md`](./schemas/v2/closures.md) | `schemas/v2/closures.json` |
 | `minijail-profile.json` | [`schemas/v2/minijail-profile.md`](./schemas/v2/minijail-profile.md) | `schemas/v2/minijail-profile.json` |

--- a/docs/reference/schemas/v2/bundle.json
+++ b/docs/reference/schemas/v2/bundle.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "artifactHashes": {
-      "description": "Per-artifact SHA-256 hashes for tamper detection of every private bundle artifact loaded by the resolver.\n\nKeys match the path strings stored in the bundle path fields: absolute paths for `host_path`, `processes_path`, `privileges_path`; bundle-relative paths for `closures[*].path` and `minijail_profiles[*].path`.  Values are `\"sha256:<hex64>\"` strings.\n\nWhen `None`, per-artifact hash verification is skipped (backwards compatibility with bundles that pre-date this field).",
+      "description": "Per-artifact SHA-256 hashes for tamper detection of every private bundle artifact loaded by the resolver.\n\nKeys match the path strings stored in the bundle path fields: absolute paths for `host_path`, `processes_path`, `privileges_path`, `storage_path`, and `sync_path`; bundle-relative paths for `closures[*].path` and `minijail_profiles[*].path`. Values are `\"sha256:<hex64>\"` strings.\n\nWhen `None`, per-artifact hash verification is skipped (backwards compatibility with bundles that pre-date this field).",
       "type": [
         "object",
         "null"
@@ -33,7 +33,7 @@
       ]
     },
     "bundleVersion": {
-      "description": "Version of the bundle format; the current additive LiveNative mutating-verb rev is bundleVersion 4 while artifact schemaVersion stays v2.",
+      "description": "Version of the bundle format; bundleVersion 6 adds the private storage lifecycle and synchronization artifacts while artifact schemaVersion stays v2.",
       "type": "integer",
       "format": "uint32",
       "minimum": 0.0
@@ -92,6 +92,20 @@
     "schemaVersion": {
       "description": "Schema version directory used to validate all artifacts in this bundle.",
       "type": "string"
+    },
+    "storagePath": {
+      "description": "Private storage lifecycle artifact path.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "syncPath": {
+      "description": "Private synchronization/lock contract artifact path.",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "additionalProperties": false,

--- a/docs/reference/schemas/v2/bundle.md
+++ b/docs/reference/schemas/v2/bundle.md
@@ -5,15 +5,18 @@ Schema: [`bundle.json`](./bundle.json)
 `bundle.json` is the private bundle index installed beside the public
 `vms.json` manifest. It gives the daemon and broker one stable place to
 find the current `host.json`, `processes.json`, `privileges.json`,
-`closures/*.json`, and `minijail-profile.json` artifacts.
+`closures/*.json`, `storage.json`, `sync.json`, and
+`minijail-profile.json` artifacts.
 
 ## Top-level fields
 
 - `schemaVersion` — schema directory/version for every referenced artifact.
-- `bundleVersion` — additive bundle contract rev (`4` in the current tree).
+- `bundleVersion` — additive bundle contract rev (`6` in the current tree).
 - `publicManifestPath` — path to the public `vms.json` manifest.
 - `hostPath` — path to the private `host.json` artifact.
 - `processesPath` — path to the private `processes.json` artifact.
+- `storagePath` — path to the private `storage.json` artifact.
+- `syncPath` — path to the private `sync.json` artifact.
 - `privilegesPath` — path to the private `privileges.json` artifact.
 - `closures` — per-VM closure artifact paths.
 - `minijailProfiles` — shipped minijail profile metadata paths.

--- a/docs/reference/schemas/v2/storage.json
+++ b/docs/reference/schemas/v2/storage.json
@@ -1,0 +1,620 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "StorageJson",
+  "type": "object",
+  "required": [
+    "paths",
+    "schemaVersion"
+  ],
+  "properties": {
+    "degradedStates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DegradedStateSpec"
+      }
+    },
+    "paths": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/StoragePathSpec"
+      }
+    },
+    "remediations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RemediationSpec"
+      }
+    },
+    "restartPolicies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ProcessRestartPolicy"
+      }
+    },
+    "roots": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/StorageRoot"
+      }
+    },
+    "schemaVersion": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "AclGrant": {
+      "type": "object",
+      "required": [
+        "permissions",
+        "principal"
+      ],
+      "properties": {
+        "permissions": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "principal": {
+          "$ref": "#/definitions/PrincipalRef"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ActorKind": {
+      "type": "string",
+      "enum": [
+        "nix-module",
+        "daemon",
+        "broker",
+        "role",
+        "guest",
+        "operator",
+        "external"
+      ]
+    },
+    "ActorRef": {
+      "type": "object",
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ActorKind"
+        },
+        "value": {
+          "$ref": "#/definitions/ContractId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AdoptionInputs": {
+      "type": "object",
+      "properties": {
+        "cgroupLeaf": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContractId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "identityChecks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IdentityCheck"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "CleanupPolicy": {
+      "type": "string",
+      "enum": [
+        "never",
+        "boot",
+        "process-exit-with-proof",
+        "vm-stop-with-proof",
+        "cutover-only",
+        "external"
+      ]
+    },
+    "ContractId": {
+      "description": "Bounded storage/synchronization contract identifier.",
+      "type": "string",
+      "maxLength": 160,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$"
+    },
+    "ContractText": {
+      "description": "Bounded human-readable contract text.",
+      "type": "string",
+      "maxLength": 512,
+      "minLength": 1,
+      "pattern": "^[^\\u0000]*$"
+    },
+    "DegradeScope": {
+      "type": "string",
+      "enum": [
+        "role",
+        "vm",
+        "host",
+        "realm"
+      ]
+    },
+    "DegradedReason": {
+      "type": "string",
+      "enum": [
+        "storage-drift",
+        "storage-repair-failed",
+        "adoption-pending",
+        "adoption-quarantined",
+        "restart-required",
+        "lock-owner-ambiguous",
+        "lock-acquire-timeout",
+        "external-dependency-unhealthy",
+        "migration-required",
+        "migration-failed",
+        "violation-audit-throttled",
+        "role-component-degraded"
+      ]
+    },
+    "DegradedStateSpec": {
+      "type": "object",
+      "required": [
+        "reason",
+        "remediationId",
+        "scope",
+        "storageClass"
+      ],
+      "properties": {
+        "reason": {
+          "$ref": "#/definitions/DegradedReason"
+        },
+        "remediationId": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "scope": {
+          "$ref": "#/definitions/DegradeScope"
+        },
+        "storageClass": {
+          "$ref": "#/definitions/LedgerStorageClass"
+        }
+      },
+      "additionalProperties": false
+    },
+    "IdentityCheck": {
+      "type": "string",
+      "enum": [
+        "cgroup-membership",
+        "executable-path",
+        "profile-id",
+        "cmdline-shape",
+        "start-time-diagnostic",
+        "pidfd-open-after-candidate-read"
+      ]
+    },
+    "LeaseClass": {
+      "type": "string",
+      "enum": [
+        "none",
+        "process-pidfd",
+        "cgroup-leaf",
+        "file-record",
+        "external"
+      ]
+    },
+    "LedgerStorageClass": {
+      "type": "string",
+      "enum": [
+        "tamper-evident-segmented",
+        "append-only-bounded",
+        "plain-bounded-diagnostic"
+      ]
+    },
+    "PathTemplate": {
+      "description": "Absolute path template with typed variables expanded by the broker.",
+      "type": "string",
+      "maxLength": 1024,
+      "minLength": 1,
+      "pattern": "^/[^\\u0000]*$"
+    },
+    "PrincipalKind": {
+      "type": "string",
+      "enum": [
+        "user",
+        "group",
+        "uid",
+        "gid",
+        "role",
+        "none"
+      ]
+    },
+    "PrincipalRef": {
+      "type": "object",
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/PrincipalKind"
+        },
+        "value": {
+          "$ref": "#/definitions/ContractId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ProcessRestartPolicy": {
+      "type": "object",
+      "required": [
+        "adoptionInputs",
+        "cleanupBeforeRestart",
+        "degradeOnFailure",
+        "degradeScope",
+        "readinessAfterAdopt",
+        "remediationId",
+        "restartClass",
+        "roleId",
+        "vm"
+      ],
+      "properties": {
+        "adoptionInputs": {
+          "$ref": "#/definitions/AdoptionInputs"
+        },
+        "cleanupBeforeRestart": {
+          "type": "boolean"
+        },
+        "degradeOnFailure": {
+          "$ref": "#/definitions/DegradedReason"
+        },
+        "degradeScope": {
+          "$ref": "#/definitions/DegradeScope"
+        },
+        "persistentStateRefs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContractId"
+          }
+        },
+        "readinessAfterAdopt": {
+          "$ref": "#/definitions/ReadinessAfterAdopt"
+        },
+        "remediationId": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "restartClass": {
+          "$ref": "#/definitions/RestartClass"
+        },
+        "roleId": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "runtimeStateRefs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContractId"
+          }
+        },
+        "vm": {
+          "$ref": "#/definitions/ContractId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReadinessAfterAdopt": {
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ReadinessAfterAdoptKind"
+        },
+        "storageRef": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContractId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReadinessAfterAdoptKind": {
+      "type": "string",
+      "enum": [
+        "existing-predicate",
+        "unix-socket-listening",
+        "pidfd-alive",
+        "external-probe",
+        "none"
+      ]
+    },
+    "RemediationSpec": {
+      "type": "object",
+      "required": [
+        "command",
+        "description",
+        "id"
+      ],
+      "properties": {
+        "command": {
+          "$ref": "#/definitions/ContractText"
+        },
+        "description": {
+          "$ref": "#/definitions/ContractText"
+        },
+        "id": {
+          "$ref": "#/definitions/ContractId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RepairPolicy": {
+      "type": "string",
+      "enum": [
+        "none",
+        "nix-activation",
+        "broker-reconcile",
+        "broker-fail-closed",
+        "operator-only"
+      ]
+    },
+    "RestartClass": {
+      "type": "string",
+      "enum": [
+        "adoptable",
+        "recreatable",
+        "stateful-quarantine",
+        "non-resumable",
+        "external-observed"
+      ]
+    },
+    "SensitivityClass": {
+      "type": "string",
+      "enum": [
+        "public",
+        "private",
+        "secret-adjacent",
+        "audit",
+        "realm-scoped"
+      ]
+    },
+    "StorageAdoptionPolicy": {
+      "type": "string",
+      "enum": [
+        "adopt-with-live-owner-proof",
+        "recreate-from-persistent",
+        "quarantine-on-ambiguity",
+        "delete-if-owner-dead",
+        "not-adoptable"
+      ]
+    },
+    "StorageAuthority": {
+      "type": "string",
+      "enum": [
+        "nix-module",
+        "daemon",
+        "broker",
+        "guest",
+        "external"
+      ]
+    },
+    "StorageInvariant": {
+      "type": "string",
+      "enum": [
+        "no-symlink",
+        "no-magic-link",
+        "no-recursive-mutation",
+        "same-filesystem",
+        "hardlink-farm-no-recursion",
+        "broker-opaque-id-only",
+        "root-owned-parent",
+        "scope-authorization-required"
+      ]
+    },
+    "StorageLifecycle": {
+      "type": "string",
+      "enum": [
+        "config",
+        "persistent",
+        "boot-scoped-readoptable",
+        "boot-scoped-disposable",
+        "process-scoped",
+        "external-observe-only"
+      ]
+    },
+    "StoragePathKind": {
+      "type": "string",
+      "enum": [
+        "directory",
+        "regular-file",
+        "unix-socket",
+        "symlink",
+        "device-node",
+        "external-grant-only"
+      ]
+    },
+    "StoragePathSpec": {
+      "type": "object",
+      "required": [
+        "adoptionPolicy",
+        "cleanupPolicy",
+        "creator",
+        "group",
+        "id",
+        "kind",
+        "leaseClass",
+        "lifecycle",
+        "mode",
+        "noFollow",
+        "owner",
+        "pathTemplate",
+        "persistence",
+        "recursive",
+        "repairPolicy",
+        "restartPolicy",
+        "scope",
+        "sensitivity"
+      ],
+      "properties": {
+        "accessAcl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AclGrant"
+          }
+        },
+        "adoptionPolicy": {
+          "$ref": "#/definitions/StorageAdoptionPolicy"
+        },
+        "cleanupPolicy": {
+          "$ref": "#/definitions/CleanupPolicy"
+        },
+        "creator": {
+          "$ref": "#/definitions/ActorRef"
+        },
+        "defaultAcl": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AclGrant"
+          }
+        },
+        "group": {
+          "$ref": "#/definitions/PrincipalRef"
+        },
+        "id": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "invariants": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StorageInvariant"
+          }
+        },
+        "kind": {
+          "$ref": "#/definitions/StoragePathKind"
+        },
+        "leaseClass": {
+          "$ref": "#/definitions/LeaseClass"
+        },
+        "lifecycle": {
+          "$ref": "#/definitions/StorageLifecycle"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "noFollow": {
+          "type": "boolean"
+        },
+        "owner": {
+          "$ref": "#/definitions/PrincipalRef"
+        },
+        "pathTemplate": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "persistence": {
+          "$ref": "#/definitions/StoragePersistence"
+        },
+        "readers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActorRef"
+          }
+        },
+        "recursive": {
+          "type": "boolean"
+        },
+        "repairPolicy": {
+          "$ref": "#/definitions/RepairPolicy"
+        },
+        "restartPolicy": {
+          "$ref": "#/definitions/StorageRestartPolicy"
+        },
+        "scope": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "sensitivity": {
+          "$ref": "#/definitions/SensitivityClass"
+        },
+        "writers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActorRef"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "StoragePersistence": {
+      "type": "string",
+      "enum": [
+        "persistent",
+        "boot-scoped",
+        "process-scoped",
+        "regenerable",
+        "external"
+      ]
+    },
+    "StorageRestartPolicy": {
+      "type": "string",
+      "enum": [
+        "preserve-across-daemon-restart",
+        "recreate-after-owner-death",
+        "cleanup-after-owner-death",
+        "manual-recovery",
+        "not-applicable"
+      ]
+    },
+    "StorageRoot": {
+      "type": "object",
+      "required": [
+        "authority",
+        "class",
+        "group",
+        "id",
+        "mode",
+        "owner",
+        "path"
+      ],
+      "properties": {
+        "authority": {
+          "$ref": "#/definitions/StorageAuthority"
+        },
+        "class": {
+          "$ref": "#/definitions/StorageRootClass"
+        },
+        "group": {
+          "$ref": "#/definitions/PrincipalRef"
+        },
+        "id": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "owner": {
+          "$ref": "#/definitions/PrincipalRef"
+        },
+        "path": {
+          "$ref": "#/definitions/PathTemplate"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StorageRootClass": {
+      "type": "string",
+      "enum": [
+        "config",
+        "persistent",
+        "runtime",
+        "cache",
+        "external-observe-only"
+      ]
+    }
+  }
+}

--- a/docs/reference/schemas/v2/storage.md
+++ b/docs/reference/schemas/v2/storage.md
@@ -1,0 +1,35 @@
+# `storage.json` schema (`v2`)
+
+Schema: [`storage.json`](./storage.json)
+
+`storage.json` is the private storage lifecycle contract selected by
+[ADR 0034](../../adr/0034-storage-lifecycle-restart-and-synchronization.md).
+It inventories nixling-managed paths, their lifecycle, owners, ACL posture,
+cleanup policy, restart/adoption policy, degraded-state taxonomy, and static
+remediation IDs.
+
+The artifact is private (`root:nixlingd` `0640`) and is broker authority
+only when referenced through opaque bundle ids. Daemon-owned degraded ledgers
+and operator-facing status output are diagnostics, not privileged repair
+authority.
+
+## Top-level fields
+
+- `schemaVersion` — schema version for this artifact.
+- `roots` — declared root directories such as `/etc/nixling`,
+  `/var/lib/nixling`, and `/run/nixling`.
+- `paths` — storage path specs with kind, lifecycle, owner/group/mode,
+  access/default ACLs, cleanup/repair/restart/adoption policy, sensitivity,
+  and invariants.
+- `restartPolicies` — per-VM/per-role restart classes and adoption inputs.
+- `degradedStates` — closed degraded-state reason slugs and storage class.
+- `remediations` — static remediation IDs and human-facing commands.
+
+## Contract notes
+
+- Pidfds are never persisted. Restart policies may persist only logical
+  adoption metadata such as cgroup leaf and identity checks.
+- Runtime paths are not swept on daemon restart until live-owner adoption or
+  dead-owner proof has completed.
+- Path hashes are for structured audit/local doctor output only; they must
+  never become metric labels.

--- a/docs/reference/schemas/v2/sync.json
+++ b/docs/reference/schemas/v2/sync.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SyncJson",
+  "type": "object",
+  "required": [
+    "locks",
+    "schemaVersion"
+  ],
+  "properties": {
+    "locks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LockSpec"
+      }
+    },
+    "schemaVersion": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "ActorKind": {
+      "type": "string",
+      "enum": [
+        "nix-module",
+        "daemon",
+        "broker",
+        "role",
+        "guest",
+        "operator",
+        "external"
+      ]
+    },
+    "ActorRef": {
+      "type": "object",
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ActorKind"
+        },
+        "value": {
+          "$ref": "#/definitions/ContractId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ContractId": {
+      "description": "Bounded storage/synchronization contract identifier.",
+      "type": "string",
+      "maxLength": 160,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$"
+    },
+    "DegradeScope": {
+      "type": "string",
+      "enum": [
+        "role",
+        "vm",
+        "host",
+        "realm"
+      ]
+    },
+    "DegradedReason": {
+      "type": "string",
+      "enum": [
+        "storage-drift",
+        "storage-repair-failed",
+        "adoption-pending",
+        "adoption-quarantined",
+        "restart-required",
+        "lock-owner-ambiguous",
+        "lock-acquire-timeout",
+        "external-dependency-unhealthy",
+        "migration-required",
+        "migration-failed",
+        "violation-audit-throttled",
+        "role-component-degraded"
+      ]
+    },
+    "FdPassingMechanism": {
+      "type": "string",
+      "enum": [
+        "none",
+        "scm-rights",
+        "explicit-fd-mapping"
+      ]
+    },
+    "FdPassingPolicy": {
+      "type": "object",
+      "required": [
+        "leaseTransferRecordRequired",
+        "mechanism"
+      ],
+      "properties": {
+        "leaseTransferRecordRequired": {
+          "type": "boolean"
+        },
+        "mechanism": {
+          "$ref": "#/definitions/FdPassingMechanism"
+        }
+      },
+      "additionalProperties": false
+    },
+    "InheritancePolicy": {
+      "type": "string",
+      "enum": [
+        "close-on-exec",
+        "explicit-fd-mapping-only",
+        "scm-rights-only",
+        "not-applicable"
+      ]
+    },
+    "LockAcquireOrder": {
+      "type": "object",
+      "required": [
+        "anchoredRoot",
+        "lockId",
+        "normalizedPath",
+        "scopeClass"
+      ],
+      "properties": {
+        "anchoredRoot": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "lockId": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "normalizedPath": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "scopeClass": {
+          "$ref": "#/definitions/LockScopeClass"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LockAdoptionPolicy": {
+      "type": "string",
+      "enum": [
+        "reacquire-after-proof",
+        "transfer-with-lease-record",
+        "quarantine-on-ambiguity",
+        "not-adoptable"
+      ]
+    },
+    "LockKind": {
+      "type": "string",
+      "enum": [
+        "ofd",
+        "file-record",
+        "in-process",
+        "kernel-object"
+      ]
+    },
+    "LockScopeClass": {
+      "type": "string",
+      "enum": [
+        "global",
+        "host",
+        "vm",
+        "role",
+        "external"
+      ]
+    },
+    "LockSpec": {
+      "type": "object",
+      "required": [
+        "acquireOrder",
+        "adoptionPolicy",
+        "cloexecRequired",
+        "degradeScope",
+        "fdPassingPolicy",
+        "id",
+        "inheritancePolicy",
+        "kind",
+        "ownerProcess",
+        "releaseAuthority",
+        "scope",
+        "stalePolicy",
+        "timeoutPolicy"
+      ],
+      "properties": {
+        "acquireOrder": {
+          "$ref": "#/definitions/LockAcquireOrder"
+        },
+        "adoptionPolicy": {
+          "$ref": "#/definitions/LockAdoptionPolicy"
+        },
+        "allowedHolders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActorRef"
+          }
+        },
+        "cloexecRequired": {
+          "type": "boolean"
+        },
+        "degradeScope": {
+          "$ref": "#/definitions/DegradeScope"
+        },
+        "fdPassingPolicy": {
+          "$ref": "#/definitions/FdPassingPolicy"
+        },
+        "id": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "inheritancePolicy": {
+          "$ref": "#/definitions/InheritancePolicy"
+        },
+        "kind": {
+          "$ref": "#/definitions/LockKind"
+        },
+        "ownerProcess": {
+          "$ref": "#/definitions/ActorRef"
+        },
+        "pathTemplate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PathTemplate"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "releaseAuthority": {
+          "$ref": "#/definitions/ActorRef"
+        },
+        "resourceId": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContractId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scope": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "stalePolicy": {
+          "$ref": "#/definitions/LockStalePolicy"
+        },
+        "timeoutPolicy": {
+          "$ref": "#/definitions/LockTimeoutPolicy"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LockStaleKind": {
+      "type": "string",
+      "enum": [
+        "pidfd-proof-required",
+        "cgroup-empty-proof-required",
+        "file-record-owner-match",
+        "cutover-only",
+        "manual-recovery"
+      ]
+    },
+    "LockStalePolicy": {
+      "type": "object",
+      "required": [
+        "degradedReason",
+        "kind"
+      ],
+      "properties": {
+        "degradedReason": {
+          "$ref": "#/definitions/DegradedReason"
+        },
+        "kind": {
+          "$ref": "#/definitions/LockStaleKind"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LockTimeoutKind": {
+      "type": "string",
+      "enum": [
+        "fail-fast",
+        "bounded-wait",
+        "no-wait"
+      ]
+    },
+    "LockTimeoutPolicy": {
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/LockTimeoutKind"
+        },
+        "timeoutMs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "PathTemplate": {
+      "description": "Absolute path template with typed variables expanded by the broker.",
+      "type": "string",
+      "maxLength": 1024,
+      "minLength": 1,
+      "pattern": "^/[^\\u0000]*$"
+    }
+  }
+}

--- a/docs/reference/schemas/v2/sync.md
+++ b/docs/reference/schemas/v2/sync.md
@@ -1,0 +1,24 @@
+# `sync.json` schema (`v2`)
+
+Schema: [`sync.json`](./sync.json)
+
+`sync.json` is the private synchronization and lock contract selected by
+[ADR 0034](../../adr/0034-storage-lifecycle-restart-and-synchronization.md).
+It declares framework locks, holders, fd inheritance policy, fd transfer
+mechanism, acquisition order, stale-owner policy, adoption behavior, and
+degraded-state handling.
+
+## Top-level fields
+
+- `schemaVersion` — schema version for this artifact.
+- `locks` — lock specs keyed by stable lock id.
+
+## Contract notes
+
+- New advisory file locks use Linux OFD locks (`F_OFD_SETLK`).
+- Lock fds are opened with `O_CLOEXEC` and are not inherited by runner
+  payloads unless the sync spec explicitly allows `SCM_RIGHTS` or explicit
+  fd mapping plus a lease transfer record.
+- Multi-lock operations acquire locks through the declared total order.
+- Ambiguous owner state degrades/quarantines the protected scope rather than
+  force-unlocking behind a possible live owner.

--- a/flake.nix
+++ b/flake.nix
@@ -331,6 +331,8 @@
           cp ${bundle.privilegesJson.path} $out/privileges.json
           cp ${bundle.hostJson.path} $out/host.json
           cp ${bundle.processesJson.path} $out/processes.json
+          cp ${bundle.storageJson.path} $out/storage.json
+          cp ${bundle.syncJson.path} $out/sync.json
           cp ${bundle.bundle.path} $out/bundle.json
           cp ${manifestPkg}/share/nixling/vms.json $out/manifest.json
           ${nixpkgs.lib.concatStringsSep "\n" (nixpkgs.lib.mapAttrsToList
@@ -405,6 +407,8 @@
           cp ${bundle.privilegesJson.path} $out/privileges.json
           cp ${bundle.hostJson.path} $out/host.json
           cp ${bundle.processesJson.path} $out/processes.json
+          cp ${bundle.storageJson.path} $out/storage.json
+          cp ${bundle.syncJson.path} $out/sync.json
           cp ${bundle.bundle.path} $out/bundle.json
           cp ${manifestPkg}/share/nixling/vms.json $out/manifest.json
           ${nixpkgs.lib.concatStringsSep "\n" (nixpkgs.lib.mapAttrsToList

--- a/nixos-modules/bundle.nix
+++ b/nixos-modules/bundle.nix
@@ -50,6 +50,14 @@ let
         key = "/etc/nixling/privileges.json";
         path = config.nixling._bundle.privilegesJson.path;
       }
+      {
+        key = "/etc/nixling/storage.json";
+        path = config.nixling._bundle.storageJson.path;
+      }
+      {
+        key = "/etc/nixling/sync.json";
+        path = config.nixling._bundle.syncJson.path;
+      }
     ]
     ++ map (ref: {
       key = ref.path;
@@ -68,12 +76,14 @@ let
   # presence of this field; the resolver nullifies it before comparing.
   dataWithoutHash = {
     artifactHashes = null;
-    bundleVersion = 5;
+    bundleVersion = 6;
     schemaVersion = "v2";
     publicManifestPath = "/run/current-system/sw/share/nixling/vms.json";
     hostPath = "/etc/nixling/host.json";
     processesPath = "/etc/nixling/processes.json";
     privilegesPath = "/etc/nixling/privileges.json";
+    storagePath = "/etc/nixling/storage.json";
+    syncPath = "/etc/nixling/sync.json";
     closures = closureRefs;
     minijailProfiles = profileRefs;
     managedKeys = {

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -54,6 +54,8 @@
     ./guest-control-host.nix
     ./host-json.nix
     ./processes-json.nix
+    ./storage-json.nix
+    ./sync-json.nix
     ./privileges-json.nix
     ./closures-json.nix
     ./minijail-profiles.nix

--- a/nixos-modules/storage-json.nix
+++ b/nixos-modules/storage-json.nix
@@ -1,0 +1,370 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.nixling;
+  processDags = cfg._bundle.processesJson.data.vms or [ ];
+
+  privateEtc = source: {
+    inherit source;
+    mode = "0640";
+    user = "root";
+    group = if cfg.daemonExperimental.enable then "nixlingd" else "root";
+  };
+
+  actor = kind: value: { inherit kind value; };
+  principal = kind: value: { inherit kind value; };
+  uidPrincipal = uid: principal "uid" (toString uid);
+  gidPrincipal = gid: principal "gid" (toString gid);
+
+  pathId = prefix: path: "${prefix}:${builtins.hashString "sha256" (builtins.unsafeDiscardStringContext path)}";
+  modeForKind = kind:
+    if kind == "unix-socket" then "0660"
+    else if kind == "regular-file" then "0640"
+    else "0750";
+  modeString = mode:
+    if mode == 384 then "0600"
+    else if mode == 416 then "0640"
+    else if mode == 432 then "0660"
+    else toString mode;
+
+  mkPath =
+    {
+      id,
+      scope,
+      path,
+      kind ? "directory",
+      lifecycle ? "persistent",
+      persistence ? "persistent",
+      owner ? principal "user" "nixlingd",
+      group ? principal "group" "nixlingd",
+      mode ? modeForKind kind,
+      creator ? actor "broker" "nixling-priv-broker",
+      writers ? [ creator ],
+      readers ? [ (actor "daemon" "nixlingd") ],
+      cleanupPolicy ? "never",
+      repairPolicy ? "broker-reconcile",
+      restartPolicy ? "preserve-across-daemon-restart",
+      adoptionPolicy ? "adopt-with-live-owner-proof",
+      leaseClass ? "none",
+      sensitivity ? "private",
+      noFollow ? true,
+      recursive ? false,
+      invariants ? [ "no-symlink" "broker-opaque-id-only" ],
+    }:
+    {
+      inherit
+        id
+        scope
+        kind
+        lifecycle
+        persistence
+        owner
+        group
+        mode
+        creator
+        writers
+        readers
+        cleanupPolicy
+        repairPolicy
+        restartPolicy
+        adoptionPolicy
+        leaseClass
+        sensitivity
+        noFollow
+        recursive
+        invariants
+        ;
+      pathTemplate = path;
+      accessAcl = [ ];
+      defaultAcl = [ ];
+    };
+
+  bundleArtifactPaths = [
+    "/etc/nixling/bundle.json"
+    "/etc/nixling/host.json"
+    "/etc/nixling/processes.json"
+    "/etc/nixling/privileges.json"
+    "/etc/nixling/storage.json"
+    "/etc/nixling/sync.json"
+  ];
+
+  basePaths = [
+    (mkPath {
+      id = "path:etc-root";
+      scope = "host";
+      path = "/etc/nixling";
+      lifecycle = "config";
+      persistence = "persistent";
+      owner = principal "user" "root";
+      group = principal "group" "nixlingd";
+      creator = actor "nix-module" "environment.etc";
+      writers = [ (actor "nix-module" "environment.etc") ];
+      cleanupPolicy = "never";
+      repairPolicy = "nix-activation";
+      restartPolicy = "not-applicable";
+      adoptionPolicy = "not-adoptable";
+    })
+    (mkPath {
+      id = "path:state-root";
+      scope = "host";
+      path = toString cfg.site.stateDir;
+      persistence = "persistent";
+      owner = principal "user" "root";
+      group = principal "group" "nixlingd";
+      creator = actor "nix-module" "tmpfiles";
+    })
+    (mkPath {
+      id = "path:run-root";
+      scope = "host";
+      path = "/run/nixling";
+      lifecycle = "boot-scoped-readoptable";
+      persistence = "boot-scoped";
+      owner = principal "user" "nixlingd";
+      group = principal "group" "nixling";
+      mode = "0750";
+      creator = actor "nix-module" "tmpfiles";
+      cleanupPolicy = "boot";
+      leaseClass = "process-pidfd";
+    })
+  ] ++ map
+    (path: mkPath {
+      id = pathId "path:artifact" path;
+      scope = "host";
+      inherit path;
+      kind = "regular-file";
+      lifecycle = "config";
+      persistence = "persistent";
+      owner = principal "user" "root";
+      group = principal "group" "nixlingd";
+      creator = actor "nix-module" "environment.etc";
+      writers = [ (actor "nix-module" "environment.etc") ];
+      cleanupPolicy = "never";
+      repairPolicy = "nix-activation";
+      restartPolicy = "not-applicable";
+      adoptionPolicy = "not-adoptable";
+      sensitivity = "private";
+    })
+    bundleArtifactPaths;
+
+  nodeWritablePaths = lib.flatten (map
+    (dag: lib.flatten (map
+      (node: map
+        (writable:
+          mkPath {
+            id = pathId "path:writable" "${dag.vm}:${node.id}:${writable.path}";
+            scope = "role:${dag.vm}:${node.id}";
+            path = writable.path;
+            lifecycle =
+              if lib.hasPrefix "/run/" writable.path then "boot-scoped-readoptable" else "persistent";
+            persistence =
+              if lib.hasPrefix "/run/" writable.path then "boot-scoped" else "persistent";
+            owner = uidPrincipal node.profile.uid;
+            group = gidPrincipal node.profile.gid;
+            creator = actor "broker" "nixling-priv-broker";
+            writers = [ (actor "role" "role:${dag.vm}:${node.id}") ];
+            readers = [
+              (actor "daemon" "nixlingd")
+              (actor "role" "role:${dag.vm}:${node.id}")
+            ];
+            cleanupPolicy =
+              if lib.hasPrefix "/run/" writable.path then "process-exit-with-proof" else "never";
+            repairPolicy = "broker-reconcile";
+            leaseClass =
+              if lib.hasPrefix "/run/" writable.path then "process-pidfd" else "none";
+            invariants = [ "no-symlink" "broker-opaque-id-only" ];
+          })
+        (node.profile.mountPolicy.writablePaths or [ ]))
+      (dag.nodes or [ ])))
+    processDags);
+
+  readinessSocketPaths = lib.flatten (map
+    (dag: lib.flatten (map
+      (node: map
+        (ready:
+          mkPath {
+            id = pathId "path:readiness" "${dag.vm}:${node.id}:${ready.value}";
+            scope = "role:${dag.vm}:${node.id}";
+            path = ready.value;
+            kind = "unix-socket";
+            lifecycle = "boot-scoped-readoptable";
+            persistence = "boot-scoped";
+            owner = uidPrincipal node.profile.uid;
+            group = gidPrincipal node.profile.gid;
+            creator = actor "role" "role:${dag.vm}:${node.id}";
+            writers = [ (actor "role" "role:${dag.vm}:${node.id}") ];
+            readers = [
+              (actor "daemon" "nixlingd")
+              (actor "broker" "nixling-priv-broker")
+            ];
+            cleanupPolicy = "process-exit-with-proof";
+            leaseClass = "process-pidfd";
+            sensitivity = "private";
+          })
+        (lib.filter
+          (ready: builtins.elem (ready.kind or "") [ "unix-socket-exists" "unix-socket-listening" ])
+          (node.readiness or [ ])))
+      (dag.nodes or [ ])))
+    processDags);
+
+  diskInitPaths = lib.flatten (map
+    (dag: lib.flatten (map
+      (node: map
+        (op:
+          mkPath {
+            id = pathId "path:disk-init" "${dag.vm}:${node.id}:${op.targetPath}";
+            scope = "role:${dag.vm}:${node.id}";
+            path = op.targetPath;
+            kind = "regular-file";
+            lifecycle = "persistent";
+            persistence = "persistent";
+            owner = uidPrincipal op.ownerUid;
+            group = gidPrincipal op.ownerGid;
+            mode = modeString op.mode;
+            creator = actor "broker" "nixling-priv-broker";
+            writers = [ (actor "broker" "nixling-priv-broker") ];
+            readers = [ (actor "role" "role:${dag.vm}:cloud-hypervisor") ];
+            cleanupPolicy = "never";
+            repairPolicy = "broker-reconcile";
+            leaseClass = "none";
+            invariants = [ "no-symlink" "broker-opaque-id-only" "root-owned-parent" ];
+          })
+        (lib.filter (op: (op.kind or "") == "diskInit") (node.planOps or [ ])))
+      (dag.nodes or [ ])))
+    processDags);
+
+  adoptableRoles = [
+    "audio"
+    "cloud-hypervisor-runner"
+    "gpu"
+    "gpu-render-node"
+    "otel-host-bridge"
+    "swtpm"
+    "usbip"
+    "video"
+    "virtiofsd"
+    "vsock-relay"
+    "wayland-proxy"
+  ];
+
+  restartPolicyFor = dag: node:
+    let
+      role = node.role;
+      adoptable = builtins.elem role adoptableRoles;
+    in {
+      vm = dag.vm;
+      roleId = node.id;
+      restartClass = if adoptable then "adoptable" else "recreatable";
+      adoptionInputs = {
+        cgroupLeaf = node.profile.cgroupPlacement.subtree or null;
+        identityChecks = lib.optionals adoptable [
+          "cgroup-membership"
+          "executable-path"
+          "profile-id"
+          "pidfd-open-after-candidate-read"
+        ];
+      };
+      persistentStateRefs = [ ];
+      runtimeStateRefs = [ ];
+      cleanupBeforeRestart = false;
+      degradeOnFailure = if adoptable then "adoption-quarantined" else "restart-required";
+      degradeScope = "role";
+      readinessAfterAdopt = {
+        kind = if adoptable then "existing-predicate" else "none";
+        storageRef = null;
+      };
+      remediationId = if adoptable then "remediate:vm-status" else "remediate:vm-restart";
+    };
+
+  degradedStates = map
+    (reason: {
+      inherit reason;
+      scope = "role";
+      storageClass = "tamper-evident-segmented";
+      remediationId = "remediate:host-doctor";
+    })
+    [
+      "storage-drift"
+      "storage-repair-failed"
+      "adoption-pending"
+      "adoption-quarantined"
+      "restart-required"
+      "lock-owner-ambiguous"
+      "lock-acquire-timeout"
+      "external-dependency-unhealthy"
+      "migration-required"
+      "migration-failed"
+      "violation-audit-throttled"
+    ];
+
+  data = {
+    schemaVersion = "v2";
+    roots = [
+      {
+        id = "root:etc";
+        path = "/etc/nixling";
+        class = "config";
+        owner = principal "user" "root";
+        group = principal "group" "nixlingd";
+        mode = "0750";
+        authority = "nix-module";
+      }
+      {
+        id = "root:state";
+        path = toString cfg.site.stateDir;
+        class = "persistent";
+        owner = principal "user" "root";
+        group = principal "group" "nixlingd";
+        mode = "0750";
+        authority = "broker";
+      }
+      {
+        id = "root:run";
+        path = "/run/nixling";
+        class = "runtime";
+        owner = principal "user" "nixlingd";
+        group = principal "group" "nixling";
+        mode = "0750";
+        authority = "daemon";
+      }
+    ];
+    paths = basePaths ++ nodeWritablePaths ++ readinessSocketPaths ++ diskInitPaths;
+    restartPolicies = lib.flatten (map (dag: map (node: restartPolicyFor dag node) (dag.nodes or [ ])) processDags);
+    degradedStates = degradedStates;
+    remediations = [
+      {
+        id = "remediate:host-doctor";
+        command = "nixling host doctor --storage --read-only";
+        description = "Inspect storage/degraded state without mutating the host.";
+      }
+      {
+        id = "remediate:vm-status";
+        command = "nixling vm status <vm>";
+        description = "Inspect the VM's role-level degraded state and adoption evidence.";
+      }
+      {
+        id = "remediate:vm-restart";
+        command = "nixling vm restart <vm> --apply";
+        description = "Restart a VM whose role cannot be safely re-adopted.";
+      }
+    ];
+  };
+
+  jsonText = builtins.toJSON data;
+  jsonFile = pkgs.writeText "nixling-storage.json" jsonText;
+in
+{
+  options.nixling._bundle.storageJson = lib.mkOption {
+    type = lib.types.unspecified;
+    readOnly = true;
+    internal = true;
+    description = "Internal schema-v2 storage lifecycle artifact metadata.";
+  };
+
+  config = {
+    nixling._bundle.storageJson = {
+      inherit data jsonText;
+      path = "${jsonFile}";
+    };
+    environment.etc."nixling/storage.json" = privateEtc jsonFile;
+  };
+}

--- a/nixos-modules/sync-json.nix
+++ b/nixos-modules/sync-json.nix
@@ -1,0 +1,156 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.nixling;
+  enabledVms = lib.filterAttrs (_: vm: vm.enable) cfg.vms;
+
+  privateEtc = source: {
+    inherit source;
+    mode = "0640";
+    user = "root";
+    group = if cfg.daemonExperimental.enable then "nixlingd" else "root";
+  };
+
+  actor = kind: value: { inherit kind value; };
+  lockId = prefix: key: "${prefix}:${builtins.hashString "sha256" key}";
+
+  fdNone = {
+    mechanism = "none";
+    leaseTransferRecordRequired = false;
+  };
+
+  order = scopeClass: root: normalizedPath: id: {
+    inherit scopeClass normalizedPath;
+    anchoredRoot = root;
+    lockId = id;
+  };
+
+  ofdLock = { id, scope, path, owner ? actor "daemon" "nixlingd", scopeClass ? "host", root ? "run" }: {
+    inherit id scope;
+    pathTemplate = path;
+    resourceId = null;
+    kind = "ofd";
+    ownerProcess = owner;
+    allowedHolders = [ owner ];
+    inheritancePolicy = "close-on-exec";
+    fdPassingPolicy = fdNone;
+    acquireOrder = order scopeClass root id id;
+    timeoutPolicy = {
+      kind = "fail-fast";
+      timeoutMs = null;
+    };
+    stalePolicy = {
+      kind = "pidfd-proof-required";
+      degradedReason = "lock-owner-ambiguous";
+    };
+    adoptionPolicy = "reacquire-after-proof";
+    degradeScope = if scopeClass == "vm" then "vm" else "host";
+    releaseAuthority = owner;
+    cloexecRequired = true;
+  };
+
+  inProcessLock = vm: {
+    id = "lock:op:${vm}";
+    scope = "vm:${vm}";
+    pathTemplate = null;
+    resourceId = "op-lock:${vm}";
+    kind = "in-process";
+    ownerProcess = actor "daemon" "nixlingd";
+    allowedHolders = [ (actor "daemon" "nixlingd") ];
+    inheritancePolicy = "not-applicable";
+    fdPassingPolicy = fdNone;
+    acquireOrder = order "vm" "daemon" "op-lock:${vm}" "lock:op:${vm}";
+    timeoutPolicy = {
+      kind = "bounded-wait";
+      timeoutMs = 60000;
+    };
+    stalePolicy = {
+      kind = "manual-recovery";
+      degradedReason = "lock-owner-ambiguous";
+    };
+    adoptionPolicy = "quarantine-on-ambiguity";
+    degradeScope = "vm";
+    releaseAuthority = actor "daemon" "nixlingd";
+    cloexecRequired = true;
+  };
+
+  storeSyncLock = vm: ofdLock {
+    id = "lock:store-sync:${vm}";
+    scope = "vm:${vm}";
+    path = "${toString cfg.store.stateDir}/${vm}/store-view/sync.lock";
+    owner = actor "broker" "nixling-priv-broker";
+    scopeClass = "vm";
+    root = "state";
+  };
+
+  usbipLock = vm: busid:
+    let
+      id = lockId "lock:usbip" "${vm}:${busid}";
+    in {
+      inherit id;
+      scope = "vm:${vm}";
+      pathTemplate = "/run/nixling/locks/usbip/${busid}";
+      resourceId = null;
+      kind = "file-record";
+      ownerProcess = actor "broker" "nixling-priv-broker";
+      allowedHolders = [
+        (actor "broker" "nixling-priv-broker")
+        (actor "daemon" "nixlingd")
+      ];
+      inheritancePolicy = "close-on-exec";
+      fdPassingPolicy = fdNone;
+      acquireOrder = order "vm" "run" id id;
+      timeoutPolicy = {
+        kind = "fail-fast";
+        timeoutMs = null;
+      };
+      stalePolicy = {
+        kind = "file-record-owner-match";
+        degradedReason = "lock-owner-ambiguous";
+      };
+      adoptionPolicy = "reacquire-after-proof";
+      degradeScope = "vm";
+      releaseAuthority = actor "broker" "nixling-priv-broker";
+      cloexecRequired = true;
+    };
+
+  usbipLocks = lib.flatten (lib.mapAttrsToList
+    (vm: vmCfg: map (busid: usbipLock vm busid) (vmCfg.usbip.busids or [ ]))
+    (lib.filterAttrs (_: vm: vm.enable && vm.usbip.yubikey) cfg.vms));
+
+  data = {
+    schemaVersion = "v2";
+    locks = [
+      (ofdLock {
+        id = "lock:daemon";
+        scope = "host";
+        path = "/run/nixling/daemon.lock";
+        owner = actor "daemon" "nixlingd";
+        scopeClass = "global";
+        root = "run";
+      })
+    ]
+    ++ (lib.mapAttrsToList (vm: _: inProcessLock vm) enabledVms)
+    ++ (lib.mapAttrsToList (vm: _: storeSyncLock vm) enabledVms)
+    ++ usbipLocks;
+  };
+
+  jsonText = builtins.toJSON data;
+  jsonFile = pkgs.writeText "nixling-sync.json" jsonText;
+in
+{
+  options.nixling._bundle.syncJson = lib.mkOption {
+    type = lib.types.unspecified;
+    readOnly = true;
+    internal = true;
+    description = "Internal schema-v2 synchronization and lock artifact metadata.";
+  };
+
+  config = {
+    nixling._bundle.syncJson = {
+      inherit data jsonText;
+      path = "${jsonFile}";
+    };
+    environment.etc."nixling/sync.json" = privateEtc jsonFile;
+  };
+}

--- a/packages/nixling-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/nixling-contract-tests/tests/storage_sync_contracts.rs
@@ -1,0 +1,144 @@
+use std::{collections::BTreeSet, env, fs, path::PathBuf};
+
+use nixling_contract_tests::read_repo_file;
+use nixling_core::{
+    processes::ProcessesJson,
+    storage::{StorageJson, StoragePathKind},
+    sync::{LockKind, SyncJson},
+};
+
+#[test]
+fn storage_and_sync_emitters_are_wired_into_private_bundle() {
+    let default_nix = read_repo_file("nixos-modules/default.nix");
+    assert!(
+        default_nix.contains("./storage-json.nix"),
+        "default.nix must import storage-json.nix"
+    );
+    assert!(
+        default_nix.contains("./sync-json.nix"),
+        "default.nix must import sync-json.nix"
+    );
+
+    let bundle_nix = read_repo_file("nixos-modules/bundle.nix");
+    for needle in [
+        "storagePath = \"/etc/nixling/storage.json\";",
+        "syncPath = \"/etc/nixling/sync.json\";",
+        "key = \"/etc/nixling/storage.json\";",
+        "key = \"/etc/nixling/sync.json\";",
+    ] {
+        assert!(
+            bundle_nix.contains(needle),
+            "bundle.nix missing storage/sync wiring: {needle}"
+        );
+    }
+
+    let bundle_doc = read_repo_file("docs/reference/manifest-bundle.md");
+    assert!(bundle_doc.contains("`storage.json`"));
+    assert!(bundle_doc.contains("`sync.json`"));
+}
+
+#[test]
+fn storage_and_sync_schemas_are_committed_and_closed() {
+    let storage_schema = read_repo_file("docs/reference/schemas/v2/storage.json");
+    let sync_schema = read_repo_file("docs/reference/schemas/v2/sync.json");
+    for (name, schema) in [
+        ("storage.json", storage_schema.as_str()),
+        ("sync.json", sync_schema.as_str()),
+    ] {
+        assert!(
+            schema.contains("\"additionalProperties\": false"),
+            "{name} must deny unknown fields"
+        );
+    }
+    assert!(storage_schema.contains("\"adoption-quarantined\""));
+    assert!(storage_schema.contains("\"tamper-evident-segmented\""));
+    assert!(sync_schema.contains("\"ofd\""));
+    assert!(sync_schema.contains("\"scm-rights\""));
+    assert!(sync_schema.contains("\"explicit-fd-mapping\""));
+}
+
+#[test]
+fn rendered_storage_contract_covers_process_writable_paths_when_fixture_available() {
+    let Some(dir) = env::var_os("NL_FIXTURES").map(PathBuf::from) else {
+        eprintln!("  (skipping rendered storage/sync contract check; NL_FIXTURES unset)");
+        return;
+    };
+    let storage: StorageJson = read_json(&dir, "storage.json");
+    let sync: SyncJson = read_json(&dir, "sync.json");
+    let processes: ProcessesJson = read_json(&dir, "processes.json");
+
+    storage
+        .validate_unique_ids()
+        .expect("rendered storage contract must have unique ids");
+    sync.validate_lock_order()
+        .expect("rendered sync contract must have valid lock order");
+
+    let storage_paths: BTreeSet<&str> = storage
+        .paths
+        .iter()
+        .map(|path| path.path_template.as_str())
+        .collect();
+    for dag in &processes.vms {
+        for node in &dag.nodes {
+            let restart = storage.restart_policies.iter().find(|policy| {
+                policy.vm.as_str() == dag.vm && policy.role_id.as_str() == node.id.0
+            });
+            assert!(
+                restart.is_some(),
+                "missing restart policy for {}:{}",
+                dag.vm,
+                node.id.0
+            );
+            for writable in &node.profile.mount_policy.writable_paths {
+                assert!(
+                    storage_paths.contains(writable.path.as_str()),
+                    "storage.json missing writable path for {}:{} -> {}",
+                    dag.vm,
+                    node.id.0,
+                    writable.path
+                );
+            }
+        }
+    }
+
+    assert!(
+        storage
+            .paths
+            .iter()
+            .any(|path| path.path_template.as_str() == "/etc/nixling/storage.json"),
+        "storage.json must describe itself as a private bundle artifact"
+    );
+    assert!(
+        storage
+            .paths
+            .iter()
+            .any(|path| path.path_template.as_str() == "/etc/nixling/sync.json"),
+        "storage.json must describe sync.json as a private bundle artifact"
+    );
+    assert!(
+        storage
+            .paths
+            .iter()
+            .any(|path| path.kind == StoragePathKind::UnixSocket),
+        "storage.json should include role/readiness Unix socket paths"
+    );
+    assert!(
+        sync.locks
+            .iter()
+            .any(|lock| lock.kind == LockKind::Ofd && lock.cloexec_required),
+        "sync.json must include at least one O_CLOEXEC OFD lock"
+    );
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(dir: &std::path::Path, name: &str) -> T {
+    let path = dir.join(name);
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    serde_json::from_str(&raw).unwrap_or_else(|err| {
+        panic!(
+            "failed to parse {} as {}: {err}",
+            path.display(),
+            std::any::type_name::<T>()
+        )
+    })
+}

--- a/packages/nixling-core/fuzz/src/bin/core.rs
+++ b/packages/nixling-core/fuzz/src/bin/core.rs
@@ -524,8 +524,6 @@ fn build_synthetic_resolver() -> BundleResolver {
         "fnv1a64:synthetic-bundle".to_owned(),
         host,
         processes,
-        None,
-        None,
         manifest,
         closures,
     )

--- a/packages/nixling-core/fuzz/src/bin/core.rs
+++ b/packages/nixling-core/fuzz/src/bin/core.rs
@@ -315,6 +315,8 @@ fn build_synthetic_resolver() -> BundleResolver {
         host_path: "/etc/nixling/host.json".to_owned(),
         processes_path: "/etc/nixling/processes.json".to_owned(),
         privileges_path: "/etc/nixling/privileges.json".to_owned(),
+        storage_path: None,
+        sync_path: None,
         closures: Vec::new(),
         minijail_profiles: Vec::new(),
         managed_keys: BundleManagedKeys::default(),
@@ -522,6 +524,8 @@ fn build_synthetic_resolver() -> BundleResolver {
         "fnv1a64:synthetic-bundle".to_owned(),
         host,
         processes,
+        None,
+        None,
         manifest,
         closures,
     )

--- a/packages/nixling-core/src/bundle.rs
+++ b/packages/nixling-core/src/bundle.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Bundle {
-    /// Version of the bundle format; the current additive LiveNative
-    /// mutating-verb rev is bundleVersion 4 while artifact
+    /// Version of the bundle format; bundleVersion 6 adds the private
+    /// storage lifecycle and synchronization artifacts while artifact
     /// schemaVersion stays v2.
     pub bundle_version: u32,
     /// Schema version directory used to validate all artifacts in this bundle.
@@ -22,6 +22,12 @@ pub struct Bundle {
     pub processes_path: String,
     /// Private privileges.json artifact path.
     pub privileges_path: String,
+    /// Private storage lifecycle artifact path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_path: Option<String>,
+    /// Private synchronization/lock contract artifact path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sync_path: Option<String>,
     /// Per-VM closure artifact paths keyed by VM name.
     pub closures: Vec<BundleClosureRef>,
     /// Minijail profile metadata paths shipped with the bundle.
@@ -46,9 +52,10 @@ pub struct Bundle {
     /// bundle artifact loaded by the resolver.
     ///
     /// Keys match the path strings stored in the bundle path fields:
-    /// absolute paths for `host_path`, `processes_path`, `privileges_path`;
-    /// bundle-relative paths for `closures[*].path` and
-    /// `minijail_profiles[*].path`.  Values are `"sha256:<hex64>"` strings.
+    /// absolute paths for `host_path`, `processes_path`, `privileges_path`,
+    /// `storage_path`, and `sync_path`; bundle-relative paths for
+    /// `closures[*].path` and `minijail_profiles[*].path`. Values are
+    /// `"sha256:<hex64>"` strings.
     ///
     /// When `None`, per-artifact hash verification is skipped (backwards
     /// compatibility with bundles that pre-date this field).

--- a/packages/nixling-core/src/bundle_resolver.rs
+++ b/packages/nixling-core/src/bundle_resolver.rs
@@ -114,6 +114,15 @@ pub struct BundleResolver {
     rotate_known_host_intents: BTreeMap<String, ResolvedRotateKnownHostIntent>,
 }
 
+struct ParsedBundleArtifacts {
+    host: HostJson,
+    processes: ProcessesJson,
+    storage: Option<StorageJson>,
+    sync: Option<SyncJson>,
+    manifest: ManifestV04,
+    closures: Vec<ClosureMetadata>,
+}
+
 /// Resolved nft script ready for `live_apply_nftables`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedNftIntent {
@@ -869,8 +878,6 @@ impl BundleResolver {
             bundle_hash,
             host,
             processes,
-            None,
-            None,
             manifest,
             Vec::new(),
         )
@@ -883,11 +890,36 @@ impl BundleResolver {
         bundle_hash: String,
         host: HostJson,
         processes: ProcessesJson,
-        storage: Option<StorageJson>,
-        sync: Option<SyncJson>,
         manifest: ManifestV04,
         closures: Vec<ClosureMetadata>,
     ) -> Self {
+        Self::from_parsed_artifacts(
+            bundle,
+            bundle_hash,
+            ParsedBundleArtifacts {
+                host,
+                processes,
+                storage: None,
+                sync: None,
+                manifest,
+                closures,
+            },
+        )
+    }
+
+    fn from_parsed_artifacts(
+        bundle: Bundle,
+        bundle_hash: String,
+        artifacts: ParsedBundleArtifacts,
+    ) -> Self {
+        let ParsedBundleArtifacts {
+            host,
+            processes,
+            storage,
+            sync,
+            manifest,
+            closures,
+        } = artifacts;
         let nft_intents = build_nft_intents(&host);
         let route_intents = build_route_intents(&host);
         let sysctl_intents = build_sysctl_intents(&host);
@@ -947,15 +979,17 @@ impl BundleResolver {
                 .expect("bundle serialization for audit hashing must succeed")
                 .as_slice(),
         );
-        Self::from_artifacts_with_closures(
+        Self::from_parsed_artifacts(
             bundle,
             bundle_hash,
-            host,
-            processes,
-            storage,
-            sync,
-            manifest,
-            Vec::new(),
+            ParsedBundleArtifacts {
+                host,
+                processes,
+                storage,
+                sync,
+                manifest,
+                closures: Vec::new(),
+            },
         )
     }
 
@@ -994,15 +1028,17 @@ impl BundleResolver {
         // which is root-owned 0444; skip the private-artifact policy for it.
         let manifest = ManifestV04::from_path(manifest_path)?;
         let closures = load_closure_metadata_verified(&bundle, bundle_root, policy)?;
-        Ok(Self::from_artifacts_with_closures(
+        Ok(Self::from_parsed_artifacts(
             bundle,
             bundle_hash,
-            host,
-            processes,
-            storage,
-            sync,
-            manifest,
-            closures,
+            ParsedBundleArtifacts {
+                host,
+                processes,
+                storage,
+                sync,
+                manifest,
+                closures,
+            },
         ))
     }
 

--- a/packages/nixling-core/src/bundle_resolver.rs
+++ b/packages/nixling-core/src/bundle_resolver.rs
@@ -75,6 +75,8 @@ use crate::host_w3::{ModuleRequirementW3, TapRoleW3};
 use crate::manifest_v04::{ManifestV04, VmEntry};
 use crate::minijail_profile::{CgroupPlacement, MountPolicy, NamespaceSet};
 use crate::processes::{ProcessNode, ProcessRole, ProcessesJson, RoleProfile, VmProcessDag};
+use crate::storage::StorageJson;
+use crate::sync::SyncJson;
 use sha2::Digest as _;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read as _;
@@ -88,6 +90,8 @@ pub struct BundleResolver {
     pub bundle: Bundle,
     pub host: HostJson,
     pub processes: ProcessesJson,
+    pub storage: Option<StorageJson>,
+    pub sync: Option<SyncJson>,
     pub manifest: ManifestV04,
     audit_bundle_version: String,
     audit_bundle_hash: String,
@@ -865,6 +869,8 @@ impl BundleResolver {
             bundle_hash,
             host,
             processes,
+            None,
+            None,
             manifest,
             Vec::new(),
         )
@@ -877,6 +883,8 @@ impl BundleResolver {
         bundle_hash: String,
         host: HostJson,
         processes: ProcessesJson,
+        storage: Option<StorageJson>,
+        sync: Option<SyncJson>,
         manifest: ManifestV04,
         closures: Vec<ClosureMetadata>,
     ) -> Self {
@@ -903,6 +911,8 @@ impl BundleResolver {
             bundle,
             host,
             processes,
+            storage,
+            sync,
             manifest,
             nft_intents,
             route_intents,
@@ -922,6 +932,31 @@ impl BundleResolver {
             host_key_trust_intents,
             rotate_known_host_intents,
         }
+    }
+
+    pub fn from_artifacts_with_optional_contracts(
+        bundle: Bundle,
+        host: HostJson,
+        processes: ProcessesJson,
+        storage: Option<StorageJson>,
+        sync: Option<SyncJson>,
+        manifest: ManifestV04,
+    ) -> Self {
+        let bundle_hash = stable_digest_bytes(
+            serde_json::to_vec(&bundle)
+                .expect("bundle serialization for audit hashing must succeed")
+                .as_slice(),
+        );
+        Self::from_artifacts_with_closures(
+            bundle,
+            bundle_hash,
+            host,
+            processes,
+            storage,
+            sync,
+            manifest,
+            Vec::new(),
+        )
     }
 
     fn load_with_paths(
@@ -953,6 +988,8 @@ impl BundleResolver {
         let processes: ProcessesJson = serde_json::from_slice(&processes_bytes).map_err(|e| {
             Error::manifest_parse_error("processes.json", manifest_parse_reason(&e.to_string()))
         })?;
+        let storage = load_optional_storage_artifact(&bundle, bundle_root, policy)?;
+        let sync = load_optional_sync_artifact(&bundle, bundle_root, policy)?;
         // The public manifest (vms.json) lives under /run/current-system/…
         // which is root-owned 0444; skip the private-artifact policy for it.
         let manifest = ManifestV04::from_path(manifest_path)?;
@@ -962,6 +999,8 @@ impl BundleResolver {
             bundle_hash,
             host,
             processes,
+            storage,
+            sync,
             manifest,
             closures,
         ))
@@ -2587,6 +2626,50 @@ fn load_closure_metadata_verified(
     Ok(closures)
 }
 
+fn load_optional_storage_artifact(
+    bundle: &Bundle,
+    bundle_root: &Path,
+    policy: &BundleVerifyPolicy,
+) -> Result<Option<StorageJson>, Error> {
+    let Some(storage_ref) = bundle.storage_path.as_deref() else {
+        return Ok(None);
+    };
+    let storage_path = resolve_bundle_ref(bundle_root, storage_ref);
+    let bytes = secure_open_and_read(&storage_path, policy)?;
+    verify_artifact_hash(
+        &storage_path,
+        &bytes,
+        bundle.artifact_hashes.as_ref(),
+        storage_ref,
+    )?;
+    let storage: StorageJson = serde_json::from_slice(&bytes).map_err(|e| {
+        Error::manifest_parse_error("storage.json", manifest_parse_reason(&e.to_string()))
+    })?;
+    Ok(Some(storage))
+}
+
+fn load_optional_sync_artifact(
+    bundle: &Bundle,
+    bundle_root: &Path,
+    policy: &BundleVerifyPolicy,
+) -> Result<Option<SyncJson>, Error> {
+    let Some(sync_ref) = bundle.sync_path.as_deref() else {
+        return Ok(None);
+    };
+    let sync_path = resolve_bundle_ref(bundle_root, sync_ref);
+    let bytes = secure_open_and_read(&sync_path, policy)?;
+    verify_artifact_hash(
+        &sync_path,
+        &bytes,
+        bundle.artifact_hashes.as_ref(),
+        sync_ref,
+    )?;
+    let sync: SyncJson = serde_json::from_slice(&bytes).map_err(|e| {
+        Error::manifest_parse_error("sync.json", manifest_parse_reason(&e.to_string()))
+    })?;
+    Ok(Some(sync))
+}
+
 // ---------------------------------------------------------------
 // Stable digest helper.
 // ---------------------------------------------------------------
@@ -2690,6 +2773,8 @@ mod tests {
                 host_path: "host.json".to_owned(),
                 processes_path: "processes.json".to_owned(),
                 privileges_path: "privileges.json".to_owned(),
+                storage_path: None,
+                sync_path: None,
                 closures: Vec::new(),
                 minijail_profiles: Vec::new(),
                 managed_keys: Default::default(),
@@ -2975,6 +3060,8 @@ mod tests {
             host_path: "host.json".to_owned(),
             processes_path: "processes.json".to_owned(),
             privileges_path: "privileges.json".to_owned(),
+            storage_path: None,
+            sync_path: None,
             closures: vec![BundleClosureRef {
                 vm: "personal-dev".to_owned(),
                 path: "closures/personal-dev.json".to_owned(),

--- a/packages/nixling-core/src/contract_id.rs
+++ b/packages/nixling-core/src/contract_id.rs
@@ -1,0 +1,200 @@
+use schemars::{
+    JsonSchema,
+    r#gen::SchemaGenerator,
+    schema::{InstanceType, Schema, SchemaObject, SingleOrVec, StringValidation},
+};
+use serde::{Deserialize, Deserializer, Serialize};
+
+pub const MAX_CONTRACT_TOKEN_LEN: usize = 160;
+pub const MAX_PATH_TEMPLATE_LEN: usize = 1024;
+pub const MAX_CONTRACT_TEXT_LEN: usize = 512;
+
+const TOKEN_PATTERN: &str = "^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$";
+const SLUG_PATTERN: &str = "^[a-z][a-z0-9-]*$";
+const PATH_PATTERN: &str = "^/[^\\u0000]*$";
+const TEXT_PATTERN: &str = "^[^\\u0000]*$";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContractStringError {
+    Empty,
+    TooLong { max: usize },
+    BadShape,
+}
+
+impl std::fmt::Display for ContractStringError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("value is empty"),
+            Self::TooLong { max } => write!(f, "value exceeds {max} bytes"),
+            Self::BadShape => f.write_str("value has an invalid shape"),
+        }
+    }
+}
+
+impl std::error::Error for ContractStringError {}
+
+fn bounded(raw: String, max: usize) -> Result<String, ContractStringError> {
+    if raw.is_empty() {
+        return Err(ContractStringError::Empty);
+    }
+    if raw.len() > max {
+        return Err(ContractStringError::TooLong { max });
+    }
+    if raw.contains('\0') {
+        return Err(ContractStringError::BadShape);
+    }
+    Ok(raw)
+}
+
+fn token(raw: String) -> Result<String, ContractStringError> {
+    let raw = bounded(raw, MAX_CONTRACT_TOKEN_LEN)?;
+    if raw
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '/' | '@' | '+' | '-'))
+        && raw
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+    {
+        Ok(raw)
+    } else {
+        Err(ContractStringError::BadShape)
+    }
+}
+
+fn slug(raw: String) -> Result<String, ContractStringError> {
+    let raw = bounded(raw, MAX_CONTRACT_TOKEN_LEN)?;
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return Err(ContractStringError::BadShape),
+    }
+    if chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+        Ok(raw)
+    } else {
+        Err(ContractStringError::BadShape)
+    }
+}
+
+fn path_template(raw: String) -> Result<String, ContractStringError> {
+    let raw = bounded(raw, MAX_PATH_TEMPLATE_LEN)?;
+    if raw.starts_with('/') {
+        Ok(raw)
+    } else {
+        Err(ContractStringError::BadShape)
+    }
+}
+
+fn text(raw: String) -> Result<String, ContractStringError> {
+    bounded(raw, MAX_CONTRACT_TEXT_LEN)
+}
+
+macro_rules! contract_string {
+    ($name:ident, $parse_fn:ident, $max:expr, $pattern:expr, $description:expr) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn parse(raw: impl Into<String>) -> Result<Self, ContractStringError> {
+                $parse_fn(raw.into()).map(Self)
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Self::parse(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+            }
+        }
+
+        impl JsonSchema for $name {
+            fn schema_name() -> String {
+                stringify!($name).to_owned()
+            }
+
+            fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+                Schema::Object(SchemaObject {
+                    instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
+                    string: Some(Box::new(StringValidation {
+                        max_length: Some($max as u32),
+                        min_length: Some(1),
+                        pattern: Some($pattern.to_owned()),
+                    })),
+                    metadata: Some(Box::new(schemars::schema::Metadata {
+                        description: Some($description.to_owned()),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })
+            }
+        }
+    };
+}
+
+contract_string!(
+    ContractId,
+    token,
+    MAX_CONTRACT_TOKEN_LEN,
+    TOKEN_PATTERN,
+    "Bounded storage/synchronization contract identifier."
+);
+contract_string!(
+    ReasonSlug,
+    slug,
+    MAX_CONTRACT_TOKEN_LEN,
+    SLUG_PATTERN,
+    "Closed degraded-state or audit reason slug."
+);
+contract_string!(
+    PathTemplate,
+    path_template,
+    MAX_PATH_TEMPLATE_LEN,
+    PATH_PATTERN,
+    "Absolute path template with typed variables expanded by the broker."
+);
+contract_string!(
+    ContractText,
+    text,
+    MAX_CONTRACT_TEXT_LEN,
+    TEXT_PATTERN,
+    "Bounded human-readable contract text."
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_are_bounded_and_shaped() {
+        assert!(ContractId::parse("storage:path/etc").is_ok());
+        assert!(ContractId::parse("").is_err());
+        assert!(ContractId::parse("bad space").is_err());
+        assert!(ContractId::parse(format!("a{}", "b".repeat(MAX_CONTRACT_TOKEN_LEN))).is_err());
+    }
+
+    #[test]
+    fn slugs_are_lowercase() {
+        assert!(ReasonSlug::parse("storage-drift").is_ok());
+        assert!(ReasonSlug::parse("StorageDrift").is_err());
+    }
+
+    #[test]
+    fn path_templates_are_absolute() {
+        assert!(PathTemplate::parse("/run/nixling/<vm>").is_ok());
+        assert!(PathTemplate::parse("relative/path").is_err());
+        assert!(PathTemplate::parse("/bad\0path").is_err());
+    }
+}

--- a/packages/nixling-core/src/lib.rs
+++ b/packages/nixling-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod base64_codec;
 pub mod bundle;
 pub mod bundle_resolver;
 pub mod closures;
+pub mod contract_id;
 pub mod error;
 pub mod host;
 pub mod host_check;
@@ -15,6 +16,8 @@ pub mod privileges;
 pub mod privileges_w3;
 pub mod processes;
 pub mod static_invariants;
+pub mod storage;
+pub mod sync;
 
 // `test_support` is needed both by external crates (which opt in via the
 // `test-support` feature) and by nixling-core's OWN tests. Gating on

--- a/packages/nixling-core/src/storage.rs
+++ b/packages/nixling-core/src/storage.rs
@@ -1,0 +1,440 @@
+use std::collections::BTreeSet;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::contract_id::{ContractId, ContractText, PathTemplate};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StorageJson {
+    pub schema_version: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roots: Vec<StorageRoot>,
+    pub paths: Vec<StoragePathSpec>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub restart_policies: Vec<ProcessRestartPolicy>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub degraded_states: Vec<DegradedStateSpec>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub remediations: Vec<RemediationSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StorageRoot {
+    pub id: ContractId,
+    pub path: PathTemplate,
+    pub class: StorageRootClass,
+    pub owner: PrincipalRef,
+    pub group: PrincipalRef,
+    pub mode: String,
+    pub authority: StorageAuthority,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageRootClass {
+    Config,
+    Persistent,
+    Runtime,
+    Cache,
+    ExternalObserveOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageAuthority {
+    NixModule,
+    Daemon,
+    Broker,
+    Guest,
+    External,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StoragePathSpec {
+    pub id: ContractId,
+    pub scope: ContractId,
+    pub path_template: PathTemplate,
+    pub kind: StoragePathKind,
+    pub lifecycle: StorageLifecycle,
+    pub persistence: StoragePersistence,
+    pub owner: PrincipalRef,
+    pub group: PrincipalRef,
+    pub mode: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub access_acl: Vec<AclGrant>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub default_acl: Vec<AclGrant>,
+    pub creator: ActorRef,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub writers: Vec<ActorRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub readers: Vec<ActorRef>,
+    pub cleanup_policy: CleanupPolicy,
+    pub repair_policy: RepairPolicy,
+    pub restart_policy: StorageRestartPolicy,
+    pub adoption_policy: StorageAdoptionPolicy,
+    pub lease_class: LeaseClass,
+    pub sensitivity: SensitivityClass,
+    pub no_follow: bool,
+    pub recursive: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invariants: Vec<StorageInvariant>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoragePathKind {
+    Directory,
+    RegularFile,
+    UnixSocket,
+    Symlink,
+    DeviceNode,
+    ExternalGrantOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageLifecycle {
+    Config,
+    Persistent,
+    BootScopedReadoptable,
+    BootScopedDisposable,
+    ProcessScoped,
+    ExternalObserveOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StoragePersistence {
+    Persistent,
+    BootScoped,
+    ProcessScoped,
+    Regenerable,
+    External,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PrincipalRef {
+    pub kind: PrincipalKind,
+    pub value: ContractId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum PrincipalKind {
+    User,
+    Group,
+    Uid,
+    Gid,
+    Role,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ActorRef {
+    pub kind: ActorKind,
+    pub value: ContractId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ActorKind {
+    NixModule,
+    Daemon,
+    Broker,
+    Role,
+    Guest,
+    Operator,
+    External,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AclGrant {
+    pub principal: PrincipalRef,
+    pub permissions: ContractId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum CleanupPolicy {
+    Never,
+    Boot,
+    ProcessExitWithProof,
+    VmStopWithProof,
+    CutoverOnly,
+    External,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum RepairPolicy {
+    None,
+    NixActivation,
+    BrokerReconcile,
+    BrokerFailClosed,
+    OperatorOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageRestartPolicy {
+    PreserveAcrossDaemonRestart,
+    RecreateAfterOwnerDeath,
+    CleanupAfterOwnerDeath,
+    ManualRecovery,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageAdoptionPolicy {
+    AdoptWithLiveOwnerProof,
+    RecreateFromPersistent,
+    QuarantineOnAmbiguity,
+    DeleteIfOwnerDead,
+    NotAdoptable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LeaseClass {
+    None,
+    ProcessPidfd,
+    CgroupLeaf,
+    FileRecord,
+    External,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum SensitivityClass {
+    Public,
+    Private,
+    SecretAdjacent,
+    Audit,
+    RealmScoped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageInvariant {
+    NoSymlink,
+    NoMagicLink,
+    NoRecursiveMutation,
+    SameFilesystem,
+    HardlinkFarmNoRecursion,
+    BrokerOpaqueIdOnly,
+    RootOwnedParent,
+    ScopeAuthorizationRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProcessRestartPolicy {
+    pub vm: ContractId,
+    pub role_id: ContractId,
+    pub restart_class: RestartClass,
+    pub adoption_inputs: AdoptionInputs,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub persistent_state_refs: Vec<ContractId>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_state_refs: Vec<ContractId>,
+    pub cleanup_before_restart: bool,
+    pub degrade_on_failure: DegradedReason,
+    pub degrade_scope: DegradeScope,
+    pub readiness_after_adopt: ReadinessAfterAdopt,
+    pub remediation_id: ContractId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum RestartClass {
+    Adoptable,
+    Recreatable,
+    StatefulQuarantine,
+    NonResumable,
+    ExternalObserved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdoptionInputs {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cgroup_leaf: Option<ContractId>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub identity_checks: Vec<IdentityCheck>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum IdentityCheck {
+    CgroupMembership,
+    ExecutablePath,
+    ProfileId,
+    CmdlineShape,
+    StartTimeDiagnostic,
+    PidfdOpenAfterCandidateRead,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum DegradeScope {
+    Role,
+    Vm,
+    Host,
+    Realm,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum DegradedReason {
+    StorageDrift,
+    StorageRepairFailed,
+    AdoptionPending,
+    AdoptionQuarantined,
+    RestartRequired,
+    LockOwnerAmbiguous,
+    LockAcquireTimeout,
+    ExternalDependencyUnhealthy,
+    MigrationRequired,
+    MigrationFailed,
+    ViolationAuditThrottled,
+    RoleComponentDegraded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReadinessAfterAdopt {
+    pub kind: ReadinessAfterAdoptKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_ref: Option<ContractId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReadinessAfterAdoptKind {
+    ExistingPredicate,
+    UnixSocketListening,
+    PidfdAlive,
+    ExternalProbe,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DegradedStateSpec {
+    pub reason: DegradedReason,
+    pub scope: DegradeScope,
+    pub storage_class: LedgerStorageClass,
+    pub remediation_id: ContractId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LedgerStorageClass {
+    TamperEvidentSegmented,
+    AppendOnlyBounded,
+    PlainBoundedDiagnostic,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RemediationSpec {
+    pub id: ContractId,
+    pub command: ContractText,
+    pub description: ContractText,
+}
+
+impl StorageJson {
+    pub fn validate_unique_ids(&self) -> Result<(), String> {
+        let mut ids = BTreeSet::new();
+        for path in &self.paths {
+            if !ids.insert(path.id.as_str()) {
+                return Err(format!("duplicate storage path id {}", path.id));
+            }
+        }
+        let mut restart_ids = BTreeSet::new();
+        for restart in &self.restart_policies {
+            let key = (restart.vm.as_str(), restart.role_id.as_str());
+            if !restart_ids.insert(key) {
+                return Err(format!(
+                    "duplicate restart policy for {}:{}",
+                    restart.vm, restart.role_id
+                ));
+            }
+        }
+        let mut reasons = BTreeSet::new();
+        for state in &self.degraded_states {
+            if !reasons.insert(state.reason) {
+                return Err(format!("duplicate degraded reason {:?}", state.reason));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actor(kind: ActorKind, value: &str) -> ActorRef {
+        ActorRef {
+            kind,
+            value: ContractId::parse(value).unwrap(),
+        }
+    }
+
+    fn principal(kind: PrincipalKind, value: &str) -> PrincipalRef {
+        PrincipalRef {
+            kind,
+            value: ContractId::parse(value).unwrap(),
+        }
+    }
+
+    #[test]
+    fn storage_json_rejects_duplicate_ids() {
+        let path = StoragePathSpec {
+            id: ContractId::parse("path:one").unwrap(),
+            scope: ContractId::parse("host").unwrap(),
+            path_template: PathTemplate::parse("/run/nixling").unwrap(),
+            kind: StoragePathKind::Directory,
+            lifecycle: StorageLifecycle::BootScopedReadoptable,
+            persistence: StoragePersistence::BootScoped,
+            owner: principal(PrincipalKind::User, "nixlingd"),
+            group: principal(PrincipalKind::Group, "nixlingd"),
+            mode: "0750".to_owned(),
+            access_acl: Vec::new(),
+            default_acl: Vec::new(),
+            creator: actor(ActorKind::NixModule, "tmpfiles"),
+            writers: vec![actor(ActorKind::Daemon, "nixlingd")],
+            readers: vec![actor(ActorKind::Daemon, "nixlingd")],
+            cleanup_policy: CleanupPolicy::Boot,
+            repair_policy: RepairPolicy::BrokerReconcile,
+            restart_policy: StorageRestartPolicy::PreserveAcrossDaemonRestart,
+            adoption_policy: StorageAdoptionPolicy::AdoptWithLiveOwnerProof,
+            lease_class: LeaseClass::None,
+            sensitivity: SensitivityClass::Private,
+            no_follow: true,
+            recursive: false,
+            invariants: vec![StorageInvariant::NoSymlink],
+        };
+        let contract = StorageJson {
+            schema_version: "v2".to_owned(),
+            roots: Vec::new(),
+            paths: vec![path.clone(), path],
+            restart_policies: Vec::new(),
+            degraded_states: Vec::new(),
+            remediations: Vec::new(),
+        };
+        assert!(contract.validate_unique_ids().is_err());
+    }
+}

--- a/packages/nixling-core/src/sync.rs
+++ b/packages/nixling-core/src/sync.rs
@@ -1,0 +1,232 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::contract_id::{ContractId, PathTemplate};
+use crate::storage::{ActorRef, DegradeScope, DegradedReason};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SyncJson {
+    pub schema_version: String,
+    pub locks: Vec<LockSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LockSpec {
+    pub id: ContractId,
+    pub scope: ContractId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_template: Option<PathTemplate>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_id: Option<ContractId>,
+    pub kind: LockKind,
+    pub owner_process: ActorRef,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_holders: Vec<ActorRef>,
+    pub inheritance_policy: InheritancePolicy,
+    pub fd_passing_policy: FdPassingPolicy,
+    pub acquire_order: LockAcquireOrder,
+    pub timeout_policy: LockTimeoutPolicy,
+    pub stale_policy: LockStalePolicy,
+    pub adoption_policy: LockAdoptionPolicy,
+    pub degrade_scope: DegradeScope,
+    pub release_authority: ActorRef,
+    pub cloexec_required: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockKind {
+    Ofd,
+    FileRecord,
+    InProcess,
+    KernelObject,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum InheritancePolicy {
+    CloseOnExec,
+    ExplicitFdMappingOnly,
+    ScmRightsOnly,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FdPassingPolicy {
+    pub mechanism: FdPassingMechanism,
+    pub lease_transfer_record_required: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum FdPassingMechanism {
+    None,
+    ScmRights,
+    ExplicitFdMapping,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LockAcquireOrder {
+    pub scope_class: LockScopeClass,
+    pub anchored_root: ContractId,
+    pub normalized_path: ContractId,
+    pub lock_id: ContractId,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockScopeClass {
+    Global,
+    Host,
+    Vm,
+    Role,
+    External,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LockTimeoutPolicy {
+    pub kind: LockTimeoutKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockTimeoutKind {
+    FailFast,
+    BoundedWait,
+    NoWait,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LockStalePolicy {
+    pub kind: LockStaleKind,
+    pub degraded_reason: DegradedReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockStaleKind {
+    PidfdProofRequired,
+    CgroupEmptyProofRequired,
+    FileRecordOwnerMatch,
+    CutoverOnly,
+    ManualRecovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockAdoptionPolicy {
+    ReacquireAfterProof,
+    TransferWithLeaseRecord,
+    QuarantineOnAmbiguity,
+    NotAdoptable,
+}
+
+impl SyncJson {
+    pub fn validate_lock_order(&self) -> Result<(), String> {
+        let mut ids = BTreeSet::new();
+        let mut order_keys: BTreeMap<(&LockScopeClass, &str, &str, &str), &ContractId> =
+            BTreeMap::new();
+        for lock in &self.locks {
+            if !ids.insert(lock.id.as_str()) {
+                return Err(format!("duplicate lock id {}", lock.id));
+            }
+            if lock.kind == LockKind::Ofd && !lock.cloexec_required {
+                return Err(format!("OFD lock {} must require O_CLOEXEC", lock.id));
+            }
+            if lock.fd_passing_policy.mechanism != FdPassingMechanism::None
+                && !lock.fd_passing_policy.lease_transfer_record_required
+            {
+                return Err(format!(
+                    "fd-passing lock {} must require a lease transfer record",
+                    lock.id
+                ));
+            }
+            let key = (
+                &lock.acquire_order.scope_class,
+                lock.acquire_order.anchored_root.as_str(),
+                lock.acquire_order.normalized_path.as_str(),
+                lock.acquire_order.lock_id.as_str(),
+            );
+            if let Some(existing) = order_keys.insert(key, &lock.id) {
+                return Err(format!(
+                    "lock {} shares acquire order key with {}",
+                    lock.id, existing
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{ActorKind, ActorRef};
+
+    fn actor(kind: ActorKind, value: &str) -> ActorRef {
+        ActorRef {
+            kind,
+            value: ContractId::parse(value).unwrap(),
+        }
+    }
+
+    fn order(id: &str) -> LockAcquireOrder {
+        LockAcquireOrder {
+            scope_class: LockScopeClass::Global,
+            anchored_root: ContractId::parse("run").unwrap(),
+            normalized_path: ContractId::parse(id).unwrap(),
+            lock_id: ContractId::parse(id).unwrap(),
+        }
+    }
+
+    #[test]
+    fn ofd_locks_require_cloexec() {
+        let lock = LockSpec {
+            id: ContractId::parse("lock:daemon").unwrap(),
+            scope: ContractId::parse("host").unwrap(),
+            path_template: Some(PathTemplate::parse("/run/nixling/daemon.lock").unwrap()),
+            resource_id: None,
+            kind: LockKind::Ofd,
+            owner_process: actor(ActorKind::Daemon, "nixlingd"),
+            allowed_holders: vec![actor(ActorKind::Daemon, "nixlingd")],
+            inheritance_policy: InheritancePolicy::CloseOnExec,
+            fd_passing_policy: FdPassingPolicy {
+                mechanism: FdPassingMechanism::None,
+                lease_transfer_record_required: false,
+            },
+            acquire_order: order("lock:daemon"),
+            timeout_policy: LockTimeoutPolicy {
+                kind: LockTimeoutKind::FailFast,
+                timeout_ms: None,
+            },
+            stale_policy: LockStalePolicy {
+                kind: LockStaleKind::PidfdProofRequired,
+                degraded_reason: DegradedReason::LockOwnerAmbiguous,
+            },
+            adoption_policy: LockAdoptionPolicy::ReacquireAfterProof,
+            degrade_scope: DegradeScope::Host,
+            release_authority: actor(ActorKind::Daemon, "nixlingd"),
+            cloexec_required: false,
+        };
+        assert!(
+            SyncJson {
+                schema_version: "v2".to_owned(),
+                locks: vec![lock],
+            }
+            .validate_lock_order()
+            .is_err()
+        );
+    }
+}

--- a/packages/nixling-priv-broker/src/ops/tap.rs
+++ b/packages/nixling-priv-broker/src/ops/tap.rs
@@ -710,6 +710,8 @@ mod tests {
             host_path: "host.json".to_owned(),
             processes_path: "processes.json".to_owned(),
             privileges_path: "privileges.json".to_owned(),
+            storage_path: None,
+            sync_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/nixling-priv-broker/src/runtime.rs
+++ b/packages/nixling-priv-broker/src/runtime.rs
@@ -6906,6 +6906,8 @@ mod tests {
             host_path: "host.json".to_owned(),
             processes_path: "processes.json".to_owned(),
             privileges_path: "privileges.json".to_owned(),
+            storage_path: None,
+            sync_path: None,
             closures: vec![BundleClosureRef {
                 vm: "corp-vm".to_owned(),
                 path: "closures/corp-vm.json".to_owned(),

--- a/packages/nixling-priv-broker/tests/w15_install_migrate.rs
+++ b/packages/nixling-priv-broker/tests/w15_install_migrate.rs
@@ -58,6 +58,8 @@ fn installer_bundle_resolver(public_manifest_path: &str) -> BundleResolver {
         host_path: "/ignored/host.json".to_owned(),
         processes_path: "/ignored/processes.json".to_owned(),
         privileges_path: "/ignored/privileges.json".to_owned(),
+            storage_path: None,
+            sync_path: None,
         closures: Vec::new(),
         minijail_profiles: Vec::new(),
         managed_keys: BundleManagedKeys::default(),

--- a/packages/nixlingd/src/kernel_module_check.rs
+++ b/packages/nixlingd/src/kernel_module_check.rs
@@ -506,6 +506,8 @@ mod tests {
             host_path: "host.json".to_owned(),
             processes_path: "processes.json".to_owned(),
             privileges_path: "privileges.json".to_owned(),
+            storage_path: None,
+            sync_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/nixlingd/src/net_vm_bundle_gate.rs
+++ b/packages/nixlingd/src/net_vm_bundle_gate.rs
@@ -406,6 +406,8 @@ mod tests {
             host_path: "host.json".to_owned(),
             processes_path: "processes.json".to_owned(),
             privileges_path: "privileges.json".to_owned(),
+            storage_path: None,
+            sync_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/nixlingd/src/supervisor/stop_dag.rs
+++ b/packages/nixlingd/src/supervisor/stop_dag.rs
@@ -266,6 +266,8 @@ mod tests {
             host_path: "host.json".to_owned(),
             processes_path: "processes.json".to_owned(),
             privileges_path: "privileges.json".to_owned(),
+            storage_path: None,
+            sync_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -17,7 +17,7 @@ use nixling::{
 use nixling_core::{
     bundle::Bundle, closures::ClosureMetadata, error::Error, host::HostJson,
     manifest_v04::ManifestV04, minijail_profile::MinijailProfile, privileges::PrivilegesJson,
-    processes::ProcessesJson,
+    processes::ProcessesJson, storage::StorageJson, sync::SyncJson,
 };
 use nixling_ipc::{WireProtocolSchema, guest_wire::GuestControlSchema};
 use schemars::schema::RootSchema;
@@ -217,10 +217,12 @@ fn gen_schemas() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
         .join(SCHEMA_VERSION);
     fs::create_dir_all(&out_dir)?;
 
-    let schemas: [(&str, RootSchema); 9] = [
+    let schemas: [(&str, RootSchema); 11] = [
         ("bundle.json", schemars::schema_for!(Bundle)),
         ("host.json", schemars::schema_for!(HostJson)),
         ("processes.json", schemars::schema_for!(ProcessesJson)),
+        ("storage.json", schemars::schema_for!(StorageJson)),
+        ("sync.json", schemars::schema_for!(SyncJson)),
         ("privileges.json", schemars::schema_for!(PrivilegesJson)),
         ("closures.json", schemars::schema_for!(ClosureMetadata)),
         (


### PR DESCRIPTION
## Summary
- add `storage.json` and `sync.json` private bundle artifacts with typed Rust DTOs and generated schemas
- emit storage/restart/degraded-state and lock/lease contracts from Nix and include them in bundle hashing
- bump `bundleVersion` to 6 and extend fixture outputs + contract coverage

## Validation
- cargo fmt --all
- cargo run -p xtask -- gen-schemas
- cargo test -p nixling-core -- --nocapture
- cargo test -p nixling-contract-tests --test storage_sync_contracts -- --nocapture
- fixture-smoke + fixture-smoke-full builds with `storage.json`/`sync.json` jq checks
- NL_FIXTURES/NL_FIXTURES_FULL cargo test -p nixling-contract-tests -- --nocapture
- cargo test --workspace --exclude nixling-contract-tests -- --nocapture
- cargo test in packages/nixling-priv-broker
- git diff --check
- bash tests/test-drift.sh
- make test-policy
- make test-flake

## Panel
- Gemini 3.1 Pro implementation panel: architect/security/nixos/rust/product-docs/observability all signed off

## Host adoption
- `/etc/nixos` is intentionally untouched; host consumption happens only after merged PRs land.