### PR TITLE
adr032: add named stream mux foundations ( W5 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ deprecations ship one minor release before removal.
   handshake-accepted/rejected frames, bind codec schema fingerprints into
   plain and secure peer handshakes, and document the length-delimited
   semantic frame skeleton for future gateway transports.
+- Named stream plumbing now supports resumable log cursors,
+  deterministic stream draining, and retry-safe cancellation for future
+  remote execution and display sessions.
 
 ### Changed
 

--- a/docs/reference/constellation-core.md
+++ b/docs/reference/constellation-core.md
@@ -140,9 +140,12 @@ The pure `StreamMux` state machine enforces:
 - an open-stream cap;
 - strictly increasing per-stream sequence numbers;
 - credit-based backpressure through non-zero `StreamFlow` grants;
+- deterministic sendable-stream selection for fair draining;
 - `Stdout`/`Stderr` channels only on `Stdio` streams;
 - resume cursors only on `Logs` streams;
-- no data after close and no double close.
+- `StreamResume` only on resumable stream kinds;
+- idempotent cancellation retries for already-cancelled streams;
+- no data after close and no double close for non-cancel terminal states.
 
 ## Audit and error redaction
 

--- a/docs/reference/constellation-protocol.md
+++ b/docs/reference/constellation-protocol.md
@@ -50,8 +50,26 @@ realm, principal, node, operation kind, and idempotency key. A lost-reply
 retry with the same request replays the recorded response, while a
 same-key different request or a post-retention reuse fails closed.
 
+## Named streams
+
+Post-handshake stream frames are typed and mux-validated before callers see
+them. A stream must open with a `StreamDescriptor` and capability-derived
+`StreamAuthz`; data before open, unknown streams, invalid channels, and
+data after close fail closed.
+
+Flow control is credit-based. `StreamFlow` grants a non-zero number of
+frames, `StreamData.sequence` is strictly increasing per stream, and the
+mux exposes deterministic sendable-stream ordering plus a round-robin
+selection primitive for fair draining. Cancellation is idempotent for
+already-cancelled streams so reconnect/cancel retries do not create
+spurious protocol errors.
+
+`StreamResume` carries a durable cursor and is accepted only for resumable
+stream kinds, currently logs. Non-resumable streams reject cursor resume
+requests before any transport replay or provider action.
+
 ## Non-goals
 
 This skeleton does not implement Azure Relay, remote full-host transport,
-stream lifecycle beyond the existing semantic frame/mux primitives, or
-durable execution. Those are later ADR 0032 waves.
+provider-specific display, or durable execution. Those are later ADR 0032
+waves.

--- a/docs/reference/schemas/v2/constellation-core.json
+++ b/docs/reference/schemas/v2/constellation-core.json
@@ -85,6 +85,9 @@
       "$ref": "#/definitions/OperationResponse"
     },
     {
+      "$ref": "#/definitions/StreamResume"
+    },
+    {
       "$ref": "#/definitions/AdmissionAuditRecord"
     },
     {
@@ -1283,6 +1286,39 @@
           }
         },
         {
+          "description": "Resume a durable stream from a cursor.",
+          "type": "object",
+          "required": [
+            "cursor",
+            "frame",
+            "stream"
+          ],
+          "properties": {
+            "cursor": {
+              "description": "Durable cursor the peer wants to resume from.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/StreamCursor"
+                }
+              ]
+            },
+            "frame": {
+              "type": "string",
+              "enum": [
+                "stream-resume"
+              ]
+            },
+            "stream": {
+              "description": "Stream being resumed.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/StreamId"
+                }
+              ]
+            }
+          }
+        },
+        {
           "description": "A typed error frame.",
           "type": "object",
           "required": [
@@ -2270,6 +2306,33 @@
           ]
         }
       ]
+    },
+    "StreamResume": {
+      "description": "Reattach/resume request for a durable stream. The cursor is meaningful only for resumable stream kinds such as logs; the mux rejects resumes for non-resumable streams before any transport replay can occur.",
+      "type": "object",
+      "required": [
+        "cursor",
+        "stream"
+      ],
+      "properties": {
+        "cursor": {
+          "description": "Durable cursor the peer wants to resume from.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StreamCursor"
+            }
+          ]
+        },
+        "stream": {
+          "description": "Stream being resumed.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StreamId"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "TraceContext": {
       "type": "object",

--- a/docs/reference/schemas/v2/constellation-core.md
+++ b/docs/reference/schemas/v2/constellation-core.md
@@ -26,6 +26,7 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
 - `Handshake`, `HandshakeAccepted`, `HandshakeRejected`,
   `HandshakeRejectedReason`;
 - `OperationKind`, `OperationRequest`, `OperationResponse`;
+- `StreamResume`;
 - `AdmissionAuditRecord`, `AuditEnvelope`, `AuditHash`,
   `AuditChainLink`, `AuditChainRecord`, `AuditChainCheckResult`,
   `AuditSinkHealth`, `AuditRetentionFloorStatus`;
@@ -54,3 +55,5 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
   `ConstellationFrame` and preserve the same capability-derived authz and
   backpressure constraints described in
   [`constellation-core.md`](../../constellation-core.md).
+- `StreamResume` carries only a stream id and durable cursor; the mux
+  accepts it only for resumable stream kinds such as logs.

--- a/packages/nixling-constellation-codec-protobuf/src/lib.rs
+++ b/packages/nixling-constellation-codec-protobuf/src/lib.rs
@@ -6,8 +6,8 @@ use nixling_constellation_core::{
     HandshakeRejectedReason, IdempotencyKey, NodeId, OpaquePayload, OperationId, OperationKind,
     OperationRequest, OperationResponse, PeerContext, PrincipalId, ProtocolToken, RealmId,
     RealmPath, StreamAuthz, StreamChannel, StreamClose, StreamCloseReason, StreamCursor,
-    StreamData, StreamDescriptor, StreamFlow, StreamId, StreamKind, StreamOpen, TraceContext,
-    WorkloadId,
+    StreamData, StreamDescriptor, StreamFlow, StreamId, StreamKind, StreamOpen, StreamResume,
+    TraceContext, WorkloadId,
 };
 use nixling_constellation_provider::ProtocolCodec;
 use nixling_ipc::MAX_FRAME_SIZE;
@@ -17,7 +17,7 @@ use prost::Message;
 pub const CODEC_ID: &str = "protobuf.v1";
 
 /// Deterministic fingerprint for the hand-authored prost schema in this crate.
-pub const SCHEMA_FINGERPRINT: &str = "pb.v1:f11:h4:op14:sk12:err19:audit11";
+pub const SCHEMA_FINGERPRINT: &str = "pb.v1:f12:h4:op14:sk12:err19:audit11";
 
 /// A prost-backed constellation frame codec.
 #[derive(Debug, Clone, Copy, Default)]
@@ -61,7 +61,7 @@ impl ProtocolCodec for ProtobufCodec {
 struct ProtoFrame {
     #[prost(
         oneof = "proto_frame::Body",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12"
     )]
     body: Option<proto_frame::Body>,
 }
@@ -91,6 +91,8 @@ mod proto_frame {
         HandshakeAccepted(super::ProtoHandshakeAccepted),
         #[prost(message, tag = "11")]
         HandshakeRejected(super::ProtoHandshakeRejected),
+        #[prost(message, tag = "12")]
+        StreamResume(super::ProtoStreamResume),
     }
 }
 
@@ -217,6 +219,14 @@ struct ProtoStreamClose {
 }
 
 #[derive(Clone, PartialEq, prost::Message)]
+struct ProtoStreamResume {
+    #[prost(string, tag = "1")]
+    stream: String,
+    #[prost(string, tag = "2")]
+    cursor: String,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
 struct ProtoError {
     #[prost(int32, tag = "1")]
     kind: i32,
@@ -318,6 +328,9 @@ fn encode_proto_frame(frame: &ConstellationFrame) -> Result<ProtoFrame, Constell
         ConstellationFrame::StreamClose(frame) => {
             proto_frame::Body::StreamClose(encode_stream_close(frame))
         }
+        ConstellationFrame::StreamResume(frame) => {
+            proto_frame::Body::StreamResume(encode_stream_resume(frame))
+        }
         ConstellationFrame::TypedError(frame) => {
             proto_frame::Body::TypedError(encode_error(frame)?)
         }
@@ -359,6 +372,9 @@ fn decode_proto_frame(frame: ProtoFrame) -> Result<ConstellationFrame, Constella
         }
         proto_frame::Body::StreamClose(frame) => {
             decode_stream_close(frame).map(ConstellationFrame::StreamClose)
+        }
+        proto_frame::Body::StreamResume(frame) => {
+            decode_stream_resume(frame).map(ConstellationFrame::StreamResume)
         }
         proto_frame::Body::TypedError(frame) => {
             decode_error(frame).map(ConstellationFrame::TypedError)
@@ -634,6 +650,20 @@ fn decode_stream_close(frame: ProtoStreamClose) -> Result<StreamClose, Constella
     Ok(StreamClose {
         stream: parse_stream_id(frame.stream, "stream_close stream")?,
         reason: decode_close_reason(frame.reason)?,
+    })
+}
+
+fn encode_stream_resume(frame: &StreamResume) -> ProtoStreamResume {
+    ProtoStreamResume {
+        stream: frame.stream.as_str().to_owned(),
+        cursor: frame.cursor.as_str().to_owned(),
+    }
+}
+
+fn decode_stream_resume(frame: ProtoStreamResume) -> Result<StreamResume, ConstellationError> {
+    Ok(StreamResume {
+        stream: parse_stream_id(frame.stream, "stream_resume stream")?,
+        cursor: parse_stream_cursor(frame.cursor, "stream_resume cursor")?,
     })
 }
 
@@ -1358,6 +1388,10 @@ mod tests {
             ConstellationFrame::StreamClose(StreamClose {
                 stream: stream.clone(),
                 reason: StreamCloseReason::Completed,
+            }),
+            ConstellationFrame::StreamResume(StreamResume {
+                stream: stream.clone(),
+                cursor: StreamCursor::parse("cur-resume").unwrap(),
             }),
             ConstellationFrame::TypedError(ConstellationError::capability_denied(
                 Capability::WindowForwarding,

--- a/packages/nixling-constellation-core/src/frame.rs
+++ b/packages/nixling-constellation-core/src/frame.rs
@@ -435,6 +435,18 @@ pub struct StreamClose {
     pub reason: StreamCloseReason,
 }
 
+/// Reattach/resume request for a durable stream. The cursor is meaningful
+/// only for resumable stream kinds such as logs; the mux rejects resumes for
+/// non-resumable streams before any transport replay can occur.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct StreamResume {
+    /// Stream being resumed.
+    pub stream: StreamId,
+    /// Durable cursor the peer wants to resume from.
+    pub cursor: StreamCursor,
+}
+
 /// The semantic frame exchanged over a constellation peer session. The
 /// codec layer maps bytes to/from this enum; the operation layer never
 /// depends on the encoding. Every variant wraps a `deny_unknown_fields`
@@ -460,6 +472,8 @@ pub enum ConstellationFrame {
     StreamFlow(StreamFlow),
     /// Close a named stream.
     StreamClose(StreamClose),
+    /// Resume a durable stream from a cursor.
+    StreamResume(StreamResume),
     /// A typed error frame.
     TypedError(ConstellationError),
     /// A redacted pre-auth/session-admission denial frame.
@@ -633,12 +647,17 @@ mod tests {
         assert!(serde_json::from_str::<ConstellationFrame>(data).is_ok());
         let close = "{\"frame\":\"stream-close\",\"stream\":\"s1\",\"reason\":\"completed\"}";
         assert!(serde_json::from_str::<ConstellationFrame>(close).is_ok());
+        let resume = "{\"frame\":\"stream-resume\",\"stream\":\"s1\",\"cursor\":\"cur-1\"}";
+        assert!(serde_json::from_str::<ConstellationFrame>(resume).is_ok());
         // Extra peer-supplied fields are rejected (deny_unknown_fields).
         let data_extra = "{\"frame\":\"stream-data\",\"stream\":\"s1\",\"sequence\":0,\"data\":[1],\"evil\":true}";
         assert!(serde_json::from_str::<ConstellationFrame>(data_extra).is_err());
         let close_extra =
             "{\"frame\":\"stream-close\",\"stream\":\"s1\",\"reason\":\"completed\",\"evil\":true}";
         assert!(serde_json::from_str::<ConstellationFrame>(close_extra).is_err());
+        let resume_extra =
+            "{\"frame\":\"stream-resume\",\"stream\":\"s1\",\"cursor\":\"cur-1\",\"evil\":true}";
+        assert!(serde_json::from_str::<ConstellationFrame>(resume_extra).is_err());
     }
 
     #[test]

--- a/packages/nixling-constellation-core/src/lib.rs
+++ b/packages/nixling-constellation-core/src/lib.rs
@@ -38,7 +38,7 @@ pub use execution::{ExecState, ExecutionSummary};
 pub use frame::{
     ConstellationFrame, Handshake, HandshakeAccepted, HandshakeRejected, HandshakeRejectedReason,
     OperationKind, OperationRequest, OperationResponse, PeerContext, StreamClose, StreamData,
-    StreamFlow, StreamOpen,
+    StreamFlow, StreamOpen, StreamResume,
 };
 pub use ids::{
     ExecutionId, GatewayId, IdempotencyKey, NodeId, OperationId, PrincipalId, ProviderId, RealmId,

--- a/packages/nixling-constellation-core/src/mux.rs
+++ b/packages/nixling-constellation-core/src/mux.rs
@@ -15,22 +15,28 @@
 //!   (only `Stdio` carries `Stdout`/`Stderr`; every other kind is
 //!   `Primary`-only);
 //! - a resume [`crate::ids::StreamCursor`] only rides a `Logs` stream;
-//! - data after a close, or a double close, is rejected.
+//! - data after close is rejected, while repeated cancellation is
+//!   idempotent and non-cancel double-close remains a protocol error.
 //!
 //! The state machine is deliberately codec- and transport-neutral so the
 //! same enforcement runs identically over AF_VSOCK (host↔gateway) and over
 //! an Azure Relay peer session (gateway↔container).
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::ops::Bound::{Excluded, Unbounded};
 
 use crate::error::{ConstellationError, ErrorKind};
-use crate::frame::{StreamClose, StreamData, StreamFlow, StreamOpen};
+use crate::frame::{StreamClose, StreamData, StreamFlow, StreamOpen, StreamResume};
 use crate::ids::{OperationId, StreamId};
 use crate::stream::{StreamChannel, StreamCloseReason, StreamKind};
 
 /// Default cap on concurrently-open streams in one peer session. Bounds the
 /// mux's memory against a peer that opens streams without closing them.
 pub const DEFAULT_MAX_OPEN_STREAMS: usize = 256;
+/// Default cap on recently-closed stream records retained for idempotent
+/// cancel/reconnect diagnostics. Older closed records are pruned so a
+/// long-lived session cannot grow with total historical stream count.
+pub const DEFAULT_MAX_CLOSED_STREAMS: usize = 1024;
 
 /// Lifecycle state of a single multiplexed stream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,8 +69,12 @@ struct StreamEntry {
 /// A pure stream-mux state machine for one peer-session endpoint.
 #[derive(Debug, Clone)]
 pub struct StreamMux {
-    streams: HashMap<StreamId, StreamEntry>,
+    streams: BTreeMap<StreamId, StreamEntry>,
+    open_streams: BTreeSet<StreamId>,
+    sendable_streams: BTreeSet<StreamId>,
+    closed_order: VecDeque<StreamId>,
     max_open: usize,
+    max_closed: usize,
 }
 
 impl Default for StreamMux {
@@ -81,25 +91,29 @@ impl StreamMux {
 
     /// A mux with an explicit open-stream cap (must be non-zero).
     pub fn with_max_open(max_open: usize) -> Self {
+        Self::with_limits(max_open, DEFAULT_MAX_CLOSED_STREAMS)
+    }
+
+    /// A mux with explicit open-stream and closed-history caps.
+    pub fn with_limits(max_open: usize, max_closed: usize) -> Self {
         Self {
-            streams: HashMap::new(),
+            streams: BTreeMap::new(),
+            open_streams: BTreeSet::new(),
+            sendable_streams: BTreeSet::new(),
+            closed_order: VecDeque::new(),
             max_open: max_open.max(1),
+            max_closed: max_closed.max(1),
         }
     }
 
     /// Number of streams currently in the `Open` state.
     pub fn open_stream_count(&self) -> usize {
-        self.streams
-            .values()
-            .filter(|e| e.state == StreamState::Open)
-            .count()
+        self.open_streams.len()
     }
 
     /// Whether `stream` is known and currently open.
     pub fn is_open(&self, stream: &StreamId) -> bool {
-        self.streams
-            .get(stream)
-            .is_some_and(|e| e.state == StreamState::Open)
+        self.open_streams.contains(stream)
     }
 
     /// The recorded close reason for a closed stream, if any.
@@ -148,6 +162,7 @@ impl StreamMux {
                 send_credit: 0,
             },
         );
+        self.open_streams.insert(id.clone());
         Ok(())
     }
 
@@ -223,8 +238,33 @@ impl StreamMux {
             ));
         }
         let entry = self.open_entry_mut(&flow.stream)?;
+        let was_unsendable = entry.send_credit == 0;
         entry.send_credit = entry.send_credit.saturating_add(u64::from(flow.credits));
+        if was_unsendable {
+            self.sendable_streams.insert(flow.stream.clone());
+        }
         Ok(())
+    }
+
+    /// Return open streams with outbound credit in deterministic order. The
+    /// caller can use this to fairly drain sendable streams without peeking
+    /// into mux internals.
+    pub fn sendable_streams(&self) -> Vec<StreamId> {
+        self.sendable_streams.iter().cloned().collect()
+    }
+
+    /// Return the next sendable stream after `after`, wrapping around. This
+    /// gives callers a deterministic round-robin primitive; they store the
+    /// last selected stream and feed it back on the next scheduling pass.
+    pub fn next_sendable_after(&self, after: Option<&StreamId>) -> Option<StreamId> {
+        let Some(after) = after else {
+            return self.sendable_streams.iter().next().cloned();
+        };
+        self.sendable_streams
+            .range((Excluded(after), Unbounded))
+            .next()
+            .cloned()
+            .or_else(|| self.sendable_streams.iter().next().cloned())
     }
 
     /// Reserve the next outbound chunk on `stream`: validates the channel
@@ -253,15 +293,24 @@ impl StreamMux {
         entry.send_credit -= 1;
         let seq = entry.next_send_seq;
         entry.next_send_seq += 1;
+        if entry.send_credit == 0 {
+            self.sendable_streams.remove(stream);
+        }
         Ok(seq)
     }
 
-    /// Close a stream, recording the reason. A double close is rejected.
+    /// Close a stream, recording the reason. Repeated `Cancelled` closes are
+    /// idempotent; every other double close is rejected.
     pub fn close(&mut self, close: &StreamClose) -> Result<(), ConstellationError> {
         let entry = self.streams.get_mut(&close.stream).ok_or_else(|| {
             ConstellationError::new(ErrorKind::MalformedFrame, "close of an unknown stream")
         })?;
         if entry.state == StreamState::Closed {
+            if entry.close_reason == Some(StreamCloseReason::Cancelled)
+                && close.reason == StreamCloseReason::Cancelled
+            {
+                return Ok(());
+            }
             return Err(ConstellationError::new(
                 ErrorKind::MalformedFrame,
                 "stream is already closed",
@@ -269,12 +318,64 @@ impl StreamMux {
         }
         entry.state = StreamState::Closed;
         entry.close_reason = Some(close.reason);
+        self.open_streams.remove(&close.stream);
+        self.sendable_streams.remove(&close.stream);
+        self.remember_closed(close.stream.clone());
+        Ok(())
+    }
+
+    /// Cancel a stream idempotently. The first cancel closes an open stream
+    /// and returns `Ok(true)`. Repeating a cancel, racing a peer close, or
+    /// cancelling an already-pruned/unknown stream returns `Ok(false)` so a
+    /// reconnect/cancel retry cannot wedge or tear down the session.
+    pub fn cancel(&mut self, stream: &StreamId) -> Result<bool, ConstellationError> {
+        match self.streams.get_mut(stream) {
+            Some(entry) if entry.state == StreamState::Open => {
+                entry.state = StreamState::Closed;
+                entry.close_reason = Some(StreamCloseReason::Cancelled);
+                self.open_streams.remove(stream);
+                self.sendable_streams.remove(stream);
+                self.remember_closed(stream.clone());
+                Ok(true)
+            }
+            Some(_) | None => Ok(false),
+        }
+    }
+
+    /// Validate a resume request. Today only `Logs` streams are resumable:
+    /// other stream kinds carry no durable cursor contract and fail closed.
+    /// A closed logs stream can still validate a resume request so a later
+    /// transport wave can reattach before reopening provider state.
+    pub fn validate_resume(&self, resume: &StreamResume) -> Result<(), ConstellationError> {
+        let entry = self.streams.get(&resume.stream).ok_or_else(|| {
+            ConstellationError::new(ErrorKind::MalformedFrame, "resume of an unknown stream")
+        })?;
+        if entry.kind != StreamKind::Logs {
+            return Err(ConstellationError::new(
+                ErrorKind::MalformedFrame,
+                "only logs streams support cursor resume",
+            ));
+        }
         Ok(())
     }
 
     /// The operation id a stream is bound to (for audit/correlation).
     pub fn operation_id(&self, stream: &StreamId) -> Option<&OperationId> {
         self.streams.get(stream).map(|e| &e.operation_id)
+    }
+
+    fn remember_closed(&mut self, stream: StreamId) {
+        self.closed_order.push_back(stream);
+        while self.closed_order.len() > self.max_closed {
+            if let Some(old) = self.closed_order.pop_front()
+                && self
+                    .streams
+                    .get(&old)
+                    .is_some_and(|entry| entry.state == StreamState::Closed)
+            {
+                self.streams.remove(&old);
+            }
+        }
     }
 
     fn open_entry(&self, stream: &StreamId) -> Result<&StreamEntry, ConstellationError> {
@@ -517,7 +618,13 @@ mod tests {
                 .kind(),
             ErrorKind::Cancelled
         );
-        // A double close is rejected.
+        // A repeated cancel close from the peer is idempotent.
+        mux.close(&StreamClose {
+            stream: sid("s1"),
+            reason: StreamCloseReason::Cancelled,
+        })
+        .unwrap();
+        // A double close with another terminal reason is rejected.
         assert_eq!(
             mux.close(&StreamClose {
                 stream: sid("s1"),
@@ -527,6 +634,27 @@ mod tests {
             .kind(),
             ErrorKind::MalformedFrame
         );
+    }
+
+    #[test]
+    fn cancel_is_idempotent_only_for_cancelled_streams() {
+        let mut mux = StreamMux::new();
+        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        assert_eq!(mux.cancel(&sid("s1")), Ok(true));
+        assert_eq!(mux.cancel(&sid("s1")), Ok(false));
+        assert_eq!(
+            mux.close_reason(&sid("s1")),
+            Some(StreamCloseReason::Cancelled)
+        );
+
+        mux.open(&open_frame("s2", StreamKind::Display)).unwrap();
+        mux.close(&StreamClose {
+            stream: sid("s2"),
+            reason: StreamCloseReason::Completed,
+        })
+        .unwrap();
+        assert_eq!(mux.cancel(&sid("s2")), Ok(false));
+        assert_eq!(mux.cancel(&sid("unknown")), Ok(false));
     }
 
     #[test]
@@ -562,5 +690,102 @@ mod tests {
                 .kind(),
             ErrorKind::Backpressure
         );
+    }
+
+    #[test]
+    fn sendable_streams_are_deterministic_and_round_robin() {
+        let mut mux = StreamMux::new();
+        mux.open(&open_frame("b-stream", StreamKind::Display))
+            .unwrap();
+        mux.open(&open_frame("a-stream", StreamKind::Display))
+            .unwrap();
+        mux.receive_flow(&StreamFlow {
+            stream: sid("b-stream"),
+            credits: 1,
+        })
+        .unwrap();
+        mux.receive_flow(&StreamFlow {
+            stream: sid("a-stream"),
+            credits: 1,
+        })
+        .unwrap();
+        assert_eq!(
+            mux.sendable_streams(),
+            vec![sid("a-stream"), sid("b-stream")]
+        );
+        assert_eq!(mux.next_sendable_after(None), Some(sid("a-stream")));
+        assert_eq!(
+            mux.next_sendable_after(Some(&sid("a-stream"))),
+            Some(sid("b-stream"))
+        );
+        assert_eq!(
+            mux.next_sendable_after(Some(&sid("b-stream"))),
+            Some(sid("a-stream"))
+        );
+        // If the last-serviced stream drops out of the sendable set, the
+        // scheduler still moves to the next strictly greater stream rather
+        // than restarting at the beginning and starving later streams.
+        assert_eq!(
+            mux.reserve_send(&sid("a-stream"), StreamChannel::Primary)
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            mux.next_sendable_after(Some(&sid("a-stream"))),
+            Some(sid("b-stream"))
+        );
+    }
+
+    #[test]
+    fn resume_is_allowed_only_for_logs_streams() {
+        let mut mux = StreamMux::new();
+        mux.open(&open_frame("logs", StreamKind::Logs)).unwrap();
+        mux.open(&open_frame("display", StreamKind::Display))
+            .unwrap();
+        let logs_resume = StreamResume {
+            stream: sid("logs"),
+            cursor: StreamCursor::parse("cur-1").unwrap(),
+        };
+        mux.validate_resume(&logs_resume).unwrap();
+        mux.close(&StreamClose {
+            stream: sid("logs"),
+            reason: StreamCloseReason::PeerGone,
+        })
+        .unwrap();
+        mux.validate_resume(&logs_resume).unwrap();
+
+        let display_resume = StreamResume {
+            stream: sid("display"),
+            cursor: StreamCursor::parse("cur-2").unwrap(),
+        };
+        assert_eq!(
+            mux.validate_resume(&display_resume).unwrap_err().kind(),
+            ErrorKind::MalformedFrame
+        );
+    }
+
+    #[test]
+    fn closed_stream_history_is_bounded() {
+        let mut mux = StreamMux::with_limits(4, 2);
+        for id in ["s1", "s2", "s3"] {
+            mux.open(&open_frame(id, StreamKind::Display)).unwrap();
+            mux.close(&StreamClose {
+                stream: sid(id),
+                reason: StreamCloseReason::Completed,
+            })
+            .unwrap();
+        }
+        assert_eq!(mux.close_reason(&sid("s1")), None);
+        assert_eq!(
+            mux.close_reason(&sid("s2")),
+            Some(StreamCloseReason::Completed)
+        );
+        assert_eq!(
+            mux.close_reason(&sid("s3")),
+            Some(StreamCloseReason::Completed)
+        );
+        // Once the old closed record is pruned, that id can be reused.
+        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        assert!(mux.is_open(&sid("s1")));
     }
 }

--- a/packages/nixling-constellation-router/src/mux_session.rs
+++ b/packages/nixling-constellation-router/src/mux_session.rs
@@ -9,7 +9,7 @@
 
 use nixling_constellation_core::{
     ConstellationError, ConstellationFrame, OpaquePayload, StreamChannel, StreamClose,
-    StreamCloseReason, StreamData, StreamId, StreamMux, StreamOpen,
+    StreamCloseReason, StreamData, StreamId, StreamMux, StreamOpen, StreamResume,
 };
 use nixling_constellation_provider::error::ProviderResult;
 use nixling_constellation_provider::provider::ProtocolCodec;
@@ -90,6 +90,29 @@ impl<C: ProtocolCodec> MuxSession<C> {
             .await
     }
 
+    /// Send a stream resume request after validating the stream/cursor shape.
+    pub async fn resume_stream(&mut self, resume: StreamResume) -> ProviderResult<()> {
+        self.mux.validate_resume(&resume)?;
+        self.peer
+            .send(&ConstellationFrame::StreamResume(resume))
+            .await
+    }
+
+    /// Cancel a stream idempotently and notify the peer only for the first
+    /// cancel transition.
+    pub async fn cancel_stream(&mut self, stream: &StreamId) -> ProviderResult<bool> {
+        let first_cancel = self.mux.cancel(stream)?;
+        if first_cancel {
+            self.peer
+                .send(&ConstellationFrame::StreamClose(StreamClose {
+                    stream: stream.clone(),
+                    reason: StreamCloseReason::Cancelled,
+                }))
+                .await?;
+        }
+        Ok(first_cancel)
+    }
+
     /// Receive one frame and apply the mux state transition before exposing it.
     pub async fn recv(&mut self) -> ProviderResult<ConstellationFrame> {
         let frame = self.peer.recv().await?;
@@ -103,6 +126,7 @@ impl<C: ProtocolCodec> MuxSession<C> {
             ConstellationFrame::StreamData(data) => self.mux.accept_data(data),
             ConstellationFrame::StreamFlow(flow) => self.mux.receive_flow(flow),
             ConstellationFrame::StreamClose(close) => self.mux.close(close),
+            ConstellationFrame::StreamResume(resume) => self.mux.validate_resume(resume),
             ConstellationFrame::Handshake(_)
             | ConstellationFrame::HandshakeAccepted(_)
             | ConstellationFrame::HandshakeRejected(_)

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -19,7 +19,7 @@ use nixling_constellation_core::{
     ConstellationFrame, ExecutionId, ExecutionSummary, GatewayId, Handshake, HandshakeAccepted,
     HandshakeRejected, HandshakeRejectedReason, IdempotencyKey, NodeId, NodeSummary, OperationId,
     OperationKind, OperationRequest, OperationResponse, PrincipalId, ProviderId, RealmId,
-    RealmPath, StreamCursor, StreamId, WorkloadId, WorkloadSelector, WorkloadSummary,
+    RealmPath, StreamCursor, StreamId, StreamResume, WorkloadId, WorkloadSelector, WorkloadSummary,
     audit::{
         AuditChainCheckFailure, AuditChainCheckResult, AuditChainLink, AuditChainRecord, AuditHash,
         AuditRetentionFloorReason, AuditRetentionFloorStatus, AuditSinkHealth,
@@ -67,6 +67,7 @@ enum ConstellationCoreSchema {
     OperationKind(OperationKind),
     OperationRequest(OperationRequest),
     OperationResponse(OperationResponse),
+    StreamResume(StreamResume),
     AdmissionAuditRecord(AdmissionAuditRecord),
     AuditEnvelope(AuditEnvelope),
     AuditHash(AuditHash),


### PR DESCRIPTION
## Summary
- add `StreamResume`, protobuf support, and generated schemas for resumable named streams
- add bounded stream mux state: active/sendable indexes, fair scheduling, bounded closed history, and idempotent cancellation
- update stream protocol docs and changelog

## Validation
- `cargo fmt --check`
- `cargo test -p nixling-constellation-core --quiet`
- `cargo test -p nixling-constellation-codec-protobuf --quiet`
- `cargo test -p nixling-constellation-router --quiet`
- `cargo check -p xtask --quiet`
- `make test-drift`
- `cargo clippy -p nixling-constellation-core --all-targets -- -D warnings`
- `cargo clippy -p nixling-constellation-codec-protobuf --all-targets -- -D warnings`
- `cargo clippy -p nixling-constellation-router --all-targets -- -D warnings`
- `git diff --check` / `git diff --cached --check`
- process-marker grep over changed shipped docs/changelog

## Panel
Gemini 3.1 Pro Wave 5 panel reached unanimous signoff after follow-up fixes. Follow-up re-review closed fairness, bounded-memory, cancellation-idempotency, hot-path allocation, and changelog clarity findings.