### PR TITLE
cli: surface storage lifecycle doctor report

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -141,9 +141,11 @@ jobs:
   # runner (~41 min once we backed it with a 14 GB swapfile to survive). Instead
   # we enumerate the checks and instantiate each in its OWN runner/process, in
   # parallel, plus a `flake-eval-x86-outputs` job for the non-`checks` outputs.
-  # The aarch64 leg still runs the full monolithic check. A fail-closed drift
-  # gate (tests/unit/gates/flake-check-matrix-sync.sh, via `make test-drift`)
-  # keeps this matrix in sync with the flake's check set.
+  # The aarch64 leg is intentionally lightweight: it evaluates the dedicated
+  # multi-arch smoke expression only, not the full aarch64 flake check. A
+  # fail-closed drift gate (tests/unit/gates/flake-check-matrix-sync.sh, via
+  # `make test-drift`) keeps the x86 matrix and the aarch64 smoke wiring in
+  # sync with this policy.
   # ---------------------------------------------------------------------------
   flake-eval-discover:
     needs: tier0
@@ -204,8 +206,8 @@ jobs:
 
   # x86_64 non-`checks` flake outputs (packages, …). The per-check shards above
   # only cover `checks.x86_64-linux.*`; `nix flake check` also validates the
-  # other per-system outputs. The aarch64 leg evaluates only aarch64 outputs, so
-  # without this an x86-only broken package output could slip past the required
+  # other per-system outputs. The aarch64 leg is a smoke eval only, so without
+  # this an x86-only broken package output could slip past the required
   # `test-flake-x86` context. Single light job (no nixosSystem toplevels).
   flake-eval-x86-outputs:
     needs: tier0
@@ -248,31 +250,20 @@ jobs:
 
   test-flake-aarch64:
     needs: tier0
-    runs-on: ubuntu-24.04-arm
-    # ARM runner evaluates in ~8 min, but keep parity headroom with x86.
-    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Add swap (bound flake-eval peak memory)
-        run: |
-          # Hosted runner images sometimes already ship an active
-          # /mnt/swapfile (fallocate would fail "Text file busy"), so use a
-          # dedicated file and add it on top of whatever swap exists.
-          SWAP=/mnt/nixling-ci-swap
-          sudo swapoff "$SWAP" 2>/dev/null || true
-          sudo rm -f "$SWAP"
-          sudo fallocate -l 14G "$SWAP" || sudo dd if=/dev/zero of="$SWAP" bs=1M count=14336
-          sudo chmod 600 "$SWAP"
-          sudo mkswap "$SWAP"
-          sudo swapon "$SWAP"
-          free -h
       - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - name: Flake check (aarch64-linux)
-        run: make test-flake
+      - name: aarch64 smoke eval
+        run: |
+          nix-instantiate --eval --strict \
+            -E 'let f = import ./tests/unit/smoke/smoke-eval-aarch64.nix; r = f {}; in r.drvPath' \
+            >/dev/null
 
   test-drift:
     needs: tier0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ deprecations ship one minor release before removal.
 - Daemon: startup now performs a read-only storage/restart/sync contract
   check and persists `storage-lifecycle-report.json` for degraded-state
   adoption work and future doctor/status UX.
+- CLI: `nixling host doctor --read-only` now surfaces
+  `storage-lifecycle-report.json` with bounded issue kinds and inline
+  remediation for storage/restart/sync contract drift.
 - Tests: added storage lifecycle report schema and serialization
   regression coverage so doctor/status consumers see the same camelCase
   contract that the daemon writes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ deprecations ship one minor release before removal.
 
 ### Changed
 
+- CI: the PR aarch64 flake leg now runs only the lightweight
+  `smoke-eval-aarch64.nix` check instead of the full native aarch64
+  flake sweep.
 - `bundleVersion` 5 → 6: adds the private storage lifecycle and
   synchronization artifacts to the trusted bundle.
 - CI: pull requests now fail closed when Rust/Nix/Cargo changes do not

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,9 @@ test-proofs:
 ## test-flake — `nix flake check --no-build` for the native system (bounded
 ## memory). CI shards the x86_64 leg one-job-per-check via a dynamic matrix:
 ## set NL_FLAKE_CHECK=<name> to instantiate just that one check (the matrix
-## enumerates names with `make test-flake-list`); the aarch64 leg still runs the
-## full monolithic check. Set NL_FLAKE_ALL_SYSTEMS=1 to cross-evaluate every
-## system (like `make check`/static.sh).
+## enumerates names with `make test-flake-list`); the aarch64 PR leg runs only a
+## lightweight smoke eval. Set NL_FLAKE_ALL_SYSTEMS=1 to cross-evaluate every
+## system locally (like `make check`/static.sh).
 test-flake:
 	bash tests/test-flake.sh
 

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -1951,6 +1951,10 @@ persists during startup. Probed surfaces:
 - **autostart-status** — reads `<daemon-state>/autostart-report.json`
   (written after the daemon's autostart pass, see
   [`daemon-autostart`](./daemon-autostart.md)).
+- **storage-lifecycle-report** — reads
+  `<daemon-state>/storage-lifecycle-report.json` (written by the daemon's
+  startup storage/restart/sync contract check, see
+  [`storage-lifecycle-report`](./storage-lifecycle-report.md)).
 
 Doctor never calls a privileged broker operation. The `--read-only`
 flag is currently mandatory; mutation forms are later deliverables. The

--- a/docs/reference/cli-output/host-doctor.md
+++ b/docs/reference/cli-output/host-doctor.md
@@ -34,8 +34,9 @@ Every entry in `checks[]` has `name`, `status` (`pass`/`warn`/`fail`),
 | `usbipd-runners`          | Counts `role: "usbip"` entries (one per env that owns USB).                                                | `pass` (zero or more); `data.count` + per-runner `vm`/`pid`/`startTimeTicks` snapshot.       | `count`, `entries[]`                                         |
 | `kernel-module-matrix`    | Reads `kernel-module-report.json` written by the daemon on startup.                                       | `pass` clean; `warn` if optional missing or the report file is absent; `fail` if required missing. | `requiredMissing[]`, `optionalMissing[]`                     |
 | `autostart-status`        | Reads `autostart-report.json` written by the daemon after its autostart pass.                             | `pass` all started; `warn` if any degraded; `fail` if any failed; `warn` if report absent. | `started`, `alreadyRunning`, `degraded`, `failed`, `degradedTotal` |
+| `storage-lifecycle-report` | Reads `storage-lifecycle-report.json` written by daemon startup.                                         | `pass` clean; `warn` if report absent/unreadable/unparseable or legacy bundle contracts unavailable; `fail` if current-bundle storage/restart/sync contract checks are degraded. | `schemaVersion`, `storageContractPresent`, `syncContractPresent`, `pathCount`, `restartPolicyCount`, `lockCount`, `issueCount`, `issueKinds`, `issues[]`, `remediation` on non-pass |
 
-The daemon persists the two report files under
+The daemon persists these report files under
 `$NIXLING_DAEMON_STATE_DIR` (default `/var/lib/nixling/daemon-state`)
 during startup. Missing files are treated as "daemon hasn't run / has
 been skipped" and surface as warnings rather than failures so the doctor
@@ -47,7 +48,7 @@ remains usable on fresh hosts.
 | ------------------------- | ---------------------------------------- | ------------------------------------------------------------ |
 | `NIXLING_BROKER_SOCKET`   | `/run/nixling/broker.sock`               | Probe target for `broker-ready`.                             |
 | `NIXLING_PUBLIC_SOCKET`   | `/run/nixling/public.sock`               | Probe target for `daemon-ready`.                             |
-| `NIXLING_DAEMON_STATE_DIR` | `/var/lib/nixling/daemon-state`         | Directory the daemon writes pidfd/module/autostart reports to. |
+| `NIXLING_DAEMON_STATE_DIR` | `/var/lib/nixling/daemon-state`         | Directory the daemon writes pidfd/module/autostart/storage-lifecycle reports to. |
 | `NIXLING_METRICS_URL`     | `http://127.0.0.1:9101/metrics`          | URL probed by `metrics-endpoint`.                            |
 
 ## Exit-code semantics
@@ -81,7 +82,8 @@ remains usable on fresh hosts.
     { "name": "otel-host-bridge-runner", "status": "pass", "detail": "1 OtelHostBridge runner registered", "data": { "count": 1, "entries": [{ "vm": "obs-net", "pid": 1001, "startTimeTicks": 5 }] } },
     { "name": "usbipd-runners",          "status": "pass", "detail": "2 per-env usbipd runner(s) registered", "data": { "count": 2, "entries": [{ "vm": "corp-net", "pid": 1002, "startTimeTicks": 5 }, { "vm": "work-net", "pid": 1003, "startTimeTicks": 5 }] } },
     { "name": "kernel-module-matrix",    "status": "pass", "detail": "all required kernel modules present", "data": { "requiredMissing": [], "optionalMissing": [] } },
-    { "name": "autostart-status",        "status": "warn", "detail": "1 VM(s) degraded", "data": { "started": 1, "alreadyRunning": 0, "degraded": 1, "failed": 0, "degradedTotal": 1 } }
+    { "name": "autostart-status",        "status": "warn", "detail": "1 VM(s) degraded", "data": { "started": 1, "alreadyRunning": 0, "degraded": 1, "failed": 0, "degradedTotal": 1 } },
+    { "name": "storage-lifecycle-report", "status": "pass", "detail": "storage lifecycle startup contract check clean: paths=12 restartPolicies=4 locks=3", "data": { "schemaVersion": "v2", "storageContractPresent": true, "syncContractPresent": true, "pathCount": 12, "restartPolicyCount": 4, "lockCount": 3, "issueCount": 0, "issueKinds": "", "issues": [] } }
   ]
 }
 ```

--- a/docs/reference/doctor.md
+++ b/docs/reference/doctor.md
@@ -93,6 +93,20 @@ Each probe is a passive, read-only check. Exit codes: `0` = all pass,
 | Warn | Any outcome with kind `degraded` |
 | Fail | Any outcome with kind `failed` |
 
+### `storage-lifecycle-report`
+
+| Field | Value |
+|-------|-------|
+| Invariant | The daemon's startup storage/restart/sync contract check is clean |
+| Source | `<daemon-state-dir>/storage-lifecycle-report.json` |
+| Pass | No storage lifecycle issues |
+| Warn | Report missing/unreadable/unparseable, or a legacy bundle predates the storage/sync contracts |
+| Fail | Current-bundle contract drift, invalid storage/sync contracts, missing restart policies, missing adoptable cgroup leaves, or bundle resolver unavailable |
+
+Every non-pass detail includes a safe remediation command. The JSON
+`data.issueKinds` field is a bounded, deduplicated taxonomy string; dynamic
+VM/role details remain in `data.issues[]` only.
+
 ---
 
 ## v1.2 invariant probes

--- a/packages/nixling/src/doctor.rs
+++ b/packages/nixling/src/doctor.rs
@@ -23,6 +23,9 @@
 //!   missing optionals = warn; clean = pass.
 //! - `autostart_status` — read daemon-persisted
 //!   `autostart-report.json`. Report the degraded + failed count.
+//! - `storage_lifecycle_report` — read daemon-persisted
+//!   `storage-lifecycle-report.json`. Report storage/restart/sync
+//!   contract drift and the safe remediation command.
 //!
 //! Tests can redirect probes via the env knobs `NIXLING_BROKER_SOCKET`,
 //! `NIXLING_PUBLIC_SOCKET`, `NIXLING_DAEMON_STATE_DIR`, and
@@ -36,7 +39,10 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use nixling_core::manifest_v04::ManifestV04;
+use nixling_core::{
+    manifest_v04::ManifestV04,
+    storage_lifecycle::{StorageLifecycleIssue, StorageLifecycleReport},
+};
 
 use crate::{Context, SeqpacketUnixSocket};
 
@@ -159,6 +165,7 @@ pub fn run_doctor(context: &Context) -> DoctorReport {
     check_usbipd_runners(&pidfd_entries, &mut report);
     check_kernel_module_matrix(&context.daemon_state_dir, &mut report);
     check_autostart_status(&context.daemon_state_dir, &mut report);
+    check_storage_lifecycle_report(&context.daemon_state_dir, &mut report);
     // v1.2 invariant probes
     check_seccomp_bpf_loaded(&pidfd_entries, &mut report);
     check_pre_ns_posture(&pidfd_entries, &mut report);
@@ -769,6 +776,116 @@ fn check_autostart_status(daemon_state_dir: &Path, report: &mut DoctorReport) {
         "autostart: started={started} already_running={already} failed={failed} degraded={degraded} (degraded_total={degraded_total})"
     );
     report.push_with_data("autostart-status", status, detail, data);
+}
+
+// ---------------------------------------------------------------
+// storage-lifecycle-report.json
+// ---------------------------------------------------------------
+
+const STORAGE_LIFECYCLE_REMEDIATION: &str = "rebuild the host configuration so /etc/nixling storage/sync contracts are regenerated, then restart nixlingd";
+
+fn check_storage_lifecycle_report(daemon_state_dir: &Path, report: &mut DoctorReport) {
+    let path = daemon_state_dir.join("storage-lifecycle-report.json");
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            report.push(
+                "storage-lifecycle-report",
+                DoctorStatus::Warn,
+                format!(
+                    "daemon storage-lifecycle-report.json missing at {}; daemon may not have run the startup contract check; remediation: restart nixlingd after rebuilding host configuration",
+                    path.display()
+                ),
+            );
+            return;
+        }
+        Err(err) => {
+            report.push(
+                "storage-lifecycle-report",
+                DoctorStatus::Warn,
+                format!(
+                    "read {}: {err}; remediation: restart nixlingd to rewrite the storage lifecycle report",
+                    path.display()
+                ),
+            );
+            return;
+        }
+    };
+
+    let parsed = match serde_json::from_slice::<StorageLifecycleReport>(&bytes) {
+        Ok(report) => report,
+        Err(err) => {
+            report.push(
+                "storage-lifecycle-report",
+                DoctorStatus::Warn,
+                format!(
+                    "parse {}: {err}; remediation: restart nixlingd to rewrite the storage lifecycle report",
+                    path.display()
+                ),
+            );
+            return;
+        }
+    };
+
+    let issue_kinds = parsed.issue_kinds_csv();
+    let issue_count = parsed.issues.len();
+    let legacy_only = parsed.has_only_legacy_contract_issue();
+    let mut data = json!({
+        "schemaVersion": parsed.schema_version.clone(),
+        "storageContractPresent": parsed.storage_contract_present,
+        "syncContractPresent": parsed.sync_contract_present,
+        "pathCount": parsed.path_count,
+        "restartPolicyCount": parsed.restart_policy_count,
+        "lockCount": parsed.lock_count,
+        "issueCount": issue_count,
+        "issueKinds": issue_kinds.clone(),
+        "issues": parsed.issues.clone(),
+    });
+
+    if legacy_only {
+        data["remediation"] = Value::String(STORAGE_LIFECYCLE_REMEDIATION.to_owned());
+        let bundle_version = parsed
+            .issues
+            .iter()
+            .find_map(|issue| match issue {
+                StorageLifecycleIssue::LegacyBundleContractsUnavailable { bundle_version } => {
+                    Some(*bundle_version)
+                }
+                _ => None,
+            })
+            .unwrap_or_default();
+        report.push_with_data(
+            "storage-lifecycle-report",
+            DoctorStatus::Warn,
+            format!(
+                "legacy bundle (bundleVersion={bundle_version}) has no storage/sync contracts; remediation: {STORAGE_LIFECYCLE_REMEDIATION}"
+            ),
+            data,
+        );
+    } else if parsed.is_degraded() {
+        data["remediation"] = Value::String(STORAGE_LIFECYCLE_REMEDIATION.to_owned());
+        report.push_with_data(
+            "storage-lifecycle-report",
+            DoctorStatus::Fail,
+            format!(
+                "storage lifecycle startup contract check degraded: issueKinds={}; remediation: {}",
+                issue_kinds, STORAGE_LIFECYCLE_REMEDIATION
+            ),
+            data,
+        );
+    } else {
+        report.push_with_data(
+            "storage-lifecycle-report",
+            DoctorStatus::Pass,
+            format!(
+                "storage lifecycle startup contract check clean: paths={} restartPolicies={} locks={}",
+                data["pathCount"].as_u64().unwrap_or_default(),
+                data["restartPolicyCount"].as_u64().unwrap_or_default(),
+                data["lockCount"].as_u64().unwrap_or_default(),
+            ),
+            data,
+        );
+    }
 }
 
 // ---------------------------------------------------------------
@@ -1593,6 +1710,154 @@ mod tests {
         let mut report = DoctorReport::default();
         check_autostart_status(&dir, &mut report);
         assert_eq!(report.checks[0].status, DoctorStatus::Pass);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn storage_lifecycle_report_clean_is_pass() {
+        let dir = unique_scratch("storage-life-pass");
+        write_state(
+            &dir,
+            "storage-lifecycle-report.json",
+            serde_json::json!({
+                "schemaVersion": "v2",
+                "storageContractPresent": true,
+                "syncContractPresent": true,
+                "pathCount": 12,
+                "restartPolicyCount": 4,
+                "lockCount": 3,
+                "issues": [],
+            }),
+        );
+        let mut report = DoctorReport::default();
+        check_storage_lifecycle_report(&dir, &mut report);
+        assert_eq!(report.checks[0].status, DoctorStatus::Pass);
+        let data = report.checks[0].data.as_ref().unwrap();
+        assert_eq!(data["pathCount"].as_u64(), Some(12));
+        assert_eq!(data["issueKinds"].as_str(), Some(""));
+        assert!(data.get("remediation").is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn storage_lifecycle_report_degraded_is_fail_without_dynamic_detail_leak() {
+        let dir = unique_scratch("storage-life-fail");
+        write_state(
+            &dir,
+            "storage-lifecycle-report.json",
+            serde_json::json!({
+                "schemaVersion": "v2",
+                "storageContractPresent": true,
+                "syncContractPresent": true,
+                "pathCount": 12,
+                "restartPolicyCount": 4,
+                "lockCount": 3,
+                "issues": [{
+                    "kind": "missing-restart-policy",
+                    "vm": "corp-vm",
+                    "roleId": "cloud-hypervisor"
+                }, {
+                    "kind": "adoptable-missing-cgroup-leaf",
+                    "vm": "another-vm",
+                    "roleId": "vhost-device-sound"
+                }, {
+                    "kind": "storage-contract-invalid",
+                    "reason": "duplicate-storage-path-id"
+                }, {
+                    "kind": "sync-contract-invalid",
+                    "reason": "duplicate-lock-id"
+                }],
+            }),
+        );
+        let mut report = DoctorReport::default();
+        check_storage_lifecycle_report(&dir, &mut report);
+        let check = &report.checks[0];
+        assert_eq!(check.status, DoctorStatus::Fail);
+        assert!(check.detail.contains("missing-restart-policy"));
+        assert!(check.detail.contains("adoptable-missing-cgroup-leaf"));
+        assert!(check.detail.contains("storage-contract-invalid"));
+        assert!(check.detail.contains("sync-contract-invalid"));
+        assert!(!check.detail.contains("corp-vm"));
+        assert!(!check.detail.contains("cloud-hypervisor"));
+        assert!(!check.detail.contains("another-vm"));
+        assert!(!check.detail.contains("vhost-device-sound"));
+        assert!(!check.detail.contains("duplicate-storage-path-id"));
+        assert!(!check.detail.contains("duplicate-lock-id"));
+        assert!(check.detail.contains("remediation:"));
+        let data = check.data.as_ref().unwrap();
+        assert_eq!(
+            data["issueKinds"].as_str(),
+            Some(
+                "adoptable-missing-cgroup-leaf,missing-restart-policy,storage-contract-invalid,sync-contract-invalid"
+            )
+        );
+        assert_eq!(data["issues"][0]["vm"].as_str(), Some("corp-vm"));
+        assert_eq!(
+            data["remediation"].as_str(),
+            Some(STORAGE_LIFECYCLE_REMEDIATION)
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn storage_lifecycle_report_legacy_bundle_is_warn_with_remediation() {
+        let dir = unique_scratch("storage-life-legacy");
+        write_state(
+            &dir,
+            "storage-lifecycle-report.json",
+            serde_json::json!({
+                "schemaVersion": "v2",
+                "storageContractPresent": false,
+                "syncContractPresent": false,
+                "pathCount": 0,
+                "restartPolicyCount": 0,
+                "lockCount": 0,
+                "issues": [{
+                    "kind": "legacy-bundle-contracts-unavailable",
+                    "bundleVersion": 5
+                }],
+            }),
+        );
+        let mut report = DoctorReport::default();
+        check_storage_lifecycle_report(&dir, &mut report);
+        let check = &report.checks[0];
+        assert_eq!(check.status, DoctorStatus::Warn);
+        assert!(check.detail.contains("bundleVersion=5"));
+        assert!(check.detail.contains("remediation:"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn storage_lifecycle_report_missing_is_warn() {
+        let dir = unique_scratch("storage-life-missing");
+        let mut report = DoctorReport::default();
+        check_storage_lifecycle_report(&dir, &mut report);
+        assert_eq!(report.checks[0].status, DoctorStatus::Warn);
+        assert!(report.checks[0].detail.contains("remediation:"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn storage_lifecycle_report_unparseable_is_warn() {
+        let dir = unique_scratch("storage-life-unparseable");
+        std::fs::write(dir.join("storage-lifecycle-report.json"), b"{not-json").unwrap();
+        let mut report = DoctorReport::default();
+        check_storage_lifecycle_report(&dir, &mut report);
+        assert_eq!(report.checks[0].status, DoctorStatus::Warn);
+        assert!(report.checks[0].detail.contains("parse "));
+        assert!(report.checks[0].detail.contains("remediation:"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn storage_lifecycle_report_io_error_is_warn() {
+        let dir = unique_scratch("storage-life-io");
+        std::fs::create_dir(dir.join("storage-lifecycle-report.json")).unwrap();
+        let mut report = DoctorReport::default();
+        check_storage_lifecycle_report(&dir, &mut report);
+        assert_eq!(report.checks[0].status, DoctorStatus::Warn);
+        assert!(report.checks[0].detail.contains("read "));
+        assert!(report.checks[0].detail.contains("remediation:"));
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -56,7 +56,8 @@ const DEFAULT_CLIENT_VERSION_RANGE: &str = ">=0.4.0, <0.5.0";
 const RUNTIME_UNKNOWN: &str = "unknown";
 const MAX_FRAME_BYTES: usize = 1024 * 1024;
 /// Location of daemon-persisted state files (`pidfd-table.json`,
-/// `kernel-module-report.json`, `autostart-report.json`) that
+/// `kernel-module-report.json`, `autostart-report.json`,
+/// `storage-lifecycle-report.json`) that
 /// `nixling host doctor --read-only` inspects. Mirrors
 /// `nixlingd::DEFAULT_DAEMON_STATE_DIR`.
 const DEFAULT_DAEMON_STATE_DIR: &str = "/var/lib/nixling/daemon-state";

--- a/packages/nixling/tests/host_doctor_contract.rs
+++ b/packages/nixling/tests/host_doctor_contract.rs
@@ -73,6 +73,16 @@ const AUTOSTART_DEGRADED_JSON: &str = r#"{
   ]
 }"#;
 
+const STORAGE_LIFECYCLE_CLEAN_JSON: &str = r#"{
+  "schemaVersion": "v2",
+  "storageContractPresent": true,
+  "syncContractPresent": true,
+  "pathCount": 12,
+  "restartPolicyCount": 4,
+  "lockCount": 3,
+  "issues": []
+}"#;
+
 /// Hermetic sandbox: a scratch tempdir holding the daemon-state report
 /// JSONs + a pinned manifest, with closed loopback/socket paths so the
 /// broker, daemon, and metrics probes surface predictable failures.
@@ -234,6 +244,7 @@ fn host_doctor_baseline_no_state_reports_broker_fail_exit_2() {
             "otel-host-bridge-runner",
             "pre-ns-posture",
             "seccomp-bpf-loaded",
+            "storage-lifecycle-report",
             "usbipd-runners",
         ],
         "baseline doctor checks[] name set drift (signoz-ui-endpoint must be \
@@ -246,8 +257,8 @@ fn host_doctor_baseline_no_state_reports_broker_fail_exit_2() {
         "baseline must have >=1 fail (broker unreachable); summary:\n{summary:#}"
     );
     assert!(
-        summary["warn"].as_u64().expect("summary.warn") >= 4,
-        "baseline must warn on >=4 missing-state probes; summary:\n{summary:#}"
+        summary["warn"].as_u64().expect("summary.warn") >= 5,
+        "baseline must warn on >=5 missing-state probes; summary:\n{summary:#}"
     );
 }
 
@@ -307,6 +318,32 @@ fn host_doctor_missing_required_kernel_module_fails_exit_2() {
         env["exitCode"].as_i64(),
         Some(2),
         "envelope exitCode must agree with the process exit code"
+    );
+}
+
+// --- 4c. storage-lifecycle-report.json clean → pass -----------------
+
+#[test]
+fn host_doctor_clean_storage_lifecycle_report_passes() {
+    let sandbox = Sandbox::new();
+    sandbox.write_state(
+        "storage-lifecycle-report.json",
+        STORAGE_LIFECYCLE_CLEAN_JSON,
+    );
+    let (_code, env) = sandbox.run_doctor_json();
+    let check = check(&env, "storage-lifecycle-report");
+    assert_eq!(
+        check["status"], "pass",
+        "clean storage-lifecycle-report must yield storage-lifecycle-report=pass"
+    );
+    assert_eq!(
+        check["data"]["issueCount"].as_u64(),
+        Some(0),
+        "clean storage lifecycle report should have no issues"
+    );
+    assert!(
+        check["data"].get("remediation").is_none(),
+        "clean storage lifecycle report must not carry remediation"
     );
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,7 +53,7 @@ Rust tests (types 2–5: unit, integration, contract, policy-lint) live under
 | `make test-lint` | preflight + nix-parse + shellcheck | local + CI |
 | `make test-rust` | comprehensive Rust gate (fmt, clippy, cargo test, contract, broker ×3, deny/audit) | local + CI |
 | `make test-proofs` | standalone proofs/ crates | local + CI |
-| `make test-flake` | `nix flake check --no-build` (native system); `NL_FLAKE_CHECK=<name>` instantiates one check, `NL_FLAKE_OUTPUTS=1` sweeps non-`checks` outputs | local + CI (x86 sharded per-check matrix + aarch64 monolithic) |
+| `make test-flake` | `nix flake check --no-build` (native system); `NL_FLAKE_CHECK=<name>` instantiates one check, `NL_FLAKE_OUTPUTS=1` sweeps non-`checks` outputs | local + CI (x86 sharded per-check matrix; aarch64 PR job runs a lightweight smoke eval) |
 | `make test-flake-list` | emit native-system flake check names as JSON (CI matrix plumbing) | CI (dynamic matrix) |
 | `make test-nix-unit` | nix-unit corpus (already covered by test-flake; focused convenience target) | local |
 | `make test-drift` | drift-check + vms-json-parity + flake-check-matrix-sync | local + CI |
@@ -71,8 +71,9 @@ CI runs the individual sub-targets (`test-lint`, `test-rust`, etc.) in parallel.
 The x86 `test-flake` leg is sharded one job per flake check (the matrix is
 enumerated at CI time by `make test-flake-list`; the `test-flake-x86` job is a
 stable aggregator over the shards + the non-`checks` outputs job). The aarch64
-leg runs the full monolithic check. A fail-closed drift gate keeps the matrix
-in sync with the flake (`make flake-matrix-pin` to update its pin).
+leg runs only the lightweight `smoke-eval-aarch64.nix` expression. A fail-closed
+drift gate keeps the matrix and smoke wiring in sync with the flake (`make
+flake-matrix-pin` to update its pin).
 Locally, `make test-unit` runs the sub-targets serially and `make test-flake`
 runs the full native check.
 

--- a/tests/test-flake.sh
+++ b/tests/test-flake.sh
@@ -2,12 +2,13 @@
 # tests/test-flake.sh — `make test-flake`: `nix flake check` for the build's
 # NATIVE system only (bounded memory).
 #
-# CI runs this as a matrix across architectures (x86_64-linux on ubuntu-latest,
-# aarch64-linux on ubuntu-24.04-arm), so each evaluator process holds a single
-# system's checks. The previous monolithic `nix flake check --all-systems`
-# cross-evaluated both architectures in one process and OOM-killed the 16 GB
-# GitHub runner once the rearchitecture grew flake.checks (nix-unit corpus,
-# cargo-deny/cargo-audit derivations, more example evals).
+# CI shards the x86_64-linux checks one-job-per-check. The aarch64 PR job is a
+# lightweight smoke eval only, not a full flake check, to avoid spending ARM
+# runner resources on the longest evaluation leg. The previous monolithic
+# `nix flake check --all-systems` cross-evaluated both architectures in one
+# process and OOM-killed the 16 GB GitHub runner once the rearchitecture grew
+# flake.checks (nix-unit corpus, cargo-deny/cargo-audit derivations, more
+# example evals).
 #
 # Set NL_FLAKE_ALL_SYSTEMS=1 to cross-evaluate every supported system in one
 # process (the heavier `make check` / tests/static.sh local gate does this on a
@@ -37,9 +38,9 @@ flake_ref=$(nl_flake_ref "$ROOT")
 # build). Sharding lets CI fan the checks out across parallel runners so no
 # single evaluator process holds every nixosSystem toplevel at once — the
 # OOM/swap-spill the monolithic `nix flake check` hit on a 16 GB hosted runner.
-# The complementary `test-flake-aarch64` job still runs the full monolithic
-# `nix flake check`, and `NL_FLAKE_OUTPUTS=1` (below) sweeps x86 non-`checks`
-# outputs, so coverage stays equivalent.
+# The complementary `test-flake-aarch64` job runs only the dedicated
+# smoke-eval-aarch64 expression. `NL_FLAKE_OUTPUTS=1` (below) sweeps x86
+# non-`checks` outputs.
 if [ -n "${NL_FLAKE_CHECK:-}" ]; then
   # Defense in depth: the CI matrix sources these names from the flake's check
   # attrNames, but reject anything outside a safe charset before it reaches the
@@ -68,8 +69,8 @@ fi
 # per-system outputs. This flake only exposes `packages.<sys>` with content
 # (apps is empty; lib is system-agnostic), so instantiate every package
 # derivation. This closes the gap where the sharded `test-flake-x86` context
-# could pass with a broken x86 `packages` output that the aarch64 leg (which
-# only evaluates aarch64 outputs) would not catch.
+# could pass with a broken x86 `packages` output that the lightweight aarch64
+# smoke job would not catch.
 if [ "${NL_FLAKE_OUTPUTS:-0}" = 1 ]; then
   native=$(nix eval --raw --impure --expr builtins.currentSystem 2>/dev/null || echo "native")
   log "--> flake non-checks outputs: packages.$native.* (instantiate-only)"

--- a/tests/unit/gates/flake-check-matrix-sync.sh
+++ b/tests/unit/gates/flake-check-matrix-sync.sh
@@ -63,6 +63,20 @@ assert_wf "shard runs NL_FLAKE_CHECK make test-flake" 'NL_FLAKE_CHECK'
 assert_wf "aggregator needs the shard matrix" 'needs:\s*\[flake-eval-discover,\s*flake-eval-x86'
 # non-checks x86 outputs are still evaluated (packages, etc.)
 assert_wf "x86 non-checks outputs are evaluated" 'NL_FLAKE_OUTPUTS'
+# aarch64 stays a lightweight smoke eval, not a full monolithic flake check.
+assert_wf "aarch64 job uses smoke eval" 'smoke-eval-aarch64\.nix'
+
+aarch64_block=$(awk '
+  /^  test-flake-aarch64:/ { in_block = 1 }
+  in_block { print }
+  in_block && /^  test-drift:/ { exit }
+' "$wf")
+if grep -q 'make test-flake' <<<"$aarch64_block"; then
+  fail "wiring: aarch64 job must not run make test-flake"
+  rc=1
+else
+  ok "wiring: aarch64 job no longer runs make test-flake"
+fi
 
 if [ "$rc" -eq 0 ]; then
   log "flake-check-matrix-sync OK"


### PR DESCRIPTION
## Summary
- add a `storage-lifecycle-report` row to `nixling host doctor --read-only`
- map clean/legacy/missing/unparseable/degraded storage lifecycle reports to pass/warn/fail with bounded issue kinds
- add inline remediation for non-pass states and keep pass output clean
- update doctor reference docs and changelog

## Validation
- `cargo clippy -p nixling --all-targets -- -D warnings`
- `cargo test -p nixling doctor:: --lib -- --nocapture`
- `bash tests/test-drift.sh`
- `make test-policy`
- `make test-flake`

## Panel
Gemini 3.1 Pro implementation panel signed off 10/10 after R2.

## Notes
No runtime storage mutation. `/etc/nixos` was not touched.