### PR TITLE
daemon: persist storage lifecycle startup report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ deprecations ship one minor release before removal.
   `ValidateLockSpec` operations so storage and synchronization contracts
   can be inspected and, for static directory specs, reconciled without
   daemon-supplied raw paths.
+- Daemon: startup now performs a read-only storage/restart/sync contract
+  check and persists `storage-lifecycle-report.json` for degraded-state
+  adoption work and future doctor/status UX.
 - Documentation: ADR 0034 and the storage lifecycle explanation now
   define the planned generated contracts for managed paths, process
   restart/adoption, synchronization, lock ownership, degraded-state

--- a/docs/reference/schemas/v2/storage-lifecycle-report.json
+++ b/docs/reference/schemas/v2/storage-lifecycle-report.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "StorageLifecycleReport",
+  "description": "Host-local daemon startup report for storage/restart/sync contract posture.",
+  "type": "object",
+  "required": [
+    "issues",
+    "lockCount",
+    "pathCount",
+    "restartPolicyCount",
+    "schemaVersion",
+    "storageContractPresent",
+    "syncContractPresent"
+  ],
+  "properties": {
+    "issues": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/StorageLifecycleIssue"
+      }
+    },
+    "lockCount": {
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
+    "pathCount": {
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
+    "restartPolicyCount": {
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "storageContractPresent": {
+      "type": "boolean"
+    },
+    "syncContractPresent": {
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "StorageContractValidationReason": {
+      "type": "string",
+      "enum": [
+        "duplicate-storage-path-id",
+        "duplicate-restart-policy",
+        "duplicate-degraded-reason",
+        "unclassified"
+      ]
+    },
+    "StorageLifecycleIssue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "missing-storage-contract"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "missing-sync-contract"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "bundleVersion",
+            "kind"
+          ],
+          "properties": {
+            "bundleVersion": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "legacy-bundle-contracts-unavailable"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "bundle-resolver-unavailable"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "reason"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "storage-contract-invalid"
+              ]
+            },
+            "reason": {
+              "$ref": "#/definitions/StorageContractValidationReason"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "reason"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "sync-contract-invalid"
+              ]
+            },
+            "reason": {
+              "$ref": "#/definitions/SyncContractValidationReason"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "roleId",
+            "vm"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "missing-restart-policy"
+              ]
+            },
+            "roleId": {
+              "type": "string"
+            },
+            "vm": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "roleId",
+            "vm"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "adoptable-missing-cgroup-leaf"
+              ]
+            },
+            "roleId": {
+              "type": "string"
+            },
+            "vm": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "SyncContractValidationReason": {
+      "type": "string",
+      "enum": [
+        "duplicate-lock-id",
+        "ofd-lock-missing-cloexec",
+        "fd-passing-missing-lease-transfer-record",
+        "duplicate-acquire-order",
+        "unclassified"
+      ]
+    }
+  }
+}

--- a/docs/reference/storage-lifecycle-report.md
+++ b/docs/reference/storage-lifecycle-report.md
@@ -1,0 +1,20 @@
+# Storage lifecycle report
+
+**Diataxis category:** reference.
+
+`nixlingd` writes a host-local startup contract report at:
+
+```text
+/var/lib/nixling/daemon-state/storage-lifecycle-report.json
+```
+
+The report records the daemon's read-only check of the generated
+storage, restart, and synchronization contracts in the active bundle.
+It is diagnostic evidence for host doctor/status surfaces; privileged
+repair still resolves trusted bundle IDs through the broker and must
+not trust this report as authority.
+
+The report never contains raw managed paths. Issue entries use a closed
+`kind` taxonomy and bounded VM/role identifiers from the bundle. The
+schema is generated at
+[`docs/reference/schemas/v2/storage-lifecycle-report.json`](./schemas/v2/storage-lifecycle-report.json).

--- a/packages/nixling-core/src/lib.rs
+++ b/packages/nixling-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod privileges_w3;
 pub mod processes;
 pub mod static_invariants;
 pub mod storage;
+pub mod storage_lifecycle;
 pub mod sync;
 
 // `test_support` is needed both by external crates (which opt in via the

--- a/packages/nixling-core/src/storage_lifecycle.rs
+++ b/packages/nixling-core/src/storage_lifecycle.rs
@@ -1,0 +1,132 @@
+//! Host-local storage lifecycle report DTOs.
+
+use std::collections::BTreeSet;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Host-local daemon startup report for storage/restart/sync contract posture.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageLifecycleReport {
+    pub schema_version: String,
+    pub storage_contract_present: bool,
+    pub sync_contract_present: bool,
+    pub path_count: usize,
+    pub restart_policy_count: usize,
+    pub lock_count: usize,
+    pub issues: Vec<StorageLifecycleIssue>,
+}
+
+impl StorageLifecycleReport {
+    pub fn is_degraded(&self) -> bool {
+        !self.issues.is_empty()
+    }
+
+    pub fn issue_kinds_csv(&self) -> String {
+        self.issues
+            .iter()
+            .map(StorageLifecycleIssue::kind_name)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    pub fn has_only_legacy_contract_issue(&self) -> bool {
+        matches!(
+            self.issues.as_slice(),
+            [StorageLifecycleIssue::LegacyBundleContractsUnavailable { .. }]
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum StorageLifecycleIssue {
+    MissingStorageContract,
+    MissingSyncContract,
+    LegacyBundleContractsUnavailable {
+        #[serde(rename = "bundleVersion")]
+        bundle_version: u32,
+    },
+    BundleResolverUnavailable,
+    StorageContractInvalid {
+        reason: StorageContractValidationReason,
+    },
+    SyncContractInvalid {
+        reason: SyncContractValidationReason,
+    },
+    MissingRestartPolicy {
+        vm: String,
+        #[serde(rename = "roleId")]
+        role_id: String,
+    },
+    AdoptableMissingCgroupLeaf {
+        vm: String,
+        #[serde(rename = "roleId")]
+        role_id: String,
+    },
+}
+
+impl StorageLifecycleIssue {
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::MissingStorageContract => "missing-storage-contract",
+            Self::MissingSyncContract => "missing-sync-contract",
+            Self::LegacyBundleContractsUnavailable { .. } => "legacy-bundle-contracts-unavailable",
+            Self::BundleResolverUnavailable => "bundle-resolver-unavailable",
+            Self::StorageContractInvalid { .. } => "storage-contract-invalid",
+            Self::SyncContractInvalid { .. } => "sync-contract-invalid",
+            Self::MissingRestartPolicy { .. } => "missing-restart-policy",
+            Self::AdoptableMissingCgroupLeaf { .. } => "adoptable-missing-cgroup-leaf",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum StorageContractValidationReason {
+    DuplicateStoragePathId,
+    DuplicateRestartPolicy,
+    DuplicateDegradedReason,
+    Unclassified,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum SyncContractValidationReason {
+    DuplicateLockId,
+    OfdLockMissingCloexec,
+    FdPassingMissingLeaseTransferRecord,
+    DuplicateAcquireOrder,
+    Unclassified,
+}
+
+pub fn classify_storage_validation_reason(detail: &str) -> StorageContractValidationReason {
+    if detail.starts_with("duplicate storage path id ") {
+        StorageContractValidationReason::DuplicateStoragePathId
+    } else if detail.starts_with("duplicate restart policy for ") {
+        StorageContractValidationReason::DuplicateRestartPolicy
+    } else if detail.starts_with("duplicate degraded reason ") {
+        StorageContractValidationReason::DuplicateDegradedReason
+    } else {
+        StorageContractValidationReason::Unclassified
+    }
+}
+
+pub fn classify_sync_validation_reason(detail: &str) -> SyncContractValidationReason {
+    if detail.starts_with("duplicate lock id ") {
+        SyncContractValidationReason::DuplicateLockId
+    } else if detail.starts_with("OFD lock ") && detail.ends_with(" must require O_CLOEXEC") {
+        SyncContractValidationReason::OfdLockMissingCloexec
+    } else if detail.starts_with("fd-passing lock ")
+        && detail.ends_with(" must require a lease transfer record")
+    {
+        SyncContractValidationReason::FdPassingMissingLeaseTransferRecord
+    } else if detail.starts_with("lock ") && detail.contains(" shares acquire order key with ") {
+        SyncContractValidationReason::DuplicateAcquireOrder
+    } else {
+        SyncContractValidationReason::Unclassified
+    }
+}

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -148,6 +148,8 @@ pub mod net_route_preflight;
 // Defense-in-depth alongside the static `tests/v1.1-kernel-floor-eval.sh`
 // gate. Per ADR 0008 + ADR 0018.
 pub mod pidfs_probe;
+// ADR 0034 startup contract check for generated storage/restart/sync artifacts.
+pub mod storage_lifecycle;
 // Contract for bringing autostart VMs up on daemon startup (net VMs
 // first, concurrency cap, degraded-mode tolerant, idempotent). See
 // docs/reference/daemon-autostart.md.
@@ -552,6 +554,30 @@ pub fn autostart_report_path(daemon_state_dir: &Path) -> PathBuf {
     daemon_state_dir.join("autostart-report.json")
 }
 
+/// Path of the persisted storage/restart/sync startup contract report.
+pub fn storage_lifecycle_report_path(daemon_state_dir: &Path) -> PathBuf {
+    daemon_state_dir.join("storage-lifecycle-report.json")
+}
+
+fn persist_json_report(path: &Path, json: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut file = File::create(&tmp)?;
+        file.write_all(json)?;
+        file.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    if let Some(parent) = path.parent()
+        && let Ok(parent_dir) = File::open(parent)
+    {
+        let _ = parent_dir.sync_all();
+    }
+    Ok(())
+}
+
 /// Persist the latest kernel-module-check report to
 /// `kernel-module-report.json`. Best-effort: a write failure logs a
 /// warning but does NOT abort daemon startup.
@@ -567,10 +593,7 @@ fn persist_kernel_module_report(
             return;
         }
     };
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Err(err) = std::fs::write(&path, &json) {
+    if let Err(err) = persist_json_report(&path, &json) {
         tracing::warn!(
             error = %err,
             path = %path.display(),
@@ -591,14 +614,32 @@ fn persist_autostart_report(daemon_state_dir: &Path, report: &autostart::Autosta
             return;
         }
     };
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Err(err) = std::fs::write(&path, &json) {
+    if let Err(err) = persist_json_report(&path, &json) {
         tracing::warn!(
             error = %err,
             path = %path.display(),
             "autostart: persist report failed",
+        );
+    }
+}
+
+fn persist_storage_lifecycle_report(
+    daemon_state_dir: &Path,
+    report: &storage_lifecycle::StorageLifecycleReport,
+) {
+    let path = storage_lifecycle_report_path(daemon_state_dir);
+    let json = match serde_json::to_vec_pretty(report) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            tracing::warn!(error = %err, "storage-lifecycle: serialize report failed");
+            return;
+        }
+    };
+    if let Err(err) = persist_json_report(&path, &json) {
+        tracing::warn!(
+            error = %err,
+            path = %path.display(),
+            "storage-lifecycle: persist report failed",
         );
     }
 }
@@ -722,6 +763,66 @@ pub async fn serve(options: ServeOptions) -> Result<(), TypedError> {
         op_locks: crate::concurrency::OpLockManager::new(),
     };
     refresh_broker_reap_log(&state, "startup");
+
+    match load_bundle_resolver(&state) {
+        Ok(resolver) => {
+            let report = storage_lifecycle::run_startup_contract_check(&resolver);
+            let report_path = storage_lifecycle_report_path(&state.daemon_state_dir);
+            if report.has_only_legacy_contract_issue() {
+                tracing::info!(
+                    bundle_version = resolver.bundle.bundle_version,
+                    report_path = %report_path.display(),
+                    "storage-lifecycle: legacy bundle lacks storage/sync contracts; rebuild host configuration to enable startup contract checks",
+                );
+            } else if report.is_degraded() {
+                let issue_kinds = report.issue_kinds_csv();
+                tracing::warn!(
+                    issue_count = report.issues.len(),
+                    issue_kinds = %issue_kinds,
+                    path_count = report.path_count,
+                    restart_policy_count = report.restart_policy_count,
+                    lock_count = report.lock_count,
+                    report_path = %report_path.display(),
+                    "storage-lifecycle: startup contract check degraded",
+                );
+            } else {
+                tracing::info!(
+                    path_count = report.path_count,
+                    restart_policy_count = report.restart_policy_count,
+                    lock_count = report.lock_count,
+                    report_path = %report_path.display(),
+                    "storage-lifecycle: startup contract check clean",
+                );
+            }
+            persist_storage_lifecycle_report(&state.daemon_state_dir, &report);
+        }
+        Err(error) => {
+            let report_path = storage_lifecycle_report_path(&state.daemon_state_dir);
+            // Fail closed for doctor/status consumers if the replacement
+            // report cannot be written below: stale clean evidence is worse
+            // than an absent report.
+            match std::fs::remove_file(&report_path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        report_path = %report_path.display(),
+                        "storage-lifecycle: remove stale report failed",
+                    );
+                }
+            }
+            let report = storage_lifecycle::bundle_resolver_unavailable_report();
+            persist_storage_lifecycle_report(&state.daemon_state_dir, &report);
+            let issue_kinds = report.issue_kinds_csv();
+            tracing::warn!(
+                error = %error.message(),
+                issue_kinds = %issue_kinds,
+                report_path = %report_path.display(),
+                "storage-lifecycle: skipped (bundle resolver unavailable)",
+            );
+        }
+    }
     adopt_orphaned_runners_on_startup(&state);
 
     // Startup self-check on the kernel-module matrix the bundle requires.

--- a/packages/nixlingd/src/storage_lifecycle.rs
+++ b/packages/nixlingd/src/storage_lifecycle.rs
@@ -1,0 +1,527 @@
+//! Daemon startup storage/restart/synchronization contract checks.
+//!
+//! ADR 0034 makes storage, process restart, and lock ownership explicit
+//! generated contracts. This module is the daemon-side startup gate that
+//! checks those contracts before any broad cleanup or adoption logic grows
+//! around them. It is intentionally read-only: it never mutates storage,
+//! never opens lock files, and never treats persisted PID values as
+//! authority.
+
+use std::collections::BTreeSet;
+
+use nixling_core::bundle_resolver::BundleResolver;
+use nixling_core::storage::RestartClass;
+pub use nixling_core::storage_lifecycle::{
+    StorageContractValidationReason, StorageLifecycleIssue, StorageLifecycleReport,
+    SyncContractValidationReason, classify_storage_validation_reason,
+    classify_sync_validation_reason,
+};
+
+pub const STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION: u32 = 6;
+pub const STORAGE_LIFECYCLE_REPORT_SCHEMA_VERSION: &str = "v2";
+
+pub fn bundle_resolver_unavailable_report() -> StorageLifecycleReport {
+    StorageLifecycleReport {
+        schema_version: STORAGE_LIFECYCLE_REPORT_SCHEMA_VERSION.to_owned(),
+        storage_contract_present: false,
+        sync_contract_present: false,
+        path_count: 0,
+        restart_policy_count: 0,
+        lock_count: 0,
+        issues: vec![StorageLifecycleIssue::BundleResolverUnavailable],
+    }
+}
+
+/// Run a read-only startup check over the bundle's storage/restart/sync
+/// contracts. Output is bounded to ids and closed reason kinds; it never
+/// includes raw storage paths.
+pub fn run_startup_contract_check(resolver: &BundleResolver) -> StorageLifecycleReport {
+    let mut issues = Vec::new();
+
+    let storage = resolver.storage.as_ref();
+    let sync = resolver.sync.as_ref();
+    let contracts_expected =
+        resolver.bundle.bundle_version >= STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION;
+
+    if let Some(storage) = storage {
+        if let Err(detail) = storage.validate_unique_ids() {
+            issues.push(StorageLifecycleIssue::StorageContractInvalid {
+                reason: classify_storage_validation_reason(&detail),
+            });
+        }
+    } else if contracts_expected {
+        issues.push(StorageLifecycleIssue::MissingStorageContract);
+    } else {
+        issues.push(StorageLifecycleIssue::LegacyBundleContractsUnavailable {
+            bundle_version: resolver.bundle.bundle_version,
+        });
+    }
+
+    if let Some(sync) = sync {
+        if let Err(detail) = sync.validate_lock_order() {
+            issues.push(StorageLifecycleIssue::SyncContractInvalid {
+                reason: classify_sync_validation_reason(&detail),
+            });
+        }
+    } else if contracts_expected {
+        issues.push(StorageLifecycleIssue::MissingSyncContract);
+    } else {
+        if !issues.iter().any(|issue| {
+            matches!(
+                issue,
+                StorageLifecycleIssue::LegacyBundleContractsUnavailable { .. }
+            )
+        }) {
+            issues.push(StorageLifecycleIssue::LegacyBundleContractsUnavailable {
+                bundle_version: resolver.bundle.bundle_version,
+            });
+        }
+    }
+
+    if let Some(storage) = storage {
+        let restart_keys: BTreeSet<(&str, &str)> = storage
+            .restart_policies
+            .iter()
+            .map(|policy| (policy.vm.as_str(), policy.role_id.as_str()))
+            .collect();
+        for dag in &resolver.processes.vms {
+            for node in &dag.nodes {
+                let key = (dag.vm.as_str(), node.id.0.as_str());
+                if !restart_keys.contains(&key) {
+                    issues.push(StorageLifecycleIssue::MissingRestartPolicy {
+                        vm: dag.vm.clone(),
+                        role_id: node.id.0.clone(),
+                    });
+                }
+            }
+        }
+        for policy in &storage.restart_policies {
+            if policy.restart_class == RestartClass::Adoptable
+                && policy.adoption_inputs.cgroup_leaf.is_none()
+            {
+                issues.push(StorageLifecycleIssue::AdoptableMissingCgroupLeaf {
+                    vm: policy.vm.as_str().to_owned(),
+                    role_id: policy.role_id.as_str().to_owned(),
+                });
+            }
+        }
+    }
+
+    StorageLifecycleReport {
+        schema_version: STORAGE_LIFECYCLE_REPORT_SCHEMA_VERSION.to_owned(),
+        storage_contract_present: storage.is_some(),
+        sync_contract_present: sync.is_some(),
+        path_count: storage.map(|s| s.paths.len()).unwrap_or_default(),
+        restart_policy_count: storage
+            .map(|s| s.restart_policies.len())
+            .unwrap_or_default(),
+        lock_count: sync.map(|s| s.locks.len()).unwrap_or_default(),
+        issues,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nixling_core::bundle::Bundle;
+    use nixling_core::bundle_resolver::BundleResolver;
+    use nixling_core::host::HostJson;
+    use nixling_core::manifest_v04::ManifestV04;
+    use nixling_core::processes::{
+        ProcessNode, ProcessRole, ProcessesJson, RoleProfile, VmProcessDag, VmProcessInvariants,
+    };
+    use nixling_core::storage::{
+        AdoptionInputs, CleanupPolicy, DegradeScope, DegradedReason, LedgerStorageClass,
+        ProcessRestartPolicy, ReadinessAfterAdopt, ReadinessAfterAdoptKind, RemediationSpec,
+        RepairPolicy, RestartClass, StorageAdoptionPolicy, StorageJson, StorageLifecycle,
+        StoragePathKind, StoragePathSpec, StoragePersistence, StorageRestartPolicy,
+    };
+    use nixling_core::sync::{
+        FdPassingMechanism, FdPassingPolicy, InheritancePolicy, LockAcquireOrder,
+        LockAdoptionPolicy, LockKind, LockScopeClass, LockSpec, LockStaleKind, LockStalePolicy,
+        LockTimeoutKind, LockTimeoutPolicy, SyncJson,
+    };
+    use nixling_core::{
+        contract_id::{ContractId, ContractText, PathTemplate},
+        minijail_profile::{CgroupPlacement, MountPolicy, NamespaceSet},
+        storage::{
+            ActorKind, ActorRef, LeaseClass, PrincipalKind, PrincipalRef, SensitivityClass,
+            StorageInvariant,
+        },
+    };
+
+    use super::*;
+
+    #[test]
+    fn reports_clean_when_every_process_has_restart_policy_and_lock_contracts() {
+        let resolver = resolver_with_contracts(true, true);
+        let report = run_startup_contract_check(&resolver);
+        assert!(!report.is_degraded(), "{report:?}");
+        assert_eq!(report.restart_policy_count, 1);
+        assert_eq!(report.lock_count, 1);
+    }
+
+    #[test]
+    fn reports_missing_restart_policy() {
+        let resolver = resolver_with_contracts(false, true);
+        let report = run_startup_contract_check(&resolver);
+        assert!(report.issues.iter().any(|issue| {
+            matches!(
+                issue,
+                StorageLifecycleIssue::MissingRestartPolicy { vm, role_id }
+                    if vm == "corp-vm" && role_id == "cloud-hypervisor"
+            )
+        }));
+    }
+
+    #[test]
+    fn reports_adoptable_policy_without_cgroup_leaf() {
+        let resolver = resolver_with_contracts(true, false);
+        let report = run_startup_contract_check(&resolver);
+        assert!(report.issues.iter().any(|issue| {
+            matches!(
+                issue,
+                StorageLifecycleIssue::AdoptableMissingCgroupLeaf { vm, role_id }
+                    if vm == "corp-vm" && role_id == "cloud-hypervisor"
+            )
+        }));
+    }
+
+    #[test]
+    fn reports_missing_contracts_for_current_bundle() {
+        let resolver =
+            resolver_with_optional_contracts(STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION, None, None);
+        let report = run_startup_contract_check(&resolver);
+        assert!(
+            report
+                .issues
+                .contains(&StorageLifecycleIssue::MissingStorageContract)
+        );
+        assert!(
+            report
+                .issues
+                .contains(&StorageLifecycleIssue::MissingSyncContract)
+        );
+    }
+
+    #[test]
+    fn reports_legacy_bundle_without_warning_issue_fanout() {
+        let resolver = resolver_with_optional_contracts(
+            STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION - 1,
+            None,
+            None,
+        );
+        let report = run_startup_contract_check(&resolver);
+        assert!(report.has_only_legacy_contract_issue(), "{report:?}");
+    }
+
+    #[test]
+    fn reports_invalid_storage_contract_without_raw_detail() {
+        let mut storage = storage(true, true);
+        storage.paths.push(storage.paths[0].clone());
+        let resolver = resolver_with_optional_contracts(
+            STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION,
+            Some(storage),
+            Some(sync()),
+        );
+        let report = run_startup_contract_check(&resolver);
+        assert!(report.issues.iter().any(|issue| {
+            matches!(
+                issue,
+                StorageLifecycleIssue::StorageContractInvalid {
+                    reason: StorageContractValidationReason::DuplicateStoragePathId
+                }
+            )
+        }));
+    }
+
+    #[test]
+    fn reports_invalid_sync_contract_without_raw_detail() {
+        let mut sync = sync();
+        sync.locks.push(sync.locks[0].clone());
+        let resolver = resolver_with_optional_contracts(
+            STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION,
+            Some(storage(true, true)),
+            Some(sync),
+        );
+        let report = run_startup_contract_check(&resolver);
+        assert!(report.issues.iter().any(|issue| {
+            matches!(
+                issue,
+                StorageLifecycleIssue::SyncContractInvalid {
+                    reason: SyncContractValidationReason::DuplicateLockId
+                }
+            )
+        }));
+    }
+
+    #[test]
+    fn classifiers_fall_back_to_unclassified_for_unknown_details() {
+        assert_eq!(
+            classify_storage_validation_reason("future storage validation failure"),
+            StorageContractValidationReason::Unclassified,
+        );
+        assert_eq!(
+            classify_sync_validation_reason("future sync validation failure"),
+            SyncContractValidationReason::Unclassified,
+        );
+    }
+
+    #[test]
+    fn bundle_resolver_unavailable_report_is_degraded_and_schema_current() {
+        let report = bundle_resolver_unavailable_report();
+        assert_eq!(
+            report.schema_version,
+            STORAGE_LIFECYCLE_REPORT_SCHEMA_VERSION
+        );
+        assert!(report.is_degraded());
+        assert_eq!(
+            report.issues,
+            vec![StorageLifecycleIssue::BundleResolverUnavailable]
+        );
+    }
+
+    fn resolver_with_contracts(include_restart: bool, include_cgroup_leaf: bool) -> BundleResolver {
+        resolver_with_optional_contracts(
+            STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION,
+            Some(storage(include_restart, include_cgroup_leaf)),
+            Some(sync()),
+        )
+    }
+
+    fn resolver_with_optional_contracts(
+        bundle_version: u32,
+        storage_contract: Option<StorageJson>,
+        sync_contract: Option<SyncJson>,
+    ) -> BundleResolver {
+        let bundle = Bundle {
+            bundle_version,
+            schema_version: "v2".to_owned(),
+            public_manifest_path: "manifest.json".to_owned(),
+            host_path: "host.json".to_owned(),
+            processes_path: "processes.json".to_owned(),
+            privileges_path: "privileges.json".to_owned(),
+            storage_path: storage_contract.as_ref().map(|_| "storage.json".to_owned()),
+            sync_path: sync_contract.as_ref().map(|_| "sync.json".to_owned()),
+            closures: Vec::new(),
+            minijail_profiles: Vec::new(),
+            managed_keys: Default::default(),
+            generation: nixling_core::bundle::BundleGeneration {
+                generator: "test".to_owned(),
+                source_revision: None,
+                generated_at: None,
+            },
+            bundle_hash: None,
+            artifact_hashes: None,
+        };
+        BundleResolver::from_artifacts_with_optional_contracts(
+            bundle,
+            minimal_host(),
+            processes(),
+            storage_contract,
+            sync_contract,
+            manifest(),
+        )
+    }
+
+    fn actor(kind: ActorKind, value: &str) -> ActorRef {
+        ActorRef {
+            kind,
+            value: ContractId::parse(value).unwrap(),
+        }
+    }
+
+    fn principal(kind: PrincipalKind, value: &str) -> PrincipalRef {
+        PrincipalRef {
+            kind,
+            value: ContractId::parse(value).unwrap(),
+        }
+    }
+
+    fn storage(include_restart: bool, include_cgroup_leaf: bool) -> StorageJson {
+        let restart_policies = if include_restart {
+            vec![ProcessRestartPolicy {
+                vm: ContractId::parse("corp-vm").unwrap(),
+                role_id: ContractId::parse("cloud-hypervisor").unwrap(),
+                restart_class: RestartClass::Adoptable,
+                adoption_inputs: AdoptionInputs {
+                    cgroup_leaf: include_cgroup_leaf.then(|| {
+                        ContractId::parse("nixling.slice/corp-vm/cloud-hypervisor").unwrap()
+                    }),
+                    identity_checks: Vec::new(),
+                },
+                persistent_state_refs: Vec::new(),
+                runtime_state_refs: Vec::new(),
+                cleanup_before_restart: false,
+                degrade_on_failure: DegradedReason::AdoptionQuarantined,
+                degrade_scope: DegradeScope::Role,
+                readiness_after_adopt: ReadinessAfterAdopt {
+                    kind: ReadinessAfterAdoptKind::ExistingPredicate,
+                    storage_ref: None,
+                },
+                remediation_id: ContractId::parse("remediate:vm-status").unwrap(),
+            }]
+        } else {
+            Vec::new()
+        };
+        StorageJson {
+            schema_version: "v2".to_owned(),
+            roots: Vec::new(),
+            paths: vec![StoragePathSpec {
+                id: ContractId::parse("path:run-root").unwrap(),
+                scope: ContractId::parse("host").unwrap(),
+                path_template: PathTemplate::parse("/run/nixling").unwrap(),
+                kind: StoragePathKind::Directory,
+                lifecycle: StorageLifecycle::BootScopedReadoptable,
+                persistence: StoragePersistence::BootScoped,
+                owner: principal(PrincipalKind::User, "nixlingd"),
+                group: principal(PrincipalKind::Group, "nixling"),
+                mode: "0750".to_owned(),
+                access_acl: Vec::new(),
+                default_acl: Vec::new(),
+                creator: actor(ActorKind::Daemon, "nixlingd"),
+                writers: vec![actor(ActorKind::Daemon, "nixlingd")],
+                readers: vec![actor(ActorKind::Daemon, "nixlingd")],
+                cleanup_policy: CleanupPolicy::Boot,
+                repair_policy: RepairPolicy::BrokerReconcile,
+                restart_policy: StorageRestartPolicy::PreserveAcrossDaemonRestart,
+                adoption_policy: StorageAdoptionPolicy::AdoptWithLiveOwnerProof,
+                lease_class: LeaseClass::None,
+                sensitivity: SensitivityClass::Private,
+                no_follow: true,
+                recursive: false,
+                invariants: vec![StorageInvariant::NoSymlink],
+            }],
+            restart_policies,
+            degraded_states: vec![nixling_core::storage::DegradedStateSpec {
+                reason: DegradedReason::AdoptionQuarantined,
+                scope: DegradeScope::Role,
+                storage_class: LedgerStorageClass::TamperEvidentSegmented,
+                remediation_id: ContractId::parse("remediate:vm-status").unwrap(),
+            }],
+            remediations: vec![RemediationSpec {
+                id: ContractId::parse("remediate:vm-status").unwrap(),
+                command: ContractText::parse("nixling vm status <vm>").unwrap(),
+                description: ContractText::parse("Inspect VM status").unwrap(),
+            }],
+        }
+    }
+
+    fn sync() -> SyncJson {
+        SyncJson {
+            schema_version: "v2".to_owned(),
+            locks: vec![LockSpec {
+                id: ContractId::parse("lock:daemon").unwrap(),
+                scope: ContractId::parse("host").unwrap(),
+                path_template: Some(PathTemplate::parse("/run/nixling/daemon.lock").unwrap()),
+                resource_id: None,
+                kind: LockKind::Ofd,
+                owner_process: actor(ActorKind::Daemon, "nixlingd"),
+                allowed_holders: vec![actor(ActorKind::Daemon, "nixlingd")],
+                inheritance_policy: InheritancePolicy::CloseOnExec,
+                fd_passing_policy: FdPassingPolicy {
+                    mechanism: FdPassingMechanism::None,
+                    lease_transfer_record_required: false,
+                },
+                acquire_order: LockAcquireOrder {
+                    scope_class: LockScopeClass::Global,
+                    anchored_root: ContractId::parse("run").unwrap(),
+                    normalized_path: ContractId::parse("daemon.lock").unwrap(),
+                    lock_id: ContractId::parse("lock:daemon").unwrap(),
+                },
+                timeout_policy: LockTimeoutPolicy {
+                    kind: LockTimeoutKind::FailFast,
+                    timeout_ms: None,
+                },
+                stale_policy: LockStalePolicy {
+                    kind: LockStaleKind::PidfdProofRequired,
+                    degraded_reason: DegradedReason::LockOwnerAmbiguous,
+                },
+                adoption_policy: LockAdoptionPolicy::ReacquireAfterProof,
+                degrade_scope: DegradeScope::Host,
+                release_authority: actor(ActorKind::Daemon, "nixlingd"),
+                cloexec_required: true,
+            }],
+        }
+    }
+
+    fn processes() -> ProcessesJson {
+        ProcessesJson {
+            schema_version: "v2".to_owned(),
+            vms: vec![VmProcessDag {
+                vm: "corp-vm".to_owned(),
+                nodes: vec![ProcessNode {
+                    id: nixling_core::processes::NodeId("cloud-hypervisor".to_owned()),
+                    role: ProcessRole::CloudHypervisorRunner,
+                    unit: None,
+                    binary_path: Some("/nix/store/ch/bin/cloud-hypervisor".to_owned()),
+                    argv: vec!["cloud-hypervisor".to_owned()],
+                    env: Vec::new(),
+                    plan_ops: Vec::new(),
+                    profile: RoleProfile {
+                        profile_id: "vm-corp-vm-cloud-hypervisor".to_owned(),
+                        uid: 1000,
+                        gid: 1000,
+                        adr_carve_out: None,
+                        caps: Vec::new(),
+                        namespaces: NamespaceSet {
+                            mount: true,
+                            pid: false,
+                            net: false,
+                            ipc: true,
+                            uts: false,
+                            user: false,
+                        },
+                        seccomp_policy_ref: Some("w1-cloud-hypervisor-runner".to_owned()),
+                        mount_policy: MountPolicy {
+                            read_only_paths: Vec::new(),
+                            writable_paths: Vec::new(),
+                            nix_store_read_only: true,
+                            hide_device_nodes_by_default: true,
+                            device_binds: Vec::new(),
+                            bind_mounts: Vec::new(),
+                        },
+                        cgroup_placement: CgroupPlacement {
+                            subtree: "nixling.slice/corp-vm/cloud-hypervisor".to_owned(),
+                            controllers: Vec::new(),
+                            delegated: false,
+                        },
+                        user_namespace: None,
+                        umask: None,
+                    },
+                    readiness: Vec::new(),
+                }],
+                edges: Vec::new(),
+                invariants: VmProcessInvariants {
+                    swtpm_pre_start_flush: true,
+                    per_vm_audit_pipeline: true,
+                    usbip_gating: true,
+                    tpm_ownership_migration_without_running_vm_mutation: true,
+                },
+            }],
+        }
+    }
+
+    fn minimal_host() -> HostJson {
+        serde_json::from_str(r##"{
+            "schemaVersion":"v2",
+            "site":{"allowUnsafeEastWest":false},
+            "environments":[],
+            "nftables":{"family":"inet","table":"nixling","chains":[],"tableHashAfterApply":null,"ownershipId":"test"},
+            "hostsFile":{"startMarker":"# begin","endMarker":"# end","rule":"test"},
+            "networkManager":{"filePath":"/etc/NetworkManager/conf.d/00-nixling.conf","matchCriteria":[],"reloadBehavior":"none","ownership":{"owner":"root","group":"root","mode":"0644","driftPolicy":"replace-managed-block"}},
+            "kernelModules":[],
+            "fdOwnership":[],
+            "cloudHypervisorCapabilities":[],
+            "ifNameMappings":[],
+            "ch":{"netHandoffMode":"tap-fd"},
+            "firewallCoexistencePolicy":{"manager":"none","policy":"coexist","rationale":"test"}
+        }"##)
+        .expect("minimal HostJson")
+    }
+
+    fn manifest() -> ManifestV04 {
+        ManifestV04::from_slice(
+            br#"{"_manifest":{"manifestVersion":5},"_observability":{"enabled":false,"obsVsockCid":0,"obsVsockHostSocket":"","signozOtlpGrpcPort":4317,"signozOtlpHttpPort":4318,"signozUrl":"","vmName":""},"corp-vm":{"apiSocket":"/run/nixling/vms/corp-vm/api.sock","audio":false,"audioService":"","audioStateFile":"","bridge":"nl-brTEST","env":"work","mtu":null,"mssClamp":null,"lan":null,"gpuSocket":"","graphics":false,"isNetVm":false,"name":"corp-vm","netVm":null,"observability":{"agentSocket":"","enabled":false,"vsockCid":0,"vsockHostSocket":""},"sshUser":"alice","stateDir":"/var/lib/nixling/vms/corp-vm","staticIp":"10.20.0.10","tap":"nl-tTEST","tpm":false,"tpmSocket":"","usbipYubikey":false,"usbipdHostIp":null}}"#,
+        ).expect("minimal ManifestV04")
+    }
+}

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -17,7 +17,8 @@ use nixling::{
 use nixling_core::{
     bundle::Bundle, closures::ClosureMetadata, error::Error, host::HostJson,
     manifest_v04::ManifestV04, minijail_profile::MinijailProfile, privileges::PrivilegesJson,
-    processes::ProcessesJson, storage::StorageJson, sync::SyncJson,
+    processes::ProcessesJson, storage::StorageJson, storage_lifecycle::StorageLifecycleReport,
+    sync::SyncJson,
 };
 use nixling_ipc::{WireProtocolSchema, guest_wire::GuestControlSchema};
 use schemars::schema::RootSchema;
@@ -217,12 +218,16 @@ fn gen_schemas() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
         .join(SCHEMA_VERSION);
     fs::create_dir_all(&out_dir)?;
 
-    let schemas: [(&str, RootSchema); 11] = [
+    let schemas: [(&str, RootSchema); 12] = [
         ("bundle.json", schemars::schema_for!(Bundle)),
         ("host.json", schemars::schema_for!(HostJson)),
         ("processes.json", schemars::schema_for!(ProcessesJson)),
         ("storage.json", schemars::schema_for!(StorageJson)),
         ("sync.json", schemars::schema_for!(SyncJson)),
+        (
+            "storage-lifecycle-report.json",
+            schemars::schema_for!(StorageLifecycleReport),
+        ),
         ("privileges.json", schemars::schema_for!(PrivilegesJson)),
         ("closures.json", schemars::schema_for!(ClosureMetadata)),
         (


### PR DESCRIPTION
## Summary
- run the read-only storage/restart/sync contract check before daemon runner adoption
- persist `storage-lifecycle-report.json` atomically under daemon-state with stale-report protection on bundle resolver failure
- add the shared nixling-core report DTO, generated schema, reference doc, and expanded daemon tests

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --exclude nixling-contract-tests`
- `make test-policy`
- `make test-flake`
- `bash tests/test-drift.sh`

## Panel
Gemini 3.1 Pro implementation panel signed off 10/10 after R3.

## Notes
`/etc/nixos` was not touched. Host consumption remains deferred until the framework PR lands.