### PR TITLE
daemon: make diagnostics readable by host doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ deprecations ship one minor release before removal.
 - CI: the PR aarch64 flake leg now runs only the lightweight
   `smoke-eval-aarch64.nix` check instead of the full native aarch64
   flake sweep.
+- NixOS module: `nixling.site.usePrebuiltHostTools = false` now also
+  forces `nixling-priv-broker` to build from the local source checkout,
+  keeping the broker wire/bundle parser aligned with `nixlingd`.
 - `bundleVersion` 5 → 6: adds the private storage lifecycle and
   synchronization artifacts to the trusted bundle.
 - CI: pull requests now fail closed when Rust/Nix/Cargo changes do not

--- a/docs/reference/kernel-module-check.md
+++ b/docs/reference/kernel-module-check.md
@@ -57,14 +57,11 @@ list in the public message. KVM alternatives render as
 | `virtio_console` | Always. |
 | `virtiofs` | Any VM has a `Virtiofsd` process node. |
 | `udmabuf` | Any VM has `graphics = true` or a `Gpu` process node. |
-| `drm_virtgpu` | Any VM has `graphics = true` or a `Gpu` process node. |
 
 A module is "present" when either `/proc/modules` contains it OR the
-caller passed it in the built-in set. The daemon currently does not
-read the built-in set (TODO once the host probe path is daemon-
-callable); on hosts where required modules are statically linked,
-operators must `modprobe` an alias or surface them in
-`/proc/modules` to satisfy the gate.
+daemon can prove the corresponding `CONFIG_*` option is built into the
+running kernel. This matters for `udmabuf`, which many kernels expose
+as `CONFIG_UDMABUF=y` with no loadable `.ko`.
 
 ### OPTIONAL — warn-only, may degrade VMs
 

--- a/nixos-modules/host-broker.nix
+++ b/nixos-modules/host-broker.nix
@@ -16,7 +16,10 @@
 
 let
   cfg = config.nixling;
-  prebuilt = import ./prebuilt-packages.nix { inherit pkgs lib; };
+  prebuilt =
+    if cfg.site.usePrebuiltHostTools
+    then import ./prebuilt-packages.nix { inherit pkgs lib; }
+    else { };
 
   # filter out `target/` dev caches from the source
   # so the Nix copy stays small (broker target alone is ~6 GB).

--- a/nixos-modules/options-site.nix
+++ b/nixos-modules/options-site.nix
@@ -59,8 +59,9 @@
       type = lib.types.bool;
       default = true;
       description = ''
-        Use release prebuilt host binaries for `nixling`, `nixlingd`, and the
-        activation helper when they are available. Set to `false` on
+        Use release prebuilt host binaries for `nixling`, `nixlingd`,
+        `nixling-priv-broker`, and the activation helper when they are
+        available. Set to `false` on
         development hosts that intentionally validate the checked-out flake's
         Rust sources before a release artifact exists.
       '';

--- a/packages/nixlingd/src/kernel_module_check.rs
+++ b/packages/nixlingd/src/kernel_module_check.rs
@@ -8,8 +8,7 @@
 //! host kernel modules: KVM for hardware-assisted virtualization,
 //! `vhost_net` + `tun` for the TAP-fd data path, `virtio_*` for the
 //! guest-side device drivers, plus the per-feature add-ons
-//! (`virtiofs` for the per-VM `/nix/store` share, `udmabuf` +
-//! `drm_virtgpu` for graphics VMs, `usbip_host` for USBIP
+//! (`virtiofs` for the per-VM `/nix/store` share, `udmabuf` for graphics VMs, `usbip_host` for USBIP
 //! passthrough, `tpm_vtpm_proxy` for swtpm). If any of those are
 //! missing at daemon startup the eventual VM-start request fails
 //! deep inside `cloud-hypervisor` with a generic ENODEV that takes
@@ -23,7 +22,7 @@
 //!
 //! * `required` — modules every VM in the bundle conditionally
 //!   demands (kvm_*, vhost_net, tun, virtio_*, plus virtiofs /
-//!   udmabuf / drm_virtgpu when the bundle uses them).
+//!   udmabuf when the bundle uses them).
 //! * `present` — required modules detected loaded.
 //! * `missing_required` — required modules NOT loaded. Non-empty →
 //!   daemon refuses to start.
@@ -51,7 +50,7 @@ use std::fs;
 
 use nixling_core::bundle_resolver::BundleResolver;
 use nixling_core::processes::ProcessRole;
-use nixling_host::modules::LoadedModuleSet;
+use nixling_host::modules::{KernelConfig, LoadedModuleSet, read_kernel_config};
 use serde::{Deserialize, Serialize};
 
 use crate::typed_error::TypedError;
@@ -79,8 +78,9 @@ pub const REQUIRED_IF_VIRTIOFS: &str = "virtiofs";
 
 /// Required if and only if at least one VM in the bundle is a
 /// graphics VM (= manifest `graphics = true` and/or `Gpu` process
-/// node).
-pub const REQUIRED_IF_GRAPHICS: &[&str] = &["udmabuf", "drm_virtgpu"];
+/// node). `udmabuf` may be built into the host kernel; the startup
+/// wrapper maps `CONFIG_UDMABUF=y` to this module name.
+pub const REQUIRED_IF_GRAPHICS: &[&str] = &["udmabuf"];
 
 /// Optional accelerator modules for nvidia-equipped graphics
 /// hosts. Absence is warn-only — VMs continue to autostart with
@@ -354,6 +354,27 @@ pub fn check_kernel_modules(
     }
 }
 
+fn kernel_config_builtin_modules(config: &KernelConfig) -> BTreeSet<String> {
+    [
+        ("kvm_intel", "CONFIG_KVM_INTEL"),
+        ("kvm_amd", "CONFIG_KVM_AMD"),
+        ("vhost_net", "CONFIG_VHOST_NET"),
+        ("tun", "CONFIG_TUN"),
+        ("virtio_net", "CONFIG_VIRTIO_NET"),
+        ("virtio_blk", "CONFIG_VIRTIO_BLK"),
+        ("virtio_pci", "CONFIG_VIRTIO_PCI"),
+        ("virtio_console", "CONFIG_VIRTIO_CONSOLE"),
+        ("virtiofs", "CONFIG_VIRTIO_FS"),
+        ("udmabuf", "CONFIG_UDMABUF"),
+        ("usbip_host", "CONFIG_USBIP_HOST"),
+        ("tpm_vtpm_proxy", "CONFIG_TCG_VTPM_PROXY"),
+    ]
+    .into_iter()
+    .filter_map(|(module, config_key)| (config.get(config_key) == Some("y")).then_some(module))
+    .map(str::to_owned)
+    .collect()
+}
+
 /// Default path used by [`run_kernel_module_check`] when the
 /// `proc_modules_override` is `None`. Exposed so tests can assert
 /// the production read path is `/proc/modules`.
@@ -382,16 +403,10 @@ pub fn run_kernel_module_check(resolver: &BundleResolver) -> ModuleCheckReport {
             LoadedModuleSet::default()
         }
     };
-    // Built-in detection is intentionally conservative here: we
-    // pass an empty set. The same fail-closed logic above applies
-    // — a host whose required modules are all built-in is rare
-    // enough on the supported tiers (Tier 0 NixOS loads them as
-    // modules, Tier 1+ load via modprobe) that requiring an
-    // explicit modprobe on those targets is acceptable. The
-    // signature accepts a builtin set so tests / future work can
-    // wire `nixling_host::modules::BuiltinModuleSet` once the
-    // probe path is daemon-callable.
-    let builtin = BTreeSet::new();
+    let mut builtin = BTreeSet::new();
+    if let Some(config) = read_kernel_config() {
+        builtin.extend(kernel_config_builtin_modules(&config));
+    }
     check_kernel_modules(resolver, &loaded, &builtin)
 }
 
@@ -594,7 +609,7 @@ mod tests {
     }
 
     #[test]
-    fn graphics_vm_requires_udmabuf_and_drm_virtgpu() {
+    fn graphics_vm_requires_udmabuf() {
         let resolver = build_resolver(
             |vms| {
                 vms.get_mut("corp-vm").unwrap().graphics = true;
@@ -605,7 +620,15 @@ mod tests {
         let report = check_kernel_modules(&resolver, &loaded, &empty_builtin());
         assert!(report.is_fatal());
         assert!(report.missing_required.contains("udmabuf"));
-        assert!(report.missing_required.contains("drm_virtgpu"));
+        assert!(!report.required.contains("drm_virtgpu"));
+    }
+
+    #[test]
+    fn kernel_config_y_counts_as_builtin_module() {
+        let config = KernelConfig::parse("CONFIG_UDMABUF=y\nCONFIG_DRM_VIRTIO_GPU=m\n");
+        let builtins = kernel_config_builtin_modules(&config);
+        assert!(builtins.contains("udmabuf"));
+        assert!(!builtins.contains("virtio_gpu"));
     }
 
     #[test]
@@ -682,7 +705,6 @@ mod tests {
             "virtio_pci",
             "virtio_console",
             "udmabuf",
-            "drm_virtgpu",
         ]);
         let report = check_kernel_modules(&resolver, &loaded, &empty_builtin());
         assert!(!report.is_fatal(), "{:?}", report);

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -569,6 +569,10 @@ fn persist_json_report(path: &Path, json: &[u8]) -> std::io::Result<()> {
     {
         let mut file = File::create(&tmp)?;
         file.write_all(json)?;
+        // host doctor is an unprivileged read-only CLI surface. Keep
+        // diagnostic reports world-readable beneath the ACL-gated daemon-state
+        // tree; they contain bounded posture data, not authority or secrets.
+        file.set_permissions(fs::Permissions::from_mode(0o644))?;
         file.sync_all()?;
     }
     std::fs::rename(&tmp, path)?;

--- a/packages/nixlingd/src/supervisor/pidfd_table.rs
+++ b/packages/nixlingd/src/supervisor/pidfd_table.rs
@@ -3,6 +3,7 @@ use std::ffi::OsString;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::os::fd::{AsFd, OwnedFd};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -626,6 +627,15 @@ fn write_snapshot(path: &Path, snapshot: &PersistedPidfdTable) -> Result<(), Pid
         path: path.to_path_buf(),
         detail: err.to_string(),
     })?;
+    if let Err(err) = file.set_permissions(fs::Permissions::from_mode(0o644)) {
+        if let Err(rm_err) = fs::remove_file(&tmp) {
+            tracing::debug!(?tmp, %rm_err, "pidfd-table: tmpfile cleanup failed (chmod path)");
+        }
+        return Err(PidfdTableError::SnapshotFailed {
+            path: path.to_path_buf(),
+            detail: err.to_string(),
+        });
+    }
     if let Err(err) = file.write_all(&bytes) {
         // panel-rust v1.1.2-final-R1 should-fix: log cleanup
         // failures so disk-full / permission regressions surface.


### PR DESCRIPTION
## Summary
- make `nixling.site.usePrebuiltHostTools = false` also force source-built `nixling-priv-broker`
- publish daemon diagnostic reports and pidfd-table snapshots with read-only permissions so unprivileged `host doctor` can read them
- fix the kernel-module graphics matrix: require `udmabuf`, count `CONFIG_UDMABUF=y`, and stop requiring nonexistent `drm_virtgpu`

## Validation
- `nix flake check --no-build --no-write-lock-file`
- `cargo test -p nixlingd kernel_module_check -- --nocapture`
- `cargo test -p nixlingd storage_lifecycle -- --nocapture`
- `cargo test -p nixlingd pidfd_table -- --nocapture`
- `cargo clippy -p nixlingd --all-targets -- -D warnings`

## Context
Found during `/etc/nixos` deployment: the source-built daemon/CLI were paired with the v1.3.1 prebuilt broker, so the broker could not parse the bundleVersion 6 storage/sync bundle. After switching to a source-built broker, `host doctor` still needed root because diagnostic reports were `0640 nixlingd:nixlingd`; this PR makes the documented read-only doctor path work unprivileged.