### PR TITLE
adr032: add peer protocol skeleton ( W4 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ deprecations ship one minor release before removal.
   audit hash chaining, explicit audit-sink health reports, and
   host-boundary tests proving gateway relay/provider material stays out
   of host daemon artifacts.
+- ADR 0032 peer protocol foundations now expose explicit
+  handshake-accepted/rejected frames, bind codec schema fingerprints into
+  plain and secure peer handshakes, and document the length-delimited
+  semantic frame skeleton for future gateway transports.
 
 ### Changed
 

--- a/docs/reference/constellation-core.md
+++ b/docs/reference/constellation-core.md
@@ -25,9 +25,9 @@ Regenerate that file; do not edit generated JSON by hand.
 | Root | Source | Contract |
 | --- | --- | --- |
 | `ConstellationCoreSchema` | `packages/xtask/src/main.rs` | Generated schema wrapper whose top-level `anyOf` enumerates the committed core roots. |
-| `ConstellationFrame` | `src/frame.rs` | Top-level semantic frame enum: handshake, operation request/response, stream open/data/flow/close, typed error, and admission audit. |
+| `ConstellationFrame` | `src/frame.rs` | Top-level semantic frame enum: handshake proposal/accept/reject, operation request/response, stream open/data/flow/close, typed error, and admission audit. |
 | `OperationRequest` / `OperationResponse` | `src/frame.rs` | Operation envelope with target realm/node/workload, authenticated principal, bounded body, trace context, and required idempotency for mutating kinds. |
-| `Handshake` / `OperationKind` | `src/frame.rs` | Negotiation and closed operation taxonomy roots. |
+| `Handshake` / `HandshakeAccepted` / `HandshakeRejected` / `OperationKind` | `src/frame.rs` | Negotiation outcome roots and closed operation taxonomy roots. |
 | `AuditEnvelope` | `src/audit.rs` | Redacted post-auth audit metadata for mutating operations and stream opens. |
 | `AdmissionAuditRecord` | `src/audit.rs` | Redacted pre-auth/session-admission denial metadata; principal may be absent only in this shape. |
 | `AuditChainRecord` / `AuditChainLink` / `AuditHash` | `src/audit.rs` | Tamper-evident audit-chain metadata for gateway, remote-node, and daemon audit streams. |
@@ -99,6 +99,20 @@ Display, clipboard, audio, HID, and USB are deliberately independent so
 one capability cannot smuggle another. Local GPU acceleration is not
 automatically relay-exportable.
 
+## Peer protocol handshake
+
+`Handshake` is the codec-neutral peer-session proposal/selection shape.
+It carries the protocol version, codec id, codec schema fingerprint, and
+an optional non-secret peer-binding context. Plain peer sessions exchange
+an explicit `HandshakeAccepted` or `HandshakeRejected`; secure sessions
+bind version, codec id, schema fingerprint, authenticated identity, and
+both nonces into the HMAC transcript before encrypted frames are accepted.
+
+The protobuf codec advertises a bounded schema fingerprint via
+`ProtocolCodec::schema_fingerprint()`. A version, codec, schema, identity,
+or channel-binding mismatch fails closed before operation or stream frames
+can be routed.
+
 ## Operation authorization and idempotency
 
 `OperationKind` is a closed, typed enum. The required capability is
@@ -167,6 +181,7 @@ the structured capability.
 ## Related references
 
 - [ADR 0032 — nixling v2 constellation control plane](../adr/0032-nixling-v2-constellation-control-plane.md)
+- [Constellation peer protocol reference](./constellation-protocol.md)
 - [Daemon API reference](./daemon-api.md)
 - [Naming conventions](./naming-conventions.md)
 - [Manifest bundle reference](./manifest-bundle.md)

--- a/docs/reference/constellation-protocol.md
+++ b/docs/reference/constellation-protocol.md
@@ -1,0 +1,57 @@
+# Constellation peer protocol reference
+
+**Diataxis category:** reference.
+
+This page documents the ADR 0032 peer-protocol skeleton. It is
+transport-neutral: transports provide reachability, while the peer-session
+layer owns version/codec/schema negotiation, authentication binding, frame
+caps, and typed semantic frames.
+
+## Session establishment
+
+Plain peer sessions use a length-delimited semantic `Handshake` frame and
+receive either `HandshakeAccepted` or `HandshakeRejected`. A peer is refused
+before any operation or stream frame is routed when any of these fields do
+not match the local session policy:
+
+- protocol version;
+- codec id;
+- codec schema fingerprint;
+- channel-binding/peer-binding context.
+
+Secure peer sessions bind the protocol version, codec id, schema
+fingerprint, peer identity, and both nonces into the HMAC transcript. After
+that handshake succeeds, frames are encrypted with directional keys derived
+from the same transcript. A replayed nonce, identity mismatch, codec/schema
+mismatch, or invalid MAC is rejected as an authentication failure.
+
+## Frame format
+
+The session layer carries a 4-byte little-endian length followed by one
+codec frame. The frame cap is 1 MiB and is enforced before payload
+allocation or protobuf decode.
+
+The protobuf codec maps bytes to the codec-neutral `ConstellationFrame`.
+The router consumes only semantic frames; it never depends on protobuf
+types. The schema fingerprint for the current protobuf shape is exposed by
+`ProtocolCodec::schema_fingerprint()` and participates in handshake
+binding.
+
+## Operation routing
+
+`OperationRequest` carries realm, node, principal, operation kind,
+optional workload, bounded body, trace context, and a caller-generated
+idempotency key for mutating operations. The required capability is derived
+from `OperationKind` in trusted code; peers never supply the required
+capability as a wire field.
+
+The router owns idempotency for its node/gateway scope. It keys dedup by
+realm, principal, node, operation kind, and idempotency key. A lost-reply
+retry with the same request replays the recorded response, while a
+same-key different request or a post-retention reuse fails closed.
+
+## Non-goals
+
+This skeleton does not implement Azure Relay, remote full-host transport,
+stream lifecycle beyond the existing semantic frame/mux primitives, or
+durable execution. Those are later ADR 0032 waves.

--- a/docs/reference/schemas/v2/constellation-core.json
+++ b/docs/reference/schemas/v2/constellation-core.json
@@ -67,6 +67,15 @@
       "$ref": "#/definitions/Handshake"
     },
     {
+      "$ref": "#/definitions/HandshakeAccepted"
+    },
+    {
+      "$ref": "#/definitions/HandshakeRejected"
+    },
+    {
+      "$ref": "#/definitions/HandshakeRejectedReason"
+    },
+    {
       "$ref": "#/definitions/OperationKind"
     },
     {
@@ -880,7 +889,8 @@
           "required": [
             "codec_id",
             "frame",
-            "protocol_version"
+            "protocol_version",
+            "schema_fingerprint"
           ],
           "properties": {
             "codec_id": {
@@ -913,6 +923,62 @@
               "type": "integer",
               "format": "uint32",
               "minimum": 0.0
+            },
+            "schema_fingerprint": {
+              "description": "Codec schema fingerprint selected for this session (bounded token).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ProtocolToken"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Session handshake accepted.",
+          "type": "object",
+          "required": [
+            "frame",
+            "selected"
+          ],
+          "properties": {
+            "frame": {
+              "type": "string",
+              "enum": [
+                "handshake-accepted"
+              ]
+            },
+            "selected": {
+              "description": "The accepted handshake parameters.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Handshake"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Session handshake rejected.",
+          "type": "object",
+          "required": [
+            "frame",
+            "reason"
+          ],
+          "properties": {
+            "frame": {
+              "type": "string",
+              "enum": [
+                "handshake-rejected"
+              ]
+            },
+            "reason": {
+              "description": "Why the session was refused.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/HandshakeRejectedReason"
+                }
+              ]
             }
           }
         },
@@ -1586,7 +1652,8 @@
       "type": "object",
       "required": [
         "codec_id",
-        "protocol_version"
+        "protocol_version",
+        "schema_fingerprint"
       ],
       "properties": {
         "codec_id": {
@@ -1613,9 +1680,64 @@
           "type": "integer",
           "format": "uint32",
           "minimum": 0.0
+        },
+        "schema_fingerprint": {
+          "description": "Codec schema fingerprint selected for this session (bounded token).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ProtocolToken"
+            }
+          ]
         }
       },
       "additionalProperties": false
+    },
+    "HandshakeAccepted": {
+      "description": "Successful handshake outcome. Carries the exact version/codec/schema fingerprint selected for the session.",
+      "type": "object",
+      "required": [
+        "selected"
+      ],
+      "properties": {
+        "selected": {
+          "description": "The accepted handshake parameters.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Handshake"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "HandshakeRejected": {
+      "description": "Fail-closed handshake rejection. The reason is a closed enum so callers never parse an unbounded peer-provided string for authz behavior.",
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "description": "Why the session was refused.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HandshakeRejectedReason"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "HandshakeRejectedReason": {
+      "description": "Closed reason a peer handshake was refused.",
+      "type": "string",
+      "enum": [
+        "version-skew",
+        "codec-mismatch",
+        "schema-fingerprint-mismatch",
+        "channel-binding-mismatch",
+        "malformed-handshake"
+      ]
     },
     "IdempotencyKey": {
       "type": "string",

--- a/docs/reference/schemas/v2/constellation-core.md
+++ b/docs/reference/schemas/v2/constellation-core.md
@@ -23,8 +23,9 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
 - `Capability`, `CapabilitySet`;
 - `NodeSummary`, `WorkloadSelector`, `WorkloadSummary`,
   `ExecutionSummary`;
-- `Handshake`, `OperationKind`, `OperationRequest`,
-  `OperationResponse`;
+- `Handshake`, `HandshakeAccepted`, `HandshakeRejected`,
+  `HandshakeRejectedReason`;
+- `OperationKind`, `OperationRequest`, `OperationResponse`;
 - `AdmissionAuditRecord`, `AuditEnvelope`, `AuditHash`,
   `AuditChainLink`, `AuditChainRecord`, `AuditChainCheckResult`,
   `AuditSinkHealth`, `AuditRetentionFloorStatus`;
@@ -37,6 +38,10 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
 - Capabilities are positive assertions. Missing capability means typed
   refusal, not fallback.
 - Mutating operation requests require an idempotency key at decode.
+- Peer handshakes carry a bounded codec schema fingerprint and explicit
+  accept/reject outcome shapes. A protocol, codec, schema, identity, or
+  channel-binding mismatch is a typed refusal before operations or streams
+  are routed.
 - `AuditEnvelope` is post-auth and requires a principal.
   `AdmissionAuditRecord` is the pre-auth/session-admission denial shape and
   may omit the principal.

--- a/packages/nixling-constellation-codec-protobuf/src/lib.rs
+++ b/packages/nixling-constellation-codec-protobuf/src/lib.rs
@@ -2,9 +2,10 @@
 
 use nixling_constellation_core::{
     AdmissionAuditRecord, AuthorizationScope, AuthzDecision, Capability, ConstellationError,
-    ConstellationFrame, ErrorKind, Handshake, IdempotencyKey, NodeId, OpaquePayload, OperationId,
-    OperationKind, OperationRequest, OperationResponse, PeerContext, PrincipalId, ProtocolToken,
-    RealmId, RealmPath, StreamAuthz, StreamChannel, StreamClose, StreamCloseReason, StreamCursor,
+    ConstellationFrame, ErrorKind, Handshake, HandshakeAccepted, HandshakeRejected,
+    HandshakeRejectedReason, IdempotencyKey, NodeId, OpaquePayload, OperationId, OperationKind,
+    OperationRequest, OperationResponse, PeerContext, PrincipalId, ProtocolToken, RealmId,
+    RealmPath, StreamAuthz, StreamChannel, StreamClose, StreamCloseReason, StreamCursor,
     StreamData, StreamDescriptor, StreamFlow, StreamId, StreamKind, StreamOpen, TraceContext,
     WorkloadId,
 };
@@ -16,7 +17,7 @@ use prost::Message;
 pub const CODEC_ID: &str = "protobuf.v1";
 
 /// Deterministic fingerprint for the hand-authored prost schema in this crate.
-pub const SCHEMA_FINGERPRINT: &str = "protobuf.v1/frames=9/fields=handshake3,opreq9,opresp2,streamopen3,streamdata5,streamflow2,streamclose2,error3,audit11";
+pub const SCHEMA_FINGERPRINT: &str = "pb.v1:f11:h4:op14:sk12:err19:audit11";
 
 /// A prost-backed constellation frame codec.
 #[derive(Debug, Clone, Copy, Default)]
@@ -58,7 +59,10 @@ impl ProtocolCodec for ProtobufCodec {
 
 #[derive(Clone, PartialEq, prost::Message)]
 struct ProtoFrame {
-    #[prost(oneof = "proto_frame::Body", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
+    #[prost(
+        oneof = "proto_frame::Body",
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11"
+    )]
     body: Option<proto_frame::Body>,
 }
 
@@ -83,6 +87,10 @@ mod proto_frame {
         AdmissionAudit(super::ProtoAuditEnvelope),
         #[prost(message, tag = "9")]
         StreamFlow(super::ProtoStreamFlow),
+        #[prost(message, tag = "10")]
+        HandshakeAccepted(super::ProtoHandshakeAccepted),
+        #[prost(message, tag = "11")]
+        HandshakeRejected(super::ProtoHandshakeRejected),
     }
 }
 
@@ -94,6 +102,20 @@ struct ProtoHandshake {
     codec_id: String,
     #[prost(message, optional, tag = "3")]
     peer: Option<ProtoPeerContext>,
+    #[prost(string, tag = "4")]
+    schema_fingerprint: String,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct ProtoHandshakeAccepted {
+    #[prost(message, optional, tag = "1")]
+    selected: Option<ProtoHandshake>,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct ProtoHandshakeRejected {
+    #[prost(int32, tag = "1")]
+    reason: i32,
 }
 
 #[derive(Clone, PartialEq, prost::Message)]
@@ -272,6 +294,12 @@ fn encode_proto_frame(frame: &ConstellationFrame) -> Result<ProtoFrame, Constell
         ConstellationFrame::Handshake(frame) => {
             proto_frame::Body::Handshake(encode_handshake(frame))
         }
+        ConstellationFrame::HandshakeAccepted(frame) => {
+            proto_frame::Body::HandshakeAccepted(encode_handshake_accepted(frame))
+        }
+        ConstellationFrame::HandshakeRejected(frame) => {
+            proto_frame::Body::HandshakeRejected(encode_handshake_rejected(frame)?)
+        }
         ConstellationFrame::OperationRequest(frame) => {
             proto_frame::Body::OperationRequest(encode_operation_request(frame)?)
         }
@@ -308,6 +336,12 @@ fn decode_proto_frame(frame: ProtoFrame) -> Result<ConstellationFrame, Constella
         proto_frame::Body::Handshake(frame) => {
             decode_handshake(frame).map(ConstellationFrame::Handshake)
         }
+        proto_frame::Body::HandshakeAccepted(frame) => {
+            decode_handshake_accepted(frame).map(ConstellationFrame::HandshakeAccepted)
+        }
+        proto_frame::Body::HandshakeRejected(frame) => {
+            decode_handshake_rejected(frame).map(ConstellationFrame::HandshakeRejected)
+        }
         proto_frame::Body::OperationRequest(frame) => {
             decode_operation_request(frame).map(ConstellationFrame::OperationRequest)
         }
@@ -339,6 +373,7 @@ fn encode_handshake(frame: &Handshake) -> ProtoHandshake {
     ProtoHandshake {
         protocol_version: Some(frame.protocol_version),
         codec_id: frame.codec_id.as_str().to_owned(),
+        schema_fingerprint: frame.schema_fingerprint.as_str().to_owned(),
         peer: frame.peer.as_ref().map(encode_peer_context),
     }
 }
@@ -349,7 +384,45 @@ fn decode_handshake(frame: ProtoHandshake) -> Result<Handshake, ConstellationErr
             .protocol_version
             .ok_or_else(|| malformed("handshake protocol_version is missing"))?,
         codec_id: parse_protocol_token(frame.codec_id, "handshake codec_id")?,
+        schema_fingerprint: parse_protocol_token(
+            frame.schema_fingerprint,
+            "handshake schema_fingerprint",
+        )?,
         peer: frame.peer.map(decode_peer_context).transpose()?,
+    })
+}
+
+fn encode_handshake_accepted(frame: &HandshakeAccepted) -> ProtoHandshakeAccepted {
+    ProtoHandshakeAccepted {
+        selected: Some(encode_handshake(&frame.selected)),
+    }
+}
+
+fn decode_handshake_accepted(
+    frame: ProtoHandshakeAccepted,
+) -> Result<HandshakeAccepted, ConstellationError> {
+    Ok(HandshakeAccepted {
+        selected: decode_handshake(
+            frame
+                .selected
+                .ok_or_else(|| malformed("handshake_accepted selected is missing"))?,
+        )?,
+    })
+}
+
+fn encode_handshake_rejected(
+    frame: &HandshakeRejected,
+) -> Result<ProtoHandshakeRejected, ConstellationError> {
+    Ok(ProtoHandshakeRejected {
+        reason: encode_handshake_rejection(frame.reason),
+    })
+}
+
+fn decode_handshake_rejected(
+    frame: ProtoHandshakeRejected,
+) -> Result<HandshakeRejected, ConstellationError> {
+    Ok(HandshakeRejected {
+        reason: decode_handshake_rejection(frame.reason)?,
     })
 }
 
@@ -750,6 +823,29 @@ parse_id_fn!(parse_stream_id, StreamId);
 parse_id_fn!(parse_stream_cursor, StreamCursor);
 parse_id_fn!(parse_protocol_token, ProtocolToken);
 
+fn encode_handshake_rejection(reason: HandshakeRejectedReason) -> i32 {
+    match reason {
+        HandshakeRejectedReason::VersionSkew => 1,
+        HandshakeRejectedReason::CodecMismatch => 2,
+        HandshakeRejectedReason::SchemaFingerprintMismatch => 3,
+        HandshakeRejectedReason::ChannelBindingMismatch => 4,
+        HandshakeRejectedReason::MalformedHandshake => 5,
+    }
+}
+
+fn decode_handshake_rejection(raw: i32) -> Result<HandshakeRejectedReason, ConstellationError> {
+    match raw {
+        1 => Ok(HandshakeRejectedReason::VersionSkew),
+        2 => Ok(HandshakeRejectedReason::CodecMismatch),
+        3 => Ok(HandshakeRejectedReason::SchemaFingerprintMismatch),
+        4 => Ok(HandshakeRejectedReason::ChannelBindingMismatch),
+        5 => Ok(HandshakeRejectedReason::MalformedHandshake),
+        _ => Err(malformed(format!(
+            "unknown handshake rejection value {raw}"
+        ))),
+    }
+}
+
 fn encode_operation_kind(kind: OperationKind) -> Result<i32, ConstellationError> {
     Ok(match kind {
         OperationKind::NodeRegister => 1,
@@ -1079,6 +1175,19 @@ mod tests {
     }
 
     #[test]
+    fn protobuf_decode_rejects_unknown_handshake_rejection_reason() {
+        let codec = ProtobufCodec::new();
+        let invalid = ProtoFrame {
+            body: Some(proto_frame::Body::HandshakeRejected(
+                ProtoHandshakeRejected { reason: 99 },
+            )),
+        }
+        .encode_to_vec();
+
+        assert_malformed(codec.decode_frame(&invalid));
+    }
+
+    #[test]
     fn protobuf_decode_rejects_missing_required_stream_id() {
         let codec = ProtobufCodec::new();
         let invalid = ProtoFrame {
@@ -1187,11 +1296,23 @@ mod tests {
             ConstellationFrame::Handshake(Handshake {
                 protocol_version: 1,
                 codec_id: token(CODEC_ID),
+                schema_fingerprint: token(SCHEMA_FINGERPRINT),
                 peer: Some(PeerContext {
                     auth_mechanism: token("none"),
                     peer_principal: Some(principal.clone()),
                     peer_node: Some(node.clone()),
                 }),
+            }),
+            ConstellationFrame::HandshakeAccepted(HandshakeAccepted {
+                selected: Handshake {
+                    protocol_version: 1,
+                    codec_id: token(CODEC_ID),
+                    schema_fingerprint: token(SCHEMA_FINGERPRINT),
+                    peer: None,
+                },
+            }),
+            ConstellationFrame::HandshakeRejected(HandshakeRejected {
+                reason: HandshakeRejectedReason::SchemaFingerprintMismatch,
             }),
             ConstellationFrame::OperationRequest(OperationRequest {
                 operation_id: operation_id.clone(),

--- a/packages/nixling-constellation-core/src/frame.rs
+++ b/packages/nixling-constellation-core/src/frame.rs
@@ -44,9 +44,40 @@ pub struct Handshake {
     pub protocol_version: u32,
     /// Codec id negotiated for this session (bounded token).
     pub codec_id: ProtocolToken,
+    /// Codec schema fingerprint selected for this session (bounded token).
+    pub schema_fingerprint: ProtocolToken,
     /// Reserved peer-binding seam. Absent in the bootstrap protocol.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub peer: Option<PeerContext>,
+}
+
+/// Successful handshake outcome. Carries the exact version/codec/schema
+/// fingerprint selected for the session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct HandshakeAccepted {
+    /// The accepted handshake parameters.
+    pub selected: Handshake,
+}
+
+/// Closed reason a peer handshake was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum HandshakeRejectedReason {
+    VersionSkew,
+    CodecMismatch,
+    SchemaFingerprintMismatch,
+    ChannelBindingMismatch,
+    MalformedHandshake,
+}
+
+/// Fail-closed handshake rejection. The reason is a closed enum so callers
+/// never parse an unbounded peer-provided string for authz behavior.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct HandshakeRejected {
+    /// Why the session was refused.
+    pub reason: HandshakeRejectedReason,
 }
 
 /// The kind of an operation (ADR 0032 examples). Closed enum; unknown
@@ -413,6 +444,10 @@ pub struct StreamClose {
 pub enum ConstellationFrame {
     /// Session handshake (version + codec negotiation).
     Handshake(Handshake),
+    /// Session handshake accepted.
+    HandshakeAccepted(HandshakeAccepted),
+    /// Session handshake rejected.
+    HandshakeRejected(HandshakeRejected),
     /// An operation request.
     OperationRequest(OperationRequest),
     /// An operation response.
@@ -443,6 +478,29 @@ mod tests {
         let json = serde_json::to_string(&frame).unwrap();
         let back: ConstellationFrame = serde_json::from_str(&json).unwrap();
         assert_eq!(frame, back);
+    }
+
+    #[test]
+    fn handshake_outcome_frames_parse_and_reject_unknown_fields() {
+        let accepted = "{\"frame\":\"handshake-accepted\",\"selected\":{\
+                        \"protocol_version\":1,\
+                        \"codec_id\":\"protobuf.v1\",\
+                        \"schema_fingerprint\":\"pb.v1:schema\"}}";
+        assert!(serde_json::from_str::<ConstellationFrame>(accepted).is_ok());
+
+        let rejected = "{\"frame\":\"handshake-rejected\",\"reason\":\"codec-mismatch\"}";
+        assert!(serde_json::from_str::<ConstellationFrame>(rejected).is_ok());
+
+        let accepted_extra = "{\"frame\":\"handshake-accepted\",\"selected\":{\
+                              \"protocol_version\":1,\
+                              \"codec_id\":\"protobuf.v1\",\
+                              \"schema_fingerprint\":\"pb.v1:schema\"},\
+                              \"extra\":true}";
+        assert!(serde_json::from_str::<ConstellationFrame>(accepted_extra).is_err());
+
+        let rejected_extra =
+            "{\"frame\":\"handshake-rejected\",\"reason\":\"codec-mismatch\",\"extra\":true}";
+        assert!(serde_json::from_str::<ConstellationFrame>(rejected_extra).is_err());
     }
 
     #[test]
@@ -554,13 +612,18 @@ mod tests {
 
     #[test]
     fn handshake_codec_id_is_bounded_at_decode() {
-        let ok = "{\"protocol_version\":1,\"codec_id\":\"protobuf.v1\"}";
+        let ok = "{\"protocol_version\":1,\"codec_id\":\"protobuf.v1\",\"schema_fingerprint\":\"schema1\"}";
         assert!(serde_json::from_str::<Handshake>(ok).is_ok());
-        let overlong = format!(
-            "{{\"protocol_version\":1,\"codec_id\":\"{}\"}}",
+        let overlong_codec = format!(
+            "{{\"protocol_version\":1,\"codec_id\":\"{}\",\"schema_fingerprint\":\"schema1\"}}",
             "x".repeat(200)
         );
-        assert!(serde_json::from_str::<Handshake>(&overlong).is_err());
+        assert!(serde_json::from_str::<Handshake>(&overlong_codec).is_err());
+        let overlong_schema = format!(
+            "{{\"protocol_version\":1,\"codec_id\":\"protobuf.v1\",\"schema_fingerprint\":\"{}\"}}",
+            "x".repeat(200)
+        );
+        assert!(serde_json::from_str::<Handshake>(&overlong_schema).is_err());
     }
 
     #[test]

--- a/packages/nixling-constellation-core/src/lib.rs
+++ b/packages/nixling-constellation-core/src/lib.rs
@@ -36,8 +36,9 @@ pub use capability::{Capability, CapabilitySet};
 pub use error::{ConstellationError, ErrorKind};
 pub use execution::{ExecState, ExecutionSummary};
 pub use frame::{
-    ConstellationFrame, Handshake, OperationKind, OperationRequest, OperationResponse, PeerContext,
-    StreamClose, StreamData, StreamFlow, StreamOpen,
+    ConstellationFrame, Handshake, HandshakeAccepted, HandshakeRejected, HandshakeRejectedReason,
+    OperationKind, OperationRequest, OperationResponse, PeerContext, StreamClose, StreamData,
+    StreamFlow, StreamOpen,
 };
 pub use ids::{
     ExecutionId, GatewayId, IdempotencyKey, NodeId, OperationId, PrincipalId, ProviderId, RealmId,

--- a/packages/nixling-constellation-router/src/lib.rs
+++ b/packages/nixling-constellation-router/src/lib.rs
@@ -681,6 +681,40 @@ mod tests {
     }
 
     #[test]
+    fn lost_reply_retry_replays_recorded_result_without_new_accept() {
+        let mut shared_router = OperationRouter::new();
+        let p = principal("alice");
+        let first = req_with_op(
+            OperationKind::WorkloadStart,
+            Some("lost-reply-key"),
+            b"start-once",
+            "alice",
+            "op-original",
+        );
+        assert!(matches!(
+            shared_router.route(&first, &p),
+            RouteDecision::Accept { .. }
+        ));
+        assert!(shared_router.mark_completed(&first, result(b"started")));
+
+        let retry_after_disconnect = req_with_op(
+            OperationKind::WorkloadStart,
+            Some("lost-reply-key"),
+            b"start-once",
+            "alice",
+            "op-retry",
+        );
+        assert_eq!(
+            shared_router.route(&retry_after_disconnect, &p),
+            RouteDecision::Replay {
+                original_operation_id: OperationId::parse("op-original").unwrap(),
+                result: result(b"started"),
+            }
+        );
+        assert_eq!(shared_router.tracked(), 1);
+    }
+
+    #[test]
     fn same_key_different_request_conflicts() {
         let mut r = OperationRouter::new();
         let p = principal("alice");

--- a/packages/nixling-constellation-router/src/mux_session.rs
+++ b/packages/nixling-constellation-router/src/mux_session.rs
@@ -104,6 +104,8 @@ impl<C: ProtocolCodec> MuxSession<C> {
             ConstellationFrame::StreamFlow(flow) => self.mux.receive_flow(flow),
             ConstellationFrame::StreamClose(close) => self.mux.close(close),
             ConstellationFrame::Handshake(_)
+            | ConstellationFrame::HandshakeAccepted(_)
+            | ConstellationFrame::HandshakeRejected(_)
             | ConstellationFrame::OperationRequest(_)
             | ConstellationFrame::OperationResponse(_)
             | ConstellationFrame::TypedError(_)

--- a/packages/nixling-constellation-router/src/secure_session.rs
+++ b/packages/nixling-constellation-router/src/secure_session.rs
@@ -74,6 +74,7 @@ impl NonceReplayGuard {
 struct Hello {
     version: u32,
     codec_id: ProtocolToken,
+    schema_fingerprint: ProtocolToken,
     identity: SecurePeerIdentity,
     nonce: [u8; 32],
     mac: [u8; 32],
@@ -115,6 +116,7 @@ impl<C: ProtocolCodec> SecurePeerSession<C> {
             "client",
             &key,
             codec.codec_id(),
+            &codec.schema_fingerprint(),
             local.clone(),
             client_nonce,
             &[],
@@ -130,6 +132,7 @@ impl<C: ProtocolCodec> SecurePeerSession<C> {
             "server",
             &key,
             codec.codec_id(),
+            &codec.schema_fingerprint(),
             &server,
             &expected_remote,
             &client.nonce,
@@ -163,6 +166,7 @@ impl<C: ProtocolCodec> SecurePeerSession<C> {
             "client",
             &key,
             codec.codec_id(),
+            &codec.schema_fingerprint(),
             &client,
             &expected_remote,
             &[],
@@ -177,6 +181,7 @@ impl<C: ProtocolCodec> SecurePeerSession<C> {
             "server",
             &key,
             codec.codec_id(),
+            &codec.schema_fingerprint(),
             local,
             server_nonce,
             &client.nonce,
@@ -254,15 +259,23 @@ fn hello(
     label: &str,
     key: &SecureSessionKey,
     codec_id: &str,
+    schema_fingerprint: &str,
     identity: SecurePeerIdentity,
     nonce: [u8; 32],
     peer_nonce: &[u8],
 ) -> ProviderResult<Hello> {
     let codec_id = ProtocolToken::parse(codec_id)
         .map_err(|err| ProviderError::new(ErrorKind::MalformedFrame, format!("codec id: {err}")))?;
+    let schema_fingerprint = ProtocolToken::parse(schema_fingerprint).map_err(|err| {
+        ProviderError::new(
+            ErrorKind::MalformedFrame,
+            format!("schema fingerprint: {err}"),
+        )
+    })?;
     let mut hello = Hello {
         version: PROTOCOL_VERSION,
         codec_id,
+        schema_fingerprint,
         identity,
         nonce,
         mac: [0u8; 32],
@@ -275,12 +288,14 @@ fn verify_hello(
     label: &str,
     key: &SecureSessionKey,
     codec_id: &str,
+    schema_fingerprint: &str,
     hello: &Hello,
     expected_identity: &SecurePeerIdentity,
     peer_nonce: &[u8],
 ) -> ProviderResult<()> {
     if hello.version != PROTOCOL_VERSION
         || hello.codec_id.as_str() != codec_id
+        || hello.schema_fingerprint.as_str() != schema_fingerprint
         || &hello.identity != expected_identity
     {
         return Err(ProviderError::new(
@@ -310,6 +325,7 @@ fn mac_hello(
     mac_update_field(&mut mac, label.as_bytes());
     mac_update_field(&mut mac, &hello.version.to_be_bytes());
     mac_update_field(&mut mac, hello.codec_id.as_str().as_bytes());
+    mac_update_field(&mut mac, hello.schema_fingerprint.as_str().as_bytes());
     mac_update_field(&mut mac, hello.identity.realm.target_form().as_bytes());
     mac_update_field(&mut mac, hello.identity.principal.as_str().as_bytes());
     mac_update_field(&mut mac, hello.identity.node.as_str().as_bytes());
@@ -480,11 +496,13 @@ mod tests {
         let key = SecureSessionKey::from_bytes([7u8; 32]);
         let client_id = id("client");
         let server_id = id("server");
+        let codec = ProtobufCodec::new();
 
         let hello = hello(
             "client",
             &key,
-            ProtobufCodec::new().codec_id(),
+            codec.codec_id(),
+            &codec.schema_fingerprint(),
             client_id.clone(),
             test_nonce("wrong-principal"),
             &[],
@@ -493,7 +511,8 @@ mod tests {
         let err = verify_hello(
             "client",
             &key,
-            ProtobufCodec::new().codec_id(),
+            codec.codec_id(),
+            &codec.schema_fingerprint(),
             &hello,
             &server_id,
             &[],
@@ -516,6 +535,7 @@ mod tests {
             "client",
             &key,
             codec.codec_id(),
+            &codec.schema_fingerprint(),
             client_id.clone(),
             test_nonce("invalid-mac"),
             &[],
@@ -524,9 +544,17 @@ mod tests {
 
         h.mac[0] ^= 0xff;
         assert_eq!(
-            verify_hello("client", &key, codec.codec_id(), &h, &client_id, &[])
-                .unwrap_err()
-                .kind(),
+            verify_hello(
+                "client",
+                &key,
+                codec.codec_id(),
+                &codec.schema_fingerprint(),
+                &h,
+                &client_id,
+                &[]
+            )
+            .unwrap_err()
+            .kind(),
             ErrorKind::AuthenticationFailed
         );
 
@@ -534,6 +562,7 @@ mod tests {
             "client",
             &key,
             codec.codec_id(),
+            &codec.schema_fingerprint(),
             client_id.clone(),
             test_nonce("invalid-version"),
             &[],
@@ -541,9 +570,17 @@ mod tests {
         .unwrap();
         h.version += 1;
         assert_eq!(
-            verify_hello("client", &key, codec.codec_id(), &h, &client_id, &[])
-                .unwrap_err()
-                .kind(),
+            verify_hello(
+                "client",
+                &key,
+                codec.codec_id(),
+                &codec.schema_fingerprint(),
+                &h,
+                &client_id,
+                &[]
+            )
+            .unwrap_err()
+            .kind(),
             ErrorKind::AuthenticationFailed
         );
 
@@ -551,15 +588,39 @@ mod tests {
             "client",
             &key,
             codec.codec_id(),
+            &codec.schema_fingerprint(),
             client_id.clone(),
             test_nonce("invalid-codec"),
             &[],
         )
         .unwrap();
         assert_eq!(
-            verify_hello("client", &key, "other-codec", &h, &client_id, &[])
-                .unwrap_err()
-                .kind(),
+            verify_hello(
+                "client",
+                &key,
+                "other-codec",
+                &codec.schema_fingerprint(),
+                &h,
+                &client_id,
+                &[]
+            )
+            .unwrap_err()
+            .kind(),
+            ErrorKind::AuthenticationFailed
+        );
+
+        assert_eq!(
+            verify_hello(
+                "client",
+                &key,
+                codec.codec_id(),
+                "pb.v1:other-schema",
+                &h,
+                &client_id,
+                &[]
+            )
+            .unwrap_err()
+            .kind(),
             ErrorKind::AuthenticationFailed
         );
     }

--- a/packages/nixling-constellation-router/src/session.rs
+++ b/packages/nixling-constellation-router/src/session.rs
@@ -15,7 +15,10 @@
 //! fragmenting stream transport (Relay, vsock) is reassembled correctly —
 //! unlike a seqpacket one-read-per-frame socket.
 
-use nixling_constellation_core::{ConstellationFrame, ErrorKind, Handshake};
+use nixling_constellation_core::{
+    ConstellationFrame, ErrorKind, Handshake, HandshakeAccepted, HandshakeRejected,
+    HandshakeRejectedReason,
+};
 use nixling_constellation_provider::error::{ProviderError, ProviderResult};
 use nixling_constellation_provider::provider::ProtocolCodec;
 use nixling_constellation_provider::types::{ByteStream, TransportSession};
@@ -75,19 +78,31 @@ impl<C: ProtocolCodec> PeerSession<C> {
         let ours = Handshake {
             protocol_version: PROTOCOL_VERSION,
             codec_id: parse_codec_id(codec.codec_id())?,
+            schema_fingerprint: parse_codec_id(&codec.schema_fingerprint())?,
             peer: None,
         };
         let negotiated = match role {
             Role::Client => {
                 write_frame(stream.as_mut(), &codec.encode_frame(&hs(ours.clone()))?).await?;
-                let theirs = expect_handshake(&codec, &read_frame(stream.as_mut()).await?)?;
-                reconcile(&codec, &ours, &theirs)?;
-                theirs
+                let accepted =
+                    expect_handshake_accept(&codec, &read_frame(stream.as_mut()).await?)?;
+                if let Err(reason) = reconcile(&ours, &accepted.selected) {
+                    return Err(handshake_rejected_error(reason));
+                }
+                accepted.selected
             }
             Role::Server => {
                 let theirs = expect_handshake(&codec, &read_frame(stream.as_mut()).await?)?;
-                reconcile(&codec, &ours, &theirs)?;
-                write_frame(stream.as_mut(), &codec.encode_frame(&hs(ours.clone()))?).await?;
+                if let Err(reason) = reconcile(&ours, &theirs) {
+                    let rejected =
+                        ConstellationFrame::HandshakeRejected(HandshakeRejected { reason });
+                    let _ = write_frame(stream.as_mut(), &codec.encode_frame(&rejected)?).await;
+                    return Err(handshake_rejected_error(reason));
+                }
+                let accepted = ConstellationFrame::HandshakeAccepted(HandshakeAccepted {
+                    selected: ours.clone(),
+                });
+                write_frame(stream.as_mut(), &codec.encode_frame(&accepted)?).await?;
                 // The server adopts its own (validated-equal) view.
                 ours
             }
@@ -121,6 +136,22 @@ fn parse_codec_id(id: &str) -> ProviderResult<nixling_constellation_core::Protoc
         .map_err(|err| ProviderError::new(ErrorKind::MalformedFrame, format!("codec id: {err}")))
 }
 
+fn expect_handshake_accept(
+    codec: &impl ProtocolCodec,
+    bytes: &[u8],
+) -> ProviderResult<HandshakeAccepted> {
+    match codec.decode_frame(bytes)? {
+        ConstellationFrame::HandshakeAccepted(h) => Ok(h),
+        ConstellationFrame::HandshakeRejected(rejected) => {
+            Err(handshake_rejected_error(rejected.reason))
+        }
+        _ => Err(ProviderError::new(
+            ErrorKind::MalformedFrame,
+            "expected a handshake-accepted frame before any other traffic",
+        )),
+    }
+}
+
 fn expect_handshake(codec: &impl ProtocolCodec, bytes: &[u8]) -> ProviderResult<Handshake> {
     match codec.decode_frame(bytes)? {
         ConstellationFrame::Handshake(h) => Ok(h),
@@ -131,24 +162,31 @@ fn expect_handshake(codec: &impl ProtocolCodec, bytes: &[u8]) -> ProviderResult<
     }
 }
 
-fn reconcile(
-    codec: &impl ProtocolCodec,
-    ours: &Handshake,
-    theirs: &Handshake,
-) -> ProviderResult<()> {
+fn reconcile(ours: &Handshake, theirs: &Handshake) -> Result<(), HandshakeRejectedReason> {
     if theirs.protocol_version != ours.protocol_version {
-        return Err(ProviderError::new(
-            ErrorKind::VersionSkew,
-            "peer proposed an unsupported protocol version",
-        ));
+        return Err(HandshakeRejectedReason::VersionSkew);
     }
-    if theirs.codec_id.as_str() != codec.codec_id() {
-        return Err(ProviderError::new(
-            ErrorKind::VersionSkew,
-            "peer proposed a codec this session does not speak",
-        ));
+    if theirs.codec_id != ours.codec_id {
+        return Err(HandshakeRejectedReason::CodecMismatch);
+    }
+    if theirs.schema_fingerprint != ours.schema_fingerprint {
+        return Err(HandshakeRejectedReason::SchemaFingerprintMismatch);
+    }
+    if theirs.peer != ours.peer {
+        return Err(HandshakeRejectedReason::ChannelBindingMismatch);
     }
     Ok(())
+}
+
+fn handshake_rejected_error(reason: HandshakeRejectedReason) -> ProviderError {
+    let kind = match reason {
+        HandshakeRejectedReason::VersionSkew => ErrorKind::VersionSkew,
+        HandshakeRejectedReason::CodecMismatch
+        | HandshakeRejectedReason::SchemaFingerprintMismatch => ErrorKind::VersionSkew,
+        HandshakeRejectedReason::ChannelBindingMismatch => ErrorKind::AuthenticationFailed,
+        HandshakeRejectedReason::MalformedHandshake => ErrorKind::MalformedFrame,
+    };
+    ProviderError::new(kind, format!("peer handshake rejected: {reason:?}"))
 }
 
 async fn write_frame(stream: &mut dyn ByteStream, payload: &[u8]) -> ProviderResult<()> {
@@ -205,7 +243,9 @@ async fn read_frame(stream: &mut dyn ByteStream) -> ProviderResult<Vec<u8>> {
 mod tests {
     use super::*;
     use nixling_constellation_codec_protobuf::ProtobufCodec;
-    use nixling_constellation_core::{Capability, ConstellationError};
+    use nixling_constellation_core::{
+        Capability, ConstellationError, NodeId, PrincipalId, ProtocolToken,
+    };
     use nixling_constellation_provider::provider::TransportProvider;
     use nixling_constellation_provider::types::{NodeRegistration, TransportTarget};
     use nixling_constellation_transport::LoopbackTransport;
@@ -267,12 +307,100 @@ mod tests {
         let bogus = Handshake {
             protocol_version: PROTOCOL_VERSION + 99,
             codec_id: parse_codec_id(codec.codec_id()).unwrap(),
+            schema_fingerprint: parse_codec_id(&codec.schema_fingerprint()).unwrap(),
             peer: None,
         };
         let bytes = codec.encode_frame(&hs(bogus)).unwrap();
         write_frame(client_s.stream_mut(), &bytes).await.unwrap();
         let err = server.await.unwrap().unwrap_err();
         assert_eq!(err.kind(), ErrorKind::VersionSkew);
+    }
+
+    #[tokio::test]
+    async fn client_schema_fingerprint_skew_is_rejected_fail_closed() {
+        let (mut client_s, server_s) = connected_pair().await;
+        let server = tokio::spawn(async move {
+            PeerSession::accept(server_s, ProtobufCodec::new())
+                .await
+                .map(|_| ())
+        });
+        let codec = ProtobufCodec::new();
+        let bogus = Handshake {
+            protocol_version: PROTOCOL_VERSION,
+            codec_id: parse_codec_id(codec.codec_id()).unwrap(),
+            schema_fingerprint: parse_codec_id("pb.v1:other-schema").unwrap(),
+            peer: None,
+        };
+        let bytes = codec.encode_frame(&hs(bogus)).unwrap();
+        write_frame(client_s.stream_mut(), &bytes).await.unwrap();
+        let err = server.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::VersionSkew);
+    }
+
+    #[tokio::test]
+    async fn client_receives_explicit_handshake_rejection_fail_closed() {
+        #[derive(Clone, Copy)]
+        struct SkewedSchemaCodec;
+
+        impl ProtocolCodec for SkewedSchemaCodec {
+            fn codec_id(&self) -> &str {
+                nixling_constellation_codec_protobuf::CODEC_ID
+            }
+
+            fn encode_frame(
+                &self,
+                frame: &ConstellationFrame,
+            ) -> Result<Vec<u8>, ConstellationError> {
+                ProtobufCodec::new().encode_frame(frame)
+            }
+
+            fn decode_frame(&self, bytes: &[u8]) -> Result<ConstellationFrame, ConstellationError> {
+                ProtobufCodec::new().decode_frame(bytes)
+            }
+
+            fn schema_fingerprint(&self) -> String {
+                "pb.v1:other-schema".to_owned()
+            }
+        }
+
+        let (client_s, server_s) = connected_pair().await;
+        let server = tokio::spawn(async move {
+            PeerSession::accept(server_s, SkewedSchemaCodec)
+                .await
+                .map(|_| ())
+        });
+        let client_err = match PeerSession::connect(client_s, ProtobufCodec::new()).await {
+            Ok(_) => panic!("schema mismatch must reject the client"),
+            Err(err) => err,
+        };
+        let server_err = server.await.unwrap().unwrap_err();
+        assert_eq!(client_err.kind(), ErrorKind::VersionSkew);
+        assert_eq!(server_err.kind(), ErrorKind::VersionSkew);
+    }
+
+    #[tokio::test]
+    async fn peer_binding_mismatch_is_rejected_fail_closed() {
+        let (mut client_s, server_s) = connected_pair().await;
+        let server = tokio::spawn(async move {
+            PeerSession::accept(server_s, ProtobufCodec::new())
+                .await
+                .map(|_| ())
+        });
+        let codec = ProtobufCodec::new();
+        let forged = Handshake {
+            protocol_version: PROTOCOL_VERSION,
+            codec_id: parse_codec_id(codec.codec_id()).unwrap(),
+            schema_fingerprint: parse_codec_id(&codec.schema_fingerprint()).unwrap(),
+            peer: Some(nixling_constellation_core::PeerContext {
+                auth_mechanism: ProtocolToken::parse("forged-binding").unwrap(),
+                peer_principal: Some(PrincipalId::parse("principal-1").unwrap()),
+                peer_node: Some(NodeId::parse("node-a").unwrap()),
+            }),
+        };
+        let bytes = codec.encode_frame(&hs(forged)).unwrap();
+        write_frame(client_s.stream_mut(), &bytes).await.unwrap();
+        let err = server.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::AuthenticationFailed);
     }
 
     #[tokio::test]

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -16,10 +16,10 @@ use nixling::{
 };
 use nixling_constellation_core::{
     AdmissionAuditRecord, AuditEnvelope, Capability, CapabilitySet, ConstellationError,
-    ConstellationFrame, ExecutionId, ExecutionSummary, GatewayId, Handshake, IdempotencyKey,
-    NodeId, NodeSummary, OperationId, OperationKind, OperationRequest, OperationResponse,
-    PrincipalId, ProviderId, RealmId, RealmPath, StreamCursor, StreamId, WorkloadId,
-    WorkloadSelector, WorkloadSummary,
+    ConstellationFrame, ExecutionId, ExecutionSummary, GatewayId, Handshake, HandshakeAccepted,
+    HandshakeRejected, HandshakeRejectedReason, IdempotencyKey, NodeId, NodeSummary, OperationId,
+    OperationKind, OperationRequest, OperationResponse, PrincipalId, ProviderId, RealmId,
+    RealmPath, StreamCursor, StreamId, WorkloadId, WorkloadSelector, WorkloadSummary,
     audit::{
         AuditChainCheckFailure, AuditChainCheckResult, AuditChainLink, AuditChainRecord, AuditHash,
         AuditRetentionFloorReason, AuditRetentionFloorStatus, AuditSinkHealth,
@@ -61,6 +61,9 @@ enum ConstellationCoreSchema {
     WorkloadSummary(WorkloadSummary),
     ExecutionSummary(ExecutionSummary),
     Handshake(Handshake),
+    HandshakeAccepted(HandshakeAccepted),
+    HandshakeRejected(HandshakeRejected),
+    HandshakeRejectedReason(HandshakeRejectedReason),
     OperationKind(OperationKind),
     OperationRequest(OperationRequest),
     OperationResponse(OperationResponse),


### PR DESCRIPTION
## Summary
- add explicit `HandshakeAccepted` / `HandshakeRejected` semantic frames and bounded schema fingerprint negotiation
- bind schema fingerprints into plain and secure peer handshakes, including secure-session HMAC transcript coverage
- extend the protobuf codec, router loopback harness, generated schemas, and peer protocol reference docs

## Validation
- `cargo fmt --check`
- `cargo test -p nixling-constellation-core --quiet`
- `cargo test -p nixling-constellation-codec-protobuf --quiet`
- `cargo test -p nixling-constellation-router --quiet`
- `cargo check -p xtask --quiet`
- `make test-drift`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check` / `git diff --cached --check`
- process-marker grep over changed shipped docs/changelog

## Panel
Gemini 3.1 Pro Wave 4 panel reached unanimous signoff after follow-up fixes. Follow-up re-review closed missing handshake outcome tests, schema-fingerprint bounds, explicit rejection handling, lost-reply idempotency coverage, and channel-binding validation.