### PR TITLE
adr032: add auth audit foundations ( W3 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ deprecations ship one minor release before removal.
   `realm-entrypoints.json` table, allow separate gateway guests for
   separate realm/env segments, and add `nixling realm enter/run` plus
   manifest-backed realm target routing for gateway-backed VM verbs.
+- ADR 0032 auth/audit foundations now define redacted daemon-access
+  principal mapping records, tamper-evident audit-chain DTOs, daemon
+  audit hash chaining, explicit audit-sink health reports, and
+  host-boundary tests proving gateway relay/provider material stays out
+  of host daemon artifacts.
 
 ### Changed
 
@@ -108,6 +113,10 @@ deprecations ship one minor release before removal.
   require idempotency keys, and audit/error/trace payloads carry only
   redacted, bounded metadata. This is a contributor-facing contract; it
   does not change CLI, daemon, or host behavior.
+- Daemon audit JSONL records now carry `prev_hash` and `record_hash`
+  chain fields, with verifier and sink-health helpers that report
+  tampering, write unavailability, and retention-floor degradation
+  without exposing filesystem paths or credential-shaped detail.
 - `qemu-media` VMs now emit a typed QMP-only QEMU runner process node
   instead of being absent from `processes.json`; they still do not emit
   Cloud Hypervisor, store/virtiofs, or guest-control runner data.

--- a/docs/reference/constellation-core.md
+++ b/docs/reference/constellation-core.md
@@ -30,6 +30,8 @@ Regenerate that file; do not edit generated JSON by hand.
 | `Handshake` / `OperationKind` | `src/frame.rs` | Negotiation and closed operation taxonomy roots. |
 | `AuditEnvelope` | `src/audit.rs` | Redacted post-auth audit metadata for mutating operations and stream opens. |
 | `AdmissionAuditRecord` | `src/audit.rs` | Redacted pre-auth/session-admission denial metadata; principal may be absent only in this shape. |
+| `AuditChainRecord` / `AuditChainLink` / `AuditHash` | `src/audit.rs` | Tamper-evident audit-chain metadata for gateway, remote-node, and daemon audit streams. |
+| `AuditSinkHealth` / `AuditRetentionFloorStatus` | `src/audit.rs` | Redacted audit-sink health and retention-floor status for degraded/fail-closed reporting. |
 | `ConstellationError` | `src/error.rs` | Typed error frame with stable `ErrorKind`, bounded message, and structured missing capability for capability denials. |
 | `NodeSummary` / `WorkloadSelector` / `WorkloadSummary` / `ExecutionSummary` | `src/node.rs`, `src/workload.rs`, `src/execution.rs` | Bounded status summaries and selectors for nodes, workloads, and durable executions. |
 | `RealmPath`, identifier newtypes, `CapabilitySet`, `TraceContext`, `OpaquePayload`, `ProtocolToken` | `src/realm.rs`, `src/ids.rs`, `src/capability.rs`, `src/trace_context.rs`, `src/payload.rs`, `src/token.rs` | Reusable bounded primitives that every higher-level root depends on. |
@@ -146,6 +148,16 @@ paths, or provider credential material. Decode rejects any audit envelope
 without a principal. Pre-auth/session-admission failures use
 `AdmissionAuditRecord`, whose principal is optional and whose decision is
 always `deny`.
+
+`AuditChainRecord` describes the tamper-evident metadata attached to
+gateway, remote-node, and daemon audit streams. The core crate validates
+hash shape (`sha256:<64 lowercase hex chars>`) and verifies a link against
+trusted recomputed previous, payload, and record hashes; hash computation
+is owned by the concrete daemon/gateway/provider crate so the core model
+stays codec- and host-neutral. `AuditSinkHealth` and
+`AuditRetentionFloorStatus` report bounded degraded/unavailable states and
+never carry paths, credential material, argv, stdio, or raw provider
+errors.
 
 `ConstellationError` carries a stable `ErrorKind`, a bounded
 operator-safe message, and a structured missing capability when

--- a/docs/reference/daemon-api.md
+++ b/docs/reference/daemon-api.md
@@ -484,6 +484,23 @@ broker `serve` CLI takes `--audit-dir <path>` instead of the prior
 > `authz_result`) carry only the local `SO_PEERCRED`-derived
 > classification, and `decision` is the local broker operation outcome.
 
+`nixlingd` also writes daemon-owned JSONL events for transitions that are
+not broker operations, such as guest-control exec session establishment
+and runner readiness failures. Those records live under the daemon state
+directory as `daemon-events-<utc-date>.jsonl`. Each daemon record carries
+bounded event metadata plus `prev_hash` and `record_hash` fields so a
+verifier can detect missing, reordered, or modified lines. The hash-chain
+helper reports tampering explicitly; the write path remains best-effort so
+an audit sink outage does not abort an already-authorized local operation.
+
+Daemon audit sink health is exposed as an explicit report rather than a
+silent fallback. The report distinguishes writable, degraded, and
+unavailable states, including retention-floor degradation. It intentionally
+records only closed reason codes such as `write-probe-failed` or
+`retention-below-floor`; it does not include filesystem paths, raw IO
+errors, argv/env content, output bytes, provider credentials, or relay
+tokens.
+
 ## Forward-compatibility policy
 
 The protocol deliberately mixes **strict shape checking** with

--- a/docs/reference/schemas/v2/constellation-core.json
+++ b/docs/reference/schemas/v2/constellation-core.json
@@ -82,6 +82,36 @@
       "$ref": "#/definitions/AuditEnvelope"
     },
     {
+      "type": "string"
+    },
+    {
+      "$ref": "#/definitions/AuditStreamKind"
+    },
+    {
+      "$ref": "#/definitions/AuditChainLink"
+    },
+    {
+      "$ref": "#/definitions/AuditChainRecord"
+    },
+    {
+      "$ref": "#/definitions/AuditChainCheckFailure"
+    },
+    {
+      "$ref": "#/definitions/AuditChainCheckResult"
+    },
+    {
+      "$ref": "#/definitions/AuditRetentionFloorReason"
+    },
+    {
+      "$ref": "#/definitions/AuditRetentionFloorStatus"
+    },
+    {
+      "$ref": "#/definitions/AuditSinkHealthReason"
+    },
+    {
+      "$ref": "#/definitions/AuditSinkHealth"
+    },
+    {
       "$ref": "#/definitions/ConstellationError"
     },
     {
@@ -169,6 +199,115 @@
               "type": "null"
             }
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuditChainCheckFailure": {
+      "description": "Closed audit-chain verification failure.",
+      "type": "string",
+      "enum": [
+        "previous-hash-mismatch",
+        "payload-hash-mismatch",
+        "record-hash-mismatch"
+      ]
+    },
+    "AuditChainCheckResult": {
+      "description": "Verification result for one audit-chain link.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "status"
+          ],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "verified"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "failure",
+            "status"
+          ],
+          "properties": {
+            "failure": {
+              "$ref": "#/definitions/AuditChainCheckFailure"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "AuditChainLink": {
+      "description": "One link in a tamper-evident audit stream.",
+      "type": "object",
+      "required": [
+        "payloadHash",
+        "previousHash",
+        "recordHash",
+        "sequence"
+      ],
+      "properties": {
+        "payloadHash": {
+          "description": "Hash of the canonical redacted audit payload.",
+          "type": "string"
+        },
+        "previousHash": {
+          "description": "Previous record hash, or the stream's genesis hash for sequence 0.",
+          "type": "string"
+        },
+        "recordHash": {
+          "description": "Hash of the canonical chain record.",
+          "type": "string"
+        },
+        "sequence": {
+          "description": "Monotonic stream sequence number.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuditChainRecord": {
+      "description": "Redacted chain metadata for a gateway, remote-node, or daemon audit event.",
+      "type": "object",
+      "required": [
+        "link",
+        "node",
+        "operationId",
+        "realm",
+        "stream"
+      ],
+      "properties": {
+        "link": {
+          "$ref": "#/definitions/AuditChainLink"
+        },
+        "node": {
+          "$ref": "#/definitions/NodeId"
+        },
+        "operationId": {
+          "$ref": "#/definitions/OperationId"
+        },
+        "realm": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RealmId"
+          }
+        },
+        "stream": {
+          "$ref": "#/definitions/AuditStreamKind"
         }
       },
       "additionalProperties": false
@@ -278,6 +417,186 @@
         }
       },
       "additionalProperties": false
+    },
+    "AuditRetentionFloorReason": {
+      "description": "Bounded reason for audit retention-floor status.",
+      "type": "string",
+      "enum": [
+        "window-below-floor",
+        "evidence-missing",
+        "sink-unavailable"
+      ]
+    },
+    "AuditRetentionFloorStatus": {
+      "description": "Retention-floor status for an audit sink.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "status"
+          ],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "met"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "reason",
+            "status"
+          ],
+          "properties": {
+            "reason": {
+              "$ref": "#/definitions/AuditRetentionFloorReason"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "belowFloor"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "reason",
+            "status"
+          ],
+          "properties": {
+            "reason": {
+              "$ref": "#/definitions/AuditRetentionFloorReason"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "unknown"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "AuditSinkHealth": {
+      "description": "Health state for a gateway/remote-node/daemon audit sink.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "retention_floor",
+            "status",
+            "stream"
+          ],
+          "properties": {
+            "retention_floor": {
+              "$ref": "#/definitions/AuditRetentionFloorStatus"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "ok"
+              ]
+            },
+            "stream": {
+              "$ref": "#/definitions/AuditStreamKind"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "reason",
+            "retention_floor",
+            "status",
+            "stream"
+          ],
+          "properties": {
+            "reason": {
+              "$ref": "#/definitions/AuditSinkHealthReason"
+            },
+            "retention_floor": {
+              "$ref": "#/definitions/AuditRetentionFloorStatus"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "degraded"
+              ]
+            },
+            "stream": {
+              "$ref": "#/definitions/AuditStreamKind"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "reason",
+            "retention_floor",
+            "status",
+            "stream"
+          ],
+          "properties": {
+            "reason": {
+              "$ref": "#/definitions/AuditSinkHealthReason"
+            },
+            "retention_floor": {
+              "$ref": "#/definitions/AuditRetentionFloorStatus"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "unavailable"
+              ]
+            },
+            "stream": {
+              "$ref": "#/definitions/AuditStreamKind"
+            }
+          }
+        }
+      ]
+    },
+    "AuditSinkHealthReason": {
+      "description": "Bounded reason for audit sink health.",
+      "type": "string",
+      "enum": [
+        "backpressure",
+        "chain-verification-failed",
+        "sink-missing",
+        "sink-unavailable",
+        "write-failed"
+      ]
+    },
+    "AuditStreamKind": {
+      "description": "Closed audit stream kinds that can carry tamper-evident hash chains.",
+      "oneOf": [
+        {
+          "description": "Gateway-guest audit stream.",
+          "type": "string",
+          "enum": [
+            "gateway"
+          ]
+        },
+        {
+          "description": "Remote full-node audit stream.",
+          "type": "string",
+          "enum": [
+            "remote-node"
+          ]
+        },
+        {
+          "description": "Local daemon audit stream.",
+          "type": "string",
+          "enum": [
+            "daemon"
+          ]
+        }
+      ]
     },
     "AuthorizationScope": {
       "description": "What an audited operation was authorized against. Workload operations require a [`Capability`]; node-control, enrollment, and read-only health operations are authorized by node enrollment / session identity, so they have their own scope rather than a synthetic capability.",

--- a/docs/reference/schemas/v2/constellation-core.md
+++ b/docs/reference/schemas/v2/constellation-core.md
@@ -25,8 +25,10 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
   `ExecutionSummary`;
 - `Handshake`, `OperationKind`, `OperationRequest`,
   `OperationResponse`;
-- `AdmissionAuditRecord`, `AuditEnvelope`, `ConstellationError`,
-  `ConstellationFrame`.
+- `AdmissionAuditRecord`, `AuditEnvelope`, `AuditHash`,
+  `AuditChainLink`, `AuditChainRecord`, `AuditChainCheckResult`,
+  `AuditSinkHealth`, `AuditRetentionFloorStatus`;
+- `ConstellationError`, `ConstellationFrame`.
 
 ## Contract notes
 
@@ -38,6 +40,9 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
 - `AuditEnvelope` is post-auth and requires a principal.
   `AdmissionAuditRecord` is the pre-auth/session-admission denial shape and
   may omit the principal.
+- Audit-chain and audit-sink health roots are redacted metadata only:
+  they carry bounded hash/status fields, not paths, credentials, argv,
+  stdio, provider tokens, or raw error strings.
 - Audit and typed-error roots carry bounded metadata only; payload bytes,
   argv, stdio, store paths, and credentials are not schema fields.
 - Stream open/data/flow/close definitions are reachable through

--- a/packages/nixling-constellation-core/src/audit.rs
+++ b/packages/nixling-constellation-core/src/audit.rs
@@ -12,6 +12,348 @@ use crate::realm::RealmPath;
 use crate::trace_context::TraceContext;
 use serde::{Deserialize, Deserializer, Serialize};
 
+const AUDIT_HASH_PREFIX: &str = "sha256:";
+const AUDIT_HASH_HEX_LEN: usize = 64;
+
+/// Closed audit stream kinds that can carry tamper-evident hash chains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuditStreamKind {
+    /// Gateway-guest audit stream.
+    Gateway,
+    /// Remote full-node audit stream.
+    RemoteNode,
+    /// Local daemon audit stream.
+    Daemon,
+}
+
+/// Validation error for [`AuditHash`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditHashError {
+    Empty,
+    BadShape,
+}
+
+impl core::fmt::Display for AuditHashError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "audit hash is empty"),
+            Self::BadShape => write!(f, "audit hash must be sha256:<64 lowercase hex chars>"),
+        }
+    }
+}
+
+impl std::error::Error for AuditHashError {}
+
+/// Bounded SHA-256 hash marker used by audit-chain metadata.
+///
+/// This pure core crate defines the contract and validation shape; daemon,
+/// gateway, or provider crates compute the canonical hashes with their local
+/// hashing dependencies.
+#[derive(Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(transparent)]
+pub struct AuditHash(String);
+
+impl AuditHash {
+    /// Parse `sha256:<64 lowercase hex chars>`.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, AuditHashError> {
+        let raw = raw.into();
+        if raw.is_empty() {
+            return Err(AuditHashError::Empty);
+        }
+        let Some(hex) = raw.strip_prefix(AUDIT_HASH_PREFIX) else {
+            return Err(AuditHashError::BadShape);
+        };
+        if hex.len() != AUDIT_HASH_HEX_LEN
+            || !hex
+                .bytes()
+                .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+        {
+            return Err(AuditHashError::BadShape);
+        }
+        Ok(Self(raw))
+    }
+
+    /// Borrow the canonical string form.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Debug for AuditHash {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("AuditHash(<redacted>)")
+    }
+}
+
+impl<'de> Deserialize<'de> for AuditHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// One link in a tamper-evident audit stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AuditChainLink {
+    /// Monotonic stream sequence number.
+    pub sequence: u64,
+    /// Previous record hash, or the stream's genesis hash for sequence 0.
+    pub previous_hash: AuditHash,
+    /// Hash of the canonical redacted audit payload.
+    pub payload_hash: AuditHash,
+    /// Hash of the canonical chain record.
+    pub record_hash: AuditHash,
+}
+
+impl AuditChainLink {
+    /// Construct a chain link from precomputed canonical hashes.
+    pub fn new(
+        sequence: u64,
+        previous_hash: AuditHash,
+        payload_hash: AuditHash,
+        record_hash: AuditHash,
+    ) -> Self {
+        Self {
+            sequence,
+            previous_hash,
+            payload_hash,
+            record_hash,
+        }
+    }
+
+    /// Verify this link against trusted recomputed hash values.
+    pub fn verify(
+        &self,
+        expected_previous_hash: &AuditHash,
+        canonical_payload_hash: &AuditHash,
+        canonical_record_hash: &AuditHash,
+    ) -> AuditChainCheckResult {
+        if &self.previous_hash != expected_previous_hash {
+            return AuditChainCheckResult::failed(AuditChainCheckFailure::PreviousHashMismatch);
+        }
+        if &self.payload_hash != canonical_payload_hash {
+            return AuditChainCheckResult::failed(AuditChainCheckFailure::PayloadHashMismatch);
+        }
+        if &self.record_hash != canonical_record_hash {
+            return AuditChainCheckResult::failed(AuditChainCheckFailure::RecordHashMismatch);
+        }
+        AuditChainCheckResult::verified()
+    }
+}
+
+/// Redacted chain metadata for a gateway, remote-node, or daemon audit event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AuditChainRecord {
+    pub stream: AuditStreamKind,
+    pub realm: RealmPath,
+    pub node: NodeId,
+    pub operation_id: OperationId,
+    pub link: AuditChainLink,
+}
+
+impl AuditChainRecord {
+    /// Construct a redacted audit-chain record.
+    pub fn new(
+        stream: AuditStreamKind,
+        realm: RealmPath,
+        node: NodeId,
+        operation_id: OperationId,
+        link: AuditChainLink,
+    ) -> Self {
+        Self {
+            stream,
+            realm,
+            node,
+            operation_id,
+            link,
+        }
+    }
+
+    /// Verify this record's link against trusted recomputed hash values.
+    pub fn verify(
+        &self,
+        expected_previous_hash: &AuditHash,
+        canonical_payload_hash: &AuditHash,
+        canonical_record_hash: &AuditHash,
+    ) -> AuditChainCheckResult {
+        self.link.verify(
+            expected_previous_hash,
+            canonical_payload_hash,
+            canonical_record_hash,
+        )
+    }
+}
+
+/// Closed audit-chain verification failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuditChainCheckFailure {
+    PreviousHashMismatch,
+    PayloadHashMismatch,
+    RecordHashMismatch,
+}
+
+/// Verification result for one audit-chain link.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum AuditChainCheckResult {
+    Verified,
+    Failed { failure: AuditChainCheckFailure },
+}
+
+impl AuditChainCheckResult {
+    /// Successful chain verification.
+    pub fn verified() -> Self {
+        Self::Verified
+    }
+
+    /// Failed chain verification.
+    pub fn failed(failure: AuditChainCheckFailure) -> Self {
+        Self::Failed { failure }
+    }
+
+    /// True when the chain check failed closed.
+    pub fn is_fail_closed(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+}
+
+/// Bounded reason for audit retention-floor status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuditRetentionFloorReason {
+    WindowBelowFloor,
+    EvidenceMissing,
+    SinkUnavailable,
+}
+
+/// Retention-floor status for an audit sink.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum AuditRetentionFloorStatus {
+    Met,
+    BelowFloor { reason: AuditRetentionFloorReason },
+    Unknown { reason: AuditRetentionFloorReason },
+}
+
+impl AuditRetentionFloorStatus {
+    pub fn met() -> Self {
+        Self::Met
+    }
+
+    pub fn below_floor(reason: AuditRetentionFloorReason) -> Self {
+        Self::BelowFloor { reason }
+    }
+
+    pub fn unknown(reason: AuditRetentionFloorReason) -> Self {
+        Self::Unknown { reason }
+    }
+
+    pub fn is_fail_closed(&self) -> bool {
+        !matches!(self, Self::Met)
+    }
+}
+
+/// Bounded reason for audit sink health.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuditSinkHealthReason {
+    Backpressure,
+    ChainVerificationFailed,
+    SinkMissing,
+    SinkUnavailable,
+    WriteFailed,
+}
+
+/// Health state for a gateway/remote-node/daemon audit sink.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum AuditSinkHealth {
+    Ok {
+        stream: AuditStreamKind,
+        retention_floor: AuditRetentionFloorStatus,
+    },
+    Degraded {
+        stream: AuditStreamKind,
+        reason: AuditSinkHealthReason,
+        retention_floor: AuditRetentionFloorStatus,
+    },
+    Unavailable {
+        stream: AuditStreamKind,
+        reason: AuditSinkHealthReason,
+        retention_floor: AuditRetentionFloorStatus,
+    },
+}
+
+impl AuditSinkHealth {
+    pub fn ok(stream: AuditStreamKind, retention_floor: AuditRetentionFloorStatus) -> Self {
+        Self::Ok {
+            stream,
+            retention_floor,
+        }
+    }
+
+    pub fn degraded(
+        stream: AuditStreamKind,
+        reason: AuditSinkHealthReason,
+        retention_floor: AuditRetentionFloorStatus,
+    ) -> Self {
+        Self::Degraded {
+            stream,
+            reason,
+            retention_floor,
+        }
+    }
+
+    pub fn unavailable(
+        stream: AuditStreamKind,
+        reason: AuditSinkHealthReason,
+        retention_floor: AuditRetentionFloorStatus,
+    ) -> Self {
+        Self::Unavailable {
+            stream,
+            reason,
+            retention_floor,
+        }
+    }
+
+    pub fn is_degraded(&self) -> bool {
+        matches!(self, Self::Degraded { .. } | Self::Unavailable { .. })
+    }
+
+    pub fn is_fail_closed(&self) -> bool {
+        matches!(self, Self::Unavailable { .. })
+            || self.retention_floor().is_fail_closed()
+            || matches!(
+                self,
+                Self::Degraded {
+                    reason: AuditSinkHealthReason::ChainVerificationFailed,
+                    ..
+                }
+            )
+    }
+
+    pub fn retention_floor(&self) -> &AuditRetentionFloorStatus {
+        match self {
+            Self::Ok {
+                retention_floor, ..
+            }
+            | Self::Degraded {
+                retention_floor, ..
+            }
+            | Self::Unavailable {
+                retention_floor, ..
+            } => retention_floor,
+        }
+    }
+}
+
 /// The authorization decision recorded for an operation/stream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
@@ -353,6 +695,20 @@ mod tests {
         RealmPath::new(vec![RealmId::parse(label).unwrap()]).unwrap()
     }
 
+    fn hash(ch: char) -> AuditHash {
+        AuditHash::parse(format!("sha256:{}", ch.to_string().repeat(64))).unwrap()
+    }
+
+    fn chain_record() -> AuditChainRecord {
+        AuditChainRecord::new(
+            AuditStreamKind::Gateway,
+            realm("work"),
+            NodeId::parse("gateway").unwrap(),
+            OperationId::parse("op-chain").unwrap(),
+            AuditChainLink::new(7, hash('a'), hash('b'), hash('c')),
+        )
+    }
+
     #[test]
     fn admission_denial_record_may_omit_principal() {
         let env = AdmissionAuditRecord::denied(
@@ -416,5 +772,122 @@ mod tests {
                                         \"scope\":{\"scope\":\"node-control\",\"capability\":\"exec\"},\
                                         \"decision\":\"deny\",\"reason\":\"authentication-failed\"}";
         assert!(serde_json::from_str::<AdmissionAuditRecord>(capability_on_node_scope).is_err());
+    }
+
+    #[test]
+    fn audit_hash_rejects_malformed_or_secret_shaped_values() {
+        assert_eq!(AuditHash::parse("").unwrap_err(), AuditHashError::Empty);
+        assert_eq!(
+            AuditHash::parse("secret-token").unwrap_err(),
+            AuditHashError::BadShape
+        );
+        assert_eq!(
+            AuditHash::parse(
+                "sha256:ABCDEF0000000000000000000000000000000000000000000000000000000000"
+            )
+            .unwrap_err(),
+            AuditHashError::BadShape
+        );
+        assert_eq!(
+            AuditHash::parse(
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            )
+            .unwrap_err(),
+            AuditHashError::BadShape
+        );
+        assert_eq!(
+            AuditHash::parse("sha256:aaaaaaaa").unwrap_err(),
+            AuditHashError::BadShape
+        );
+        assert_eq!(hash('f').as_str().len(), "sha256:".len() + 64);
+    }
+
+    #[test]
+    fn audit_chain_verify_detects_tampered_hashes() {
+        let record = chain_record();
+        let previous = hash('a');
+        let payload = hash('b');
+        let record_hash = hash('c');
+        assert_eq!(
+            record.verify(&previous, &payload, &record_hash),
+            AuditChainCheckResult::verified()
+        );
+
+        assert_eq!(
+            record.verify(&hash('d'), &payload, &record_hash),
+            AuditChainCheckResult::failed(AuditChainCheckFailure::PreviousHashMismatch)
+        );
+        assert_eq!(
+            record.verify(&previous, &hash('d'), &record_hash),
+            AuditChainCheckResult::failed(AuditChainCheckFailure::PayloadHashMismatch)
+        );
+        let failed = record.verify(&previous, &payload, &hash('d'));
+        assert_eq!(
+            failed,
+            AuditChainCheckResult::failed(AuditChainCheckFailure::RecordHashMismatch)
+        );
+        assert!(failed.is_fail_closed());
+    }
+
+    #[test]
+    fn audit_chain_record_serialization_is_redacted_and_strict() {
+        const SENTINEL: &str = "SharedAccessKey=secret-token /nix/store/leak argv env";
+        let json = serde_json::to_string(&chain_record()).unwrap();
+        assert!(!json.contains(SENTINEL));
+        assert!(!json.contains("secret-token"));
+        assert!(!json.contains("/nix/store"));
+        assert!(json.contains("\"stream\":\"gateway\""));
+
+        let with_unknown = json.replacen("\"stream\"", "\"unexpected\":true,\"stream\"", 1);
+        assert!(serde_json::from_str::<AuditChainRecord>(&with_unknown).is_err());
+    }
+
+    #[test]
+    fn audit_sink_health_reports_degraded_and_fail_closed_states() {
+        let ok = AuditSinkHealth::ok(AuditStreamKind::Daemon, AuditRetentionFloorStatus::met());
+        assert!(!ok.is_degraded());
+        assert!(!ok.is_fail_closed());
+
+        let degraded = AuditSinkHealth::degraded(
+            AuditStreamKind::Gateway,
+            AuditSinkHealthReason::Backpressure,
+            AuditRetentionFloorStatus::met(),
+        );
+        assert!(degraded.is_degraded());
+        assert!(!degraded.is_fail_closed());
+
+        let chain_failed = AuditSinkHealth::degraded(
+            AuditStreamKind::Gateway,
+            AuditSinkHealthReason::ChainVerificationFailed,
+            AuditRetentionFloorStatus::met(),
+        );
+        assert!(chain_failed.is_fail_closed());
+
+        let unavailable = AuditSinkHealth::unavailable(
+            AuditStreamKind::RemoteNode,
+            AuditSinkHealthReason::SinkMissing,
+            AuditRetentionFloorStatus::unknown(AuditRetentionFloorReason::EvidenceMissing),
+        );
+        assert!(unavailable.is_degraded());
+        assert!(unavailable.is_fail_closed());
+    }
+
+    #[test]
+    fn retention_floor_below_floor_is_fail_closed_and_redacted() {
+        let below =
+            AuditRetentionFloorStatus::below_floor(AuditRetentionFloorReason::WindowBelowFloor);
+        assert!(below.is_fail_closed());
+
+        let health = AuditSinkHealth::unavailable(
+            AuditStreamKind::Gateway,
+            AuditSinkHealthReason::WriteFailed,
+            below,
+        );
+        let json = serde_json::to_string(&health).unwrap();
+        assert!(json.contains("\"status\":\"unavailable\""));
+        assert!(json.contains("\"status\":\"belowFloor\""));
+        assert!(!json.contains("SharedAccessKey"));
+        assert!(!json.contains("token"));
+        assert!(!json.contains("/var/lib"));
     }
 }

--- a/packages/nixling-daemon-access/src/direct_tls.rs
+++ b/packages/nixling-daemon-access/src/direct_tls.rs
@@ -1,9 +1,14 @@
 use async_trait::async_trait;
-use nixling_constellation_core::ProviderId;
+use nixling_constellation_core::{PrincipalId, ProviderId};
 use nixling_constellation_provider::{
     error::{ProviderError, ProviderResult},
     provider::DaemonAccessTransport,
     types::{DaemonAccessMode, TransportSession, TransportTarget},
+};
+
+use crate::{
+    DIRECT_TLS_DAEMON_ACCESS_TRANSPORT_ID, DaemonAccessAdmissionSource,
+    RemoteDaemonAccessAdmissionSource, RemoteDaemonAccessCredential,
 };
 
 /// Declared direct-TLS daemon-access slot.
@@ -15,12 +20,27 @@ impl DirectTlsDaemonAccess {
     pub fn new() -> Self {
         Self
     }
+
+    /// Build an admission source using this transport's advertised mode/id.
+    pub fn admission_source(
+        &self,
+        credential: RemoteDaemonAccessCredential,
+        principal_id: Option<PrincipalId>,
+    ) -> DaemonAccessAdmissionSource {
+        DaemonAccessAdmissionSource::Remote(RemoteDaemonAccessAdmissionSource::new(
+            self.transport_id(),
+            self.mode(),
+            credential,
+            principal_id,
+        ))
+    }
 }
 
 #[async_trait]
 impl DaemonAccessTransport for DirectTlsDaemonAccess {
     fn transport_id(&self) -> ProviderId {
-        ProviderId::parse("direct-tls-daemon-access").expect("static provider id is valid")
+        ProviderId::parse(DIRECT_TLS_DAEMON_ACCESS_TRANSPORT_ID)
+            .expect("static provider id is valid")
     }
 
     fn mode(&self) -> DaemonAccessMode {

--- a/packages/nixling-daemon-access/src/lib.rs
+++ b/packages/nixling-daemon-access/src/lib.rs
@@ -20,8 +20,8 @@ use std::{
 use async_trait::async_trait;
 use nix::sys::socket::{AddressFamily, SockFlag, SockType, UnixAddr, connect, socket};
 use nixling_constellation_core::{
-    Capability, CapabilitySet, ErrorKind, NodeId, ProviderId, RealmPath, WorkloadId, WorkloadState,
-    WorkloadSummary,
+    Capability, CapabilitySet, ErrorKind, NodeId, PrincipalId, ProviderId, RealmPath, WorkloadId,
+    WorkloadState, WorkloadSummary,
 };
 use nixling_constellation_provider::{
     error::{ProviderError, ProviderResult},
@@ -45,9 +45,506 @@ pub use relay::RelayDaemonAccess;
 
 /// Default daemon public socket used by the current CLI and `nixlingd`.
 pub const DEFAULT_PUBLIC_SOCKET_PATH: &str = PUBLIC_SOCKET_PATH;
+/// Stable transport id for the local Unix daemon-access binding.
+pub const LOCAL_UNIX_DAEMON_ACCESS_TRANSPORT_ID: &str = "local-unix-daemon-access";
+/// Stable transport id for the declared relay daemon-access slot.
+pub const RELAY_DAEMON_ACCESS_TRANSPORT_ID: &str = "relay-daemon-access";
+/// Stable transport id for the declared direct-TLS daemon-access slot.
+pub const DIRECT_TLS_DAEMON_ACCESS_TRANSPORT_ID: &str = "direct-tls-daemon-access";
+/// Credential byte-length metadata is capped before serialization.
+pub const MAX_REDACTED_CREDENTIAL_BYTES: u16 = u16::MAX;
 const DEFAULT_CLIENT_VERSION_RANGE: &str = ">=0.4.0, <0.5.0";
 const LOCAL_NODE_ID: &str = "local";
 
+/// Redacted evidence that a credential was presented.
+///
+/// The daemon-access admission/audit model records only presence and bounded
+/// byte length. It never stores certificate PEM/DER, bearer tokens, browser
+/// cookies, CSRF values, or relay secrets.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RedactedDaemonAccessCredential {
+    pub present: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byte_len: Option<u16>,
+}
+
+impl RedactedDaemonAccessCredential {
+    /// No credential material was presented.
+    pub const fn absent() -> Self {
+        Self {
+            present: false,
+            byte_len: None,
+        }
+    }
+
+    /// Record credential presence while discarding the material itself.
+    pub fn from_secret(secret: impl AsRef<[u8]>) -> Self {
+        let byte_len = secret
+            .as_ref()
+            .len()
+            .min(MAX_REDACTED_CREDENTIAL_BYTES as usize) as u16;
+        Self {
+            present: true,
+            byte_len: Some(byte_len),
+        }
+    }
+}
+
+impl fmt::Debug for RedactedDaemonAccessCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.present {
+            f.debug_tuple("RedactedDaemonAccessCredential")
+                .field(&format_args!(
+                    "<{} bytes redacted>",
+                    self.byte_len.unwrap_or_default()
+                ))
+                .finish()
+        } else {
+            f.write_str("RedactedDaemonAccessCredential(<absent>)")
+        }
+    }
+}
+
+/// Credential evidence for a remote direct daemon-access frontend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum RemoteDaemonAccessCredential {
+    None,
+    MutualTls {
+        certificate: RedactedDaemonAccessCredential,
+    },
+    BearerToken {
+        token: RedactedDaemonAccessCredential,
+    },
+    MutualTlsAndBearerToken {
+        certificate: RedactedDaemonAccessCredential,
+        token: RedactedDaemonAccessCredential,
+    },
+}
+
+impl RemoteDaemonAccessCredential {
+    /// No authenticated daemon-access credential was presented.
+    pub const fn unauthenticated() -> Self {
+        Self::None
+    }
+
+    /// mTLS credential evidence; certificate material is discarded.
+    pub fn mutual_tls(certificate: impl AsRef<[u8]>) -> Self {
+        Self::MutualTls {
+            certificate: RedactedDaemonAccessCredential::from_secret(certificate),
+        }
+    }
+
+    /// Bearer-token credential evidence; token material is discarded.
+    pub fn bearer_token(token: impl AsRef<[u8]>) -> Self {
+        Self::BearerToken {
+            token: RedactedDaemonAccessCredential::from_secret(token),
+        }
+    }
+
+    /// Combined mTLS + bearer-token evidence; both inputs are discarded.
+    pub fn mutual_tls_and_bearer_token(
+        certificate: impl AsRef<[u8]>,
+        token: impl AsRef<[u8]>,
+    ) -> Self {
+        Self::MutualTlsAndBearerToken {
+            certificate: RedactedDaemonAccessCredential::from_secret(certificate),
+            token: RedactedDaemonAccessCredential::from_secret(token),
+        }
+    }
+}
+
+/// Relay daemon-access credential evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RelayDaemonAccessCredential {
+    pub relay_credential: RedactedDaemonAccessCredential,
+    pub daemon_credential: RemoteDaemonAccessCredential,
+}
+
+impl RelayDaemonAccessCredential {
+    /// Relay reachability without an authenticated daemon principal.
+    pub const fn unauthenticated() -> Self {
+        Self {
+            relay_credential: RedactedDaemonAccessCredential::absent(),
+            daemon_credential: RemoteDaemonAccessCredential::unauthenticated(),
+        }
+    }
+
+    /// Relay-backed credential evidence; relay secret material is discarded.
+    pub fn from_relay_secret(
+        relay_secret: impl AsRef<[u8]>,
+        daemon_credential: RemoteDaemonAccessCredential,
+    ) -> Self {
+        Self {
+            relay_credential: RedactedDaemonAccessCredential::from_secret(relay_secret),
+            daemon_credential,
+        }
+    }
+}
+
+/// Browser daemon-access credential evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum BrowserDaemonAccessCredential {
+    None,
+    CookieSession {
+        cookie: RedactedDaemonAccessCredential,
+        csrf_token: RedactedDaemonAccessCredential,
+    },
+    BearerSession {
+        token: RedactedDaemonAccessCredential,
+        csrf_token: RedactedDaemonAccessCredential,
+    },
+}
+
+impl BrowserDaemonAccessCredential {
+    /// No authenticated browser credential was presented.
+    pub const fn unauthenticated() -> Self {
+        Self::None
+    }
+
+    /// Cookie-backed browser session evidence; cookie and CSRF material are discarded.
+    pub fn cookie_session(cookie: impl AsRef<[u8]>, csrf_token: impl AsRef<[u8]>) -> Self {
+        Self::CookieSession {
+            cookie: RedactedDaemonAccessCredential::from_secret(cookie),
+            csrf_token: RedactedDaemonAccessCredential::from_secret(csrf_token),
+        }
+    }
+
+    /// Bearer-backed browser session evidence; token and CSRF material are discarded.
+    pub fn bearer_session(token: impl AsRef<[u8]>, csrf_token: impl AsRef<[u8]>) -> Self {
+        Self::BearerSession {
+            token: RedactedDaemonAccessCredential::from_secret(token),
+            csrf_token: RedactedDaemonAccessCredential::from_secret(csrf_token),
+        }
+    }
+}
+
+/// Local Unix `SO_PEERCRED` admission source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalUnixAdmissionSource {
+    pub uid: u32,
+    pub gid: u32,
+}
+
+impl LocalUnixAdmissionSource {
+    /// Construct a local Unix peer credential source.
+    pub const fn new(uid: u32, gid: u32) -> Self {
+        Self { uid, gid }
+    }
+}
+
+/// Remote direct daemon-access admission source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RemoteDaemonAccessAdmissionSource {
+    pub transport_id: ProviderId,
+    pub mode: DaemonAccessMode,
+    pub credential: RemoteDaemonAccessCredential,
+    pub principal_id: Option<PrincipalId>,
+}
+
+impl RemoteDaemonAccessAdmissionSource {
+    /// Construct a remote admission source from transport-advertised metadata.
+    pub fn new(
+        transport_id: ProviderId,
+        mode: DaemonAccessMode,
+        credential: RemoteDaemonAccessCredential,
+        principal_id: Option<PrincipalId>,
+    ) -> Self {
+        Self {
+            transport_id,
+            mode,
+            credential,
+            principal_id,
+        }
+    }
+}
+
+/// Relay-backed daemon-access admission source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RelayDaemonAccessAdmissionSource {
+    pub transport_id: ProviderId,
+    pub mode: DaemonAccessMode,
+    pub credential: RelayDaemonAccessCredential,
+    pub principal_id: Option<PrincipalId>,
+}
+
+impl RelayDaemonAccessAdmissionSource {
+    /// Construct a relay admission source from transport-advertised metadata.
+    pub fn new(
+        transport_id: ProviderId,
+        mode: DaemonAccessMode,
+        credential: RelayDaemonAccessCredential,
+        principal_id: Option<PrincipalId>,
+    ) -> Self {
+        Self {
+            transport_id,
+            mode,
+            credential,
+            principal_id,
+        }
+    }
+}
+
+/// Browser web-session daemon-access admission source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BrowserDaemonAccessAdmissionSource {
+    pub credential: BrowserDaemonAccessCredential,
+    pub session_id: Option<PrincipalId>,
+}
+
+impl BrowserDaemonAccessAdmissionSource {
+    /// Construct a browser admission source.
+    pub fn new(credential: BrowserDaemonAccessCredential, session_id: Option<PrincipalId>) -> Self {
+        Self {
+            credential,
+            session_id,
+        }
+    }
+}
+
+/// Transport-neutral daemon-access admission source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "camelCase")]
+pub enum DaemonAccessAdmissionSource {
+    LocalUnix(LocalUnixAdmissionSource),
+    Remote(RemoteDaemonAccessAdmissionSource),
+    Relay(RelayDaemonAccessAdmissionSource),
+    Browser(BrowserDaemonAccessAdmissionSource),
+}
+
+impl DaemonAccessAdmissionSource {
+    /// Construct a local Unix source from `SO_PEERCRED`.
+    pub const fn local_unix(uid: u32, gid: u32) -> Self {
+        Self::LocalUnix(LocalUnixAdmissionSource::new(uid, gid))
+    }
+
+    /// Construct a direct-TLS source using the declared direct-TLS transport id.
+    pub fn direct_tls(
+        credential: RemoteDaemonAccessCredential,
+        principal_id: Option<PrincipalId>,
+    ) -> Self {
+        Self::Remote(RemoteDaemonAccessAdmissionSource::new(
+            ProviderId::parse(DIRECT_TLS_DAEMON_ACCESS_TRANSPORT_ID)
+                .expect("static provider id is valid"),
+            DaemonAccessMode::DirectTls,
+            credential,
+            principal_id,
+        ))
+    }
+
+    /// Construct a relay source using the declared relay transport id.
+    pub fn relay(
+        credential: RelayDaemonAccessCredential,
+        principal_id: Option<PrincipalId>,
+    ) -> Self {
+        Self::Relay(RelayDaemonAccessAdmissionSource::new(
+            ProviderId::parse(RELAY_DAEMON_ACCESS_TRANSPORT_ID)
+                .expect("static provider id is valid"),
+            DaemonAccessMode::Relay,
+            credential,
+            principal_id,
+        ))
+    }
+}
+
+/// Resolved local Unix allowlist/group role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LocalUnixAllowlistRole {
+    Admin,
+    Launcher,
+    Denied,
+}
+
+/// Explicit daemon-access policy role for non-local principals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DaemonAccessPolicyRole {
+    RealmAdmin,
+    RealmOperator,
+    ReadOnly,
+    Scoped,
+}
+
+/// Bounded fail-closed admission denial reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DaemonAccessDenyReason {
+    LocalNotAllowlisted,
+    Unauthenticated,
+    Unmapped,
+}
+
+/// Admission decision for daemon-access principals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "camelCase")]
+pub enum DaemonAccessDecision {
+    Authorized { role: DaemonAccessPolicyRole },
+    Denied { reason: DaemonAccessDenyReason },
+}
+
+impl DaemonAccessDecision {
+    /// An authorized admission with an explicit daemon-access policy role.
+    pub const fn authorized(role: DaemonAccessPolicyRole) -> Self {
+        Self::Authorized { role }
+    }
+
+    /// A denied admission with a bounded reason.
+    pub const fn denied(reason: DaemonAccessDenyReason) -> Self {
+        Self::Denied { reason }
+    }
+
+    /// Whether this admission was denied.
+    pub const fn is_denied(&self) -> bool {
+        matches!(self, Self::Denied { .. })
+    }
+}
+
+/// Transport-neutral mapped principal result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum MappedDaemonAccessPrincipal {
+    LocalAdmin {
+        uid: u32,
+    },
+    LocalLauncher {
+        uid: u32,
+    },
+    LocalDenied {
+        uid: u32,
+        reason: DaemonAccessDenyReason,
+    },
+    RemotePrincipal {
+        principal_id: Option<PrincipalId>,
+        decision: DaemonAccessDecision,
+    },
+    BrowserSession {
+        session_id: Option<PrincipalId>,
+        decision: DaemonAccessDecision,
+    },
+    RelayPrincipal {
+        principal_id: Option<PrincipalId>,
+        decision: DaemonAccessDecision,
+    },
+}
+
+impl MappedDaemonAccessPrincipal {
+    /// True only for local `SO_PEERCRED` identities admitted by the local gate.
+    pub const fn is_local_admin_or_launcher(&self) -> bool {
+        matches!(self, Self::LocalAdmin { .. } | Self::LocalLauncher { .. })
+    }
+
+    /// Whether this principal mapping was denied.
+    pub const fn is_denied(&self) -> bool {
+        match self {
+            Self::LocalDenied { .. } => true,
+            Self::RemotePrincipal { decision, .. }
+            | Self::BrowserSession { decision, .. }
+            | Self::RelayPrincipal { decision, .. } => decision.is_denied(),
+            Self::LocalAdmin { .. } | Self::LocalLauncher { .. } => false,
+        }
+    }
+}
+
+/// Auditable admission record pairing source and mapped principal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DaemonAccessAdmissionRecord {
+    pub source: DaemonAccessAdmissionSource,
+    pub principal: MappedDaemonAccessPrincipal,
+}
+
+/// Map a local Unix `SO_PEERCRED` source using the existing allowlist role.
+pub fn map_local_unix_daemon_access(
+    source: &LocalUnixAdmissionSource,
+    role: LocalUnixAllowlistRole,
+) -> MappedDaemonAccessPrincipal {
+    match role {
+        LocalUnixAllowlistRole::Admin => {
+            MappedDaemonAccessPrincipal::LocalAdmin { uid: source.uid }
+        }
+        LocalUnixAllowlistRole::Launcher => {
+            MappedDaemonAccessPrincipal::LocalLauncher { uid: source.uid }
+        }
+        LocalUnixAllowlistRole::Denied => MappedDaemonAccessPrincipal::LocalDenied {
+            uid: source.uid,
+            reason: DaemonAccessDenyReason::LocalNotAllowlisted,
+        },
+    }
+}
+
+/// Map a remote direct daemon-access source through explicit daemon policy.
+pub fn map_remote_daemon_access(
+    source: &RemoteDaemonAccessAdmissionSource,
+    policy_role: Option<DaemonAccessPolicyRole>,
+) -> MappedDaemonAccessPrincipal {
+    MappedDaemonAccessPrincipal::RemotePrincipal {
+        principal_id: source.principal_id.clone(),
+        decision: non_local_decision(source.principal_id.as_ref(), policy_role),
+    }
+}
+
+/// Map a browser daemon-access source through explicit daemon policy.
+pub fn map_browser_daemon_access(
+    source: &BrowserDaemonAccessAdmissionSource,
+    policy_role: Option<DaemonAccessPolicyRole>,
+) -> MappedDaemonAccessPrincipal {
+    MappedDaemonAccessPrincipal::BrowserSession {
+        session_id: source.session_id.clone(),
+        decision: non_local_decision(source.session_id.as_ref(), policy_role),
+    }
+}
+
+/// Map a relay-backed daemon-access source through explicit daemon policy.
+pub fn map_relay_daemon_access(
+    source: &RelayDaemonAccessAdmissionSource,
+    policy_role: Option<DaemonAccessPolicyRole>,
+) -> MappedDaemonAccessPrincipal {
+    MappedDaemonAccessPrincipal::RelayPrincipal {
+        principal_id: source.principal_id.clone(),
+        decision: non_local_decision(source.principal_id.as_ref(), policy_role),
+    }
+}
+
+/// Build a complete audit/admission record from a source and policy outcome.
+pub fn map_daemon_access_admission(
+    source: DaemonAccessAdmissionSource,
+    local_role: Option<LocalUnixAllowlistRole>,
+    policy_role: Option<DaemonAccessPolicyRole>,
+) -> DaemonAccessAdmissionRecord {
+    let principal = match &source {
+        DaemonAccessAdmissionSource::LocalUnix(local) => map_local_unix_daemon_access(
+            local,
+            local_role.unwrap_or(LocalUnixAllowlistRole::Denied),
+        ),
+        DaemonAccessAdmissionSource::Remote(remote) => {
+            map_remote_daemon_access(remote, policy_role)
+        }
+        DaemonAccessAdmissionSource::Relay(relay) => map_relay_daemon_access(relay, policy_role),
+        DaemonAccessAdmissionSource::Browser(browser) => {
+            map_browser_daemon_access(browser, policy_role)
+        }
+    };
+    DaemonAccessAdmissionRecord { source, principal }
+}
+
+fn non_local_decision(
+    principal_id: Option<&PrincipalId>,
+    policy_role: Option<DaemonAccessPolicyRole>,
+) -> DaemonAccessDecision {
+    match (principal_id, policy_role) {
+        (None, _) => DaemonAccessDecision::denied(DaemonAccessDenyReason::Unauthenticated),
+        (Some(_), None) => DaemonAccessDecision::denied(DaemonAccessDenyReason::Unmapped),
+        (Some(_), Some(role)) => DaemonAccessDecision::authorized(role),
+    }
+}
 /// Lossless daemon list response for the current public socket contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -239,7 +736,7 @@ impl LocalUnixDaemonAccess {
     pub fn with_socket_path(path: impl Into<PathBuf>) -> Self {
         Self {
             socket_path: path.into(),
-            transport_id: ProviderId::parse("local-unix-daemon-access")
+            transport_id: ProviderId::parse(LOCAL_UNIX_DAEMON_ACCESS_TRANSPORT_ID)
                 .expect("static provider id is valid"),
             node_id: NodeId::parse(LOCAL_NODE_ID).expect("static node id is valid"),
         }
@@ -709,6 +1206,226 @@ mod tests {
         assert_eq!(access.socket_path(), Path::new(DEFAULT_PUBLIC_SOCKET_PATH));
     }
 
+    #[test]
+    fn local_unix_mapping_matches_allowlist_roles() {
+        let source = LocalUnixAdmissionSource::new(1000, 100);
+
+        assert_eq!(
+            map_local_unix_daemon_access(&source, LocalUnixAllowlistRole::Admin),
+            MappedDaemonAccessPrincipal::LocalAdmin { uid: 1000 }
+        );
+        assert_eq!(
+            map_local_unix_daemon_access(&source, LocalUnixAllowlistRole::Launcher),
+            MappedDaemonAccessPrincipal::LocalLauncher { uid: 1000 }
+        );
+        assert_eq!(
+            map_local_unix_daemon_access(&source, LocalUnixAllowlistRole::Denied),
+            MappedDaemonAccessPrincipal::LocalDenied {
+                uid: 1000,
+                reason: DaemonAccessDenyReason::LocalNotAllowlisted,
+            }
+        );
+    }
+
+    #[test]
+    fn remote_direct_tls_mapping_denies_without_auth_or_policy() {
+        let direct_tls = DirectTlsDaemonAccess::new();
+        let unauthenticated = remote_source(
+            direct_tls.admission_source(RemoteDaemonAccessCredential::unauthenticated(), None),
+        );
+        assert_eq!(
+            unauthenticated.transport_id.as_str(),
+            DIRECT_TLS_DAEMON_ACCESS_TRANSPORT_ID
+        );
+        assert_eq!(unauthenticated.mode, DaemonAccessMode::DirectTls);
+
+        let denied =
+            map_remote_daemon_access(&unauthenticated, Some(DaemonAccessPolicyRole::RealmAdmin));
+        assert_eq!(
+            denied,
+            MappedDaemonAccessPrincipal::RemotePrincipal {
+                principal_id: None,
+                decision: DaemonAccessDecision::denied(DaemonAccessDenyReason::Unauthenticated),
+            }
+        );
+        assert!(denied.is_denied());
+        assert!(!denied.is_local_admin_or_launcher());
+
+        let authenticated_unmapped = remote_source(direct_tls.admission_source(
+            RemoteDaemonAccessCredential::mutual_tls("cert-material"),
+            Some(principal_id("remote-principal")),
+        ));
+        let denied = map_remote_daemon_access(&authenticated_unmapped, None);
+        assert_eq!(
+            denied,
+            MappedDaemonAccessPrincipal::RemotePrincipal {
+                principal_id: Some(principal_id("remote-principal")),
+                decision: DaemonAccessDecision::denied(DaemonAccessDenyReason::Unmapped),
+            }
+        );
+        assert!(denied.is_denied());
+        assert!(!denied.is_local_admin_or_launcher());
+
+        let explicitly_mapped = map_remote_daemon_access(
+            &authenticated_unmapped,
+            Some(DaemonAccessPolicyRole::RealmAdmin),
+        );
+        assert!(matches!(
+            explicitly_mapped,
+            MappedDaemonAccessPrincipal::RemotePrincipal {
+                decision: DaemonAccessDecision::Authorized {
+                    role: DaemonAccessPolicyRole::RealmAdmin
+                },
+                ..
+            }
+        ));
+        assert!(!explicitly_mapped.is_local_admin_or_launcher());
+    }
+
+    #[test]
+    fn browser_and_relay_mapping_denies_without_auth_or_policy() {
+        let browser_unauthenticated = BrowserDaemonAccessAdmissionSource::new(
+            BrowserDaemonAccessCredential::unauthenticated(),
+            None,
+        );
+        let denied = map_browser_daemon_access(
+            &browser_unauthenticated,
+            Some(DaemonAccessPolicyRole::RealmOperator),
+        );
+        assert_eq!(
+            denied,
+            MappedDaemonAccessPrincipal::BrowserSession {
+                session_id: None,
+                decision: DaemonAccessDecision::denied(DaemonAccessDenyReason::Unauthenticated),
+            }
+        );
+        assert!(!denied.is_local_admin_or_launcher());
+
+        let browser_unmapped = BrowserDaemonAccessAdmissionSource::new(
+            BrowserDaemonAccessCredential::cookie_session("cookie-material", "csrf-material"),
+            Some(principal_id("browser-principal")),
+        );
+        let denied = map_browser_daemon_access(&browser_unmapped, None);
+        assert_eq!(
+            denied,
+            MappedDaemonAccessPrincipal::BrowserSession {
+                session_id: Some(principal_id("browser-principal")),
+                decision: DaemonAccessDecision::denied(DaemonAccessDenyReason::Unmapped),
+            }
+        );
+        assert!(!denied.is_local_admin_or_launcher());
+
+        let relay = RelayDaemonAccess::new();
+        let relay_unauthenticated = relay_source(
+            relay.admission_source(RelayDaemonAccessCredential::unauthenticated(), None),
+        );
+        assert_eq!(
+            relay_unauthenticated.transport_id.as_str(),
+            RELAY_DAEMON_ACCESS_TRANSPORT_ID
+        );
+        assert_eq!(relay_unauthenticated.mode, DaemonAccessMode::Relay);
+        let denied = map_relay_daemon_access(
+            &relay_unauthenticated,
+            Some(DaemonAccessPolicyRole::RealmOperator),
+        );
+        assert_eq!(
+            denied,
+            MappedDaemonAccessPrincipal::RelayPrincipal {
+                principal_id: None,
+                decision: DaemonAccessDecision::denied(DaemonAccessDenyReason::Unauthenticated),
+            }
+        );
+        assert!(!denied.is_local_admin_or_launcher());
+
+        let relay_unmapped = relay_source(relay.admission_source(
+            RelayDaemonAccessCredential::from_relay_secret(
+                "relay-secret-material",
+                RemoteDaemonAccessCredential::bearer_token("daemon-token-material"),
+            ),
+            Some(principal_id("relay-principal")),
+        ));
+        let denied = map_relay_daemon_access(&relay_unmapped, None);
+        assert_eq!(
+            denied,
+            MappedDaemonAccessPrincipal::RelayPrincipal {
+                principal_id: Some(principal_id("relay-principal")),
+                decision: DaemonAccessDecision::denied(DaemonAccessDenyReason::Unmapped),
+            }
+        );
+        assert!(!denied.is_local_admin_or_launcher());
+    }
+
+    #[test]
+    fn admission_record_serialization_redacts_credential_material() {
+        let cert = "-----BEGIN CERTIFICATE-----cert-canary-material-----END CERTIFICATE-----";
+        let token = "Bearer token-canary-material";
+        let cookie = "session=cookie-canary-material";
+        let csrf = "csrf-canary-material";
+        let relay_secret = "SharedAccessSignature sig=relay-canary-material";
+
+        let records = [
+            map_daemon_access_admission(
+                DaemonAccessAdmissionSource::direct_tls(
+                    RemoteDaemonAccessCredential::mutual_tls_and_bearer_token(cert, token),
+                    Some(principal_id("remote-principal")),
+                ),
+                None,
+                None,
+            ),
+            map_daemon_access_admission(
+                DaemonAccessAdmissionSource::relay(
+                    RelayDaemonAccessCredential::from_relay_secret(
+                        relay_secret,
+                        RemoteDaemonAccessCredential::bearer_token(token),
+                    ),
+                    Some(principal_id("relay-principal")),
+                ),
+                None,
+                None,
+            ),
+            map_daemon_access_admission(
+                DaemonAccessAdmissionSource::Browser(BrowserDaemonAccessAdmissionSource::new(
+                    BrowserDaemonAccessCredential::cookie_session(cookie, csrf),
+                    Some(principal_id("browser-principal")),
+                )),
+                None,
+                None,
+            ),
+        ];
+
+        for record in records {
+            let serialized = serde_json::to_string(&record).expect("serialize admission record");
+            for secret in [cert, token, cookie, csrf, relay_secret] {
+                assert!(
+                    !serialized.contains(secret),
+                    "serialized admission record leaked {secret:?}: {serialized}"
+                );
+            }
+            for canary in [
+                "cert-canary-material",
+                "token-canary-material",
+                "cookie-canary-material",
+                "csrf-canary-material",
+                "relay-canary-material",
+            ] {
+                assert!(
+                    !serialized.contains(canary),
+                    "serialized admission record leaked {canary:?}: {serialized}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn redacted_credential_length_is_capped_for_oversized_inputs() {
+        let oversized = vec![b'x'; usize::from(MAX_REDACTED_CREDENTIAL_BYTES) + 4096];
+        let redacted = RedactedDaemonAccessCredential::from_secret(&oversized);
+        assert!(redacted.present);
+        assert_eq!(redacted.byte_len, Some(MAX_REDACTED_CREDENTIAL_BYTES));
+        let serialized = serde_json::to_string(&redacted).expect("serialize redacted credential");
+        assert!(!serialized.contains(&"x".repeat(256)));
+    }
+
     #[tokio::test]
     async fn relay_and_direct_tls_fail_closed() {
         let target = TransportTarget {
@@ -976,6 +1693,23 @@ mod tests {
         assert_eq!(error.kind(), ErrorKind::GatewayUnavailable);
     }
 
+    fn principal_id(raw: &str) -> PrincipalId {
+        PrincipalId::parse(raw).expect("principal id")
+    }
+
+    fn remote_source(source: DaemonAccessAdmissionSource) -> RemoteDaemonAccessAdmissionSource {
+        match source {
+            DaemonAccessAdmissionSource::Remote(source) => source,
+            other => panic!("expected remote source, got {other:?}"),
+        }
+    }
+
+    fn relay_source(source: DaemonAccessAdmissionSource) -> RelayDaemonAccessAdmissionSource {
+        match source {
+            DaemonAccessAdmissionSource::Relay(source) => source,
+            other => panic!("expected relay source, got {other:?}"),
+        }
+    }
     fn list_entry(vm: &str, state: VmLifecycleState, graphics: bool, usbip: bool) -> ListEntry {
         list_entry_with(vm, state, false, "running", graphics, usbip)
     }

--- a/packages/nixling-daemon-access/src/relay.rs
+++ b/packages/nixling-daemon-access/src/relay.rs
@@ -1,9 +1,14 @@
 use async_trait::async_trait;
-use nixling_constellation_core::ProviderId;
+use nixling_constellation_core::{PrincipalId, ProviderId};
 use nixling_constellation_provider::{
     error::{ProviderError, ProviderResult},
     provider::DaemonAccessTransport,
     types::{DaemonAccessMode, TransportSession, TransportTarget},
+};
+
+use crate::{
+    DaemonAccessAdmissionSource, RELAY_DAEMON_ACCESS_TRANSPORT_ID,
+    RelayDaemonAccessAdmissionSource, RelayDaemonAccessCredential,
 };
 
 /// Declared relay daemon-access slot.
@@ -15,12 +20,26 @@ impl RelayDaemonAccess {
     pub fn new() -> Self {
         Self
     }
+
+    /// Build an admission source using this transport's advertised mode/id.
+    pub fn admission_source(
+        &self,
+        credential: RelayDaemonAccessCredential,
+        principal_id: Option<PrincipalId>,
+    ) -> DaemonAccessAdmissionSource {
+        DaemonAccessAdmissionSource::Relay(RelayDaemonAccessAdmissionSource::new(
+            self.transport_id(),
+            self.mode(),
+            credential,
+            principal_id,
+        ))
+    }
 }
 
 #[async_trait]
 impl DaemonAccessTransport for RelayDaemonAccess {
     fn transport_id(&self) -> ProviderId {
-        ProviderId::parse("relay-daemon-access").expect("static provider id is valid")
+        ProviderId::parse(RELAY_DAEMON_ACCESS_TRANSPORT_ID).expect("static provider id is valid")
     }
 
     fn mode(&self) -> DaemonAccessMode {

--- a/packages/nixlingd/src/daemon_audit.rs
+++ b/packages/nixlingd/src/daemon_audit.rs
@@ -5,7 +5,10 @@
 //! `{daemon_state_dir}/daemon-events-{YYYY-MM-DD}.jsonl` (daemon-owned,
 //! separate from the broker's `broker-{date}.jsonl` files). Each line is
 //! a self-contained JSON object carrying `ts_ms` + `source` + a
-//! per-variant `event` object.
+//! per-variant `event` object plus `prev_hash` / `record_hash` hash-chain
+//! fields. The record hash is SHA-256 over a stable length-prefixed payload
+//! of source, timestamp, previous hash, and canonical event JSON; it never
+//! includes `record_hash` itself.
 //!
 //! # Additive-only contract
 //!
@@ -15,12 +18,17 @@
 //! attribute). This mirrors the broker audit's forward-compat posture.
 
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
 
 /// Closed detached exec audit action.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -187,12 +195,187 @@ pub struct DaemonAuditLog {
 /// Default retention window for daemon audit JSONL files (days).
 pub const AUDIT_RETENTION_DAYS: i64 = 14;
 
+/// Minimum daemon audit retention floor used by the default health helper.
+pub const AUDIT_RETENTION_FLOOR_DAYS: i64 = 7;
+
+/// First-link marker for a daemon audit hash chain.
+pub const DAEMON_AUDIT_GENESIS_HASH: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+const DAEMON_AUDIT_SOURCE: &str = "nixlingd";
+const DAEMON_AUDIT_HASH_DOMAIN: &[u8] = b"nixlingd-daemon-audit-v1";
+const DAEMON_AUDIT_TAIL_CHUNK_BYTES: u64 = 8192;
+const MAX_DAEMON_AUDIT_TAIL_LINE_BYTES: usize = 1024 * 1024;
+static HEALTHCHECK_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 /// Serialization + day-boundary bookkeeping for the single audit appender.
 #[derive(Debug, Default)]
 struct AuditWriterState {
     /// UTC date string (`YYYY-MM-DD`) of the most recent append. Used to
     /// detect a day-boundary crossing so retention pruning re-runs.
     last_date: Option<String>,
+    /// Hash of the last record this process successfully emitted, or the
+    /// newest on-disk record discovered before the first append.
+    last_hash: Option<String>,
+    /// Whether `last_hash` has been initialized from existing on-disk daemon
+    /// audit records for this process.
+    initialized_from_disk: bool,
+}
+
+/// Overall daemon audit sink health.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DaemonAuditSinkStatus {
+    Ok,
+    Degraded,
+    Unavailable,
+}
+
+/// Bounded daemon audit sink health problem.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum DaemonAuditSinkProblem {
+    /// No state directory is configured (for example, a no-op test sink).
+    NoStateDir,
+    /// Effective retention is lower than the required floor.
+    RetentionBelowFloor {
+        configured_days: i64,
+        required_floor_days: i64,
+    },
+    /// Creating the daemon state directory failed.
+    CreateStateDirFailed { error_kind: String },
+    /// Opening/listing the daemon state directory failed.
+    OpenStateDirFailed { error_kind: String },
+    /// Opening the bounded write probe failed.
+    OpenProbeFailed { error_kind: String },
+    /// Writing the bounded probe failed.
+    WriteProbeFailed { error_kind: String },
+    /// Flushing the bounded probe failed.
+    FlushProbeFailed { error_kind: String },
+    /// Removing the bounded probe failed after a successful write.
+    CleanupProbeFailed { error_kind: String },
+}
+
+impl DaemonAuditSinkProblem {
+    fn makes_sink_unavailable(&self) -> bool {
+        matches!(
+            self,
+            Self::NoStateDir
+                | Self::CreateStateDirFailed { .. }
+                | Self::OpenStateDirFailed { .. }
+                | Self::OpenProbeFailed { .. }
+                | Self::WriteProbeFailed { .. }
+                | Self::FlushProbeFailed { .. }
+        )
+    }
+}
+
+/// Explicit daemon audit sink health report. It intentionally carries no
+/// filesystem path or raw IO message so state-dir, argv/env, and secret
+/// canaries cannot leak through health JSON.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonAuditSinkHealthReport {
+    pub source: String,
+    pub status: DaemonAuditSinkStatus,
+    pub writable: bool,
+    pub retention_days: i64,
+    pub required_retention_floor_days: i64,
+    pub problems: Vec<DaemonAuditSinkProblem>,
+}
+
+impl DaemonAuditSinkHealthReport {
+    fn unavailable(
+        retention_days: i64,
+        required_retention_floor_days: i64,
+        problem: DaemonAuditSinkProblem,
+    ) -> Self {
+        Self::from_parts(
+            false,
+            retention_days,
+            required_retention_floor_days,
+            vec![problem],
+        )
+    }
+
+    fn from_parts(
+        writable: bool,
+        retention_days: i64,
+        required_retention_floor_days: i64,
+        problems: Vec<DaemonAuditSinkProblem>,
+    ) -> Self {
+        let status = if problems
+            .iter()
+            .any(DaemonAuditSinkProblem::makes_sink_unavailable)
+        {
+            DaemonAuditSinkStatus::Unavailable
+        } else if problems.is_empty() {
+            DaemonAuditSinkStatus::Ok
+        } else {
+            DaemonAuditSinkStatus::Degraded
+        };
+        Self {
+            source: DAEMON_AUDIT_SOURCE.to_owned(),
+            status,
+            writable,
+            retention_days,
+            required_retention_floor_days,
+            problems,
+        }
+    }
+}
+
+/// One daemon audit hash-chain problem.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum DaemonAuditChainProblem {
+    ParseError {
+        message: String,
+    },
+    MissingField {
+        field: String,
+    },
+    WrongFieldType {
+        field: String,
+        expected: String,
+        actual: String,
+    },
+    SourceMismatch {
+        expected: String,
+        actual: String,
+    },
+    MalformedHash {
+        field: String,
+    },
+    PreviousHashMismatch {
+        expected: String,
+        actual: String,
+    },
+    RecordHashMismatch {
+        expected: String,
+        actual: String,
+    },
+}
+
+/// One daemon audit line plus its hash-chain problem.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonAuditChainDefect {
+    pub line_index: usize,
+    pub source_file: Option<String>,
+    pub problem: DaemonAuditChainProblem,
+}
+
+/// Aggregated daemon audit hash-chain verification report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonAuditChainReport {
+    pub records_scanned: usize,
+    pub records_ok: usize,
+    pub defects: Vec<DaemonAuditChainDefect>,
+}
+
+impl DaemonAuditChainReport {
+    pub fn is_clean(&self) -> bool {
+        self.defects.is_empty()
+    }
 }
 
 impl DaemonAuditLog {
@@ -235,29 +418,27 @@ impl DaemonAuditLog {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
-        let record = serde_json::json!({
-            "ts_ms": ts_ms,
-            "source": "nixlingd",
-            "event": serde_json::to_value(event)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-        });
+        let event_value = serde_json::to_value(event)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let mut writer = self
+            .writer
+            .lock()
+            .map_err(|_| io::Error::other("DaemonAuditLog writer mutex poisoned"))?;
+        if let Some(ref state_dir) = self.state_dir {
+            initialize_chain_from_disk(state_dir, &mut writer);
+        }
+
+        let prev_hash = writer
+            .last_hash
+            .as_deref()
+            .unwrap_or(DAEMON_AUDIT_GENESIS_HASH);
+        let (record, record_hash) = build_chained_record(ts_ms, &event_value, prev_hash)?;
         let mut line = serde_json::to_string(&record)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         line.push('\n');
 
-        #[cfg(test)]
-        {
-            self.captured
-                .lock()
-                .map_err(|_| io::Error::other("DaemonAuditLog capture mutex poisoned"))?
-                .push(line.trim_end_matches('\n').to_owned());
-        }
-
         if let Some(ref state_dir) = self.state_dir {
-            let mut writer = self
-                .writer
-                .lock()
-                .map_err(|_| io::Error::other("DaemonAuditLog writer mutex poisoned"))?;
             let today = utc_date_string();
             // First write of the process or a day-boundary crossing:
             // re-run retention pruning (best-effort) before appending.
@@ -267,7 +448,590 @@ impl DaemonAuditLog {
             }
             write_jsonl_line_for_date(state_dir, &today, &line)?;
         }
+
+        writer.last_hash = Some(record_hash);
+
+        #[cfg(test)]
+        {
+            self.captured
+                .lock()
+                .map_err(|_| io::Error::other("DaemonAuditLog capture mutex poisoned"))?
+                .push(line.trim_end_matches('\n').to_owned());
+        }
         Ok(())
+    }
+
+    /// Report explicit daemon audit sink health without changing
+    /// [`Self::write_event`]'s best-effort caller contract.
+    pub fn sink_health_report(&self) -> DaemonAuditSinkHealthReport {
+        self.sink_health_report_with_floor(AUDIT_RETENTION_FLOOR_DAYS)
+    }
+
+    /// Report explicit daemon audit sink health against a caller-provided
+    /// retention floor.
+    pub fn sink_health_report_with_floor(
+        &self,
+        required_retention_floor_days: i64,
+    ) -> DaemonAuditSinkHealthReport {
+        match self.state_dir.as_deref() {
+            Some(state_dir) => daemon_audit_sink_health_report(
+                state_dir,
+                AUDIT_RETENTION_DAYS,
+                required_retention_floor_days,
+            ),
+            None => DaemonAuditSinkHealthReport::unavailable(
+                AUDIT_RETENTION_DAYS,
+                required_retention_floor_days,
+                DaemonAuditSinkProblem::NoStateDir,
+            ),
+        }
+    }
+}
+
+/// Probe daemon audit sink health without writing an audit record.
+pub fn daemon_audit_sink_health_report(
+    state_dir: &Path,
+    configured_retention_days: i64,
+    required_retention_floor_days: i64,
+) -> DaemonAuditSinkHealthReport {
+    let mut problems = Vec::new();
+    if configured_retention_days < required_retention_floor_days {
+        problems.push(DaemonAuditSinkProblem::RetentionBelowFloor {
+            configured_days: configured_retention_days,
+            required_floor_days: required_retention_floor_days,
+        });
+    }
+
+    if let Err(err) = fs::create_dir_all(state_dir) {
+        problems.push(DaemonAuditSinkProblem::CreateStateDirFailed {
+            error_kind: io_error_kind(err.kind()).to_owned(),
+        });
+        return DaemonAuditSinkHealthReport::from_parts(
+            false,
+            configured_retention_days,
+            required_retention_floor_days,
+            problems,
+        );
+    }
+
+    if let Err(err) = fs::read_dir(state_dir) {
+        problems.push(DaemonAuditSinkProblem::OpenStateDirFailed {
+            error_kind: io_error_kind(err.kind()).to_owned(),
+        });
+        return DaemonAuditSinkHealthReport::from_parts(
+            false,
+            configured_retention_days,
+            required_retention_floor_days,
+            problems,
+        );
+    }
+
+    let probe_path = unique_health_probe_path(state_dir);
+    let mut writable = false;
+    let mut opened_probe = false;
+    match fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&probe_path)
+    {
+        Ok(mut file) => {
+            opened_probe = true;
+            match file.write_all(b"nixlingd-daemon-audit-health\n") {
+                Ok(()) => match file.flush() {
+                    Ok(()) => writable = true,
+                    Err(err) => problems.push(DaemonAuditSinkProblem::FlushProbeFailed {
+                        error_kind: io_error_kind(err.kind()).to_owned(),
+                    }),
+                },
+                Err(err) => problems.push(DaemonAuditSinkProblem::WriteProbeFailed {
+                    error_kind: io_error_kind(err.kind()).to_owned(),
+                }),
+            }
+        }
+        Err(err) => problems.push(DaemonAuditSinkProblem::OpenProbeFailed {
+            error_kind: io_error_kind(err.kind()).to_owned(),
+        }),
+    }
+
+    if opened_probe && let Err(err) = fs::remove_file(&probe_path) {
+        problems.push(DaemonAuditSinkProblem::CleanupProbeFailed {
+            error_kind: io_error_kind(err.kind()).to_owned(),
+        });
+    }
+
+    DaemonAuditSinkHealthReport::from_parts(
+        writable,
+        configured_retention_days,
+        required_retention_floor_days,
+        problems,
+    )
+}
+
+/// Verify daemon audit JSONL records as one strict hash-chain sequence.
+pub fn verify_daemon_audit_lines<'a, I>(lines: I) -> DaemonAuditChainReport
+where
+    I: IntoIterator<Item = (Option<&'a str>, &'a str)>,
+{
+    let mut report = DaemonAuditChainReport {
+        records_scanned: 0,
+        records_ok: 0,
+        defects: Vec::new(),
+    };
+    let mut expected_prev_hash = DAEMON_AUDIT_GENESIS_HASH.to_owned();
+
+    for (idx, (source_file, line)) in lines.into_iter().enumerate() {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            continue;
+        }
+        report.records_scanned += 1;
+        let line_index = idx + 1;
+        let source_owned = source_file.map(str::to_owned);
+        let mut problems = match validate_daemon_audit_chain_line(trimmed, &expected_prev_hash) {
+            Ok(record_hash) => {
+                expected_prev_hash = record_hash;
+                report.records_ok += 1;
+                Vec::new()
+            }
+            Err((line_problems, next_prev)) => {
+                if let Some(record_hash) = next_prev {
+                    expected_prev_hash = record_hash;
+                }
+                line_problems
+            }
+        };
+        for problem in problems.drain(..) {
+            report.defects.push(DaemonAuditChainDefect {
+                line_index,
+                source_file: source_owned.clone(),
+                problem,
+            });
+        }
+    }
+
+    report
+}
+
+fn validate_daemon_audit_chain_line(
+    line: &str,
+    expected_prev_hash: &str,
+) -> Result<String, (Vec<DaemonAuditChainProblem>, Option<String>)> {
+    let value: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(err) => {
+            return Err((
+                vec![DaemonAuditChainProblem::ParseError {
+                    message: err.to_string(),
+                }],
+                None,
+            ));
+        }
+    };
+    let Some(obj) = value.as_object() else {
+        return Err((
+            vec![DaemonAuditChainProblem::ParseError {
+                message: format!("expected JSON object, got {}", json_value_kind(&value)),
+            }],
+            None,
+        ));
+    };
+
+    let mut problems = Vec::new();
+    let ts_ms = match obj.get("ts_ms") {
+        Some(Value::Number(number)) => match number.as_u64() {
+            Some(ts_ms) => Some(u128::from(ts_ms)),
+            None => {
+                problems.push(DaemonAuditChainProblem::WrongFieldType {
+                    field: "ts_ms".to_owned(),
+                    expected: "unsigned-integer".to_owned(),
+                    actual: "number".to_owned(),
+                });
+                None
+            }
+        },
+        Some(value) => {
+            problems.push(DaemonAuditChainProblem::WrongFieldType {
+                field: "ts_ms".to_owned(),
+                expected: "number".to_owned(),
+                actual: json_value_kind(value).to_owned(),
+            });
+            None
+        }
+        None => {
+            problems.push(DaemonAuditChainProblem::MissingField {
+                field: "ts_ms".to_owned(),
+            });
+            None
+        }
+    };
+
+    let source = match obj.get("source") {
+        Some(Value::String(source)) => {
+            if source != DAEMON_AUDIT_SOURCE {
+                problems.push(DaemonAuditChainProblem::SourceMismatch {
+                    expected: DAEMON_AUDIT_SOURCE.to_owned(),
+                    actual: source.clone(),
+                });
+            }
+            Some(source.as_str())
+        }
+        Some(value) => {
+            problems.push(DaemonAuditChainProblem::WrongFieldType {
+                field: "source".to_owned(),
+                expected: "string".to_owned(),
+                actual: json_value_kind(value).to_owned(),
+            });
+            None
+        }
+        None => {
+            problems.push(DaemonAuditChainProblem::MissingField {
+                field: "source".to_owned(),
+            });
+            None
+        }
+    };
+
+    let event = match obj.get("event") {
+        Some(Value::Object(_)) => obj.get("event"),
+        Some(value) => {
+            problems.push(DaemonAuditChainProblem::WrongFieldType {
+                field: "event".to_owned(),
+                expected: "object".to_owned(),
+                actual: json_value_kind(value).to_owned(),
+            });
+            None
+        }
+        None => {
+            problems.push(DaemonAuditChainProblem::MissingField {
+                field: "event".to_owned(),
+            });
+            None
+        }
+    };
+
+    let prev_hash = extract_hash_field(obj, "prev_hash", &mut problems);
+    let record_hash = extract_hash_field(obj, "record_hash", &mut problems);
+
+    if let Some(prev_hash) = prev_hash
+        && prev_hash != expected_prev_hash
+    {
+        problems.push(DaemonAuditChainProblem::PreviousHashMismatch {
+            expected: expected_prev_hash.to_owned(),
+            actual: prev_hash.to_owned(),
+        });
+    }
+
+    if let (Some(ts_ms), Some(source), Some(event), Some(prev_hash), Some(record_hash)) =
+        (ts_ms, source, event, prev_hash, record_hash)
+        && source == DAEMON_AUDIT_SOURCE
+    {
+        match compute_record_hash(ts_ms, source, event, prev_hash) {
+            Ok(expected) if expected != record_hash => {
+                problems.push(DaemonAuditChainProblem::RecordHashMismatch {
+                    expected,
+                    actual: record_hash.to_owned(),
+                });
+            }
+            Ok(_) => {}
+            Err(err) => problems.push(DaemonAuditChainProblem::ParseError {
+                message: err.to_string(),
+            }),
+        }
+    }
+
+    if problems.is_empty() {
+        Ok(record_hash
+            .expect("record_hash present when problems is empty")
+            .to_owned())
+    } else {
+        Err((problems, record_hash.map(str::to_owned)))
+    }
+}
+
+fn build_chained_record(
+    ts_ms: u128,
+    event: &Value,
+    prev_hash: &str,
+) -> io::Result<(Value, String)> {
+    let record_hash = compute_record_hash(ts_ms, DAEMON_AUDIT_SOURCE, event, prev_hash)?;
+    Ok((
+        serde_json::json!({
+            "ts_ms": ts_ms,
+            "source": DAEMON_AUDIT_SOURCE,
+            "prev_hash": prev_hash,
+            "record_hash": record_hash.clone(),
+            "event": event,
+        }),
+        record_hash,
+    ))
+}
+
+fn compute_record_hash(
+    ts_ms: u128,
+    source: &str,
+    event: &Value,
+    prev_hash: &str,
+) -> io::Result<String> {
+    let event_bytes = canonical_json_bytes(event)?;
+    let mut hasher = Sha256::new();
+    hash_component(&mut hasher, DAEMON_AUDIT_HASH_DOMAIN);
+    hash_component(&mut hasher, source.as_bytes());
+    hash_component(&mut hasher, ts_ms.to_string().as_bytes());
+    hash_component(&mut hasher, prev_hash.as_bytes());
+    hash_component(&mut hasher, &event_bytes);
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+fn initialize_chain_from_disk(state_dir: &Path, writer: &mut AuditWriterState) {
+    if writer.initialized_from_disk {
+        return;
+    }
+    writer.last_hash = last_daemon_record_hash_on_disk(state_dir);
+    writer.initialized_from_disk = true;
+}
+
+fn last_daemon_record_hash_on_disk(state_dir: &Path) -> Option<String> {
+    let mut files = discover_daemon_daily_files(state_dir).ok()?;
+    files.sort();
+    for path in files.iter().rev() {
+        if let Some(hash) = last_daemon_record_hash_in_file(path) {
+            return Some(hash);
+        }
+    }
+    None
+}
+
+fn last_daemon_record_hash_in_file(path: &Path) -> Option<String> {
+    let mut file = fs::File::open(path).ok()?;
+    let mut position = file.seek(SeekFrom::End(0)).ok()?;
+    let mut reversed_line = Vec::new();
+    let mut skipping_oversized_line = false;
+
+    while position > 0 {
+        let read_len = position.min(DAEMON_AUDIT_TAIL_CHUNK_BYTES) as usize;
+        position -= read_len as u64;
+        file.seek(SeekFrom::Start(position)).ok()?;
+        let mut chunk = vec![0_u8; read_len];
+        file.read_exact(&mut chunk).ok()?;
+
+        for byte in chunk.iter().rev().copied() {
+            if byte == b'\n' {
+                if skipping_oversized_line {
+                    reversed_line.clear();
+                    skipping_oversized_line = false;
+                    continue;
+                }
+                if reversed_line.is_empty() {
+                    continue;
+                }
+                if let Some(hash) = record_hash_from_reversed_line(&reversed_line) {
+                    return Some(hash);
+                }
+                reversed_line.clear();
+                continue;
+            }
+
+            if skipping_oversized_line {
+                continue;
+            }
+            if reversed_line.len() >= MAX_DAEMON_AUDIT_TAIL_LINE_BYTES {
+                reversed_line.clear();
+                skipping_oversized_line = true;
+                continue;
+            }
+            reversed_line.push(byte);
+        }
+    }
+
+    if !skipping_oversized_line && !reversed_line.is_empty() {
+        record_hash_from_reversed_line(&reversed_line)
+    } else {
+        None
+    }
+}
+
+fn record_hash_from_reversed_line(reversed_line: &[u8]) -> Option<String> {
+    let mut line = reversed_line.to_vec();
+    line.reverse();
+    while matches!(line.last(), Some(b'\r' | b' ' | b'\t')) {
+        line.pop();
+    }
+    if line.is_empty() {
+        return None;
+    }
+    let value: Value = serde_json::from_slice(&line).ok()?;
+    let hash = value.get("record_hash").and_then(Value::as_str)?;
+    is_sha256_hex(hash).then(|| hash.to_owned())
+}
+
+fn discover_daemon_daily_files(state_dir: &Path) -> io::Result<Vec<PathBuf>> {
+    let entries = match fs::read_dir(state_dir) {
+        Ok(it) => it,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err),
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let name = name.to_str()?;
+            let date = name
+                .strip_prefix("daemon-events-")
+                .and_then(|rest| rest.strip_suffix(".jsonl"))?;
+            parse_ymd(date)?;
+            Some(entry.path())
+        })
+        .collect();
+    paths.sort();
+    Ok(paths)
+}
+
+fn unique_health_probe_path(state_dir: &Path) -> PathBuf {
+    let counter = HEALTHCHECK_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    state_dir.join(format!(
+        ".daemon-audit-healthcheck-{}-{counter}-{nanos}",
+        std::process::id()
+    ))
+}
+
+fn extract_hash_field<'a>(
+    obj: &'a serde_json::Map<String, Value>,
+    field: &str,
+    problems: &mut Vec<DaemonAuditChainProblem>,
+) -> Option<&'a str> {
+    match obj.get(field) {
+        Some(Value::String(hash)) if is_sha256_hex(hash) => Some(hash.as_str()),
+        Some(Value::String(_)) => {
+            problems.push(DaemonAuditChainProblem::MalformedHash {
+                field: field.to_owned(),
+            });
+            None
+        }
+        Some(value) => {
+            problems.push(DaemonAuditChainProblem::WrongFieldType {
+                field: field.to_owned(),
+                expected: "string".to_owned(),
+                actual: json_value_kind(value).to_owned(),
+            });
+            None
+        }
+        None => {
+            problems.push(DaemonAuditChainProblem::MissingField {
+                field: field.to_owned(),
+            });
+            None
+        }
+    }
+}
+
+fn canonical_json_bytes(value: &Value) -> io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    write_canonical_json(value, &mut out)?;
+    Ok(out)
+}
+
+fn write_canonical_json(value: &Value, out: &mut Vec<u8>) -> io::Result<()> {
+    match value {
+        Value::Null => out.extend_from_slice(b"null"),
+        Value::Bool(true) => out.extend_from_slice(b"true"),
+        Value::Bool(false) => out.extend_from_slice(b"false"),
+        Value::Number(number) => out.extend_from_slice(number.to_string().as_bytes()),
+        Value::String(string) => {
+            let encoded = serde_json::to_string(string)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            out.extend_from_slice(encoded.as_bytes());
+        }
+        Value::Array(values) => {
+            out.push(b'[');
+            for (idx, item) in values.iter().enumerate() {
+                if idx > 0 {
+                    out.push(b',');
+                }
+                write_canonical_json(item, out)?;
+            }
+            out.push(b']');
+        }
+        Value::Object(map) => {
+            out.push(b'{');
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            for (idx, key) in keys.iter().enumerate() {
+                if idx > 0 {
+                    out.push(b',');
+                }
+                let encoded_key = serde_json::to_string(*key)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                out.extend_from_slice(encoded_key.as_bytes());
+                out.push(b':');
+                let value = map.get(*key).expect("key collected from map exists");
+                write_canonical_json(value, out)?;
+            }
+            out.push(b'}');
+        }
+    }
+    Ok(())
+}
+
+fn hash_component(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn io_error_kind(kind: io::ErrorKind) -> &'static str {
+    match kind {
+        io::ErrorKind::NotFound => "not-found",
+        io::ErrorKind::PermissionDenied => "permission-denied",
+        io::ErrorKind::ConnectionRefused => "connection-refused",
+        io::ErrorKind::ConnectionReset => "connection-reset",
+        io::ErrorKind::ConnectionAborted => "connection-aborted",
+        io::ErrorKind::NotConnected => "not-connected",
+        io::ErrorKind::AddrInUse => "addr-in-use",
+        io::ErrorKind::AddrNotAvailable => "addr-not-available",
+        io::ErrorKind::BrokenPipe => "broken-pipe",
+        io::ErrorKind::AlreadyExists => "already-exists",
+        io::ErrorKind::WouldBlock => "would-block",
+        io::ErrorKind::InvalidInput => "invalid-input",
+        io::ErrorKind::InvalidData => "invalid-data",
+        io::ErrorKind::TimedOut => "timed-out",
+        io::ErrorKind::WriteZero => "write-zero",
+        io::ErrorKind::Interrupted => "interrupted",
+        io::ErrorKind::Unsupported => "unsupported",
+        io::ErrorKind::UnexpectedEof => "unexpected-eof",
+        io::ErrorKind::OutOfMemory => "out-of-memory",
+        _ => "other",
     }
 }
 
@@ -394,6 +1158,28 @@ pub fn write_vm_api_ready_state(
 mod tests {
     use super::*;
 
+    fn two_chained_records() -> Vec<String> {
+        let log = DaemonAuditLog::no_op();
+        log.write_event(&DaemonEvent::ApiReadyTimeout {
+            vm: "vm-a".to_owned(),
+            runner: "ch-runner".to_owned(),
+            elapsed_secs: 60,
+            mode: "strict".to_owned(),
+        })
+        .expect("write first audit event");
+        log.write_event(&DaemonEvent::VmStartRunnerExited {
+            vm: "vm-a".to_owned(),
+            role_id: "swtpm".to_owned(),
+            reason_kind: VmStartRunnerExitReason::RunnerExited,
+            exit_kind: Some(RunnerExitKind::Exited),
+            exit_code: Some(1),
+            exit_signal: None,
+            elapsed_ms: 12,
+        })
+        .expect("write second audit event");
+        log.captured.lock().expect("lock captured").clone()
+    }
+
     #[test]
     fn api_ready_timeout_event_writes_jsonl_and_captures() {
         let dir = tempfile::tempdir().expect("create temp dir");
@@ -420,9 +1206,19 @@ mod tests {
 
         assert_eq!(
             record.get("source").and_then(|v| v.as_str()),
-            Some("nixlingd"),
+            Some(DAEMON_AUDIT_SOURCE),
             "source field must be 'nixlingd'",
         );
+        assert_eq!(
+            record.get("prev_hash").and_then(|v| v.as_str()),
+            Some(DAEMON_AUDIT_GENESIS_HASH),
+            "first record must use the genesis previous hash",
+        );
+        let record_hash = record
+            .get("record_hash")
+            .and_then(|v| v.as_str())
+            .expect("record_hash must be present");
+        assert!(is_sha256_hex(record_hash), "malformed record_hash");
         let event = record.get("event").expect("event field must be present");
         assert_eq!(
             event.get("kind").and_then(|v| v.as_str()),
@@ -479,6 +1275,111 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("api_ready_timeout"),
         );
+        assert_eq!(
+            disk_record.get("record_hash").and_then(|v| v.as_str()),
+            Some(record_hash),
+            "disk and captured records must carry the same record hash",
+        );
+    }
+
+    #[test]
+    fn daemon_audit_records_are_hash_chained_and_verifiable() {
+        let records = two_chained_records();
+        assert_eq!(records.len(), 2);
+        let first: Value = serde_json::from_str(&records[0]).expect("first record parses");
+        let second: Value = serde_json::from_str(&records[1]).expect("second record parses");
+        let first_hash = first["record_hash"].as_str().expect("first record hash");
+        let second_prev = second["prev_hash"].as_str().expect("second prev hash");
+        assert!(is_sha256_hex(first_hash));
+        assert!(is_sha256_hex(
+            second["record_hash"].as_str().expect("second record hash")
+        ));
+        assert_eq!(first["prev_hash"].as_str(), Some(DAEMON_AUDIT_GENESIS_HASH));
+        assert_eq!(second_prev, first_hash);
+
+        let report = verify_daemon_audit_lines(
+            records
+                .iter()
+                .map(|line| (Some("daemon-events-2026-06-20.jsonl"), line.as_str())),
+        );
+        assert_eq!(report.records_scanned, 2);
+        assert_eq!(report.records_ok, 2);
+        assert!(report.is_clean(), "chain report not clean: {:?}", report);
+    }
+
+    #[test]
+    fn daemon_audit_verify_fails_on_altered_event() {
+        let mut records = two_chained_records();
+        let mut second: Value = serde_json::from_str(&records[1]).expect("parse second");
+        second["event"]["elapsed_ms"] = Value::from(99_u64);
+        records[1] = second.to_string();
+
+        let report =
+            verify_daemon_audit_lines(records.iter().map(|line| (None::<&str>, line.as_str())));
+        assert!(report.defects.iter().any(|defect| matches!(
+            defect.problem,
+            DaemonAuditChainProblem::RecordHashMismatch { .. }
+        )));
+    }
+
+    #[test]
+    fn daemon_audit_verify_fails_on_missing_link() {
+        let records = two_chained_records();
+        let report = verify_daemon_audit_lines([(None, records[1].as_str())]);
+        assert!(report.defects.iter().any(|defect| matches!(
+            &defect.problem,
+            DaemonAuditChainProblem::PreviousHashMismatch { expected, .. }
+                if expected == DAEMON_AUDIT_GENESIS_HASH
+        )));
+    }
+
+    #[test]
+    fn daemon_audit_verify_fails_on_altered_previous_hash() {
+        let mut records = two_chained_records();
+        let mut second: Value = serde_json::from_str(&records[1]).expect("parse second");
+        second["prev_hash"] = Value::String(DAEMON_AUDIT_GENESIS_HASH.to_owned());
+        records[1] = second.to_string();
+
+        let report =
+            verify_daemon_audit_lines(records.iter().map(|line| (None::<&str>, line.as_str())));
+        assert!(report.defects.iter().any(|defect| matches!(
+            defect.problem,
+            DaemonAuditChainProblem::PreviousHashMismatch { .. }
+        )));
+        assert!(report.defects.iter().any(|defect| matches!(
+            defect.problem,
+            DaemonAuditChainProblem::RecordHashMismatch { .. }
+        )));
+    }
+
+    #[test]
+    fn daemon_audit_verify_fails_on_malformed_hash_fields() {
+        let mut records = two_chained_records();
+        let mut first: Value = serde_json::from_str(&records[0]).expect("parse first");
+        first["record_hash"] = Value::String("not-a-sha256".to_owned());
+        records[0] = first.to_string();
+
+        let report =
+            verify_daemon_audit_lines(records.iter().map(|line| (None::<&str>, line.as_str())));
+        assert!(report.defects.iter().any(|defect| matches!(
+            &defect.problem,
+            DaemonAuditChainProblem::MalformedHash { field } if field == "record_hash"
+        )));
+    }
+
+    #[test]
+    fn daemon_audit_verify_fails_on_missing_chain_field() {
+        let mut records = two_chained_records();
+        let mut first: Value = serde_json::from_str(&records[0]).expect("parse first");
+        first.as_object_mut().unwrap().remove("prev_hash");
+        records[0] = first.to_string();
+
+        let report =
+            verify_daemon_audit_lines(records.iter().map(|line| (None::<&str>, line.as_str())));
+        assert!(report.defects.iter().any(|defect| matches!(
+            &defect.problem,
+            DaemonAuditChainProblem::MissingField { field } if field == "prev_hash"
+        )));
     }
 
     #[test]
@@ -487,7 +1388,7 @@ mod tests {
         // leak-safe fields (vm, peer_uid, tty). A planted sentinel standing in
         // for a session handle / argv / env / cwd must never appear, and the
         // serialized event must expose no unexpected key.
-        const SENTINEL: &str = "SENTINEL-handle-argv-env-cwd-9b2f";
+        const SENTINEL: &str = "SECRET-handle-argv-env-cwd-/nix/store/path-like-token-9b2f";
         let log = DaemonAuditLog::no_op();
 
         log.write_event(&DaemonEvent::GuestControlExecEstablished {
@@ -510,6 +1411,12 @@ mod tests {
                 !line.contains(SENTINEL),
                 "exec lifecycle audit leaked a sentinel: {line}"
             );
+            for forbidden in ["SECRET", "/nix/store", "argv", "env", "cwd"] {
+                assert!(
+                    !line.contains(forbidden),
+                    "exec lifecycle audit leaked forbidden canary {forbidden:?}: {line}",
+                );
+            }
             let record: serde_json::Value =
                 serde_json::from_str(line).expect("parse captured lifecycle record");
             assert_eq!(
@@ -550,7 +1457,7 @@ mod tests {
 
     #[test]
     fn detached_exec_audit_events_are_leak_safe() {
-        const SENTINEL: &str = "SENTINEL-argv-env-cwd-log-bytes-2d7b";
+        const SENTINEL: &str = "SECRET-argv-env-cwd-/nix/store/log-bytes-2d7b";
         let log = DaemonAuditLog::no_op();
 
         log.write_event(&DaemonEvent::GuestControlExecDetachedCreate {
@@ -578,6 +1485,12 @@ mod tests {
                 !line.contains(SENTINEL),
                 "detached exec audit leaked a sentinel: {line}"
             );
+            for forbidden in ["SECRET", "/nix/store", "argv", "env", "cwd"] {
+                assert!(
+                    !line.contains(forbidden),
+                    "detached exec audit leaked forbidden canary {forbidden:?}: {line}",
+                );
+            }
             for forbidden in [
                 "\"argv\"",
                 "\"env\"",
@@ -629,6 +1542,160 @@ mod tests {
         );
         assert_eq!(kill["event"]["action"].as_str(), Some("cancel"));
         assert_eq!(kill["event"]["result"].as_str(), Some("cancelling"));
+    }
+
+    #[test]
+    fn daemon_audit_health_ok_when_writable_and_retention_floor_met() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let report = daemon_audit_sink_health_report(
+            dir.path(),
+            AUDIT_RETENTION_DAYS,
+            AUDIT_RETENTION_FLOOR_DAYS,
+        );
+        assert_eq!(report.status, DaemonAuditSinkStatus::Ok);
+        assert!(report.writable);
+        assert!(report.problems.is_empty());
+    }
+
+    #[test]
+    fn daemon_audit_health_degraded_when_retention_below_floor() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let report = daemon_audit_sink_health_report(dir.path(), 3, 7);
+        assert_eq!(report.status, DaemonAuditSinkStatus::Degraded);
+        assert!(report.writable);
+        assert!(report.problems.iter().any(|problem| matches!(
+            problem,
+            DaemonAuditSinkProblem::RetentionBelowFloor {
+                configured_days: 3,
+                required_floor_days: 7,
+            }
+        )));
+    }
+
+    #[test]
+    fn daemon_audit_health_reports_unavailable_without_leaking_state_path() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let secret_component = "SECRET-argv-env-cwd";
+        let blocked_parent = dir.path().join(secret_component).join("nix").join("store");
+        std::fs::create_dir_all(&blocked_parent).expect("create path-like parent");
+        let blocked = blocked_parent.join("path-like-token");
+        std::fs::write(&blocked, "not a directory").expect("write blocker file");
+
+        let report = daemon_audit_sink_health_report(
+            &blocked,
+            AUDIT_RETENTION_DAYS,
+            AUDIT_RETENTION_FLOOR_DAYS,
+        );
+        assert_eq!(report.status, DaemonAuditSinkStatus::Unavailable);
+        assert!(!report.writable);
+        assert!(
+            report.problems.iter().any(|problem| matches!(
+                problem,
+                DaemonAuditSinkProblem::CreateStateDirFailed { .. }
+            ))
+        );
+        let serialized = serde_json::to_string(&report).expect("serialize health report");
+        for forbidden in [
+            secret_component,
+            "SECRET",
+            "argv",
+            "env",
+            "cwd",
+            "/nix/store",
+            "path-like-token",
+        ] {
+            assert!(
+                !serialized.contains(forbidden),
+                "daemon audit health leaked forbidden canary {forbidden:?}: {serialized}",
+            );
+        }
+    }
+
+    #[test]
+    fn daemon_audit_health_probe_uses_unique_scratch_paths() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let first = unique_health_probe_path(dir.path());
+        let second = unique_health_probe_path(dir.path());
+        assert_ne!(first, second);
+
+        let report = daemon_audit_sink_health_report(
+            dir.path(),
+            AUDIT_RETENTION_DAYS,
+            AUDIT_RETENTION_FLOOR_DAYS,
+        );
+        assert_eq!(report.status, DaemonAuditSinkStatus::Ok);
+        assert!(report.writable);
+        assert_eq!(report.problems, Vec::<DaemonAuditSinkProblem>::new());
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read temp dir")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".daemon-audit-healthcheck-")
+            })
+            .collect();
+        assert!(leftovers.is_empty(), "health probe left scratch files");
+    }
+
+    #[test]
+    fn daemon_audit_write_event_returns_error_for_unwritable_destination() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let blocker = dir.path().join("not-a-directory");
+        std::fs::write(&blocker, "blocks directory creation").expect("write blocker");
+        let log = DaemonAuditLog::new(blocker.join("child"));
+        let error = log
+            .write_event(&DaemonEvent::ApiReadyTimeout {
+                vm: "vm-a".to_owned(),
+                runner: "ch-runner".to_owned(),
+                elapsed_secs: 30,
+                mode: "strict".to_owned(),
+            })
+            .expect_err("blocked destination must return an io error");
+        assert!(matches!(
+            error.kind(),
+            io::ErrorKind::AlreadyExists
+                | io::ErrorKind::NotADirectory
+                | io::ErrorKind::PermissionDenied
+        ));
+        assert!(log.captured.lock().expect("captured").is_empty());
+    }
+
+    #[test]
+    fn no_op_sink_health_reports_unavailable() {
+        let log = DaemonAuditLog::no_op();
+        let report = log.sink_health_report();
+        assert_eq!(report.status, DaemonAuditSinkStatus::Unavailable);
+        assert!(!report.writable);
+        assert!(
+            report
+                .problems
+                .iter()
+                .any(|problem| matches!(problem, DaemonAuditSinkProblem::NoStateDir))
+        );
+    }
+
+    #[test]
+    fn last_record_hash_reads_tail_without_loading_entire_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("daemon-events-2026-06-20.jsonl");
+        let hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        {
+            let mut file = std::fs::File::create(&path).expect("create audit file");
+            for idx in 0..2048 {
+                writeln!(file, "{{\"noise\":{idx}}}").expect("write noise line");
+            }
+            writeln!(
+                file,
+                "{{\"source\":\"nixlingd\",\"record_hash\":\"{hash}\"}}"
+            )
+            .expect("write hash line");
+        }
+        assert_eq!(
+            last_daemon_record_hash_in_file(&path),
+            Some(hash.to_owned())
+        );
     }
 
     #[test]
@@ -715,6 +1782,12 @@ mod tests {
                 Some("nixlingd"),
             );
         }
+        let report = verify_daemon_audit_lines(lines.iter().map(|line| (None::<&str>, *line)));
+        assert!(
+            report.is_clean(),
+            "concurrent writes must preserve hash-chain order: {:?}",
+            report
+        );
     }
 
     #[test]

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -20,6 +20,11 @@ use nixling_constellation_core::{
     NodeId, NodeSummary, OperationId, OperationKind, OperationRequest, OperationResponse,
     PrincipalId, ProviderId, RealmId, RealmPath, StreamCursor, StreamId, WorkloadId,
     WorkloadSelector, WorkloadSummary,
+    audit::{
+        AuditChainCheckFailure, AuditChainCheckResult, AuditChainLink, AuditChainRecord, AuditHash,
+        AuditRetentionFloorReason, AuditRetentionFloorStatus, AuditSinkHealth,
+        AuditSinkHealthReason, AuditStreamKind,
+    },
 };
 use nixling_core::{
     bundle::Bundle, closures::ClosureMetadata, error::Error, host::HostJson,
@@ -61,6 +66,16 @@ enum ConstellationCoreSchema {
     OperationResponse(OperationResponse),
     AdmissionAuditRecord(AdmissionAuditRecord),
     AuditEnvelope(AuditEnvelope),
+    AuditHash(AuditHash),
+    AuditStreamKind(AuditStreamKind),
+    AuditChainLink(AuditChainLink),
+    AuditChainRecord(AuditChainRecord),
+    AuditChainCheckFailure(AuditChainCheckFailure),
+    AuditChainCheckResult(AuditChainCheckResult),
+    AuditRetentionFloorReason(AuditRetentionFloorReason),
+    AuditRetentionFloorStatus(AuditRetentionFloorStatus),
+    AuditSinkHealthReason(AuditSinkHealthReason),
+    AuditSinkHealth(AuditSinkHealth),
     TypedError(ConstellationError),
     Frame(ConstellationFrame),
 }

--- a/tests/unit/nix/cases/gateway-vm.nix
+++ b/tests/unit/nix/cases/gateway-vm.nix
@@ -2,7 +2,7 @@
 { lib, mkEval, flakeRoot, ... }:
 
 let
-  base = {
+  hostBase = {
     boot.loader.grub.enable = false;
     boot.loader.systemd-boot.enable = false;
     boot.initrd.includeDefaultModules = false;
@@ -14,6 +14,9 @@ let
       lanSubnet = "10.44.0.0/24";
       uplinkSubnet = "192.0.2.0/30";
     };
+  };
+
+  base = lib.recursiveUpdate hostBase {
     nixling.gateways.work = {
       env = "work";
       index = 20;
@@ -35,6 +38,15 @@ let
   };
 
   goodCfg = (mkEval [ base ]).config;
+  noGatewayCfg = (mkEval [ hostBase ]).config;
+  noRelayGatewayCfg = (mkEval [
+    (lib.recursiveUpdate hostBase {
+      nixling.gateways.work = {
+        env = "work";
+        index = 20;
+      };
+    })
+  ]).config;
   gatewayGuestCfg = goodCfg.nixling._computed."sys-work-gateway".config;
   gatewayGuestService = gatewayGuestCfg.systemd.services.nixlingd.serviceConfig;
   gatewayGuestTmpfiles = gatewayGuestCfg.systemd.tmpfiles.rules;
@@ -43,6 +55,54 @@ let
   hostDaemonJson = builtins.fromJSON goodCfg.environment.etc."nixling/daemon-config.json".text;
   hostGatewayJsonPresent = builtins.hasAttr "nixling/gateway.json" goodCfg.environment.etc;
   hostRealmEntrypoints = goodCfg.nixling._computed.realmEntrypoints;
+  hostPackageRefs = map (pkg: {
+    name = pkg.pname or (pkg.name or (lib.getName pkg));
+    path = toString pkg;
+  }) goodCfg.environment.systemPackages;
+  forbiddenHostRealmMaterial = [
+    "SharedAccessKey"
+    "Endpoint=sb://"
+    "AccountKey"
+    "relns-example.servicebus.windows.net"
+    "hc-nixling-display"
+    "https://example.azurecontainerapps.io"
+    "00000000-0000-0000-0000-000000000000"
+    "rg-nixling-centralus"
+    "casbx-nixling-demo"
+    "centralus"
+    "registry.example.azurecr.io/nixling-wayland:mi"
+    "nixling-wayland-mi"
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/nixling"
+    "11111111-1111-1111-1111-111111111111"
+    "/var/lib/nixling/gateways/work/credential.json"
+  ];
+  forbiddenRemoteRegistryMarkers = [
+    "\"remoteNodes\""
+    "\"remoteNodeRegistry\""
+    "\"nodeRegistry\""
+    "\"realmNodeRegistry\""
+    "\"realmRegistry\""
+    "\"registryNodes\""
+    "remote-node-registry"
+  ];
+  jsonContainsAny = needles: value:
+    lib.any (needle: lib.hasInfix needle (builtins.toJSON value)) needles;
+  containsForbiddenRealmMaterial = jsonContainsAny forbiddenHostRealmMaterial;
+  containsRemoteRegistryMarker = jsonContainsAny forbiddenRemoteRegistryMarkers;
+  localFastPathSnapshot = cfg:
+    let daemonJson = builtins.fromJSON cfg.environment.etc."nixling/daemon-config.json".text;
+    in {
+      daemonConfigPresent = builtins.hasAttr "nixling/daemon-config.json" cfg.environment.etc;
+      publicSocketPath = daemonJson.publicSocketPath;
+      publicSocketGroup = daemonJson.publicSocketGroup;
+      brokerSocketPath = daemonJson.brokerSocketPath;
+      nixlingdServicePresent = builtins.hasAttr "nixlingd" cfg.systemd.services;
+      nixlingdSupplementaryGroups = cfg.systemd.services.nixlingd.serviceConfig.SupplementaryGroups;
+      runDirAllowsLocalLaunchers = builtins.elem "d /run/nixling 0750 nixlingd nixling -" cfg.systemd.tmpfiles.rules;
+      realmEntries = lib.sort lib.lessThan (builtins.attrNames cfg.nixling._computed.realmEntrypoints.entries);
+      localEntrypoint = cfg.nixling._computed.realmEntrypoints.entries.local;
+      hostGatewayJsonPresent = builtins.hasAttr "nixling/gateway.json" cfg.environment.etc;
+    };
   gatewayProc = lib.findFirst (vm: vm.vm == "sys-work-gateway") null
     goodCfg.nixling._bundle.processesJson.data.vms;
   badCfg = (mkEval [
@@ -265,6 +325,19 @@ in
     };
   };
 
+  "gateway-vm/gateway-guest-json-retains-realm-provider-material" = {
+    expr = {
+      guestGatewayJsonPresent = builtins.hasAttr "nixling/gateway.json" gatewayGuestCfg.environment.etc;
+      guestCarriesGatewayProviderMaterial = containsForbiddenRealmMaterial gatewayJson;
+      inherit hostGatewayJsonPresent;
+    };
+    expected = {
+      guestGatewayJsonPresent = true;
+      guestCarriesGatewayProviderMaterial = true;
+      hostGatewayJsonPresent = false;
+    };
+  };
+
   "gateway-vm/guest-daemon-runs-as-nixlingd-without-no-drop-flag" = {
     expr = {
       user = gatewayGuestService.User;
@@ -316,6 +389,69 @@ in
     };
   };
 
+  "gateway-vm/host-daemon-config-excludes-realm-provider-material" = {
+    expr = {
+      daemonConfigCarriesGateway = hostDaemonJson ? gateway;
+      carriesRelayOrAcaMaterial = containsForbiddenRealmMaterial hostDaemonJson;
+      carriesRemoteNodeRegistry = containsRemoteRegistryMarker hostDaemonJson;
+      gatewayConfigPath = hostDaemonJson.gatewayConfigPath;
+    };
+    expected = {
+      daemonConfigCarriesGateway = false;
+      carriesRelayOrAcaMaterial = false;
+      carriesRemoteNodeRegistry = false;
+      gatewayConfigPath = "/etc/nixling/gateway.json";
+    };
+  };
+
+  "gateway-vm/host-system-packages-exclude-realm-provider-material" = {
+    expr = {
+      carriesRelayOrAcaMaterial = containsForbiddenRealmMaterial hostPackageRefs;
+      carriesRemoteNodeRegistry = containsRemoteRegistryMarker hostPackageRefs;
+      hasGatewayRelayPackage = lib.any
+        (pkg: lib.hasInfix "nixling-gateway-relay" pkg.name || lib.hasInfix "nixling-gateway-relay" pkg.path)
+        hostPackageRefs;
+      hasGatewayRuntimePackage = lib.any
+        (pkg: lib.hasInfix "nixling-gateway-runtime" pkg.name || lib.hasInfix "nixling-gateway-runtime" pkg.path)
+        hostPackageRefs;
+    };
+    expected = {
+      carriesRelayOrAcaMaterial = false;
+      carriesRemoteNodeRegistry = false;
+      hasGatewayRelayPackage = false;
+      hasGatewayRuntimePackage = false;
+    };
+  };
+
+  "gateway-vm/host-bundle-process-artifacts-exclude-realm-provider-material" = {
+    expr = {
+      gatewayVmProcessPresent = gatewayProc != null;
+      realmMaterial = {
+        bundle = containsForbiddenRealmMaterial goodCfg.nixling._bundle.bundle.data;
+        host = containsForbiddenRealmMaterial goodCfg.nixling._bundle.hostJson.data;
+        processes = containsForbiddenRealmMaterial goodCfg.nixling._bundle.processesJson.data;
+      };
+      remoteNodeRegistry = {
+        bundle = containsRemoteRegistryMarker goodCfg.nixling._bundle.bundle.data;
+        host = containsRemoteRegistryMarker goodCfg.nixling._bundle.hostJson.data;
+        processes = containsRemoteRegistryMarker goodCfg.nixling._bundle.processesJson.data;
+      };
+    };
+    expected = {
+      gatewayVmProcessPresent = true;
+      realmMaterial = {
+        bundle = false;
+        host = false;
+        processes = false;
+      };
+      remoteNodeRegistry = {
+        bundle = false;
+        host = false;
+        processes = false;
+      };
+    };
+  };
+
   "gateway-vm/host-realm-entrypoint-table-defaults-local-and-gateway" = {
     expr = {
       path = hostRealmEntrypoints.path;
@@ -337,6 +473,75 @@ in
         gateway = "sys-work-gateway.nixling";
       };
       workCarriesProviderConfig = false;
+    };
+  };
+
+  "gateway-vm/host-realm-entrypoints-exclude-realm-provider-material" = {
+    expr = {
+      entries = hostRealmEntrypoints.entries;
+      carriesRelayOrAcaMaterial = containsForbiddenRealmMaterial hostRealmEntrypoints;
+      carriesRemoteNodeRegistry = containsRemoteRegistryMarker hostRealmEntrypoints;
+      workCarriesProviderConfig =
+        (hostRealmEntrypoints.entries.work ? credentialPath)
+        || (hostRealmEntrypoints.entries.work ? relay)
+        || (hostRealmEntrypoints.entries.work ? aca)
+        || (hostRealmEntrypoints.entries.work ? remoteNodes)
+        || (hostRealmEntrypoints.entries.work ? remoteNodeRegistry)
+        || (hostRealmEntrypoints.entries.work ? nodeRegistry);
+    };
+    expected = {
+      entries = {
+        local = {
+          mode = "host-resident";
+          gateway = null;
+        };
+        work = {
+          mode = "gateway-backed";
+          gateway = "sys-work-gateway.nixling";
+        };
+      };
+      carriesRelayOrAcaMaterial = false;
+      carriesRemoteNodeRegistry = false;
+      workCarriesProviderConfig = false;
+    };
+  };
+
+  "gateway-vm/local-fast-path-auth-socket-does-not-require-gateway-relay" = {
+    expr = {
+      noGateway = localFastPathSnapshot noGatewayCfg;
+      gatewayWithoutRelay = localFastPathSnapshot noRelayGatewayCfg;
+    };
+    expected = {
+      noGateway = {
+        daemonConfigPresent = true;
+        publicSocketPath = "/run/nixling/public.sock";
+        publicSocketGroup = "nixling";
+        brokerSocketPath = "/run/nixling/priv.sock";
+        nixlingdServicePresent = true;
+        nixlingdSupplementaryGroups = [ "nixling" ];
+        runDirAllowsLocalLaunchers = true;
+        realmEntries = [ "local" ];
+        localEntrypoint = {
+          mode = "host-resident";
+          gateway = null;
+        };
+        hostGatewayJsonPresent = false;
+      };
+      gatewayWithoutRelay = {
+        daemonConfigPresent = true;
+        publicSocketPath = "/run/nixling/public.sock";
+        publicSocketGroup = "nixling";
+        brokerSocketPath = "/run/nixling/priv.sock";
+        nixlingdServicePresent = true;
+        nixlingdSupplementaryGroups = [ "nixling" ];
+        runDirAllowsLocalLaunchers = true;
+        realmEntries = [ "local" "work" ];
+        localEntrypoint = {
+          mode = "host-resident";
+          gateway = null;
+        };
+        hostGatewayJsonPresent = false;
+      };
     };
   };
 

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -152,11 +152,17 @@ gateway-vm/accepts-multiple-gateways-with-separate-realms-and-envs
 gateway-vm/admits-framework-sys-prefix
 gateway-vm/auto-declared-env-index
 gateway-vm/auto-declared-name
+gateway-vm/gateway-guest-json-retains-realm-provider-material
 gateway-vm/guest-daemon-runs-as-nixlingd-without-no-drop-flag
 gateway-vm/guest-services-installed-without-static-waypipe
+gateway-vm/host-bundle-process-artifacts-exclude-realm-provider-material
+gateway-vm/host-daemon-config-excludes-realm-provider-material
 gateway-vm/host-daemon-stays-credential-free-facade
 gateway-vm/host-guest-state-ownership-boundary
 gateway-vm/host-realm-entrypoint-table-defaults-local-and-gateway
+gateway-vm/host-realm-entrypoints-exclude-realm-provider-material
+gateway-vm/host-system-packages-exclude-realm-provider-material
+gateway-vm/local-fast-path-auth-socket-does-not-require-gateway-relay
 gateway-vm/realm-entrypoint-table-uses-custom-gateway-vm-name
 gateway-vm/rejects-credential-path-outside-gateway-state
 gateway-vm/rejects-duplicate-gateway-realm-entrypoints


### PR DESCRIPTION
## Summary
- add redacted core audit-chain and audit-sink health DTOs, with generated schema coverage
- add daemon-access admission/principal mapping for local Unix, remote, relay, and browser sources without mapping non-local identities to local Admin/Launcher
- add daemon audit JSONL hash chaining, bounded sink health reports, and host-boundary nix-unit coverage proving gateway provider material stays out of host artifacts

## Validation
- `cargo fmt --check`
- `cargo test -p nixling-constellation-core --quiet`
- `TMPDIR=$PWD/target/tmp cargo test -p nixling-daemon-access --quiet`
- `cargo test -p nixlingd daemon_audit --quiet`
- `cargo test -p nixlingd audit_check --quiet`
- `cargo check -p xtask --quiet`
- `bash tests/test-nix-unit.sh gateway-vm`
- `make test-drift`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check` / `git diff --cached --check`
- process-marker grep over changed shipped docs/changelog

## Panel
Gemini 3.1 Pro Wave 3 panel reached unanimous signoff after follow-up fixes. Follow-up re-review closed daemon audit tail-memory, health-probe race/leak, and requested negative-test findings.