### PR TITLE
broker: reduce default log noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ deprecations ship one minor release before removal.
   now also enable `nixling.vms.<vm>.guest.control.enable = true`. USBIP
   guest attach/detach is owned by guestd over authenticated
   guest-control; there is no SSH fallback.
+- Broker: `nixling-priv-broker.service` now defaults `RUST_LOG` to
+  `info` instead of `debug`, keeping high-volume broker diagnostics out
+  of normal journal/OTel log exports unless an operator opts into debug
+  logging.
 - CI: the PR aarch64 flake leg now runs only the lightweight
   `smoke-eval-aarch64.nix` check instead of the full native aarch64
   flake sweep.

--- a/nixos-modules/host-broker.nix
+++ b/nixos-modules/host-broker.nix
@@ -128,10 +128,13 @@ in
       # No wantedBy here.
       requires = [ "nixling-priv-broker.socket" ];
       after = [ "nixling-priv-broker.socket" "local-fs.target" ];
-      # Surface broker debug logs and point at the nft binary (NixOS
-      # has no /usr/sbin/nft default).
+      # Keep the broker at INFO by default so high-volume DEBUG payload
+      # diagnostics do not flood journal/OTel exports. Operators can
+      # temporarily force RUST_LOG=debug from host configuration when
+      # investigating a broker live-handler failure.
       environment = {
-        RUST_LOG = "debug";
+        RUST_LOG = lib.mkDefault "info";
+        # Point at host tools (NixOS has no /usr/sbin/nft default).
         NIXLING_BROKER_NFT_BINARY = "${pkgs.nftables}/bin/nft";
         # iproute2 binary lives in /bin not /sbin on NixOS.
         NIXLING_BROKER_IP_BINARY = "${pkgs.iproute2}/bin/ip";

--- a/packages/nixling-priv-broker/src/sys.rs
+++ b/packages/nixling-priv-broker/src/sys.rs
@@ -2991,8 +2991,6 @@ pub mod pidfd_sys {
             {
                 libc::_exit(CHILD_EXIT_SECCOMP);
             }
-            let m = b"DEBUG: about to execve\n";
-            libc::write(2, m.as_ptr() as *const _, m.len());
             libc::execve(binary_ptr, argv_ptrs.as_ptr(), env_ptrs.as_ptr());
             let m2 = b"DEBUG: execve returned (failed)\n";
             libc::write(2, m2.as_ptr() as *const _, m2.len());
@@ -3352,6 +3350,7 @@ mod tests {
         let global_log = concat!("nixling-broker-child", ".log");
         let argv_marker = concat!("DEBUG ", "argv[");
         let env_marker = concat!("DEBUG ", "env[");
+        let spawn_marker = concat!("DEBUG: about", " to execve");
         assert!(
             !source.contains(global_log),
             "broker child path must not create a global argv/env debug log"
@@ -3359,6 +3358,10 @@ mod tests {
         assert!(
             !source.contains(argv_marker) && !source.contains(env_marker),
             "broker child path must not log full runner argv/env"
+        );
+        assert!(
+            !source.contains(spawn_marker),
+            "broker child path must not emit a debug line for every spawn"
         );
     }
 

--- a/tests/unit/nix/cases/broker-caps.nix
+++ b/tests/unit/nix/cases/broker-caps.nix
@@ -61,7 +61,9 @@ let
     nixling.daemonExperimental.enable = true;
   };
 
-  svc = (mkEval [ base ]).config.systemd.services.nixling-priv-broker.serviceConfig;
+  brokerService = (mkEval [ base ]).config.systemd.services.nixling-priv-broker;
+  svc = brokerService.serviceConfig;
+  env = brokerService.environment;
   cbs = svc.CapabilityBoundingSet or null;
   ac = svc.AmbientCapabilities or null;
 in
@@ -81,5 +83,9 @@ in
   "broker-caps/ambient-empty-sentinel" = {
     expr = if builtins.isList ac then builtins.elem "" ac else ac == "";
     expected = true;
+  };
+  "broker-caps/default-rust-log-info" = {
+    expr = env.RUST_LOG or null;
+    expected = "info";
   };
 }


### PR DESCRIPTION
## Summary

- Default `nixling-priv-broker.service` to `RUST_LOG=info` instead of `debug` so normal broker diagnostics do not flood journal/OTel/SigNoz.
- Remove the unconditional child-process `DEBUG: about to execve` stderr write emitted on every runner spawn.
- Add nix-unit coverage that the rendered broker service default stays at `info`, and extend the broker spawn-log source policy test.

## Validation

- `make test-nix-unit`
- `cargo fmt --check && cargo test child_spawn_path_does_not_log_full_argv_or_env_to_global_file` in `packages/nixling-priv-broker`
- `git diff --check`

## Notes

A runtime-only systemd drop-in was applied on the live host to set the currently deployed broker service to `RUST_LOG=info`; the binary-level removal of the per-spawn stderr marker lands with this PR.
