### PR TITLE
cli: add storage cutover dry-run plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ deprecations ship one minor release before removal.
 - CLI: `nixling host doctor --read-only` now surfaces
   `storage-lifecycle-report.json` with bounded issue kinds and inline
   remediation for storage/restart/sync contract drift.
+- CLI: added `nixling host migrate-storage --dry-run`, which emits a
+  checkpoint ID, exact rollback command, preserved-data inventory,
+  cutover-only cleanup candidates, and fail-closed hazards for the
+  planned storage layout migration.
 - Tests: added storage lifecycle report schema and serialization
   regression coverage so doctor/status consumers see the same camelCase
   contract that the daemon writes.

--- a/docs/completions/nixling.bash
+++ b/docs/completions/nixling.bash
@@ -292,6 +292,9 @@ _nixling() {
             nixling__subcmd__help__subcmd__host,install)
                 cmd="nixling__subcmd__help__subcmd__host__subcmd__install"
                 ;;
+            nixling__subcmd__help__subcmd__host,migrate-storage)
+                cmd="nixling__subcmd__help__subcmd__host__subcmd__migrate__subcmd__storage"
+                ;;
             nixling__subcmd__help__subcmd__host,prepare)
                 cmd="nixling__subcmd__help__subcmd__host__subcmd__prepare"
                 ;;
@@ -355,6 +358,9 @@ _nixling() {
             nixling__subcmd__host,install)
                 cmd="nixling__subcmd__host__subcmd__install"
                 ;;
+            nixling__subcmd__host,migrate-storage)
+                cmd="nixling__subcmd__host__subcmd__migrate__subcmd__storage"
+                ;;
             nixling__subcmd__host,prepare)
                 cmd="nixling__subcmd__host__subcmd__prepare"
                 ;;
@@ -378,6 +384,9 @@ _nixling() {
                 ;;
             nixling__subcmd__host__subcmd__help,install)
                 cmd="nixling__subcmd__host__subcmd__help__subcmd__install"
+                ;;
+            nixling__subcmd__host__subcmd__help,migrate-storage)
+                cmd="nixling__subcmd__host__subcmd__help__subcmd__migrate__subcmd__storage"
                 ;;
             nixling__subcmd__host__subcmd__help,prepare)
                 cmd="nixling__subcmd__host__subcmd__help__subcmd__prepare"
@@ -1355,7 +1364,7 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__help__subcmd__host)
-            opts="check prepare destroy doctor install reconcile validate"
+            opts="check prepare destroy doctor migrate-storage install reconcile validate"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1411,6 +1420,20 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__help__subcmd__host__subcmd__install)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        nixling__subcmd__help__subcmd__host__subcmd__migrate__subcmd__storage)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1845,7 +1868,7 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__host)
-            opts="-h --help check prepare destroy doctor install reconcile validate help"
+            opts="-h --help check prepare destroy doctor migrate-storage install reconcile validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1901,7 +1924,7 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__host__subcmd__help)
-            opts="check prepare destroy doctor install reconcile validate help"
+            opts="check prepare destroy doctor migrate-storage install reconcile validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1984,6 +2007,20 @@ _nixling() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        nixling__subcmd__host__subcmd__help__subcmd__migrate__subcmd__storage)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         nixling__subcmd__host__subcmd__help__subcmd__prepare)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
@@ -2033,6 +2070,24 @@ _nixling() {
                 return 0
             fi
             case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        nixling__subcmd__host__subcmd__migrate__subcmd__storage)
+            opts="-h --dry-run --apply --rollback --from-checkpoint --json --human --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --from-checkpoint)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/docs/completions/nixling.fish
+++ b/docs/completions/nixling.fish
@@ -102,15 +102,16 @@ complete -c nixling -n "__fish_nixling_using_subcommand audit" -l strict
 complete -c nixling -n "__fish_nixling_using_subcommand audit" -l json
 complete -c nixling -n "__fish_nixling_using_subcommand audit" -l human
 complete -c nixling -n "__fish_nixling_using_subcommand audit" -s h -l help -d 'Print help'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -s h -l help -d 'Print help'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "check" -d 'Read-only preflight: inventories host posture without mutation'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "prepare" -d 'Reconcile host-side state (bridges, nftables, sysctls). --apply mutates'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "destroy" -d 'Tear down host-side state owned by nixling. --apply mutates'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "doctor" -d 'Read-only deep diagnostics for the daemon + broker state'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "install" -d 'Install nixlingd + broker units onto the host. --apply mutates'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "reconcile" -d 'Recover host network state after the daemon engaged operator-only mode'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "validate" -d 'Run the host-side validator suite and write evidence records'
-complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor install reconcile validate help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -s h -l help -d 'Print help'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "check" -d 'Read-only preflight: inventories host posture without mutation'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "prepare" -d 'Reconcile host-side state (bridges, nftables, sysctls). --apply mutates'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "destroy" -d 'Tear down host-side state owned by nixling. --apply mutates'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "doctor" -d 'Read-only deep diagnostics for the daemon + broker state'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "migrate-storage" -d 'Plan the one-time storage layout cutover. --apply is fail-closed until broker support lands'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "install" -d 'Install nixlingd + broker units onto the host. --apply mutates'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "reconcile" -d 'Recover host network state after the daemon engaged operator-only mode'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "validate" -d 'Run the host-side validator suite and write evidence records'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and not __fish_seen_subcommand_from check prepare destroy doctor migrate-storage install reconcile validate help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from check" -l read-only
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from check" -l strict
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from check" -l json
@@ -130,6 +131,13 @@ complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_su
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from doctor" -l json
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from doctor" -l human
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from doctor" -s h -l help -d 'Print help'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from migrate-storage" -l from-checkpoint -d 'Checkpoint ID to roll back' -r
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from migrate-storage" -l dry-run -d 'Plan the storage cutover without mutating host state'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from migrate-storage" -l apply -d 'Apply the storage cutover. Currently fails closed until broker support lands'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from migrate-storage" -l rollback -d 'Roll back from a named storage cutover checkpoint'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from migrate-storage" -l json
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from migrate-storage" -l human
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from migrate-storage" -s h -l help -d 'Print help'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from install" -l dry-run -d 'Report the planned install steps without mutating'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from install" -l apply -d 'Perform the install through the daemon → broker `RunHostInstall` path'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from install" -l enable -d 'After `--apply`, enable nixlingd.service via systemctl'
@@ -157,6 +165,7 @@ complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_su
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from help" -f -a "prepare" -d 'Reconcile host-side state (bridges, nftables, sysctls). --apply mutates'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from help" -f -a "destroy" -d 'Tear down host-side state owned by nixling. --apply mutates'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from help" -f -a "doctor" -d 'Read-only deep diagnostics for the daemon + broker state'
+complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from help" -f -a "migrate-storage" -d 'Plan the one-time storage layout cutover. --apply is fail-closed until broker support lands'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from help" -f -a "install" -d 'Install nixlingd + broker units onto the host. --apply mutates'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from help" -f -a "reconcile" -d 'Recover host network state after the daemon engaged operator-only mode'
 complete -c nixling -n "__fish_nixling_using_subcommand host; and __fish_seen_subcommand_from help" -f -a "validate" -d 'Run the host-side validator suite and write evidence records'
@@ -378,6 +387,7 @@ complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_su
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "prepare" -d 'Reconcile host-side state (bridges, nftables, sysctls). --apply mutates'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "destroy" -d 'Tear down host-side state owned by nixling. --apply mutates'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "doctor" -d 'Read-only deep diagnostics for the daemon + broker state'
+complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "migrate-storage" -d 'Plan the one-time storage layout cutover. --apply is fail-closed until broker support lands'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "install" -d 'Install nixlingd + broker units onto the host. --apply mutates'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "reconcile" -d 'Recover host network state after the daemon engaged operator-only mode'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "validate" -d 'Run the host-side validator suite and write evidence records'

--- a/docs/completions/nixling.zsh
+++ b/docs/completions/nixling.zsh
@@ -282,6 +282,18 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 && ret=0
 ;;
+(migrate-storage)
+_arguments "${_arguments_options[@]}" : \
+'--from-checkpoint=[Checkpoint ID to roll back]:ID:_default' \
+'(--apply --rollback)--dry-run[Plan the storage cutover without mutating host state]' \
+'(--dry-run --rollback)--apply[Apply the storage cutover. Currently fails closed until broker support lands]' \
+'(--dry-run --apply)--rollback[Roll back from a named storage cutover checkpoint]' \
+'(--human)--json[]' \
+'(--json)--human[]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
 (install)
 _arguments "${_arguments_options[@]}" : \
 '(--apply --enable --start --no-start)--dry-run[Report the planned install steps without mutating]' \
@@ -345,6 +357,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (doctor)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(migrate-storage)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1045,6 +1061,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(migrate-storage)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (install)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1671,6 +1691,7 @@ _nixling__subcmd__help__subcmd__host_commands() {
 'prepare:Reconcile host-side state (bridges, nftables, sysctls). --apply mutates' \
 'destroy:Tear down host-side state owned by nixling. --apply mutates' \
 'doctor:Read-only deep diagnostics for the daemon + broker state' \
+'migrate-storage:Plan the one-time storage layout cutover. --apply is fail-closed until broker support lands' \
 'install:Install nixlingd + broker units onto the host. --apply mutates' \
 'reconcile:Recover host network state after the daemon engaged operator-only mode' \
 'validate:Run the host-side validator suite and write evidence records' \
@@ -1696,6 +1717,11 @@ _nixling__subcmd__help__subcmd__host__subcmd__doctor_commands() {
 _nixling__subcmd__help__subcmd__host__subcmd__install_commands() {
     local commands; commands=()
     _describe -t commands 'nixling help host install commands' commands "$@"
+}
+(( $+functions[_nixling__subcmd__help__subcmd__host__subcmd__migrate-storage_commands] )) ||
+_nixling__subcmd__help__subcmd__host__subcmd__migrate-storage_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling help host migrate-storage commands' commands "$@"
 }
 (( $+functions[_nixling__subcmd__help__subcmd__host__subcmd__prepare_commands] )) ||
 _nixling__subcmd__help__subcmd__host__subcmd__prepare_commands() {
@@ -1871,6 +1897,7 @@ _nixling__subcmd__host_commands() {
 'prepare:Reconcile host-side state (bridges, nftables, sysctls). --apply mutates' \
 'destroy:Tear down host-side state owned by nixling. --apply mutates' \
 'doctor:Read-only deep diagnostics for the daemon + broker state' \
+'migrate-storage:Plan the one-time storage layout cutover. --apply is fail-closed until broker support lands' \
 'install:Install nixlingd + broker units onto the host. --apply mutates' \
 'reconcile:Recover host network state after the daemon engaged operator-only mode' \
 'validate:Run the host-side validator suite and write evidence records' \
@@ -1900,6 +1927,7 @@ _nixling__subcmd__host__subcmd__help_commands() {
 'prepare:Reconcile host-side state (bridges, nftables, sysctls). --apply mutates' \
 'destroy:Tear down host-side state owned by nixling. --apply mutates' \
 'doctor:Read-only deep diagnostics for the daemon + broker state' \
+'migrate-storage:Plan the one-time storage layout cutover. --apply is fail-closed until broker support lands' \
 'install:Install nixlingd + broker units onto the host. --apply mutates' \
 'reconcile:Recover host network state after the daemon engaged operator-only mode' \
 'validate:Run the host-side validator suite and write evidence records' \
@@ -1932,6 +1960,11 @@ _nixling__subcmd__host__subcmd__help__subcmd__install_commands() {
     local commands; commands=()
     _describe -t commands 'nixling host help install commands' commands "$@"
 }
+(( $+functions[_nixling__subcmd__host__subcmd__help__subcmd__migrate-storage_commands] )) ||
+_nixling__subcmd__host__subcmd__help__subcmd__migrate-storage_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling host help migrate-storage commands' commands "$@"
+}
 (( $+functions[_nixling__subcmd__host__subcmd__help__subcmd__prepare_commands] )) ||
 _nixling__subcmd__host__subcmd__help__subcmd__prepare_commands() {
     local commands; commands=()
@@ -1951,6 +1984,11 @@ _nixling__subcmd__host__subcmd__help__subcmd__validate_commands() {
 _nixling__subcmd__host__subcmd__install_commands() {
     local commands; commands=()
     _describe -t commands 'nixling host install commands' commands "$@"
+}
+(( $+functions[_nixling__subcmd__host__subcmd__migrate-storage_commands] )) ||
+_nixling__subcmd__host__subcmd__migrate-storage_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling host migrate-storage commands' commands "$@"
 }
 (( $+functions[_nixling__subcmd__host__subcmd__prepare_commands] )) ||
 _nixling__subcmd__host__subcmd__prepare_commands() {

--- a/docs/manpages/nixling-host.1
+++ b/docs/manpages/nixling-host.1
@@ -1,0 +1,41 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH nixling-host 1 1970-01-01 nixling "nixling CLI"
+.SH NAME
+host \- Host\-side preflight, install, doctor, and reconcile verbs
+.SH SYNOPSIS
+\fBhost\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Host\-side preflight, install, doctor, and reconcile verbs
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.SH SUBCOMMANDS
+.TP
+host\-check(1)
+Read\-only preflight: inventories host posture without mutation
+.TP
+host\-prepare(1)
+Reconcile host\-side state (bridges, nftables, sysctls). \-\-apply mutates
+.TP
+host\-destroy(1)
+Tear down host\-side state owned by nixling. \-\-apply mutates
+.TP
+host\-doctor(1)
+Read\-only deep diagnostics for the daemon + broker state
+.TP
+host\-migrate\-storage(1)
+Plan the one\-time storage layout cutover. \-\-apply is fail\-closed until broker support lands
+.TP
+host\-install(1)
+Install nixlingd + broker units onto the host. \-\-apply mutates
+.TP
+host\-reconcile(1)
+Recover host network state after the daemon engaged operator\-only mode
+.TP
+host\-validate(1)
+Run the host\-side validator suite and write evidence records
+.TP
+host\-help(1)
+Print this message or the help of the given subcommand(s)

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -1857,6 +1857,103 @@ host destroy --dry-run: no nixling-owned resources to remove
 
 - In v1.0 daemon-only, `exec_legacy_passthrough` always returns the typed `not-yet-implemented` envelope (exit 78 per ADR 0015); the historical bash-fallback shim was retired in v1.0.
 
+### `host migrate-storage`
+
+**Synopsis:** `nixling host migrate-storage [--dry-run | --apply | --rollback --from-checkpoint <id>] [--human | --json]`
+
+**Status**
+
+Plans the one-time breaking storage layout cutover. The current build is
+read-only for this verb: `--dry-run` emits a checkpoint ID, the exact
+rollback command, preflight requirements, preserved persistent data,
+cutover-only cleanup candidates, and fail-closed hazards. `--apply` and
+`--rollback` fail closed until the broker-backed mover ships.
+
+**Flags**
+
+| Flag | Type | Default | Semantics |
+| --- | --- | --- | --- |
+| `--dry-run` | boolean | required unless `--apply` or `--rollback` is set | Plan the storage cutover without moving or deleting host state. |
+| `--apply` | boolean | `false` | Apply the storage cutover. Currently returns a typed not-implemented envelope. |
+| `--rollback` | boolean | `false` | Roll back from a checkpoint. Currently returns a typed not-implemented envelope. |
+| `--from-checkpoint` | string | required with `--rollback` | Checkpoint ID from the dry-run plan. |
+| `--json` | boolean | `false` | Emit the dry-run plan or typed refusal envelope as JSON. |
+| `--human` | boolean | `false` | Emit the human dry-run plan. |
+
+**Arguments**
+
+| Argument | Semantics |
+| --- | --- |
+| _(none)_ | Storage cutover planning is global. |
+
+**Dry-run JSON shape**
+
+```json
+{
+  "command": "host migrate-storage",
+  "mode": "dry-run",
+  "checkpointId": "storage-cutover-…",
+  "rollbackCommand": "nixling host migrate-storage --rollback --from-checkpoint storage-cutover-…",
+  "vmCount": 2,
+  "vms": ["corp-vm", "work-vm"],
+  "preflightRequirements": [
+    "all nixling VMs stopped",
+    "nixlingd.service stopped",
+    "nixling-priv-broker.service stopped",
+    "net VMs stopped; guest routing, TAP connectivity, and dependent bridge traffic will be interrupted"
+  ],
+  "preserve": [
+    "per-VM swtpm NVRAM and swtpm identity markers",
+    "declared host bridges, TAP naming intent, nftables/NM/networkd ownership metadata, and network-preflight evidence"
+  ],
+  "cutoverOnlyCleanup": [
+    "/run/nixling-gpu",
+    "boot-scoped runtime socket files only after all nixling services are stopped"
+  ],
+  "failClosedHazards": [
+    "symlink or path traversal inside any moved path",
+    "recursive operations traversing hardlink farms or mutating shared /nix/store inodes",
+    "any attempt to unlink lock files during cutover rather than leaving /run locks for reboot/tmpfs cleanup"
+  ],
+  "applyStatus": "not-implemented-in-this-build"
+}
+```
+
+**Exit codes**
+
+| Code | Meaning | Typed error / reference |
+| --- | --- | --- |
+| `0` | Dry-run plan rendered. | — |
+| `2` | Unknown flag or invalid flag combination. | [`usage`](./error-codes.md#usage) |
+| `78` | `--apply` or `--rollback` requested before the broker-backed mover is available. | `storage-migration-apply-not-implemented`, `storage-migration-rollback-not-implemented` |
+
+**Human example**
+
+```text
+$ nixling host migrate-storage --dry-run
+host migrate-storage --dry-run: checkpoint=storage-cutover-… vm_count=2
+rollback command: nixling host migrate-storage --rollback --from-checkpoint storage-cutover-…
+preflight requirements:
+  - all nixling VMs stopped
+  - nixlingd.service stopped
+  - nixling-priv-broker.service stopped
+  - net VMs stopped; guest routing, TAP connectivity, and dependent bridge traffic will be interrupted
+```
+
+**Native**
+
+- `--dry-run` is a rust-native read-only planner.
+- `--apply` and `--rollback` fail closed with typed exit-78 envelopes until the
+  broker-backed mover lands. There is no bash fallback and no manual
+  chmod/chown/setfacl remediation.
+
+**Bash**
+
+- No bash implementation exists. The Rust CLI owns this surface.
+
+The dry-run text deliberately avoids manual `chmod`/`chown`/`setfacl`
+instructions. Operators should treat the checkpoint ID and rollback command as
+the handoff contract for the later broker-backed cutover implementation.
 
 ### `host reconcile-otel-acls` (reserved)
 
@@ -2579,6 +2676,7 @@ detached state lives in guestd's detached registry).
 | `host prepare` | `rust-native` | The Rust CLI owns dry-run output (wired live); `--apply` is **not yet wired** — it returns the typed `daemon-down` envelope (exit `1`) today (use `--dry-run` for now). When the daemon-side dispatch ships, `--apply` will route through the daemon-backed `ApplyNftables` / `ApplyRoute` / `ApplySysctl` / `UpdateHostsFile` / `ApplyNmUnmanaged` sequence, with broker failures surfacing `broker-error` (exit `78`); a Tier-0 host is refused today (exit `78`). The historical bash fallback was retired in v1.0. |
 | `host destroy` | `rust-native` | The Rust CLI owns dry-run output (wired live); `--apply` is **not yet wired** — it returns the typed `daemon-down` envelope (exit `1`) today (use `--dry-run` for now). When the daemon-side dispatch ships, `--apply` will route through the reverse-order daemon-backed host-reconcile sequence, with broker failures surfacing `broker-error` (exit `78`); a Tier-0 host is refused today (exit `78`). The historical bash fallback was retired in v1.0. |
 | `host doctor` | `rust-native` | Host doctor is a read-only daemon health probe; `--read-only` is mandatory and there is no bash fallback for mutation forms. |
+| `host migrate-storage` | `rust-native` | Storage cutover dry-run planning is native and read-only; `--apply` / `--rollback` fail closed until the broker-backed mover lands. |
 | `host install` | `rust-native` | Host install owns its dry-run preview in Rust and routes `--apply` through the daemon → broker `RunHostInstall` path without broker-error fallback to bash. |
 | `migrate` | `rust-native` | Dry-run analysis is native; `--apply` routes through `nixlingd` → broker `RunMigrate`. Daemon-unreachable / native-handler-deferred conditions surface typed envelopes (exit `1` / exit `78` per ADR 0015); the historical bash fallback was retired in v1.0. |
 | `auth status` | `rust-native` | Auth status is a read-only daemon query that reports caller mapping, socket reachability, and authorization hints. |

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -661,6 +661,9 @@ enum HostCommand {
     Destroy(HostDestroyArgs),
     /// Read-only deep diagnostics for the daemon + broker state.
     Doctor(HostDoctorArgs),
+    /// Plan the one-time storage layout cutover. --apply is fail-closed until broker support lands.
+    #[command(name = "migrate-storage")]
+    MigrateStorage(HostMigrateStorageArgs),
     /// Install nixlingd + broker units onto the host. --apply mutates.
     Install(HostInstallArgs),
     /// Recover host network state after the daemon engaged operator-only mode.
@@ -743,6 +746,26 @@ struct HostDoctorArgs {
     /// Mandatory: doctor is read-only. Mutating forms are separate verbs.
     #[arg(long)]
     read_only: bool,
+    #[arg(long, conflicts_with = "human")]
+    json: bool,
+    #[arg(long, conflicts_with = "json")]
+    human: bool,
+}
+
+#[derive(Debug, Args)]
+struct HostMigrateStorageArgs {
+    /// Plan the storage cutover without mutating host state.
+    #[arg(long, conflicts_with_all = ["apply", "rollback"])]
+    dry_run: bool,
+    /// Apply the storage cutover. Currently fails closed until broker support lands.
+    #[arg(long, conflicts_with_all = ["dry_run", "rollback"])]
+    apply: bool,
+    /// Roll back from a named storage cutover checkpoint.
+    #[arg(long, conflicts_with_all = ["dry_run", "apply"], requires = "from_checkpoint")]
+    rollback: bool,
+    /// Checkpoint ID to roll back.
+    #[arg(long, value_name = "ID", requires = "rollback")]
+    from_checkpoint: Option<String>,
     #[arg(long, conflicts_with = "human")]
     json: bool,
     #[arg(long, conflicts_with = "json")]
@@ -1821,6 +1844,7 @@ fn dispatch(
             HostCommand::Prepare(args) => cmd_host_prepare(context, args),
             HostCommand::Destroy(args) => cmd_host_destroy(context, args),
             HostCommand::Doctor(args) => cmd_host_doctor(context, args),
+            HostCommand::MigrateStorage(args) => cmd_host_migrate_storage(context, args),
             HostCommand::Install(args) => cmd_host_install(context, args, original_args),
             HostCommand::Reconcile(args) => cmd_host_reconcile(context, args, original_args),
             HostCommand::Validate(args) => cmd_host_validate(context, args),
@@ -3520,6 +3544,163 @@ fn cmd_host_doctor(context: &Context, args: &HostDoctorArgs) -> Result<i32, CliF
         print_stdout(&doctor::render_human(&report));
     }
     Ok(exit_code)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StorageMigrationPlan {
+    command: &'static str,
+    mode: &'static str,
+    checkpoint_id: String,
+    rollback_command: String,
+    vm_count: usize,
+    vms: Vec<String>,
+    preflight_requirements: Vec<&'static str>,
+    preserve: Vec<&'static str>,
+    cutover_only_cleanup: Vec<&'static str>,
+    fail_closed_hazards: Vec<&'static str>,
+    apply_status: &'static str,
+}
+
+fn storage_migration_checkpoint_id(vms: &[String]) -> String {
+    let mut basis = String::from("storage-cutover-v1\n");
+    let mut sorted = vms.to_vec();
+    sorted.sort();
+    for vm in &sorted {
+        let _ = writeln!(basis, "{vm}");
+    }
+    let digest = sha256_hex(basis.as_bytes());
+    let suffix = digest
+        .strip_prefix("sha256:")
+        .unwrap_or(digest.as_str())
+        .chars()
+        .take(12)
+        .collect::<String>();
+    format!("storage-cutover-{suffix}")
+}
+
+fn build_storage_migration_plan(manifest: &ManifestDocument) -> StorageMigrationPlan {
+    let mut vms: Vec<String> = manifest.vms().iter().map(|vm| vm.name.clone()).collect();
+    vms.sort();
+    let checkpoint_id = storage_migration_checkpoint_id(&vms);
+    let rollback_command =
+        format!("nixling host migrate-storage --rollback --from-checkpoint {checkpoint_id}");
+    StorageMigrationPlan {
+        command: "host migrate-storage",
+        mode: "dry-run",
+        checkpoint_id,
+        rollback_command,
+        vm_count: vms.len(),
+        vms,
+        preflight_requirements: vec![
+            "all nixling VMs stopped",
+            "nixlingd.service stopped",
+            "nixling-priv-broker.service stopped",
+            "operator accepts planned downtime for the one-time storage layout cutover",
+            "net VMs stopped; guest routing, TAP connectivity, and dependent bridge traffic will be interrupted",
+        ],
+        preserve: vec![
+            "per-VM swtpm NVRAM and swtpm identity markers",
+            "framework SSH keys and guest sshd host keys",
+            "VM disk images and declared persistent volumes",
+            "store-view generation metadata and gcroots",
+            "daemon diagnostic reports, audit logs, host-runtime metadata, and non-authority adoption history",
+            "declared host bridges, TAP naming intent, nftables/NM/networkd ownership metadata, and network-preflight evidence",
+        ],
+        cutover_only_cleanup: vec![
+            "/run/nixling-gpu",
+            "/run/nixling-video",
+            "/run/nixling-wlproxy",
+            "/var/lib/nixling/guest-control-<vm>",
+            "boot-scoped runtime socket files only after all nixling services are stopped",
+            "runtime network helper sockets and stale TAP pid/metadata files after all nixling services are stopped",
+            "stale migration markers from retired storage waves",
+        ],
+        fail_closed_hazards: vec![
+            "symlink or path traversal inside any moved path",
+            "foreign ownership markers on a nixling-managed path",
+            "recursive operations traversing hardlink farms or mutating shared /nix/store inodes",
+            "missing swtpm marker for a previously provisioned TPM VM",
+            "any candidate outside the generated storage root set",
+            "any open nixling daemon, broker, runner, net VM, or workload VM file descriptor",
+            "any attempt to unlink lock files during cutover rather than leaving /run locks for reboot/tmpfs cleanup",
+        ],
+        apply_status: "not-implemented-in-this-build",
+    }
+}
+
+fn cmd_host_migrate_storage(
+    context: &Context,
+    args: &HostMigrateStorageArgs,
+) -> Result<i32, CliFailure> {
+    if args.rollback {
+        let checkpoint = args.from_checkpoint.as_deref().unwrap_or("<missing>");
+        return emit_host_error(
+            &host_error_envelope(
+                "Storage rollback is not implemented in this build",
+                "storage-migration-rollback-not-implemented",
+                78,
+                "Rollback request for a storage cutover checkpoint.",
+                &format!("rollback requested from checkpoint {checkpoint}"),
+                "Keep the host stopped and use the checkpoint metadata to file an issue; do not repair with recursive chmod/chown/setfacl.",
+                "docs/reference/cli-contract.md#host-migrate-storage",
+            ),
+            args.json,
+        );
+    }
+
+    let flags = require_explicit_mutation_flag(
+        "host migrate-storage",
+        args.dry_run,
+        args.apply,
+        args.json,
+    )?;
+    if flags.apply {
+        return emit_host_error(
+            &host_error_envelope(
+                "Storage cutover apply is not implemented in this build",
+                "storage-migration-apply-not-implemented",
+                78,
+                "Broker-backed storage cutover mover availability.",
+                "apply requested, but only dry-run checkpoint planning is available",
+                "Run `nixling host migrate-storage --dry-run` and wait for the broker-backed apply implementation before moving persistent state.",
+                "docs/reference/cli-contract.md#host-migrate-storage",
+            ),
+            args.json,
+        );
+    }
+
+    let manifest = context.load_manifest()?;
+    let plan = build_storage_migration_plan(&manifest);
+    if args.json {
+        let mut rendered = serde_json::to_string_pretty(&plan).map_err(|err| {
+            CliFailure::new(
+                1,
+                format!("failed to serialize storage migration plan: {err}"),
+            )
+        })?;
+        rendered.push('\n');
+        print_stdout(&rendered);
+    } else {
+        print_stdout(&format!(
+            "host migrate-storage --dry-run: checkpoint={} vm_count={}\n",
+            plan.checkpoint_id, plan.vm_count
+        ));
+        print_stdout(&format!("rollback command: {}\n", plan.rollback_command));
+        print_stdout("preflight requirements:\n");
+        for requirement in &plan.preflight_requirements {
+            print_stdout(&format!("  - {requirement}\n"));
+        }
+        print_stdout("persistent data preserved:\n");
+        for item in &plan.preserve {
+            print_stdout(&format!("  - {item}\n"));
+        }
+        print_stdout("cutover-only cleanup candidates:\n");
+        for item in &plan.cutover_only_cleanup {
+            print_stdout(&format!("  - {item}\n"));
+        }
+    }
+    Ok(0)
 }
 
 fn cmd_host_validate(_context: &Context, args: &HostValidateArgs) -> Result<i32, CliFailure> {
@@ -8321,10 +8502,11 @@ mod host_install_dispatch_tests {
 
     use super::{
         AddressFamily, ApiReadySimple, ApiReadyStatusV1, Context, HostInstallArgs, IpcHelloOk,
-        MAX_FRAME_BYTES, MsgFlags, NativeCli, SockFlag, SockType, UnixAddr, UsbAttachArgs,
-        VmExecArgs, VmStartArgs, broker_error_envelope, cmd_host_install, cmd_vm_exec,
-        cmd_vm_start, daemon_supported_features, encode_type_tagged_message, nix_err_to_io,
-        parse_vm_exec_action, public_wire, send, socket,
+        MAX_FRAME_BYTES, ManifestDocument, ManifestVm, MsgFlags, NativeCli, SockFlag, SockType,
+        UnixAddr, UsbAttachArgs, VmExecArgs, VmStartArgs, broker_error_envelope,
+        build_storage_migration_plan, cmd_host_install, cmd_vm_exec, cmd_vm_start,
+        daemon_supported_features, encode_type_tagged_message, nix_err_to_io, parse_vm_exec_action,
+        public_wire, send, socket, storage_migration_checkpoint_id,
     };
     use nixling_ipc::Version;
 
@@ -11258,6 +11440,89 @@ mod host_install_dispatch_tests {
             let err = result.expect_err("unreadable bundle path must error");
             assert!(err.message.contains("failed to inspect"));
         }
+    }
+
+    fn manifest_with_vms(names: &[&str]) -> ManifestDocument {
+        ManifestDocument {
+            _manifest: None,
+            _observability: None,
+            entries: names
+                .iter()
+                .map(|name| {
+                    (
+                        (*name).to_owned(),
+                        ManifestVm {
+                            name: (*name).to_owned(),
+                            env: Some("work".to_owned()),
+                            graphics: false,
+                            tpm: false,
+                            audio: false,
+                            usbip_yubikey: false,
+                            static_ip: None,
+                            usbipd_host_ip: None,
+                            is_net_vm: false,
+                            state_dir: format!("/var/lib/nixling/vms/{name}"),
+                            bridge: "br-work-lan".to_owned(),
+                            ssh_user: Some("alice".to_owned()),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn storage_migration_plan_includes_checkpoint_and_rollback_command() {
+        let manifest = manifest_with_vms(&["work-vm", "corp-vm"]);
+        let plan = build_storage_migration_plan(&manifest);
+
+        assert_eq!(plan.command, "host migrate-storage");
+        assert_eq!(plan.mode, "dry-run");
+        assert_eq!(plan.vm_count, 2);
+        assert_eq!(plan.vms, vec!["corp-vm".to_owned(), "work-vm".to_owned()]);
+        assert!(plan.checkpoint_id.starts_with("storage-cutover-"));
+        assert!(
+            plan.rollback_command
+                .contains("nixling host migrate-storage --rollback --from-checkpoint")
+        );
+        assert!(plan.rollback_command.contains(&plan.checkpoint_id));
+        assert!(
+            plan.preserve
+                .iter()
+                .any(|item| item.contains("swtpm NVRAM"))
+        );
+        assert!(plan.cutover_only_cleanup.contains(&"/run/nixling-gpu"));
+        assert!(
+            plan.fail_closed_hazards
+                .iter()
+                .any(|item| item.contains("symlink"))
+        );
+    }
+
+    #[test]
+    fn storage_migration_checkpoint_id_is_order_insensitive() {
+        let a = vec!["work-vm".to_owned(), "corp-vm".to_owned()];
+        let b = vec!["corp-vm".to_owned(), "work-vm".to_owned()];
+        assert_eq!(
+            storage_migration_checkpoint_id(&a),
+            storage_migration_checkpoint_id(&b)
+        );
+    }
+
+    #[test]
+    fn storage_migration_from_checkpoint_requires_rollback() {
+        assert!(
+            NativeCli::try_parse_from([
+                "nixling",
+                "host",
+                "migrate-storage",
+                "--from-checkpoint",
+                "storage-cutover-test",
+                "--json",
+            ])
+            .is_err(),
+            "--from-checkpoint must not be silently ignored without --rollback",
+        );
     }
 
     #[test]

--- a/packages/nixling/tests/cli_contract_coverage.rs
+++ b/packages/nixling/tests/cli_contract_coverage.rs
@@ -45,6 +45,7 @@ const EXPECTED_DISPOSITION: &[(&str, &str)] = &[
     ("host check", "rust-native"),
     ("host prepare", "rust-native"),
     ("host destroy", "rust-native"),
+    ("host migrate-storage", "rust-native"),
     ("auth status", "rust-native"),
 ];
 
@@ -60,6 +61,7 @@ const HELP_GROUPS: &[(&str, &[&str])] = &[
     ("store verify", &["store verify"]),
     ("audit", &["audit"]),
     ("host check", &["host check"]),
+    ("host migrate-storage", &["host migrate-storage"]),
     ("auth status", &["auth status"]),
 ];
 
@@ -241,6 +243,46 @@ const FLAG_INVOCATIONS: &[CommandFlagMatrix] = &[
             ),
             ("--json", &["host", "check", "--read-only", "--json"]),
             ("--human", &["host", "check", "--read-only", "--human"]),
+        ],
+    ),
+    (
+        "host migrate-storage",
+        &[
+            (
+                "--dry-run",
+                &["host", "migrate-storage", "--dry-run", "--human"],
+            ),
+            ("--apply", &["host", "migrate-storage", "--apply", "--json"]),
+            (
+                "--rollback",
+                &[
+                    "host",
+                    "migrate-storage",
+                    "--rollback",
+                    "--from-checkpoint",
+                    "storage-cutover-test",
+                    "--json",
+                ],
+            ),
+            (
+                "--from-checkpoint",
+                &[
+                    "host",
+                    "migrate-storage",
+                    "--rollback",
+                    "--from-checkpoint",
+                    "storage-cutover-test",
+                    "--json",
+                ],
+            ),
+            (
+                "--json",
+                &["host", "migrate-storage", "--dry-run", "--json"],
+            ),
+            (
+                "--human",
+                &["host", "migrate-storage", "--dry-run", "--human"],
+            ),
         ],
     ),
     (

--- a/packages/nixling/tests/cli_json_output_contract.rs
+++ b/packages/nixling/tests/cli_json_output_contract.rs
@@ -642,6 +642,104 @@ fn host_lifecycle_dry_run_outputs_match_goldens() {
 }
 
 #[test]
+fn host_migrate_storage_dry_run_json_reports_checkpoint_and_rollback() {
+    let Some(env) = FixtureEnv::new() else {
+        return;
+    };
+    let out = env.run(&["host", "migrate-storage", "--dry-run", "--json"], &[]);
+    assert_success(&out, "host migrate-storage --dry-run --json");
+    let value: Value = serde_json::from_slice(&out.stdout).expect("parse migrate-storage JSON");
+    assert_eq!(value["command"], "host migrate-storage");
+    assert_eq!(value["mode"], "dry-run");
+    let checkpoint = value["checkpointId"].as_str().expect("checkpointId string");
+    assert!(checkpoint.starts_with("storage-cutover-"));
+    assert!(
+        value["rollbackCommand"]
+            .as_str()
+            .expect("rollback command string")
+            .contains(checkpoint)
+    );
+    assert_eq!(value["applyStatus"], "not-implemented-in-this-build");
+    assert!(
+        value["preserve"]
+            .as_array()
+            .expect("preserve array")
+            .iter()
+            .any(|entry| entry.as_str().is_some_and(|s| s.contains("swtpm NVRAM")))
+    );
+    assert!(
+        value["preflightRequirements"]
+            .as_array()
+            .expect("preflight array")
+            .iter()
+            .any(|entry| entry
+                .as_str()
+                .is_some_and(|s| s.contains("net VMs stopped")))
+    );
+    assert!(
+        value["failClosedHazards"]
+            .as_array()
+            .expect("hazards array")
+            .iter()
+            .any(|entry| entry
+                .as_str()
+                .is_some_and(|s| s.contains("unlink lock files")))
+    );
+}
+
+#[test]
+fn host_migrate_storage_apply_fails_closed_without_mutation() {
+    let Some(env) = FixtureEnv::new() else {
+        return;
+    };
+    let out = env.run(&["host", "migrate-storage", "--apply", "--json"], &[]);
+    assert!(
+        !out.status.success(),
+        "apply should fail closed until broker support lands"
+    );
+    let value: Value = serde_json::from_slice(&out.stdout).expect("parse apply refusal JSON");
+    assert_eq!(value["code"], "storage-migration-apply-not-implemented");
+    assert_eq!(value["exitCode"], 78);
+    assert!(
+        value["remediation"]
+            .as_str()
+            .expect("remediation")
+            .contains("host migrate-storage --dry-run")
+    );
+}
+
+#[test]
+fn host_migrate_storage_rollback_fails_closed_without_mutation() {
+    let Some(env) = FixtureEnv::new() else {
+        return;
+    };
+    let out = env.run(
+        &[
+            "host",
+            "migrate-storage",
+            "--rollback",
+            "--from-checkpoint",
+            "storage-cutover-test",
+            "--json",
+        ],
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "rollback should fail closed until broker support lands"
+    );
+    let value: Value = serde_json::from_slice(&out.stdout).expect("parse rollback refusal JSON");
+    assert_eq!(value["code"], "storage-migration-rollback-not-implemented");
+    assert_eq!(value["exitCode"], 78);
+    assert!(
+        value["observedState"]
+            .as_str()
+            .expect("observed state")
+            .contains("storage-cutover-test")
+    );
+}
+
+#[test]
 fn usb_dry_run_outputs_match_goldens() {
     let Some(env) = FixtureEnv::new() else {
         return;

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -352,6 +352,21 @@ fn gen_cli_shell_artifacts() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>>
         .manual("nixling CLI")
         .render(&mut man_buffer)?;
     fs::write(&man_path, man_buffer)?;
+    let mut host_command = nixling::cli_command()
+        .find_subcommand_mut("host")
+        .expect("host subcommand exists")
+        .clone();
+    host_command.build();
+    let host_man_path = man_dir.join("nixling-host.1");
+    let mut host_man_buffer = Vec::new();
+    Man::new(host_command)
+        .title("nixling-host")
+        .section("1")
+        .date("1970-01-01")
+        .source("nixling".to_owned())
+        .manual("nixling CLI")
+        .render(&mut host_man_buffer)?;
+    fs::write(&host_man_path, host_man_buffer)?;
 
     let bash_path = comp_dir.join("nixling.bash");
     let mut bash_command = nixling::cli_command();
@@ -373,7 +388,13 @@ fn gen_cli_shell_artifacts() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>>
     let fish_buffer = patch_vm_exec_logs_fish_completion(String::from_utf8(fish_buffer)?)?;
     fs::write(&fish_path, fish_buffer)?;
 
-    Ok(vec![man_path, bash_path, zsh_path, fish_path])
+    Ok(vec![
+        man_path,
+        host_man_path,
+        bash_path,
+        zsh_path,
+        fish_path,
+    ])
 }
 
 fn patch_vm_exec_logs_bash_completion(


### PR DESCRIPTION
## Summary
- add `nixling host migrate-storage --dry-run` as the explicit storage cutover planning surface
- emit checkpoint ID, exact rollback command, VM inventory, stopped-service/network downtime preflights, preserved data, cleanup candidates, and fail-closed hazards
- fail closed for `--apply` and `--rollback --from-checkpoint` until the broker-backed mover lands
- regenerate CLI completions/manpages and update CLI contract/changelog

## Validation
- `cargo test -p nixling storage_migration --lib -- --nocapture`
- `cargo test -p nixling --test cli_json_output_contract host_migrate_storage -- --nocapture`
- `cargo test -p nixling --test cli_contract_coverage -- --nocapture`
- `cargo clippy -p nixling -p xtask --all-targets -- -D warnings`
- `bash tests/test-drift.sh`
- `make test-policy`
- `make test-flake`

## Panel
Gemini 3.1 Pro implementation panel signed off 10/10 after R2.

## Notes
Dry-run only; no storage mutation. `/etc/nixos` was not touched.