### PR TITLE
ADR032: enforce capability negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ deprecations ship one minor release before removal.
 - Remote execution groundwork now supports reliable reconnects, bounded
   retained-log reads, and safe repeated cancellation for future durable
   remote exec sessions.
+- Capability negotiation now rejects operations and streams when a
+  session lacks the required capability, with typed missing-capability
+  errors.
 
 ### Changed
 

--- a/docs/reference/constellation-core.md
+++ b/docs/reference/constellation-core.md
@@ -35,7 +35,7 @@ Regenerate that file; do not edit generated JSON by hand.
 | `ConstellationError` | `src/error.rs` | Typed error frame with stable `ErrorKind`, bounded message, and structured missing capability for capability denials. |
 | `NodeSummary` / `WorkloadSelector` / `WorkloadSummary` / `ExecutionSummary` | `src/node.rs`, `src/workload.rs`, `src/execution.rs` | Bounded status summaries and selectors for nodes, workloads, and durable executions. |
 | `ExecStartRequest` / `ExecAttachRequest` / `ExecLogsRequest` / `ExecCancelRequest` | `src/execution.rs` | Bounded durable-execution metadata for start, reconnect, retained logs, and retry-safe cancel. |
-| `RealmPath`, identifier newtypes, `CapabilitySet`, `TraceContext`, `OpaquePayload`, `ProtocolToken` | `src/realm.rs`, `src/ids.rs`, `src/capability.rs`, `src/trace_context.rs`, `src/payload.rs`, `src/token.rs` | Reusable bounded primitives that every higher-level root depends on. |
+| `RealmPath`, identifier newtypes, `CapabilitySet`, `CapabilityNegotiation`, `TraceContext`, `OpaquePayload`, `ProtocolToken` | `src/realm.rs`, `src/ids.rs`, `src/capability.rs`, `src/trace_context.rs`, `src/payload.rs`, `src/token.rs` | Reusable bounded primitives that every higher-level root depends on. |
 
 ## Target addresses
 
@@ -85,6 +85,13 @@ storage key.
 Capabilities are positive assertions. A node, provider, workload, or
 stream advertises exactly what it supports; absence means typed refusal,
 not a silent fallback.
+
+Negotiated capability sets carry `CapabilityNegotiation` metadata: a schema
+version, the selected positive assertions both peers understand and
+support, and a deterministic bounded fingerprint for audit correlation.
+Operations and streams that require absent
+capabilities are rejected before execution with typed missing-capability
+errors.
 
 Capability codes:
 

--- a/docs/reference/constellation-protocol.md
+++ b/docs/reference/constellation-protocol.md
@@ -50,6 +50,12 @@ realm, principal, node, operation kind, and idempotency key. A lost-reply
 retry with the same request replays the recorded response, while a
 same-key different request or a post-retention reuse fails closed.
 
+Capabilities are negotiated as positive assertions; the accepted session
+uses the intersection both peers understand and support. A missing
+capability causes a typed `capability-denied` refusal before an operation
+or stream is executed. Negotiation records carry a bounded fingerprint so
+audit can cite the selected set without copying it into every event.
+
 ## Named streams
 
 Post-handshake stream frames are typed and mux-validated before callers see

--- a/docs/reference/schemas/v2/constellation-core.json
+++ b/docs/reference/schemas/v2/constellation-core.json
@@ -45,11 +45,10 @@
       "$ref": "#/definitions/Capability"
     },
     {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Capability"
-      },
-      "uniqueItems": true
+      "$ref": "#/definitions/CapabilitySet"
+    },
+    {
+      "$ref": "#/definitions/CapabilityNegotiation"
     },
     {
       "$ref": "#/definitions/NodeSummary"
@@ -866,6 +865,44 @@
         }
       ]
     },
+    "CapabilityNegotiation": {
+      "description": "Versioned negotiated capability set. The fingerprint is deterministic and bounded so audit records can cite the negotiated set without expanding it into every event.",
+      "type": "object",
+      "required": [
+        "capabilities",
+        "fingerprint",
+        "schemaVersion"
+      ],
+      "properties": {
+        "capabilities": {
+          "description": "Positive capability assertions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CapabilitySet"
+            }
+          ]
+        },
+        "fingerprint": {
+          "description": "Deterministic bounded fingerprint of `capabilities`.",
+          "type": "string",
+          "maxLength": 64
+        },
+        "schemaVersion": {
+          "description": "Capability negotiation schema version.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "CapabilitySet": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ProtocolToken"
+      },
+      "maxItems": 64,
+      "uniqueItems": true
+    },
     "ConstellationError": {
       "description": "A typed constellation error: a [`ErrorKind`], an optional structured missing capability (for `CapabilityDenied`), plus a bounded, operator-safe message. The message MUST NOT contain secrets, command output, store paths, argv, or stream payload, and is bounded at decode so it can never be an unbounded side channel.",
       "type": "object",
@@ -897,6 +934,14 @@
           "description": "Bounded operator-actionable message (no payload/secrets).",
           "type": "string",
           "maxLength": 256
+        },
+        "negotiated_capability_fingerprint": {
+          "description": "Fingerprint of the negotiated capability set used for the denial.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 64
         }
       },
       "additionalProperties": false
@@ -908,12 +953,21 @@
           "description": "Session handshake (version + codec negotiation).",
           "type": "object",
           "required": [
+            "capabilities",
             "codec_id",
             "frame",
             "protocol_version",
             "schema_fingerprint"
           ],
           "properties": {
+            "capabilities": {
+              "description": "Versioned positive capability assertions negotiated for this session.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CapabilityNegotiation"
+                }
+              ]
+            },
             "codec_id": {
               "description": "Codec id negotiated for this session (bounded token).",
               "allOf": [
@@ -1374,6 +1428,14 @@
               "description": "Bounded operator-actionable message (no payload/secrets).",
               "type": "string",
               "maxLength": 256
+            },
+            "negotiated_capability_fingerprint": {
+              "description": "Fingerprint of the negotiated capability set used for the denial.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "maxLength": 64
             }
           }
         },
@@ -1914,11 +1976,20 @@
       "description": "Negotiated wire/codec version and capability advertisement exchanged at the start of a peer session.",
       "type": "object",
       "required": [
+        "capabilities",
         "codec_id",
         "protocol_version",
         "schema_fingerprint"
       ],
       "properties": {
+        "capabilities": {
+          "description": "Versioned positive capability assertions negotiated for this session.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CapabilityNegotiation"
+            }
+          ]
+        },
         "codec_id": {
           "description": "Codec id negotiated for this session (bounded token).",
           "allOf": [
@@ -1998,6 +2069,7 @@
         "version-skew",
         "codec-mismatch",
         "schema-fingerprint-mismatch",
+        "capability-mismatch",
         "channel-binding-mismatch",
         "malformed-handshake"
       ]
@@ -2052,11 +2124,11 @@
       "properties": {
         "capabilities": {
           "description": "Advertised capabilities.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Capability"
-          },
-          "uniqueItems": true
+          "allOf": [
+            {
+              "$ref": "#/definitions/CapabilitySet"
+            }
+          ]
         },
         "id": {
           "description": "Stable node id.",
@@ -2667,11 +2739,11 @@
       "properties": {
         "capabilities": {
           "description": "Capabilities this workload can present.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Capability"
-          },
-          "uniqueItems": true
+          "allOf": [
+            {
+              "$ref": "#/definitions/CapabilitySet"
+            }
+          ]
         },
         "id": {
           "description": "Stable operator-facing alias/id.",

--- a/docs/reference/schemas/v2/constellation-core.md
+++ b/docs/reference/schemas/v2/constellation-core.md
@@ -20,7 +20,7 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
 - `NodeId`, `WorkloadId`, `ProviderId`, `GatewayId`;
 - `ExecutionId`, `StreamId`, `StreamCursor`, `PrincipalId`,
   `OperationId`, `IdempotencyKey`;
-- `Capability`, `CapabilitySet`;
+- `Capability`, `CapabilitySet`, `CapabilityNegotiation`;
 - `NodeSummary`, `WorkloadSelector`, `WorkloadSummary`,
   `ExecutionSummary`;
 - `ExecutionGeneration`, `ExecAttachMode`, `ExecStartRequest`,
@@ -40,6 +40,8 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
   printable-ASCII tokens without spaces.
 - Capabilities are positive assertions. Missing capability means typed
   refusal, not fallback.
+- `CapabilityNegotiation` carries a schema version and deterministic
+  bounded fingerprint for audit correlation.
 - Mutating operation requests require an idempotency key at decode.
 - Durable execution roots carry bounded metadata only. Reconnects are
   generation-bound, retained log requests require a non-zero byte bound,

--- a/packages/nixling-constellation-codec-protobuf/src/lib.rs
+++ b/packages/nixling-constellation-codec-protobuf/src/lib.rs
@@ -1,11 +1,11 @@
 //! Protobuf `ProtocolCodec` implementation for ADR 0032 constellation frames.
 
 use nixling_constellation_core::{
-    AdmissionAuditRecord, AuthorizationScope, AuthzDecision, Capability, ConstellationError,
-    ConstellationFrame, ErrorKind, Handshake, HandshakeAccepted, HandshakeRejected,
-    HandshakeRejectedReason, IdempotencyKey, NodeId, OpaquePayload, OperationId, OperationKind,
-    OperationRequest, OperationResponse, PeerContext, PrincipalId, ProtocolToken, RealmId,
-    RealmPath, StreamAuthz, StreamChannel, StreamClose, StreamCloseReason, StreamCursor,
+    AdmissionAuditRecord, AuthorizationScope, AuthzDecision, Capability, CapabilityNegotiation,
+    CapabilitySet, ConstellationError, ConstellationFrame, ErrorKind, Handshake, HandshakeAccepted,
+    HandshakeRejected, HandshakeRejectedReason, IdempotencyKey, NodeId, OpaquePayload, OperationId,
+    OperationKind, OperationRequest, OperationResponse, PeerContext, PrincipalId, ProtocolToken,
+    RealmId, RealmPath, StreamAuthz, StreamChannel, StreamClose, StreamCloseReason, StreamCursor,
     StreamData, StreamDescriptor, StreamFlow, StreamId, StreamKind, StreamOpen, StreamResume,
     TraceContext, WorkloadId,
 };
@@ -17,7 +17,7 @@ use prost::Message;
 pub const CODEC_ID: &str = "protobuf.v1";
 
 /// Deterministic fingerprint for the hand-authored prost schema in this crate.
-pub const SCHEMA_FINGERPRINT: &str = "pb.v1:f12:h4:op14:sk12:err19:audit11";
+pub const SCHEMA_FINGERPRINT: &str = "pb.v1:f12:h6:op14:sk12:err19:audit11:cap1";
 
 /// A prost-backed constellation frame codec.
 #[derive(Debug, Clone, Copy, Default)]
@@ -106,6 +106,12 @@ struct ProtoHandshake {
     peer: Option<ProtoPeerContext>,
     #[prost(string, tag = "4")]
     schema_fingerprint: String,
+    #[prost(int32, repeated, tag = "5")]
+    capabilities: Vec<i32>,
+    #[prost(uint32, tag = "6")]
+    capability_schema_version: u32,
+    #[prost(string, tag = "7")]
+    capability_fingerprint: String,
 }
 
 #[derive(Clone, PartialEq, prost::Message)]
@@ -234,6 +240,8 @@ struct ProtoError {
     capability: Option<i32>,
     #[prost(string, optional, tag = "3")]
     message: Option<String>,
+    #[prost(string, optional, tag = "4")]
+    negotiated_capability_fingerprint: Option<String>,
 }
 
 #[derive(Clone, PartialEq, prost::Message)]
@@ -302,10 +310,10 @@ struct ProtoUnit {}
 fn encode_proto_frame(frame: &ConstellationFrame) -> Result<ProtoFrame, ConstellationError> {
     let body = match frame {
         ConstellationFrame::Handshake(frame) => {
-            proto_frame::Body::Handshake(encode_handshake(frame))
+            proto_frame::Body::Handshake(encode_handshake(frame)?)
         }
         ConstellationFrame::HandshakeAccepted(frame) => {
-            proto_frame::Body::HandshakeAccepted(encode_handshake_accepted(frame))
+            proto_frame::Body::HandshakeAccepted(encode_handshake_accepted(frame)?)
         }
         ConstellationFrame::HandshakeRejected(frame) => {
             proto_frame::Body::HandshakeRejected(encode_handshake_rejected(frame)?)
@@ -385,13 +393,21 @@ fn decode_proto_frame(frame: ProtoFrame) -> Result<ConstellationFrame, Constella
     }
 }
 
-fn encode_handshake(frame: &Handshake) -> ProtoHandshake {
-    ProtoHandshake {
+fn encode_handshake(frame: &Handshake) -> Result<ProtoHandshake, ConstellationError> {
+    Ok(ProtoHandshake {
         protocol_version: Some(frame.protocol_version),
         codec_id: frame.codec_id.as_str().to_owned(),
         schema_fingerprint: frame.schema_fingerprint.as_str().to_owned(),
+        capabilities: frame
+            .capabilities
+            .capabilities
+            .iter()
+            .map(encode_capability)
+            .collect::<Result<Vec<_>, _>>()?,
+        capability_schema_version: frame.capabilities.schema_version,
+        capability_fingerprint: frame.capabilities.fingerprint.clone(),
         peer: frame.peer.as_ref().map(encode_peer_context),
-    }
+    })
 }
 
 fn decode_handshake(frame: ProtoHandshake) -> Result<Handshake, ConstellationError> {
@@ -404,14 +420,56 @@ fn decode_handshake(frame: ProtoHandshake) -> Result<Handshake, ConstellationErr
             frame.schema_fingerprint,
             "handshake schema_fingerprint",
         )?,
+        capabilities: decode_capability_negotiation(
+            frame.capabilities,
+            frame.capability_schema_version,
+            frame.capability_fingerprint,
+        )?,
         peer: frame.peer.map(decode_peer_context).transpose()?,
     })
 }
 
-fn encode_handshake_accepted(frame: &HandshakeAccepted) -> ProtoHandshakeAccepted {
-    ProtoHandshakeAccepted {
-        selected: Some(encode_handshake(&frame.selected)),
+fn decode_capability_negotiation(
+    capabilities: Vec<i32>,
+    schema_version: u32,
+    fingerprint: String,
+) -> Result<CapabilityNegotiation, ConstellationError> {
+    let wire_fingerprint = parse_protocol_token(fingerprint, "handshake capability_fingerprint")?;
+    let mut saw_unknown = false;
+    let caps = capabilities.into_iter().filter_map(|raw| {
+        let decoded = decode_capability(raw);
+        if decoded.is_none() {
+            saw_unknown = true;
+        }
+        decoded
+    });
+    let capabilities = CapabilitySet::from_caps(caps);
+    let expected = capabilities.stable_fingerprint();
+    if schema_version
+        != nixling_constellation_core::capability::CAPABILITY_NEGOTIATION_SCHEMA_VERSION
+    {
+        return Err(malformed(
+            "handshake capability negotiation schema version mismatch",
+        ));
     }
+    if !saw_unknown && wire_fingerprint.as_str() != expected {
+        return Err(malformed(
+            "handshake capability negotiation fingerprint mismatch",
+        ));
+    }
+    Ok(CapabilityNegotiation {
+        schema_version,
+        capabilities,
+        fingerprint: expected,
+    })
+}
+
+fn encode_handshake_accepted(
+    frame: &HandshakeAccepted,
+) -> Result<ProtoHandshakeAccepted, ConstellationError> {
+    Ok(ProtoHandshakeAccepted {
+        selected: Some(encode_handshake(&frame.selected)?),
+    })
 }
 
 fn decode_handshake_accepted(
@@ -595,7 +653,7 @@ fn decode_stream_authz(authz: ProtoStreamAuthz) -> Result<StreamAuthz, Constella
     Ok(StreamAuthz {
         principal: parse_principal_id(authz.principal, "stream_authz principal")?,
         realm: decode_realm(authz.realm, "stream_authz realm")?,
-        capability: decode_capability(authz.capability)?,
+        capability: decode_capability_strict(authz.capability)?,
     })
 }
 
@@ -675,12 +733,15 @@ fn encode_error(error: &ConstellationError) -> Result<ProtoError, ConstellationE
             .map(encode_capability)
             .transpose()?,
         message: Some(error.message().to_owned()),
+        negotiated_capability_fingerprint: error
+            .negotiated_capability_fingerprint()
+            .map(ToOwned::to_owned),
     })
 }
 
 fn decode_error(error: ProtoError) -> Result<ConstellationError, ConstellationError> {
     let kind = decode_error_kind(error.kind)?;
-    let capability = error.capability.map(decode_capability).transpose()?;
+    let capability = error.capability.map(decode_capability_strict).transpose()?;
     let message = error
         .message
         .ok_or_else(|| malformed("typed_error message is missing"))?;
@@ -688,16 +749,19 @@ fn decode_error(error: ProtoError) -> Result<ConstellationError, ConstellationEr
         let capability = capability.ok_or_else(|| {
             malformed("capability-denied typed_error is missing the capability field")
         })?;
-        let decoded = ConstellationError::capability_denied(capability);
+        let decoded = ConstellationError::capability_denied_with_fingerprint(
+            capability,
+            error.negotiated_capability_fingerprint,
+        );
         if decoded.message() != message {
             return Err(malformed(
                 "capability-denied typed_error message is not canonical",
             ));
         }
         Ok(decoded)
-    } else if capability.is_some() {
+    } else if capability.is_some() || error.negotiated_capability_fingerprint.is_some() {
         Err(malformed(
-            "non-capability-denied typed_error carries a capability field",
+            "non-capability-denied typed_error carries capability-denial context",
         ))
     } else {
         Ok(ConstellationError::new(kind, message))
@@ -786,7 +850,7 @@ fn decode_authorization_scope(
         .ok_or_else(|| malformed("authorization scope body is missing"))?
     {
         proto_authorization_scope::Scope::Capability(capability) => Ok(
-            AuthorizationScope::capability(decode_capability(capability)?),
+            AuthorizationScope::capability(decode_capability_strict(capability)?),
         ),
         proto_authorization_scope::Scope::NodeControl(_) => Ok(AuthorizationScope::NodeControl),
         proto_authorization_scope::Scope::Enrollment(_) => Ok(AuthorizationScope::Enrollment),
@@ -860,6 +924,7 @@ fn encode_handshake_rejection(reason: HandshakeRejectedReason) -> i32 {
         HandshakeRejectedReason::SchemaFingerprintMismatch => 3,
         HandshakeRejectedReason::ChannelBindingMismatch => 4,
         HandshakeRejectedReason::MalformedHandshake => 5,
+        HandshakeRejectedReason::CapabilityMismatch => 6,
     }
 }
 
@@ -870,6 +935,7 @@ fn decode_handshake_rejection(raw: i32) -> Result<HandshakeRejectedReason, Const
         3 => Ok(HandshakeRejectedReason::SchemaFingerprintMismatch),
         4 => Ok(HandshakeRejectedReason::ChannelBindingMismatch),
         5 => Ok(HandshakeRejectedReason::MalformedHandshake),
+        6 => Ok(HandshakeRejectedReason::CapabilityMismatch),
         _ => Err(malformed(format!(
             "unknown handshake rejection value {raw}"
         ))),
@@ -1018,30 +1084,34 @@ fn encode_capability(capability: Capability) -> Result<i32, ConstellationError> 
     })
 }
 
-fn decode_capability(raw: i32) -> Result<Capability, ConstellationError> {
+fn decode_capability(raw: i32) -> Option<Capability> {
     match raw {
-        1 => Ok(Capability::Lifecycle),
-        2 => Ok(Capability::Exec),
-        3 => Ok(Capability::Pty),
-        4 => Ok(Capability::Logs),
-        5 => Ok(Capability::FileCopy),
-        6 => Ok(Capability::PortForward),
-        7 => Ok(Capability::Vsock),
-        8 => Ok(Capability::Virtiofs),
-        9 => Ok(Capability::WindowForwarding),
-        10 => Ok(Capability::DisplayStreaming),
-        11 => Ok(Capability::Clipboard),
-        12 => Ok(Capability::AudioPlayback),
-        13 => Ok(Capability::AudioCapture),
-        14 => Ok(Capability::Hid),
-        15 => Ok(Capability::Usb),
-        16 => Ok(Capability::GpuAccel),
-        17 => Ok(Capability::Snapshots),
-        18 => Ok(Capability::Hotplug),
-        19 => Ok(Capability::EphemeralSessions),
-        20 => Ok(Capability::ProviderManagedIsolation),
-        _ => Err(malformed(format!("unknown capability value {raw}"))),
+        1 => Some(Capability::Lifecycle),
+        2 => Some(Capability::Exec),
+        3 => Some(Capability::Pty),
+        4 => Some(Capability::Logs),
+        5 => Some(Capability::FileCopy),
+        6 => Some(Capability::PortForward),
+        7 => Some(Capability::Vsock),
+        8 => Some(Capability::Virtiofs),
+        9 => Some(Capability::WindowForwarding),
+        10 => Some(Capability::DisplayStreaming),
+        11 => Some(Capability::Clipboard),
+        12 => Some(Capability::AudioPlayback),
+        13 => Some(Capability::AudioCapture),
+        14 => Some(Capability::Hid),
+        15 => Some(Capability::Usb),
+        16 => Some(Capability::GpuAccel),
+        17 => Some(Capability::Snapshots),
+        18 => Some(Capability::Hotplug),
+        19 => Some(Capability::EphemeralSessions),
+        20 => Some(Capability::ProviderManagedIsolation),
+        _ => None,
     }
+}
+
+fn decode_capability_strict(raw: i32) -> Result<Capability, ConstellationError> {
+    decode_capability(raw).ok_or_else(|| malformed(format!("unknown capability value {raw}")))
 }
 
 fn encode_error_kind(kind: ErrorKind) -> Result<i32, ConstellationError> {
@@ -1205,6 +1275,37 @@ mod tests {
     }
 
     #[test]
+    fn protobuf_decode_ignores_unknown_advertised_capabilities() {
+        let codec = ProtobufCodec::new();
+        let encoded = ProtoFrame {
+            body: Some(proto_frame::Body::Handshake(ProtoHandshake {
+                protocol_version: Some(1),
+                codec_id: CODEC_ID.to_owned(),
+                schema_fingerprint: SCHEMA_FINGERPRINT.to_owned(),
+                capabilities: vec![encode_capability(Capability::Exec).unwrap(), 999],
+                capability_schema_version:
+                    nixling_constellation_core::capability::CAPABILITY_NEGOTIATION_SCHEMA_VERSION,
+                capability_fingerprint: "cap-v1-future999".to_owned(),
+                peer: None,
+            })),
+        }
+        .encode_to_vec();
+
+        let decoded = codec.decode_frame(&encoded).unwrap();
+        let ConstellationFrame::Handshake(handshake) = decoded else {
+            panic!("expected handshake frame");
+        };
+        assert!(handshake.capabilities.capabilities.has(Capability::Exec));
+        assert!(!handshake.capabilities.capabilities.has(Capability::Logs));
+        assert_eq!(
+            handshake.capabilities.fingerprint,
+            CapabilitySet::empty()
+                .with(Capability::Exec)
+                .stable_fingerprint()
+        );
+    }
+
+    #[test]
     fn protobuf_decode_rejects_unknown_handshake_rejection_reason() {
         let codec = ProtobufCodec::new();
         let invalid = ProtoFrame {
@@ -1327,6 +1428,10 @@ mod tests {
                 protocol_version: 1,
                 codec_id: token(CODEC_ID),
                 schema_fingerprint: token(SCHEMA_FINGERPRINT),
+                capabilities: CapabilitySet::empty()
+                    .with(Capability::Exec)
+                    .with(Capability::WindowForwarding)
+                    .negotiation(),
                 peer: Some(PeerContext {
                     auth_mechanism: token("none"),
                     peer_principal: Some(principal.clone()),
@@ -1338,6 +1443,7 @@ mod tests {
                     protocol_version: 1,
                     codec_id: token(CODEC_ID),
                     schema_fingerprint: token(SCHEMA_FINGERPRINT),
+                    capabilities: CapabilitySet::empty().negotiation(),
                     peer: None,
                 },
             }),

--- a/packages/nixling-constellation-core/src/capability.rs
+++ b/packages/nixling-constellation-core/src/capability.rs
@@ -2,24 +2,27 @@
 //! assertions**: a node/provider advertises exactly what it supports, and
 //! an absent capability means a typed refusal, never a silent fallback.
 
-use serde::{Deserialize, Serialize};
+use crate::token::ProtocolToken;
+use schemars::{
+    JsonSchema,
+    r#gen::SchemaGenerator,
+    schema::{ArrayValidation, InstanceType, Schema, SchemaObject, SingleOrVec},
+};
+use serde::de::{SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeSet;
+use std::fmt;
+
+/// Schema version for capability negotiation metadata.
+pub const CAPABILITY_NEGOTIATION_SCHEMA_VERSION: u32 = 1;
+/// Maximum number of capability assertions accepted from a peer.
+pub const MAX_CAPABILITY_SET_LEN: usize = 64;
 
 /// A named, independently-authorized capability. Display, clipboard,
 /// audio, HID, and USB are deliberately distinct so display forwarding
 /// cannot smuggle clipboard or device access.
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    schemars::JsonSchema,
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum Capability {
@@ -92,11 +95,41 @@ impl Capability {
             Capability::ProviderManagedIsolation => "provider-managed-isolation",
         }
     }
+
+    /// Parse a stable capability code. Unknown capability strings are not
+    /// errors at the capability-set boundary; older peers ignore them during
+    /// negotiation so forward-compatible advertisements do not drop a whole
+    /// session.
+    pub fn from_code(code: &str) -> Option<Self> {
+        match code {
+            "lifecycle" => Some(Capability::Lifecycle),
+            "exec" => Some(Capability::Exec),
+            "pty" => Some(Capability::Pty),
+            "logs" => Some(Capability::Logs),
+            "file-copy" => Some(Capability::FileCopy),
+            "port-forward" => Some(Capability::PortForward),
+            "vsock" => Some(Capability::Vsock),
+            "virtiofs" => Some(Capability::Virtiofs),
+            "window-forwarding" => Some(Capability::WindowForwarding),
+            "display-streaming" => Some(Capability::DisplayStreaming),
+            "clipboard" => Some(Capability::Clipboard),
+            "audio-playback" => Some(Capability::AudioPlayback),
+            "audio-capture" => Some(Capability::AudioCapture),
+            "hid" => Some(Capability::Hid),
+            "usb" => Some(Capability::Usb),
+            "gpu-accel" => Some(Capability::GpuAccel),
+            "snapshots" => Some(Capability::Snapshots),
+            "hotplug" => Some(Capability::Hotplug),
+            "ephemeral-sessions" => Some(Capability::EphemeralSessions),
+            "provider-managed-isolation" => Some(Capability::ProviderManagedIsolation),
+            _ => None,
+        }
+    }
 }
 
 /// A set of advertised capabilities. Routing is by required capability;
 /// callers fail closed when a required capability is absent.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct CapabilitySet(BTreeSet<Capability>);
 
@@ -126,6 +159,41 @@ impl CapabilitySet {
     pub fn iter(&self) -> impl Iterator<Item = Capability> + '_ {
         self.0.iter().copied()
     }
+
+    /// Deterministic low-cardinality fingerprint for audit/negotiation.
+    pub fn stable_fingerprint(&self) -> String {
+        let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+        let mut codes = self.iter().map(Capability::code).collect::<Vec<_>>();
+        codes.sort_unstable();
+        for code in codes {
+            for byte in code.as_bytes() {
+                hash ^= u64::from(*byte);
+                hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+            }
+            hash ^= 0xff;
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        format!("cap-v{CAPABILITY_NEGOTIATION_SCHEMA_VERSION}-{hash:016x}")
+    }
+
+    /// Build a versioned, auditable negotiation record.
+    pub fn negotiation(&self) -> CapabilityNegotiation {
+        CapabilityNegotiation {
+            schema_version: CAPABILITY_NEGOTIATION_SCHEMA_VERSION,
+            capabilities: self.clone(),
+            fingerprint: self.stable_fingerprint(),
+        }
+    }
+
+    /// Capabilities shared with `other`.
+    pub fn intersection(&self, other: &Self) -> Self {
+        Self(self.0.intersection(&other.0).copied().collect())
+    }
+
+    /// True iff every advertised capability is also present in `other`.
+    pub fn is_subset_of(&self, other: &Self) -> bool {
+        self.0.is_subset(&other.0)
+    }
 }
 
 impl FromIterator<Capability> for CapabilitySet {
@@ -134,9 +202,107 @@ impl FromIterator<Capability> for CapabilitySet {
     }
 }
 
+impl<'de> Deserialize<'de> for CapabilitySet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CapabilitySetVisitor;
+
+        impl<'de> Visitor<'de> for CapabilitySetVisitor {
+            type Value = CapabilitySet;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "a bounded capability-code array")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut count = 0_usize;
+                let mut caps = BTreeSet::new();
+                while let Some(capability) = seq.next_element::<ProtocolToken>()? {
+                    count += 1;
+                    if count > MAX_CAPABILITY_SET_LEN {
+                        return Err(serde::de::Error::custom(format!(
+                            "capability set exceeds {MAX_CAPABILITY_SET_LEN} entries"
+                        )));
+                    }
+                    if let Some(capability) = Capability::from_code(capability.as_str()) {
+                        caps.insert(capability);
+                    }
+                }
+                Ok(CapabilitySet(caps))
+            }
+        }
+
+        deserializer.deserialize_seq(CapabilitySetVisitor)
+    }
+}
+
+impl JsonSchema for CapabilitySet {
+    fn schema_name() -> String {
+        "CapabilitySet".to_owned()
+    }
+
+    fn json_schema(r#gen: &mut SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Array))),
+            array: Some(Box::new(ArrayValidation {
+                items: Some(SingleOrVec::Single(Box::new(
+                    r#gen.subschema_for::<ProtocolToken>(),
+                ))),
+                max_items: Some(MAX_CAPABILITY_SET_LEN as u32),
+                unique_items: Some(true),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Versioned negotiated capability set. The fingerprint is deterministic and
+/// bounded so audit records can cite the negotiated set without expanding it
+/// into every event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityNegotiation {
+    /// Capability negotiation schema version.
+    pub schema_version: u32,
+    /// Positive capability assertions.
+    pub capabilities: CapabilitySet,
+    /// Deterministic bounded fingerprint of `capabilities`.
+    #[schemars(length(max = 64))]
+    pub fingerprint: String,
+}
+
+impl<'de> Deserialize<'de> for CapabilityNegotiation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Raw {
+            schema_version: u32,
+            capabilities: CapabilitySet,
+            fingerprint: ProtocolToken,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        Ok(Self {
+            schema_version: raw.schema_version,
+            capabilities: raw.capabilities,
+            fingerprint: raw.fingerprint.as_str().to_owned(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::token::MAX_PROTOCOL_TOKEN_LEN;
 
     #[test]
     fn absent_capability_is_not_advertised() {
@@ -147,5 +313,70 @@ mod tests {
         let disp = CapabilitySet::from_iter([Capability::WindowForwarding]);
         assert!(disp.has(Capability::WindowForwarding));
         assert!(!disp.has(Capability::Clipboard));
+    }
+
+    #[test]
+    fn capability_set_decode_ignores_unknown_future_capabilities() {
+        let caps: CapabilitySet =
+            serde_json::from_str("[\"exec\",\"future-capability\",\"logs\"]").unwrap();
+        assert!(caps.has(Capability::Exec));
+        assert!(caps.has(Capability::Logs));
+        assert!(!caps.has(Capability::Clipboard));
+    }
+
+    #[test]
+    fn capability_set_decode_rejects_unbounded_inputs() {
+        let overlong = format!("[\"{}\"]", "x".repeat(MAX_PROTOCOL_TOKEN_LEN + 1));
+        assert!(serde_json::from_str::<CapabilitySet>(&overlong).is_err());
+
+        let too_many = format!(
+            "[{}]",
+            std::iter::repeat_n("\"exec\"", MAX_CAPABILITY_SET_LEN + 1)
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        assert!(serde_json::from_str::<CapabilitySet>(&too_many).is_err());
+    }
+
+    #[test]
+    fn capability_negotiation_decode_allows_unknown_future_fields() {
+        let caps: CapabilityNegotiation = serde_json::from_str(
+            "{\"schemaVersion\":1,\"capabilities\":[\"exec\"],\
+             \"fingerprint\":\"cap-v1-af63bd4c8601b7df\",\"futureField\":true}",
+        )
+        .unwrap();
+        assert!(caps.capabilities.has(Capability::Exec));
+    }
+
+    #[test]
+    fn capability_negotiation_decode_bounds_fingerprint() {
+        let json = format!(
+            "{{\"schemaVersion\":1,\"capabilities\":[],\"fingerprint\":\"{}\"}}",
+            "x".repeat(MAX_PROTOCOL_TOKEN_LEN + 1)
+        );
+        assert!(serde_json::from_str::<CapabilityNegotiation>(&json).is_err());
+    }
+
+    #[test]
+    fn stable_fingerprint_orders_by_capability_code() {
+        let a = CapabilitySet::from_caps([Capability::Logs, Capability::Exec]);
+        let b = CapabilitySet::from_caps([Capability::Exec, Capability::Logs]);
+        assert_eq!(a.stable_fingerprint(), b.stable_fingerprint());
+    }
+
+    #[test]
+    fn capability_fingerprint_is_stable_and_order_independent() {
+        let a = CapabilitySet::from_caps([Capability::Exec, Capability::Logs]);
+        let b = CapabilitySet::from_caps([Capability::Logs, Capability::Exec]);
+        let c = CapabilitySet::from_caps([Capability::Exec]);
+        assert_eq!(a.stable_fingerprint(), b.stable_fingerprint());
+        assert_ne!(a.stable_fingerprint(), c.stable_fingerprint());
+        let negotiation = a.negotiation();
+        assert_eq!(
+            negotiation.schema_version,
+            CAPABILITY_NEGOTIATION_SCHEMA_VERSION
+        );
+        assert_eq!(negotiation.fingerprint, a.stable_fingerprint());
+        assert!(negotiation.fingerprint.len() < 32);
     }
 }

--- a/packages/nixling-constellation-core/src/error.rs
+++ b/packages/nixling-constellation-core/src/error.rs
@@ -94,6 +94,8 @@ impl ErrorKind {
 /// constructed by trusted code and never carry payload, but the length is
 /// bounded so a message can never become an unbounded side channel.
 pub const MAX_MESSAGE_LEN: usize = 256;
+/// Maximum length of a bounded capability-negotiation fingerprint.
+pub const MAX_FINGERPRINT_LEN: usize = 64;
 
 /// A typed constellation error: a [`ErrorKind`], an optional structured
 /// missing capability (for `CapabilityDenied`), plus a bounded,
@@ -111,6 +113,10 @@ pub struct ConstellationError {
     /// so callers route on a stable field rather than parsing the message.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     capability: Option<Capability>,
+    /// Fingerprint of the negotiated capability set used for the denial.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[schemars(length(max = 64))]
+    negotiated_capability_fingerprint: Option<String>,
     /// Bounded operator-actionable message (no payload/secrets).
     #[schemars(length(max = 256))]
     message: String,
@@ -138,6 +144,7 @@ impl ConstellationError {
         Self {
             kind,
             capability: None,
+            negotiated_capability_fingerprint: None,
             message: bound_message(message.into()),
         }
     }
@@ -145,9 +152,19 @@ impl ConstellationError {
     /// Convenience: a capability-denied error carrying the structured
     /// missing capability (the capability name is not a secret).
     pub fn capability_denied(missing: Capability) -> Self {
+        Self::capability_denied_with_fingerprint(missing, None)
+    }
+
+    /// Capability-denied error with the negotiated set fingerprint that
+    /// produced the refusal.
+    pub fn capability_denied_with_fingerprint(
+        missing: Capability,
+        negotiated_fingerprint: impl Into<Option<String>>,
+    ) -> Self {
         Self {
             kind: ErrorKind::CapabilityDenied,
             capability: Some(missing),
+            negotiated_capability_fingerprint: negotiated_fingerprint.into().map(bound_fingerprint),
             message: bound_message(format!(
                 "required capability {} is not advertised",
                 missing.code()
@@ -164,6 +181,11 @@ impl ConstellationError {
     /// Guaranteed `Some` whenever [`kind`](Self::kind) is `CapabilityDenied`.
     pub fn missing_capability(&self) -> Option<Capability> {
         self.capability
+    }
+
+    /// Fingerprint of the negotiated capability set used for this denial.
+    pub fn negotiated_capability_fingerprint(&self) -> Option<&str> {
+        self.negotiated_capability_fingerprint.as_deref()
     }
 
     /// The bounded, operator-safe message.
@@ -186,6 +208,8 @@ impl<'de> Deserialize<'de> for ConstellationError {
             kind: ErrorKind,
             #[serde(default)]
             capability: Option<Capability>,
+            #[serde(default)]
+            negotiated_capability_fingerprint: Option<String>,
             message: String,
         }
         let raw = Raw::deserialize(deserializer)?;
@@ -194,9 +218,19 @@ impl<'de> Deserialize<'de> for ConstellationError {
                 "capability-denied error must carry the missing capability",
             ));
         }
+        if raw.kind != ErrorKind::CapabilityDenied
+            && raw.negotiated_capability_fingerprint.is_some()
+        {
+            return Err(serde::de::Error::custom(
+                "only capability-denied errors may carry a negotiated capability fingerprint",
+            ));
+        }
         Ok(Self {
             kind: raw.kind,
             capability: raw.capability,
+            negotiated_capability_fingerprint: raw
+                .negotiated_capability_fingerprint
+                .map(bound_fingerprint),
             message: bound_message(raw.message),
         })
     }
@@ -206,6 +240,17 @@ impl<'de> Deserialize<'de> for ConstellationError {
 fn bound_message(mut s: String) -> String {
     if s.len() > MAX_MESSAGE_LEN {
         let mut end = MAX_MESSAGE_LEN;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
+    }
+    s
+}
+
+fn bound_fingerprint(mut s: String) -> String {
+    if s.len() > MAX_FINGERPRINT_LEN {
+        let mut end = MAX_FINGERPRINT_LEN;
         while end > 0 && !s.is_char_boundary(end) {
             end -= 1;
         }
@@ -232,6 +277,18 @@ mod tests {
         assert_eq!(e.kind(), ErrorKind::CapabilityDenied);
         assert_eq!(e.missing_capability(), Some(Capability::WindowForwarding));
         assert!(e.message().contains("window-forwarding"));
+    }
+
+    #[test]
+    fn capability_denied_can_carry_negotiated_fingerprint() {
+        let e = ConstellationError::capability_denied_with_fingerprint(
+            Capability::WindowForwarding,
+            Some("cap-v1-cbf29ce484222325".to_owned()),
+        );
+        assert_eq!(
+            e.negotiated_capability_fingerprint(),
+            Some("cap-v1-cbf29ce484222325")
+        );
     }
 
     #[test]

--- a/packages/nixling-constellation-core/src/frame.rs
+++ b/packages/nixling-constellation-core/src/frame.rs
@@ -4,7 +4,7 @@
 //! encoding (`prost`, protobuf-generated types, etc.).
 
 use crate::audit::AdmissionAuditRecord;
-use crate::capability::Capability;
+use crate::capability::{Capability, CapabilityNegotiation};
 use crate::error::ConstellationError;
 use crate::ids::{
     IdempotencyKey, NodeId, OperationId, PrincipalId, StreamCursor, StreamId, WorkloadId,
@@ -46,6 +46,8 @@ pub struct Handshake {
     pub codec_id: ProtocolToken,
     /// Codec schema fingerprint selected for this session (bounded token).
     pub schema_fingerprint: ProtocolToken,
+    /// Versioned positive capability assertions negotiated for this session.
+    pub capabilities: CapabilityNegotiation,
     /// Reserved peer-binding seam. Absent in the bootstrap protocol.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub peer: Option<PeerContext>,
@@ -67,6 +69,7 @@ pub enum HandshakeRejectedReason {
     VersionSkew,
     CodecMismatch,
     SchemaFingerprintMismatch,
+    CapabilityMismatch,
     ChannelBindingMismatch,
     MalformedHandshake,
 }
@@ -385,9 +388,9 @@ pub struct StreamData {
 ///
 /// The mux is credit-based: a sender may only emit a [`StreamData`] chunk
 /// while it holds positive credit, and the receiver replenishes budget by
-/// sending `StreamFlow`. Credit is counted in **frames** (not bytes) for
-/// P0; a chunk is already bounded by the frame cap. A grant of `0` is a
-/// no-op and is rejected at decode so a peer cannot use it to mask a stall.
+/// sending `StreamFlow`. Credit is counted in **frames** (not bytes); a
+/// chunk is already bounded by the frame cap. A grant of `0` is a no-op and
+/// is rejected at decode so a peer cannot use it to mask a stall.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct StreamFlow {
@@ -499,7 +502,8 @@ mod tests {
         let accepted = "{\"frame\":\"handshake-accepted\",\"selected\":{\
                         \"protocol_version\":1,\
                         \"codec_id\":\"protobuf.v1\",\
-                        \"schema_fingerprint\":\"pb.v1:schema\"}}";
+                        \"schema_fingerprint\":\"pb.v1:schema\",\
+                        \"capabilities\":{\"schemaVersion\":1,\"capabilities\":[],\"fingerprint\":\"cap-v1-cbf29ce484222325\"}}}";
         assert!(serde_json::from_str::<ConstellationFrame>(accepted).is_ok());
 
         let rejected = "{\"frame\":\"handshake-rejected\",\"reason\":\"codec-mismatch\"}";
@@ -508,7 +512,8 @@ mod tests {
         let accepted_extra = "{\"frame\":\"handshake-accepted\",\"selected\":{\
                               \"protocol_version\":1,\
                               \"codec_id\":\"protobuf.v1\",\
-                              \"schema_fingerprint\":\"pb.v1:schema\"},\
+                              \"schema_fingerprint\":\"pb.v1:schema\",\
+                              \"capabilities\":{\"schemaVersion\":1,\"capabilities\":[],\"fingerprint\":\"cap-v1-cbf29ce484222325\"}},\
                               \"extra\":true}";
         assert!(serde_json::from_str::<ConstellationFrame>(accepted_extra).is_err());
 
@@ -626,15 +631,18 @@ mod tests {
 
     #[test]
     fn handshake_codec_id_is_bounded_at_decode() {
-        let ok = "{\"protocol_version\":1,\"codec_id\":\"protobuf.v1\",\"schema_fingerprint\":\"schema1\"}";
+        let ok = "{\"protocol_version\":1,\"codec_id\":\"protobuf.v1\",\"schema_fingerprint\":\"schema1\",\
+                  \"capabilities\":{\"schemaVersion\":1,\"capabilities\":[],\"fingerprint\":\"cap-v1-cbf29ce484222325\"}}";
         assert!(serde_json::from_str::<Handshake>(ok).is_ok());
         let overlong_codec = format!(
-            "{{\"protocol_version\":1,\"codec_id\":\"{}\",\"schema_fingerprint\":\"schema1\"}}",
+            "{{\"protocol_version\":1,\"codec_id\":\"{}\",\"schema_fingerprint\":\"schema1\",\
+              \"capabilities\":{{\"schemaVersion\":1,\"capabilities\":[],\"fingerprint\":\"cap-v1-cbf29ce484222325\"}}}}",
             "x".repeat(200)
         );
         assert!(serde_json::from_str::<Handshake>(&overlong_codec).is_err());
         let overlong_schema = format!(
-            "{{\"protocol_version\":1,\"codec_id\":\"protobuf.v1\",\"schema_fingerprint\":\"{}\"}}",
+            "{{\"protocol_version\":1,\"codec_id\":\"protobuf.v1\",\"schema_fingerprint\":\"{}\",\
+              \"capabilities\":{{\"schemaVersion\":1,\"capabilities\":[],\"fingerprint\":\"cap-v1-cbf29ce484222325\"}}}}",
             "x".repeat(200)
         );
         assert!(serde_json::from_str::<Handshake>(&overlong_schema).is_err());

--- a/packages/nixling-constellation-core/src/lib.rs
+++ b/packages/nixling-constellation-core/src/lib.rs
@@ -32,7 +32,7 @@ pub mod trace_context;
 pub mod workload;
 
 pub use audit::{AdmissionAuditRecord, AuditEnvelope, AuthorizationScope, AuthzDecision};
-pub use capability::{Capability, CapabilitySet};
+pub use capability::{Capability, CapabilityNegotiation, CapabilitySet};
 pub use error::{ConstellationError, ErrorKind};
 pub use execution::{
     ExecAttachMode, ExecAttachRequest, ExecCancelRequest, ExecLogsRequest, ExecStartRequest,

--- a/packages/nixling-constellation-core/src/mux.rs
+++ b/packages/nixling-constellation-core/src/mux.rs
@@ -2,8 +2,8 @@
 //!
 //! No I/O lives here: the transport layer drives the mux by feeding it
 //! decoded [`crate::frame`] frames and emitting the control frames it asks
-//! for. The mux enforces the fail-closed multiplexing contract the P0
-//! design panel required *before* any Relay/Waypipe wiring exists:
+//! for. The mux enforces the fail-closed multiplexing contract before
+//! any Relay/Waypipe wiring exists:
 //!
 //! - a stream must be **opened** (authz-consistent, operation-bound) before
 //!   any data flows on it;
@@ -25,6 +25,7 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::Bound::{Excluded, Unbounded};
 
+use crate::capability::CapabilitySet;
 use crate::error::{ConstellationError, ErrorKind};
 use crate::frame::{StreamClose, StreamData, StreamFlow, StreamOpen, StreamResume};
 use crate::ids::{OperationId, StreamId};
@@ -121,7 +122,8 @@ impl StreamMux {
         self.streams.get(stream).and_then(|e| e.close_reason)
     }
 
-    /// Register a newly-opened stream.
+    /// Register a newly-opened stream after checking the negotiated
+    /// capability set.
     ///
     /// Fails closed when the open is authz-inconsistent (capability does
     /// not match the descriptor kind), when the stream id is already in
@@ -129,11 +131,21 @@ impl StreamMux {
     /// starts with **zero** credit in both directions: the receiver must
     /// [`grant_inbound`](Self::grant_inbound) before the peer may send, and
     /// this endpoint may only send after it [`receive_flow`](Self::receive_flow)s.
-    pub fn open(&mut self, open: &StreamOpen) -> Result<(), ConstellationError> {
+    pub fn open_with_capabilities(
+        &mut self,
+        open: &StreamOpen,
+        capabilities: &CapabilitySet,
+    ) -> Result<(), ConstellationError> {
         if !open.is_consistent() {
             return Err(ConstellationError::new(
                 ErrorKind::Unauthorized,
                 "stream open authz capability does not match the descriptor kind",
+            ));
+        }
+        if !capabilities.has(open.authz.capability) {
+            return Err(ConstellationError::capability_denied_with_fingerprint(
+                open.authz.capability,
+                Some(capabilities.stable_fingerprint()),
             ));
         }
         let id = &open.descriptor.id;
@@ -179,6 +191,7 @@ impl StreamMux {
                 "credit grant must be non-zero",
             ));
         }
+
         let entry = self.open_entry_mut(stream)?;
         entry.recv_credit = entry.recv_credit.saturating_add(u64::from(credits));
         Ok(StreamFlow {
@@ -446,6 +459,15 @@ mod tests {
         }
     }
 
+    fn caps_for(kind: StreamKind) -> CapabilitySet {
+        CapabilitySet::empty().with(kind.required_capability())
+    }
+
+    fn open_ok(mux: &mut StreamMux, id: &str, kind: StreamKind) {
+        let open = open_frame(id, kind);
+        mux.open_with_capabilities(&open, &caps_for(kind)).unwrap();
+    }
+
     fn data(id: &str, sequence: u64, channel: StreamChannel) -> StreamData {
         StreamData {
             stream: sid(id),
@@ -459,7 +481,7 @@ mod tests {
     #[test]
     fn open_then_credit_then_sequential_data_is_accepted() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         assert!(mux.is_open(&sid("s1")));
         // No credit yet: data is refused (backpressure).
         let err = mux
@@ -494,7 +516,7 @@ mod tests {
     #[test]
     fn sequence_gap_and_replay_are_rejected() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         mux.grant_inbound(&sid("s1"), 8).unwrap();
         mux.accept_data(&data("s1", 0, StreamChannel::Primary))
             .unwrap();
@@ -517,7 +539,7 @@ mod tests {
     #[test]
     fn channel_must_match_kind() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("disp", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "disp", StreamKind::Display);
         mux.grant_inbound(&sid("disp"), 4).unwrap();
         // Display is Primary-only: stdout is rejected.
         assert_eq!(
@@ -527,7 +549,7 @@ mod tests {
             ErrorKind::MalformedFrame
         );
 
-        mux.open(&open_frame("io", StreamKind::Stdio)).unwrap();
+        open_ok(&mut mux, "io", StreamKind::Stdio);
         mux.grant_inbound(&sid("io"), 4).unwrap();
         // Stdio must use Stdout/Stderr, not Primary.
         assert_eq!(
@@ -546,7 +568,7 @@ mod tests {
     #[test]
     fn cursor_only_on_logs() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("disp", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "disp", StreamKind::Display);
         mux.grant_inbound(&sid("disp"), 4).unwrap();
         let mut chunk = data("disp", 0, StreamChannel::Primary);
         chunk.cursor = Some(StreamCursor::parse("cur-1").unwrap());
@@ -555,7 +577,7 @@ mod tests {
             ErrorKind::MalformedFrame
         );
 
-        mux.open(&open_frame("logs", StreamKind::Logs)).unwrap();
+        open_ok(&mut mux, "logs", StreamKind::Logs);
         mux.grant_inbound(&sid("logs"), 4).unwrap();
         let mut log_chunk = data("logs", 0, StreamChannel::Primary);
         log_chunk.cursor = Some(StreamCursor::parse("cur-1").unwrap());
@@ -565,27 +587,57 @@ mod tests {
     #[test]
     fn duplicate_open_and_inconsistent_open_are_rejected() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         assert_eq!(
-            mux.open(&open_frame("s1", StreamKind::Display))
-                .unwrap_err()
-                .kind(),
+            mux.open_with_capabilities(
+                &open_frame("s1", StreamKind::Display),
+                &caps_for(StreamKind::Display)
+            )
+            .unwrap_err()
+            .kind(),
             ErrorKind::MalformedFrame
         );
         // An authz/kind-inconsistent open is refused.
         let mut bad = open_frame("s2", StreamKind::Display);
         bad.authz.capability = crate::capability::Capability::Clipboard;
-        assert_eq!(mux.open(&bad).unwrap_err().kind(), ErrorKind::Unauthorized);
+        assert_eq!(
+            mux.open_with_capabilities(&bad, &caps_for(StreamKind::Display))
+                .unwrap_err()
+                .kind(),
+            ErrorKind::Unauthorized
+        );
+    }
+
+    #[test]
+    fn stream_open_requires_negotiated_capability_before_state_mutation() {
+        let mut mux = StreamMux::new();
+        let open = open_frame("display", StreamKind::Display);
+        assert_eq!(
+            mux.open_with_capabilities(&open, &CapabilitySet::empty())
+                .unwrap_err()
+                .kind(),
+            ErrorKind::CapabilityDenied
+        );
+        assert_eq!(mux.open_stream_count(), 0);
+        mux.open_with_capabilities(
+            &open,
+            &CapabilitySet::empty().with(crate::capability::Capability::WindowForwarding),
+        )
+        .unwrap();
+        assert!(mux.is_open(&sid("display")));
     }
 
     #[test]
     fn open_stream_cap_is_enforced() {
         let mut mux = StreamMux::with_max_open(1);
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         assert_eq!(
-            mux.open(&open_frame("s2", StreamKind::Display))
-                .unwrap_err()
-                .kind(),
+            mux.open_with_capabilities(
+                &open_frame("s2", StreamKind::Display),
+                &caps_for(StreamKind::Display)
+            )
+            .unwrap_err()
+            .kind(),
             ErrorKind::Backpressure
         );
         // Closing s1 frees a slot.
@@ -594,13 +646,13 @@ mod tests {
             reason: StreamCloseReason::Completed,
         })
         .unwrap();
-        mux.open(&open_frame("s2", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s2", StreamKind::Display);
     }
 
     #[test]
     fn close_is_terminal_and_data_after_close_is_rejected() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         mux.grant_inbound(&sid("s1"), 4).unwrap();
         mux.close(&StreamClose {
             stream: sid("s1"),
@@ -639,7 +691,7 @@ mod tests {
     #[test]
     fn cancel_is_idempotent_only_for_cancelled_streams() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         assert_eq!(mux.cancel(&sid("s1")), Ok(true));
         assert_eq!(mux.cancel(&sid("s1")), Ok(false));
         assert_eq!(
@@ -647,7 +699,7 @@ mod tests {
             Some(StreamCloseReason::Cancelled)
         );
 
-        mux.open(&open_frame("s2", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s2", StreamKind::Display);
         mux.close(&StreamClose {
             stream: sid("s2"),
             reason: StreamCloseReason::Completed,
@@ -660,7 +712,7 @@ mod tests {
     #[test]
     fn outbound_send_respects_credit_and_assigns_sequence() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         // No outbound credit yet.
         assert_eq!(
             mux.reserve_send(&sid("s1"), StreamChannel::Primary)
@@ -695,10 +747,8 @@ mod tests {
     #[test]
     fn sendable_streams_are_deterministic_and_round_robin() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("b-stream", StreamKind::Display))
-            .unwrap();
-        mux.open(&open_frame("a-stream", StreamKind::Display))
-            .unwrap();
+        open_ok(&mut mux, "b-stream", StreamKind::Display);
+        open_ok(&mut mux, "a-stream", StreamKind::Display);
         mux.receive_flow(&StreamFlow {
             stream: sid("b-stream"),
             credits: 1,
@@ -739,9 +789,8 @@ mod tests {
     #[test]
     fn resume_is_allowed_only_for_logs_streams() {
         let mut mux = StreamMux::new();
-        mux.open(&open_frame("logs", StreamKind::Logs)).unwrap();
-        mux.open(&open_frame("display", StreamKind::Display))
-            .unwrap();
+        open_ok(&mut mux, "logs", StreamKind::Logs);
+        open_ok(&mut mux, "display", StreamKind::Display);
         let logs_resume = StreamResume {
             stream: sid("logs"),
             cursor: StreamCursor::parse("cur-1").unwrap(),
@@ -768,7 +817,7 @@ mod tests {
     fn closed_stream_history_is_bounded() {
         let mut mux = StreamMux::with_limits(4, 2);
         for id in ["s1", "s2", "s3"] {
-            mux.open(&open_frame(id, StreamKind::Display)).unwrap();
+            open_ok(&mut mux, id, StreamKind::Display);
             mux.close(&StreamClose {
                 stream: sid(id),
                 reason: StreamCloseReason::Completed,
@@ -785,7 +834,7 @@ mod tests {
             Some(StreamCloseReason::Completed)
         );
         // Once the old closed record is pruned, that id can be reused.
-        mux.open(&open_frame("s1", StreamKind::Display)).unwrap();
+        open_ok(&mut mux, "s1", StreamKind::Display);
         assert!(mux.is_open(&sid("s1")));
     }
 }

--- a/packages/nixling-constellation-router/src/lib.rs
+++ b/packages/nixling-constellation-router/src/lib.rs
@@ -37,8 +37,8 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use nixling_constellation_core::{
-    AuthorizationScope, Capability, IdempotencyKey, NodeId, OpaquePayload, OperationId,
-    OperationKind, OperationRequest, PrincipalId, RealmPath,
+    AuthorizationScope, Capability, CapabilitySet, IdempotencyKey, NodeId, OpaquePayload,
+    OperationId, OperationKind, OperationRequest, PrincipalId, RealmPath,
 };
 
 pub mod display_transport;
@@ -113,6 +113,13 @@ pub enum RouteDecision {
     MissingIdempotencyKey,
     /// The request principal does not match the authenticated session.
     PrincipalMismatch,
+    /// The target did not advertise a required capability.
+    CapabilityDenied {
+        /// Capability missing from the negotiated set.
+        capability: Capability,
+        /// Fingerprint of the negotiated set used for the denial.
+        negotiated_fingerprint: String,
+    },
     /// The router cannot retain another dedup record in this scope; refusing
     /// avoids executing a mutating operation without a durable dedup lease.
     DedupCapacityExceeded,
@@ -249,16 +256,13 @@ impl<C: Clock> OperationRouter<C> {
         self
     }
 
-    /// Route one operation against the authenticated `session_principal`.
-    ///
-    /// On `Accept` for a mutating operation the key is recorded as
-    /// in-progress; the caller MUST later call [`Self::mark_completed`]
-    /// (success) or [`Self::mark_failed`] (terminal failure) so the dedup
-    /// record reaches a terminal state instead of wedging `InProgress`.
-    pub fn route(
+    /// Route one operation after checking the negotiated capability set. A
+    /// missing capability fails before dedup state is mutated.
+    pub fn route_with_capabilities(
         &mut self,
         req: &OperationRequest,
         session_principal: &PrincipalId,
+        capabilities: &CapabilitySet,
     ) -> RouteDecision {
         // 1. Principal binding.
         if &req.principal != session_principal {
@@ -266,6 +270,14 @@ impl<C: Clock> OperationRouter<C> {
         }
 
         let scope = req.kind.authorization_scope();
+        if let Some(capability) = req.required_capability()
+            && !capabilities.has(capability)
+        {
+            return RouteDecision::CapabilityDenied {
+                capability,
+                negotiated_fingerprint: capabilities.stable_fingerprint(),
+            };
+        }
 
         // 2. Non-mutating operations need no dedup.
         if !req.kind.is_mutating() {
@@ -310,6 +322,7 @@ impl<C: Clock> OperationRouter<C> {
                             }
                         }
                     }
+
                     DedupState::Completed { result, since } => {
                         if now.duration_since(*since) > self.retention {
                             // Retention elapsed: tombstone it now (lazy) and
@@ -523,17 +536,55 @@ mod tests {
         OpaquePayload::new(bytes.to_vec()).unwrap()
     }
 
+    fn caps_for(req: &OperationRequest) -> CapabilitySet {
+        match req.required_capability() {
+            Some(cap) => CapabilitySet::empty().with(cap),
+            None => CapabilitySet::empty(),
+        }
+    }
+
+    fn route<C: Clock>(
+        router: &mut OperationRouter<C>,
+        req: &OperationRequest,
+        principal: &PrincipalId,
+    ) -> RouteDecision {
+        router.route_with_capabilities(req, principal, &caps_for(req))
+    }
+
     #[test]
     fn principal_mismatch_is_rejected() {
         let mut r = OperationRouter::new();
         let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
         assert_eq!(
-            r.route(&req, &principal("bob")),
+            route(&mut r, &req, &principal("bob")),
             RouteDecision::PrincipalMismatch
         );
         assert_eq!(r.tracked(), 0);
         assert!(matches!(
-            r.route(&req, &principal("alice")),
+            route(&mut r, &req, &principal("alice")),
+            RouteDecision::Accept { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_capability_is_denied_before_dedup_state() {
+        let mut r = OperationRouter::new();
+        let p = principal("alice");
+        let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
+        assert_eq!(
+            r.route_with_capabilities(&req, &p, &CapabilitySet::empty()),
+            RouteDecision::CapabilityDenied {
+                capability: Capability::Lifecycle,
+                negotiated_fingerprint: CapabilitySet::empty().stable_fingerprint(),
+            }
+        );
+        assert_eq!(r.tracked(), 0);
+        assert!(matches!(
+            r.route_with_capabilities(
+                &req,
+                &p,
+                &CapabilitySet::empty().with(Capability::Lifecycle)
+            ),
             RouteDecision::Accept { .. }
         ));
     }
@@ -542,7 +593,7 @@ mod tests {
     fn non_mutating_accepts_without_key() {
         let mut r = OperationRouter::new();
         let req = req(OperationKind::WorkloadList, None, b"", "alice");
-        match r.route(&req, &principal("alice")) {
+        match route(&mut r, &req, &principal("alice")) {
             RouteDecision::Accept { scope } => {
                 assert_eq!(scope, AuthorizationScope::capability(Capability::Lifecycle))
             }
@@ -634,7 +685,7 @@ mod tests {
                 &op_id,
             );
             assert_eq!(required_capability(&req), expected_capability);
-            match r.route(&req, &p) {
+            match route(&mut r, &req, &p) {
                 RouteDecision::Accept { scope } => assert_eq!(scope, expected_scope),
                 other => panic!("expected Accept for {kind:?}, got {other:?}"),
             }
@@ -646,14 +697,14 @@ mod tests {
         let mut r = OperationRouter::new().with_max_dedup_records(0);
         let missing_key = req(OperationKind::WorkloadStart, None, b"x", "alice");
         assert_eq!(
-            r.route(&missing_key, &principal("alice")),
+            route(&mut r, &missing_key, &principal("alice")),
             RouteDecision::MissingIdempotencyKey
         );
         assert_eq!(r.tracked(), 0);
 
         let keyed = req(OperationKind::WorkloadStart, Some("k1"), b"x", "alice");
         assert_eq!(
-            r.route(&keyed, &principal("alice")),
+            route(&mut r, &keyed, &principal("alice")),
             RouteDecision::DedupCapacityExceeded
         );
     }
@@ -663,10 +714,13 @@ mod tests {
         let mut r = OperationRouter::new();
         let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
         let p = principal("alice");
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
         // Still in progress before completion; carries the original op id.
         assert_eq!(
-            r.route(&req, &p),
+            route(&mut r, &req, &p),
             RouteDecision::InProgress {
                 original_operation_id: OperationId::parse("op-1").unwrap(),
             }
@@ -674,7 +728,7 @@ mod tests {
         assert!(r.mark_completed(&req, result(b"started-ok")));
         // After completion, the same key+request replays the recorded result.
         assert_eq!(
-            r.route(&req, &p),
+            route(&mut r, &req, &p),
             RouteDecision::Replay {
                 original_operation_id: OperationId::parse("op-1").unwrap(),
                 result: result(b"started-ok"),
@@ -694,7 +748,7 @@ mod tests {
             "op-original",
         );
         assert!(matches!(
-            shared_router.route(&first, &p),
+            route(&mut shared_router, &first, &p),
             RouteDecision::Accept { .. }
         ));
         assert!(shared_router.mark_completed(&first, result(b"started")));
@@ -707,7 +761,7 @@ mod tests {
             "op-retry",
         );
         assert_eq!(
-            shared_router.route(&retry_after_disconnect, &p),
+            route(&mut shared_router, &retry_after_disconnect, &p),
             RouteDecision::Replay {
                 original_operation_id: OperationId::parse("op-original").unwrap(),
                 result: result(b"started"),
@@ -732,8 +786,11 @@ mod tests {
             b"start-B",
             "alice",
         );
-        assert!(matches!(r.route(&a, &p), RouteDecision::Accept { .. }));
-        assert_eq!(r.route(&b, &p), RouteDecision::IdempotencyKeyConflict);
+        assert!(matches!(
+            route(&mut r, &a, &p),
+            RouteDecision::Accept { .. }
+        ));
+        assert_eq!(route(&mut r, &b, &p), RouteDecision::IdempotencyKeyConflict);
     }
 
     #[test]
@@ -744,13 +801,13 @@ mod tests {
         let alice = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
         let bob = req(OperationKind::WorkloadStart, Some("k1"), b"start", "bob");
         assert!(matches!(
-            r.route(&alice, &principal("alice")),
+            route(&mut r, &alice, &principal("alice")),
             RouteDecision::Accept { .. }
         ));
         // Same opaque key, different principal -> independent record, not a
         // false conflict and not a replay of alice's op.
         assert!(matches!(
-            r.route(&bob, &principal("bob")),
+            route(&mut r, &bob, &principal("bob")),
             RouteDecision::Accept { .. }
         ));
         assert_eq!(r.tracked(), 2);
@@ -777,11 +834,14 @@ mod tests {
             "alice",
             "op-2",
         );
-        assert!(matches!(r.route(&first, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &first, &p),
+            RouteDecision::Accept { .. }
+        ));
         assert!(r.mark_completed(&first, result(b"ok")));
         // Different operation_id, same fingerprint -> Replay of the original.
         assert_eq!(
-            r.route(&retry, &p),
+            route(&mut r, &retry, &p),
             RouteDecision::Replay {
                 original_operation_id: OperationId::parse("op-1").unwrap(),
                 result: result(b"ok"),
@@ -798,10 +858,13 @@ mod tests {
             OperationRouter::with_clock(clock.clone()).with_retention(Duration::from_secs(60));
         let p = principal("alice");
         let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
         clock.advance(Duration::from_secs(61));
         assert_eq!(
-            r.route(&req, &p),
+            route(&mut r, &req, &p),
             RouteDecision::InProgress {
                 original_operation_id: OperationId::parse("op-1").unwrap(),
             }
@@ -815,10 +878,16 @@ mod tests {
             OperationRouter::with_clock(clock.clone()).with_retention(Duration::from_secs(60));
         let p = principal("alice");
         let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
         assert!(r.mark_completed(&req, result(b"ok")));
         clock.advance(Duration::from_secs(61));
-        assert_eq!(r.route(&req, &p), RouteDecision::IdempotencyKeyExpired);
+        assert_eq!(
+            route(&mut r, &req, &p),
+            RouteDecision::IdempotencyKeyExpired
+        );
     }
 
     #[test]
@@ -840,13 +909,19 @@ mod tests {
             "op-2",
         );
 
-        assert!(matches!(r.route(&first, &p), RouteDecision::Accept { .. }));
-        assert_eq!(r.route(&second, &p), RouteDecision::DedupCapacityExceeded);
+        assert!(matches!(
+            route(&mut r, &first, &p),
+            RouteDecision::Accept { .. }
+        ));
+        assert_eq!(
+            route(&mut r, &second, &p),
+            RouteDecision::DedupCapacityExceeded
+        );
         assert_eq!(r.tracked(), 1);
 
         assert!(r.mark_completed(&first, result(b"first-result")));
         assert_eq!(
-            r.route(&first, &p),
+            route(&mut r, &first, &p),
             RouteDecision::Replay {
                 original_operation_id: OperationId::parse("op-1").unwrap(),
                 result: result(b"first-result"),
@@ -877,13 +952,22 @@ mod tests {
             "op-2",
         );
 
-        assert!(matches!(r.route(&first, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &first, &p),
+            RouteDecision::Accept { .. }
+        ));
         assert!(r.mark_completed(&first, result(b"first-result")));
         clock.advance(Duration::from_secs(11));
-        assert_eq!(r.route(&first, &p), RouteDecision::IdempotencyKeyExpired);
+        assert_eq!(
+            route(&mut r, &first, &p),
+            RouteDecision::IdempotencyKeyExpired
+        );
         clock.advance(Duration::from_secs(11));
 
-        assert!(matches!(r.route(&second, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &second, &p),
+            RouteDecision::Accept { .. }
+        ));
         assert_eq!(r.tracked(), 1);
     }
 
@@ -898,21 +982,33 @@ mod tests {
             .with_no_reuse_horizon(Duration::from_secs(600));
         let p = principal("alice");
         let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
         assert!(r.mark_completed(&req, result(b"ok")));
         clock.advance(Duration::from_secs(61));
         // Retention elapsed: expired (and tombstoned).
-        assert_eq!(r.route(&req, &p), RouteDecision::IdempotencyKeyExpired);
+        assert_eq!(
+            route(&mut r, &req, &p),
+            RouteDecision::IdempotencyKeyExpired
+        );
         r.gc();
         // Tombstone kept; reuse still fails closed.
         assert_eq!(r.tracked(), 1);
-        assert_eq!(r.route(&req, &p), RouteDecision::IdempotencyKeyExpired);
+        assert_eq!(
+            route(&mut r, &req, &p),
+            RouteDecision::IdempotencyKeyExpired
+        );
         // Past the no-reuse horizon the tombstone is dropped.
         clock.advance(Duration::from_secs(601));
         r.gc();
         assert_eq!(r.tracked(), 0);
         // Only now (after the full no-reuse horizon) is the key fresh again.
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
     }
 
     #[test]
@@ -922,7 +1018,10 @@ mod tests {
             OperationRouter::with_clock(clock.clone()).with_retention(Duration::from_secs(60));
         let p = principal("alice");
         let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
         clock.advance(Duration::from_secs(61));
         r.gc();
         // In-progress record is never dropped.
@@ -934,10 +1033,16 @@ mod tests {
         let mut r = OperationRouter::new();
         let p = principal("alice");
         let req = req(OperationKind::WorkloadStart, Some("k1"), b"start", "alice");
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
         assert!(r.mark_failed(&req));
         // After terminal failure the key is fresh, not wedged InProgress.
-        assert!(matches!(r.route(&req, &p), RouteDecision::Accept { .. }));
+        assert!(matches!(
+            route(&mut r, &req, &p),
+            RouteDecision::Accept { .. }
+        ));
     }
 
     #[test]
@@ -950,11 +1055,11 @@ mod tests {
         let accepted = req(OperationKind::WorkloadStart, Some("k1"), b"real", "alice");
         let conflicting = req(OperationKind::WorkloadStart, Some("k1"), b"forged", "alice");
         assert!(matches!(
-            r.route(&accepted, &p),
+            route(&mut r, &accepted, &p),
             RouteDecision::Accept { .. }
         ));
         assert_eq!(
-            r.route(&conflicting, &p),
+            route(&mut r, &conflicting, &p),
             RouteDecision::IdempotencyKeyConflict
         );
         // The conflicting caller cannot terminalize the accepted record.
@@ -962,7 +1067,7 @@ mod tests {
         assert!(!r.mark_failed(&conflicting));
         // The accepted op is still in progress and still owns its record.
         assert_eq!(
-            r.route(&accepted, &p),
+            route(&mut r, &accepted, &p),
             RouteDecision::InProgress {
                 original_operation_id: OperationId::parse("op-1").unwrap(),
             }
@@ -970,7 +1075,7 @@ mod tests {
         // The legitimate completer (matching fingerprint) still works.
         assert!(r.mark_completed(&accepted, result(b"real-result")));
         assert_eq!(
-            r.route(&accepted, &p),
+            route(&mut r, &accepted, &p),
             RouteDecision::Replay {
                 original_operation_id: OperationId::parse("op-1").unwrap(),
                 result: result(b"real-result"),
@@ -991,7 +1096,7 @@ mod tests {
             "op-1",
         );
         assert!(matches!(
-            r.route(&op, &principal(p)),
+            route(&mut r, &op, &principal(p)),
             RouteDecision::Accept { .. }
         ));
 
@@ -1008,7 +1113,7 @@ mod tests {
         );
         // Surfacing did NOT resolve it: it is still InProgress to a retry.
         assert!(matches!(
-            r.route(&op, &principal(p)),
+            route(&mut r, &op, &principal(p)),
             RouteDecision::InProgress { .. }
         ));
 

--- a/packages/nixling-constellation-router/src/mux_session.rs
+++ b/packages/nixling-constellation-router/src/mux_session.rs
@@ -1,4 +1,4 @@
-//! Post-handshake stream-mux driver (ADR 0032, P0).
+//! Post-handshake stream-mux driver (ADR 0032).
 //!
 //! [`PeerSession`](crate::PeerSession) proves that the byte transport completed
 //! protocol/codec negotiation. [`MuxSession`] is the next boundary: every
@@ -8,8 +8,8 @@
 //! fail-closed runtime seam between semantic frames and transport I/O.
 
 use nixling_constellation_core::{
-    ConstellationError, ConstellationFrame, OpaquePayload, StreamChannel, StreamClose,
-    StreamCloseReason, StreamData, StreamId, StreamMux, StreamOpen, StreamResume,
+    CapabilitySet, ConstellationError, ConstellationFrame, OpaquePayload, StreamChannel,
+    StreamClose, StreamCloseReason, StreamData, StreamId, StreamMux, StreamOpen, StreamResume,
 };
 use nixling_constellation_provider::error::ProviderResult;
 use nixling_constellation_provider::provider::ProtocolCodec;
@@ -20,21 +20,29 @@ use crate::PeerSession;
 pub struct MuxSession<C: ProtocolCodec> {
     peer: PeerSession<C>,
     mux: StreamMux,
+    capabilities: CapabilitySet,
 }
 
 impl<C: ProtocolCodec> MuxSession<C> {
     /// Wrap a successfully-handshaken peer session with a fresh mux.
     pub fn new(peer: PeerSession<C>) -> Self {
+        let capabilities = peer.negotiated().capabilities.capabilities.clone();
         Self {
             peer,
             mux: StreamMux::new(),
+            capabilities,
         }
     }
 
     /// Wrap a peer with an explicit mux (used by tests and future restored
     /// sessions).
     pub fn with_mux(peer: PeerSession<C>, mux: StreamMux) -> Self {
-        Self { peer, mux }
+        let capabilities = peer.negotiated().capabilities.capabilities.clone();
+        Self {
+            peer,
+            mux,
+            capabilities,
+        }
     }
 
     /// Borrow the mux state for reconciliation/observability.
@@ -45,7 +53,7 @@ impl<C: ProtocolCodec> MuxSession<C> {
     /// Open a stream initiated by this endpoint: validate/register it locally,
     /// then send the `StreamOpen` frame to the peer.
     pub async fn open_stream(&mut self, open: StreamOpen) -> ProviderResult<()> {
-        self.mux.open(&open)?;
+        self.mux.open_with_capabilities(&open, &self.capabilities)?;
         self.peer.send(&ConstellationFrame::StreamOpen(open)).await
     }
 
@@ -122,7 +130,9 @@ impl<C: ProtocolCodec> MuxSession<C> {
 
     fn apply_inbound(&mut self, frame: &ConstellationFrame) -> Result<(), ConstellationError> {
         match frame {
-            ConstellationFrame::StreamOpen(open) => self.mux.open(open),
+            ConstellationFrame::StreamOpen(open) => {
+                self.mux.open_with_capabilities(open, &self.capabilities)
+            }
             ConstellationFrame::StreamData(data) => self.mux.accept_data(data),
             ConstellationFrame::StreamFlow(flow) => self.mux.receive_flow(flow),
             ConstellationFrame::StreamClose(close) => self.mux.close(close),
@@ -143,7 +153,8 @@ mod tests {
     use super::*;
     use nixling_constellation_codec_protobuf::ProtobufCodec;
     use nixling_constellation_core::{
-        PrincipalId, RealmPath, StreamAuthz, StreamDescriptor, StreamFlow, StreamKind,
+        Capability, CapabilitySet, PrincipalId, RealmPath, StreamAuthz, StreamDescriptor,
+        StreamFlow, StreamKind,
     };
     use nixling_constellation_provider::provider::TransportProvider;
     use nixling_constellation_provider::types::{
@@ -191,13 +202,21 @@ mod tests {
         }
     }
 
+    fn display_caps() -> CapabilitySet {
+        CapabilitySet::empty().with(Capability::WindowForwarding)
+    }
+
     #[tokio::test]
     async fn mux_session_gates_open_flow_data_close_round_trip() {
         let (client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            let peer = PeerSession::accept(server_s, ProtobufCodec::new())
-                .await
-                .unwrap();
+            let peer = PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                display_caps(),
+            )
+            .await
+            .unwrap();
             let mut s = MuxSession::new(peer);
             assert!(matches!(
                 s.recv().await.unwrap(),
@@ -219,9 +238,10 @@ mod tests {
             );
         });
 
-        let peer = PeerSession::connect(client_s, ProtobufCodec::new())
-            .await
-            .unwrap();
+        let peer =
+            PeerSession::connect_with_capabilities(client_s, ProtobufCodec::new(), display_caps())
+                .await
+                .unwrap();
         let mut client = MuxSession::new(peer);
         client.open_stream(display_open()).await.unwrap();
         assert!(matches!(
@@ -248,9 +268,13 @@ mod tests {
     async fn inbound_data_before_credit_is_rejected() {
         let (client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            let peer = PeerSession::accept(server_s, ProtobufCodec::new())
-                .await
-                .unwrap();
+            let peer = PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                display_caps(),
+            )
+            .await
+            .unwrap();
             let mut s = MuxSession::new(peer);
             assert!(matches!(
                 s.recv().await.unwrap(),
@@ -259,9 +283,10 @@ mod tests {
             s.recv().await.unwrap_err()
         });
 
-        let mut peer = PeerSession::connect(client_s, ProtobufCodec::new())
-            .await
-            .unwrap();
+        let mut peer =
+            PeerSession::connect_with_capabilities(client_s, ProtobufCodec::new(), display_caps())
+                .await
+                .unwrap();
         peer.send(&ConstellationFrame::StreamOpen(display_open()))
             .await
             .unwrap();

--- a/packages/nixling-constellation-router/src/session.rs
+++ b/packages/nixling-constellation-router/src/session.rs
@@ -16,7 +16,7 @@
 //! unlike a seqpacket one-read-per-frame socket.
 
 use nixling_constellation_core::{
-    ConstellationFrame, ErrorKind, Handshake, HandshakeAccepted, HandshakeRejected,
+    CapabilitySet, ConstellationFrame, ErrorKind, Handshake, HandshakeAccepted, HandshakeRejected,
     HandshakeRejectedReason,
 };
 use nixling_constellation_provider::error::{ProviderError, ProviderResult};
@@ -54,18 +54,22 @@ pub struct PeerSession<C: ProtocolCodec> {
 }
 
 impl<C: ProtocolCodec> PeerSession<C> {
-    /// Perform the **client** handshake over `session`: propose
-    /// [`PROTOCOL_VERSION`] + `codec.codec_id()`, then require the server to
-    /// echo the same version and codec id (fail-closed on skew).
-    pub async fn connect(session: TransportSession, codec: C) -> ProviderResult<Self> {
-        Self::establish(session, codec, Role::Client).await
+    /// Client handshake with the explicit capabilities this endpoint proposes.
+    pub async fn connect_with_capabilities(
+        session: TransportSession,
+        codec: C,
+        capabilities: CapabilitySet,
+    ) -> ProviderResult<Self> {
+        Self::establish(session, codec, Role::Client, capabilities).await
     }
 
-    /// Perform the **server** handshake over `session`: read the client's
-    /// proposal, require it to match this build's version + codec id, then
-    /// echo the accepted handshake back (fail-closed on skew).
-    pub async fn accept(session: TransportSession, codec: C) -> ProviderResult<Self> {
-        Self::establish(session, codec, Role::Server).await
+    /// Server handshake with the explicit capabilities this endpoint supports.
+    pub async fn accept_with_capabilities(
+        session: TransportSession,
+        codec: C,
+        capabilities: CapabilitySet,
+    ) -> ProviderResult<Self> {
+        Self::establish(session, codec, Role::Server, capabilities).await
     }
 
     /// The handshake the peers agreed on.
@@ -73,12 +77,18 @@ impl<C: ProtocolCodec> PeerSession<C> {
         &self.negotiated
     }
 
-    async fn establish(session: TransportSession, codec: C, role: Role) -> ProviderResult<Self> {
+    async fn establish(
+        session: TransportSession,
+        codec: C,
+        role: Role,
+        capabilities: CapabilitySet,
+    ) -> ProviderResult<Self> {
         let mut stream = session.into_stream();
         let ours = Handshake {
             protocol_version: PROTOCOL_VERSION,
             codec_id: parse_codec_id(codec.codec_id())?,
             schema_fingerprint: parse_codec_id(&codec.schema_fingerprint())?,
+            capabilities: capabilities.negotiation(),
             peer: None,
         };
         let negotiated = match role {
@@ -86,25 +96,30 @@ impl<C: ProtocolCodec> PeerSession<C> {
                 write_frame(stream.as_mut(), &codec.encode_frame(&hs(ours.clone()))?).await?;
                 let accepted =
                     expect_handshake_accept(&codec, &read_frame(stream.as_mut()).await?)?;
-                if let Err(reason) = reconcile(&ours, &accepted.selected) {
+                if let Err(reason) = reconcile_selected(&ours, &accepted.selected) {
                     return Err(handshake_rejected_error(reason));
                 }
                 accepted.selected
             }
             Role::Server => {
                 let theirs = expect_handshake(&codec, &read_frame(stream.as_mut()).await?)?;
-                if let Err(reason) = reconcile(&ours, &theirs) {
+                if let Err(reason) = reconcile_proposal(&ours, &theirs) {
                     let rejected =
                         ConstellationFrame::HandshakeRejected(HandshakeRejected { reason });
                     let _ = write_frame(stream.as_mut(), &codec.encode_frame(&rejected)?).await;
                     return Err(handshake_rejected_error(reason));
                 }
+                let mut selected = ours.clone();
+                selected.capabilities = ours
+                    .capabilities
+                    .capabilities
+                    .intersection(&theirs.capabilities.capabilities)
+                    .negotiation();
                 let accepted = ConstellationFrame::HandshakeAccepted(HandshakeAccepted {
-                    selected: ours.clone(),
+                    selected: selected.clone(),
                 });
                 write_frame(stream.as_mut(), &codec.encode_frame(&accepted)?).await?;
-                // The server adopts its own (validated-equal) view.
-                ours
+                selected
             }
         };
         Ok(Self {
@@ -162,7 +177,7 @@ fn expect_handshake(codec: &impl ProtocolCodec, bytes: &[u8]) -> ProviderResult<
     }
 }
 
-fn reconcile(ours: &Handshake, theirs: &Handshake) -> Result<(), HandshakeRejectedReason> {
+fn reconcile_common(ours: &Handshake, theirs: &Handshake) -> Result<(), HandshakeRejectedReason> {
     if theirs.protocol_version != ours.protocol_version {
         return Err(HandshakeRejectedReason::VersionSkew);
     }
@@ -178,11 +193,35 @@ fn reconcile(ours: &Handshake, theirs: &Handshake) -> Result<(), HandshakeReject
     Ok(())
 }
 
+fn reconcile_proposal(ours: &Handshake, theirs: &Handshake) -> Result<(), HandshakeRejectedReason> {
+    reconcile_common(ours, theirs)
+}
+
+fn reconcile_selected(
+    ours: &Handshake,
+    selected: &Handshake,
+) -> Result<(), HandshakeRejectedReason> {
+    reconcile_common(ours, selected)?;
+    if !selected
+        .capabilities
+        .capabilities
+        .is_subset_of(&ours.capabilities.capabilities)
+    {
+        return Err(HandshakeRejectedReason::CapabilityMismatch);
+    }
+    if selected.capabilities.fingerprint != selected.capabilities.capabilities.stable_fingerprint()
+    {
+        return Err(HandshakeRejectedReason::CapabilityMismatch);
+    }
+    Ok(())
+}
+
 fn handshake_rejected_error(reason: HandshakeRejectedReason) -> ProviderError {
     let kind = match reason {
         HandshakeRejectedReason::VersionSkew => ErrorKind::VersionSkew,
         HandshakeRejectedReason::CodecMismatch
-        | HandshakeRejectedReason::SchemaFingerprintMismatch => ErrorKind::VersionSkew,
+        | HandshakeRejectedReason::SchemaFingerprintMismatch
+        | HandshakeRejectedReason::CapabilityMismatch => ErrorKind::VersionSkew,
         HandshakeRejectedReason::ChannelBindingMismatch => ErrorKind::AuthenticationFailed,
         HandshakeRejectedReason::MalformedHandshake => ErrorKind::MalformedFrame,
     };
@@ -276,15 +315,23 @@ mod tests {
     async fn handshake_succeeds_and_frame_round_trips() {
         let (client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            let mut s = PeerSession::accept(server_s, ProtobufCodec::new())
-                .await
-                .unwrap();
+            let mut s = PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                CapabilitySet::empty(),
+            )
+            .await
+            .unwrap();
             // The server reads one frame the client sends post-handshake.
             s.recv().await.unwrap()
         });
-        let mut client = PeerSession::connect(client_s, ProtobufCodec::new())
-            .await
-            .unwrap();
+        let mut client = PeerSession::connect_with_capabilities(
+            client_s,
+            ProtobufCodec::new(),
+            CapabilitySet::empty(),
+        )
+        .await
+        .unwrap();
         assert_eq!(client.negotiated().protocol_version, PROTOCOL_VERSION);
         let frame =
             ConstellationFrame::TypedError(ConstellationError::capability_denied(Capability::Exec));
@@ -294,20 +341,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handshake_negotiates_capability_intersection() {
+        let (client_s, server_s) = connected_pair().await;
+        let server_caps = CapabilitySet::empty().with(Capability::Exec);
+        let client_caps = CapabilitySet::empty()
+            .with(Capability::Exec)
+            .with(Capability::WindowForwarding);
+        let server = tokio::spawn(async move {
+            PeerSession::accept_with_capabilities(server_s, ProtobufCodec::new(), server_caps)
+                .await
+                .unwrap()
+                .negotiated()
+                .capabilities
+                .capabilities
+                .clone()
+        });
+        let client =
+            PeerSession::connect_with_capabilities(client_s, ProtobufCodec::new(), client_caps)
+                .await
+                .unwrap();
+        let selected = &client.negotiated().capabilities.capabilities;
+        assert!(selected.has(Capability::Exec));
+        assert!(!selected.has(Capability::WindowForwarding));
+        assert_eq!(server.await.unwrap(), selected.clone());
+    }
+
+    #[tokio::test]
+    async fn client_rejects_accepted_capabilities_outside_its_proposal() {
+        let (client_s, mut server_s) = connected_pair().await;
+        let server = tokio::spawn(async move {
+            let codec = ProtobufCodec::new();
+            let _proposal = read_frame(server_s.stream_mut()).await.unwrap();
+            let accepted = ConstellationFrame::HandshakeAccepted(HandshakeAccepted {
+                selected: Handshake {
+                    protocol_version: PROTOCOL_VERSION,
+                    codec_id: parse_codec_id(codec.codec_id()).unwrap(),
+                    schema_fingerprint: parse_codec_id(&codec.schema_fingerprint()).unwrap(),
+                    capabilities: CapabilitySet::empty()
+                        .with(Capability::Lifecycle)
+                        .negotiation(),
+                    peer: None,
+                },
+            });
+            write_frame(
+                server_s.stream_mut(),
+                &codec.encode_frame(&accepted).unwrap(),
+            )
+            .await
+            .unwrap();
+        });
+        let err = match PeerSession::connect_with_capabilities(
+            client_s,
+            ProtobufCodec::new(),
+            CapabilitySet::empty(),
+        )
+        .await
+        {
+            Ok(_) => panic!("server-selected capabilities outside the proposal must be rejected"),
+            Err(err) => err,
+        };
+        server.await.unwrap();
+        assert_eq!(err.kind(), ErrorKind::VersionSkew);
+    }
+
+    #[tokio::test]
     async fn client_version_skew_is_rejected_fail_closed() {
         // Server speaks the real protocol; the client writes a handshake with
         // a bogus version, so the server must reject with VersionSkew.
         let (mut client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            PeerSession::accept(server_s, ProtobufCodec::new())
-                .await
-                .map(|_| ())
+            PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                CapabilitySet::empty(),
+            )
+            .await
+            .map(|_| ())
         });
         let codec = ProtobufCodec::new();
         let bogus = Handshake {
             protocol_version: PROTOCOL_VERSION + 99,
             codec_id: parse_codec_id(codec.codec_id()).unwrap(),
             schema_fingerprint: parse_codec_id(&codec.schema_fingerprint()).unwrap(),
+            capabilities: CapabilitySet::empty().negotiation(),
             peer: None,
         };
         let bytes = codec.encode_frame(&hs(bogus)).unwrap();
@@ -320,15 +436,20 @@ mod tests {
     async fn client_schema_fingerprint_skew_is_rejected_fail_closed() {
         let (mut client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            PeerSession::accept(server_s, ProtobufCodec::new())
-                .await
-                .map(|_| ())
+            PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                CapabilitySet::empty(),
+            )
+            .await
+            .map(|_| ())
         });
         let codec = ProtobufCodec::new();
         let bogus = Handshake {
             protocol_version: PROTOCOL_VERSION,
             codec_id: parse_codec_id(codec.codec_id()).unwrap(),
             schema_fingerprint: parse_codec_id("pb.v1:other-schema").unwrap(),
+            capabilities: CapabilitySet::empty().negotiation(),
             peer: None,
         };
         let bytes = codec.encode_frame(&hs(bogus)).unwrap();
@@ -365,11 +486,21 @@ mod tests {
 
         let (client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            PeerSession::accept(server_s, SkewedSchemaCodec)
-                .await
-                .map(|_| ())
+            PeerSession::accept_with_capabilities(
+                server_s,
+                SkewedSchemaCodec,
+                CapabilitySet::empty(),
+            )
+            .await
+            .map(|_| ())
         });
-        let client_err = match PeerSession::connect(client_s, ProtobufCodec::new()).await {
+        let client_err = match PeerSession::connect_with_capabilities(
+            client_s,
+            ProtobufCodec::new(),
+            CapabilitySet::empty(),
+        )
+        .await
+        {
             Ok(_) => panic!("schema mismatch must reject the client"),
             Err(err) => err,
         };
@@ -382,15 +513,20 @@ mod tests {
     async fn peer_binding_mismatch_is_rejected_fail_closed() {
         let (mut client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            PeerSession::accept(server_s, ProtobufCodec::new())
-                .await
-                .map(|_| ())
+            PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                CapabilitySet::empty(),
+            )
+            .await
+            .map(|_| ())
         });
         let codec = ProtobufCodec::new();
         let forged = Handshake {
             protocol_version: PROTOCOL_VERSION,
             codec_id: parse_codec_id(codec.codec_id()).unwrap(),
             schema_fingerprint: parse_codec_id(&codec.schema_fingerprint()).unwrap(),
+            capabilities: CapabilitySet::empty().negotiation(),
             peer: Some(nixling_constellation_core::PeerContext {
                 auth_mechanism: ProtocolToken::parse("forged-binding").unwrap(),
                 peer_principal: Some(PrincipalId::parse("principal-1").unwrap()),
@@ -407,9 +543,13 @@ mod tests {
     async fn non_handshake_first_frame_is_rejected() {
         let (mut client_s, server_s) = connected_pair().await;
         let server = tokio::spawn(async move {
-            PeerSession::accept(server_s, ProtobufCodec::new())
-                .await
-                .map(|_| ())
+            PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                CapabilitySet::empty(),
+            )
+            .await
+            .map(|_| ())
         });
         // Client sends a non-handshake frame first.
         let codec = ProtobufCodec::new();

--- a/packages/nixlingd/src/constellation_stubs.rs
+++ b/packages/nixlingd/src/constellation_stubs.rs
@@ -26,7 +26,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use nixling_constellation_core::{OperationRequest, PrincipalId, TargetName};
+use nixling_constellation_core::{CapabilitySet, OperationRequest, PrincipalId, TargetName};
 use nixling_constellation_provider::error::ProviderResult;
 use nixling_constellation_provider::provider::{ProtocolCodec, WorkloadProvider};
 use nixling_constellation_router::{
@@ -122,12 +122,16 @@ impl Default for TargetResolver {
 /// dedup owner.
 pub struct PeerOperationRouter {
     router: SharedRouter,
+    capabilities: CapabilitySet,
 }
 
 impl PeerOperationRouter {
-    /// Bind a peer session to the injected node-scoped shared router.
-    pub fn new(router: SharedRouter) -> Self {
-        Self { router }
+    /// Bind a peer session to the injected router and negotiated capability set.
+    pub fn with_capabilities(router: SharedRouter, capabilities: CapabilitySet) -> Self {
+        Self {
+            router,
+            capabilities,
+        }
     }
 
     /// Route one operation against the authenticated session principal.
@@ -135,7 +139,7 @@ impl PeerOperationRouter {
         self.router
             .lock()
             .expect("shared operation router mutex poisoned")
-            .route(req, principal)
+            .route_with_capabilities(req, principal, &self.capabilities)
     }
 }
 
@@ -323,7 +327,10 @@ mod tests {
 
     #[test]
     fn peer_router_routes_through_the_codec_neutral_router() {
-        let r = PeerOperationRouter::new(new_shared_router());
+        let r = PeerOperationRouter::with_capabilities(
+            new_shared_router(),
+            CapabilitySet::empty().with(nixling_constellation_core::Capability::Lifecycle),
+        );
         let principal = PrincipalId::parse("alice").unwrap();
         let req = list_req(&principal);
         assert!(matches!(
@@ -341,8 +348,9 @@ mod tests {
         let shared = new_shared_router();
         let principal = PrincipalId::parse("alice").unwrap();
 
-        let session_a = PeerOperationRouter::new(shared.clone());
-        let session_b = PeerOperationRouter::new(shared.clone());
+        let caps = CapabilitySet::empty().with(nixling_constellation_core::Capability::Lifecycle);
+        let session_a = PeerOperationRouter::with_capabilities(shared.clone(), caps.clone());
+        let session_b = PeerOperationRouter::with_capabilities(shared.clone(), caps);
 
         let req = start_req(&principal, "op-1", "k1");
         assert!(matches!(

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -15,13 +15,13 @@ use nixling::{
     VmExecLogsOutputV1, VmExecStatusOutputV1,
 };
 use nixling_constellation_core::{
-    AdmissionAuditRecord, AuditEnvelope, Capability, CapabilitySet, ConstellationError,
-    ConstellationFrame, ExecAttachMode, ExecAttachRequest, ExecCancelRequest, ExecLogsRequest,
-    ExecStartRequest, ExecutionGeneration, ExecutionId, ExecutionSummary, GatewayId, Handshake,
-    HandshakeAccepted, HandshakeRejected, HandshakeRejectedReason, IdempotencyKey, NodeId,
-    NodeSummary, OperationId, OperationKind, OperationRequest, OperationResponse, PrincipalId,
-    ProviderId, RealmId, RealmPath, StreamCursor, StreamId, StreamResume, WorkloadId,
-    WorkloadSelector, WorkloadSummary,
+    AdmissionAuditRecord, AuditEnvelope, Capability, CapabilityNegotiation, CapabilitySet,
+    ConstellationError, ConstellationFrame, ExecAttachMode, ExecAttachRequest, ExecCancelRequest,
+    ExecLogsRequest, ExecStartRequest, ExecutionGeneration, ExecutionId, ExecutionSummary,
+    GatewayId, Handshake, HandshakeAccepted, HandshakeRejected, HandshakeRejectedReason,
+    IdempotencyKey, NodeId, NodeSummary, OperationId, OperationKind, OperationRequest,
+    OperationResponse, PrincipalId, ProviderId, RealmId, RealmPath, StreamCursor, StreamId,
+    StreamResume, WorkloadId, WorkloadSelector, WorkloadSummary,
     audit::{
         AuditChainCheckFailure, AuditChainCheckResult, AuditChainLink, AuditChainRecord, AuditHash,
         AuditRetentionFloorReason, AuditRetentionFloorStatus, AuditSinkHealth,
@@ -58,6 +58,7 @@ enum ConstellationCoreSchema {
     IdempotencyKey(IdempotencyKey),
     Capability(Capability),
     CapabilitySet(CapabilitySet),
+    CapabilityNegotiation(CapabilityNegotiation),
     NodeSummary(NodeSummary),
     WorkloadSelector(WorkloadSelector),
     WorkloadSummary(WorkloadSummary),


### PR DESCRIPTION
## Summary
- add versioned capability negotiation with bounded stable fingerprints
- require negotiated capability sets for v2 operation routing and stream opens
- negotiate peer-session capability intersections and fail closed on invalid selections
- update protobuf codec, schemas, docs, and changelog

## Validation
- cargo test -p nixling-constellation-core --quiet
- cargo test -p nixling-constellation-codec-protobuf --quiet
- cargo test -p nixling-constellation-router --quiet
- cargo test -p nixlingd constellation_stubs --quiet
- cargo test -p nixling-constellation-provider --quiet
- cargo check -p xtask --quiet
- make test-drift
- cargo clippy -p nixling-constellation-core --all-targets -- -D warnings
- cargo clippy -p nixling-constellation-codec-protobuf --all-targets -- -D warnings
- cargo clippy -p nixling-constellation-router --all-targets -- -D warnings
- cargo clippy -p nixlingd --all-targets -- -D warnings
- git diff --check && git diff --cached --check
- process-marker scan over changed shipped files

## Panel
Gemini 3.1 Pro end-of-wave panel reached unanimous signoff after R3. Reviewers were instructed not to rerun tests; raw panel output remains in session context.