### PR TITLE
tests: pin storage lifecycle report contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ deprecations ship one minor release before removal.
 - Daemon: startup now performs a read-only storage/restart/sync contract
   check and persists `storage-lifecycle-report.json` for degraded-state
   adoption work and future doctor/status UX.
+- Tests: added storage lifecycle report schema and serialization
+  regression coverage so doctor/status consumers see the same camelCase
+  contract that the daemon writes.
 - Documentation: ADR 0034 and the storage lifecycle explanation now
   define the planned generated contracts for managed paths, process
   restart/adoption, synchronization, lock ownership, degraded-state

--- a/packages/nixling-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/nixling-contract-tests/tests/storage_sync_contracts.rs
@@ -58,6 +58,53 @@ fn storage_and_sync_schemas_are_committed_and_closed() {
 }
 
 #[test]
+fn storage_lifecycle_report_schema_and_reference_are_committed() {
+    let schema = read_repo_file("docs/reference/schemas/v2/storage-lifecycle-report.json");
+    let reference = read_repo_file("docs/reference/storage-lifecycle-report.md");
+    let xtask = read_repo_file("packages/xtask/src/main.rs");
+    let schema: serde_json::Value =
+        serde_json::from_str(&schema).expect("storage lifecycle report schema parses as JSON");
+
+    assert_eq!(schema["title"], "StorageLifecycleReport");
+    assert!(schema["properties"].get("schemaVersion").is_some());
+
+    let issue_variants = schema["definitions"]["StorageLifecycleIssue"]["oneOf"]
+        .as_array()
+        .expect("StorageLifecycleIssue oneOf variants");
+    let legacy_variant = issue_variants
+        .iter()
+        .find(|variant| {
+            variant["properties"]["kind"]["enum"]
+                .as_array()
+                .is_some_and(|values| {
+                    values
+                        .iter()
+                        .any(|value| value == "legacy-bundle-contracts-unavailable")
+                })
+        })
+        .expect("legacy bundle issue variant in schema");
+    assert!(legacy_variant["properties"].get("bundleVersion").is_some());
+    assert!(legacy_variant["properties"].get("bundle_version").is_none());
+
+    for kind in ["missing-restart-policy", "adoptable-missing-cgroup-leaf"] {
+        let role_variant = issue_variants
+            .iter()
+            .find(|variant| {
+                variant["properties"]["kind"]["enum"]
+                    .as_array()
+                    .is_some_and(|values| values.iter().any(|value| value == kind))
+            })
+            .unwrap_or_else(|| panic!("{kind} issue variant in schema"));
+        assert!(role_variant["properties"].get("roleId").is_some());
+        assert!(role_variant["properties"].get("role_id").is_none());
+    }
+
+    assert!(reference.contains("/var/lib/nixling/daemon-state/storage-lifecycle-report.json"));
+    assert!(reference.contains("./schemas/v2/storage-lifecycle-report.json"));
+    assert!(xtask.contains("\"storage-lifecycle-report.json\""));
+}
+
+#[test]
 fn rendered_storage_contract_covers_process_writable_paths_when_fixture_available() {
     let Some(dir) = env::var_os("NL_FIXTURES").map(PathBuf::from) else {
         eprintln!("  (skipping rendered storage/sync contract check; NL_FIXTURES unset)");

--- a/packages/nixling-core/src/storage_lifecycle.rs
+++ b/packages/nixling-core/src/storage_lifecycle.rs
@@ -130,3 +130,104 @@ pub fn classify_sync_validation_reason(detail: &str) -> SyncContractValidationRe
         SyncContractValidationReason::Unclassified
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn issue_variant_fields_serialize_with_schema_casing() {
+        let legacy =
+            serde_json::to_value(StorageLifecycleIssue::LegacyBundleContractsUnavailable {
+                bundle_version: 5,
+            })
+            .expect("serialize legacy issue");
+        assert_eq!(
+            legacy,
+            json!({
+                "kind": "legacy-bundle-contracts-unavailable",
+                "bundleVersion": 5
+            })
+        );
+
+        let missing_restart = serde_json::to_value(StorageLifecycleIssue::MissingRestartPolicy {
+            vm: "corp-vm".to_owned(),
+            role_id: "cloud-hypervisor".to_owned(),
+        })
+        .expect("serialize missing restart issue");
+        assert_eq!(
+            missing_restart,
+            json!({
+                "kind": "missing-restart-policy",
+                "vm": "corp-vm",
+                "roleId": "cloud-hypervisor"
+            })
+        );
+
+        let adoptable_missing_cgroup =
+            serde_json::to_value(StorageLifecycleIssue::AdoptableMissingCgroupLeaf {
+                vm: "corp-vm".to_owned(),
+                role_id: "cloud-hypervisor".to_owned(),
+            })
+            .expect("serialize adoptable missing cgroup issue");
+        assert_eq!(
+            adoptable_missing_cgroup,
+            json!({
+                "kind": "adoptable-missing-cgroup-leaf",
+                "vm": "corp-vm",
+                "roleId": "cloud-hypervisor"
+            })
+        );
+    }
+
+    #[test]
+    fn report_accepts_future_top_level_fields() {
+        let report = serde_json::from_value::<StorageLifecycleReport>(json!({
+            "schemaVersion": "v2",
+            "storageContractPresent": true,
+            "syncContractPresent": true,
+            "pathCount": 1,
+            "restartPolicyCount": 1,
+            "lockCount": 1,
+            "issues": [],
+            "futureField": "ignored"
+        }))
+        .expect("top-level report is forward-compatible");
+
+        assert!(!report.is_degraded());
+    }
+
+    #[test]
+    fn issue_kinds_are_deduped_and_stable() {
+        let report = StorageLifecycleReport {
+            schema_version: "v2".to_owned(),
+            storage_contract_present: false,
+            sync_contract_present: false,
+            path_count: 0,
+            restart_policy_count: 0,
+            lock_count: 0,
+            issues: vec![
+                StorageLifecycleIssue::MissingRestartPolicy {
+                    vm: "corp-vm".to_owned(),
+                    role_id: "cloud-hypervisor".to_owned(),
+                },
+                StorageLifecycleIssue::AdoptableMissingCgroupLeaf {
+                    vm: "another-vm".to_owned(),
+                    role_id: "vhost-device-sound".to_owned(),
+                },
+                StorageLifecycleIssue::LegacyBundleContractsUnavailable { bundle_version: 5 },
+                StorageLifecycleIssue::MissingRestartPolicy {
+                    vm: "different-vm".to_owned(),
+                    role_id: "swtpm".to_owned(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            report.issue_kinds_csv(),
+            "adoptable-missing-cgroup-leaf,legacy-bundle-contracts-unavailable,missing-restart-policy"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for storage lifecycle report serialization, forward-compatible parsing, and bounded issue-kind summaries
- add a contract test that structurally validates the generated storage lifecycle report schema and reference wiring
- update the changelog with the new regression coverage

## Validation
- `cargo test -p nixling-core storage_lifecycle --lib -- --nocapture`
- `cargo test -p nixling-contract-tests --test storage_sync_contracts -- --nocapture`
- `cargo clippy -p nixling-core -p nixling-contract-tests --all-targets -- -D warnings`
- `bash tests/test-drift.sh`
- `make test-policy`
- `make test-flake`

## Panel
Gemini 3.1 Pro implementation panel signed off 10/10 after R3.

## Notes
Validation-only follow-up; no runtime behavior changes. `/etc/nixos` was not touched.