### PR TITLE
ADR032: seal gateway credentials in guest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ deprecations ship one minor release before removal.
 - Capability negotiation now rejects operations and streams when a
   session lacks the required capability, with typed missing-capability
   errors.
+- Gateway credentials can now be enrolled and rotated inside the gateway
+  guest as a sealed runtime envelope, while host-side gateway credential
+  reads and Relay Send bearer minting are rejected.
 
 ### Changed
 

--- a/docs/how-to/realm-gateway.md
+++ b/docs/how-to/realm-gateway.md
@@ -73,7 +73,62 @@ credentials or SSH.
 ## Credential boundary
 
 The host declaration carries non-secret coordinates and state paths only.
-The transitional host-resident ACA/Relay proof path is guarded by
-`allowHostRelayCredentials = false` by default and is not the production
-realm model. Production realm rollout keeps relay/provider credentials in
-the gateway guest.
+Relay/provider credentials are enrolled from inside the gateway guest and
+stored as an encrypted runtime envelope under that gateway's state
+directory. Host-side gateway credential reads and Relay Send bearer
+minting are rejected; `allowHostRelayCredentials` is retained only as a
+compatibility option that produces a clear error for older configs.
+
+## Enroll relay credentials in the gateway
+
+Start the gateway, enter it, then run enrollment from inside the guest.
+The helper reads the plaintext enrollment JSON from stdin so long-lived
+keys never appear in argv:
+
+```bash
+nixling realm enter work
+sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=/var/lib/nixling/gateways/work \
+  nixling-gateway-enroll enroll \
+  /var/lib/nixling/gateways/work/credential.sealed.json \
+  /var/lib/nixling/gateways/work/seal.key <<'JSON'
+{
+  "relayListen": { "keyName": "gateway-listen", "key": "<listen-rule-key>" },
+  "relaySend": { "keyName": "gateway-send", "key": "<send-rule-key>" }
+}
+JSON
+```
+
+Enrollment creates the sealing key if it does not exist, writes both
+files with mode `0600`, and emits only the new credential generation as
+JSON. The sealed credential file does not contain the Relay rule keys in
+plaintext.
+
+## Rotate credentials
+
+Rotate by passing the replacement JSON through the same in-guest helper:
+
+```bash
+nixling realm enter work
+sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=/var/lib/nixling/gateways/work \
+  nixling-gateway-enroll rotate \
+  /var/lib/nixling/gateways/work/credential.sealed.json \
+  /var/lib/nixling/gateways/work/seal.key <<'JSON'
+{
+  "relayListen": { "keyName": "gateway-listen", "key": "<new-listen-rule-key>" },
+  "relaySend": { "keyName": "gateway-send", "key": "<new-send-rule-key>" }
+}
+JSON
+```
+
+Rotation must unseal the existing envelope, increments the gateway
+credential generation, and rewrites the envelope atomically. Existing
+display/session credentials bound to an older generation are rejected by
+the gateway verifier on reconnect.
+
+## Recovery
+
+If the seal key is lost, the existing credential envelope cannot be
+unsealed. Remove both the stale `credential.sealed.json` and `seal.key`
+inside the gateway guest, then enroll fresh Relay credentials. Treat this
+as credential rotation at the provider: revoke the old Relay rules or keys
+before enrolling replacements.

--- a/docs/reference/per-vm-state-ownership.md
+++ b/docs/reference/per-vm-state-ownership.md
@@ -14,6 +14,22 @@ via a VM-start preflight wired into nixlingd
 
 This page documents the current ownership matrix the daemon enforces.
 
+## Gateway credential state
+
+Realm gateway credentials are not part of the per-VM ownership matrix. They
+live under each gateway's `nixling.gateways.<name>.stateDir` (default
+`/var/lib/nixling/gateways/<name>` inside the gateway guest), not under
+`/var/lib/nixling/vms/<vm>/`. The host NixOS module does not create or
+manage these credential files; they are enrolled inside the guest:
+
+| Path | Owner | Group | Mode | Rationale |
+|---|---|---|---|---|
+| `credential.sealed.json` | `nixlingd` (inside gateway guest) | `nixlingd` | `0600` | Encrypted relay/provider credential envelope. The host daemon does not read or mint from it. |
+| `seal.key` | `nixlingd` (inside gateway guest) | `nixlingd` | `0600` | Guest-local 32-byte sealing key. Losing it requires re-enrollment and provider-side credential rotation. |
+
+`allowHostRelayCredentials` is retired; host-side gateway credential reads
+and Relay Send bearer minting are rejected.
+
 ## CRITICAL: hardlink-farm carve-out
 
 > Critical detail: the per-VM hardlink farm shares inodes with

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -164,6 +164,7 @@ let
           paths = {
             stateDir = gw.stateDir;
             credentialPath = gw.credentialPath;
+            sealKeyPath = gw.sealKeyPath;
           };
         in
         lib.mapAttrsToList
@@ -184,13 +185,28 @@ let
       (lib.filterAttrs (_: gw: gw.enable) cfg.gateways));
 
   gatewayCredentialPathAssertions =
+    lib.flatten (lib.mapAttrsToList
+      (name: gw:
+        map
+          (field: {
+            assertion = absoluteRuntimePathUnder gw.stateDir gw.${field};
+            message = ''
+              nixling.gateways.${name}.${field} must live under
+              nixling.gateways.${name}.stateDir so the gateway credential
+              store stays inside the gateway runtime-state boundary.
+            '';
+          })
+          [ "credentialPath" "sealKeyPath" ])
+      (lib.filterAttrs (_: gw: gw.enable) cfg.gateways));
+
+  gatewayHostRelayCredentialAssertions =
     lib.mapAttrsToList
       (name: gw: {
-        assertion = absoluteRuntimePathUnder gw.stateDir gw.credentialPath;
+        assertion = !gw.allowHostRelayCredentials;
         message = ''
-          nixling.gateways.${name}.credentialPath must live under
-          nixling.gateways.${name}.stateDir so the gateway credential envelope
-          stays inside the gateway runtime-state boundary.
+          nixling.gateways.${name}.allowHostRelayCredentials has been retired.
+          Host-side gateway credential reads and Relay Send bearer minting are
+          rejected; enroll credentials inside the gateway guest instead.
         '';
       })
       (lib.filterAttrs (_: gw: gw.enable) cfg.gateways);
@@ -1095,6 +1111,7 @@ in
     ++ guestConfigContainmentAssertions
     ++ gatewayPathAssertions
     ++ gatewayCredentialPathAssertions
+    ++ gatewayHostRelayCredentialAssertions
     ++ gatewayStateBoundaryAssertions
     ++ gatewayCoordinateAssertions
     ++ gatewayEntrypointAssertions

--- a/nixos-modules/gateway-vm.nix
+++ b/nixos-modules/gateway-vm.nix
@@ -24,6 +24,7 @@ let
 
   nixlingdPackage = hostToolPackage "nixlingd" "nixlingd";
   nixlingPackage = hostToolPackage "nixling" "nixling";
+  nixlingGatewayRuntimePackage = hostToolPackage "nixlingGatewayRuntime" "nixling-gateway-runtime";
 
   secretShaped = s:
     lib.hasInfix "SharedAccessKey" s
@@ -44,11 +45,8 @@ let
     lib.unique (lib.filter safeRuntimePath [
       gw.stateDir
       (builtins.dirOf gw.credentialPath)
+      (builtins.dirOf gw.sealKeyPath)
     ]);
-
-  hostGatewayStateTmpfiles = lib.flatten (lib.mapAttrsToList
-    (_: gw: map (dir: "d ${dir} 0750 root nixlingd -") (gatewayStateDirs gw))
-    gateways);
 
   gatewayVm = name: gw: {
     name = gw.vmName;
@@ -97,6 +95,7 @@ let
           realm = gw.realm;
           stateDir = gw.stateDir;
           credentialPath = gw.credentialPath;
+          sealKeyPath = gw.sealKeyPath;
           inherit (gw) allowHostRelayCredentials;
           relay = {
             inherit (gw.relay) namespace entity;
@@ -159,6 +158,7 @@ let
           curl
           nixlingPackage
           nixlingdPackage
+          nixlingGatewayRuntimePackage
         ];
         systemd.tmpfiles.rules = [
           "d /run/nixling 0750 nixlingd nixling -"
@@ -196,8 +196,6 @@ let
   };
 in
 {
-  systemd.tmpfiles.rules = hostGatewayStateTmpfiles;
-
   nixling.vms = lib.mkMerge [
     (lib.listToAttrs (lib.mapAttrsToList gatewayVm gateways))
   ];

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -97,6 +97,32 @@ EOF
   };
   nixlingActivationHelperPackage = if prebuilt ? "nixling-activation-helper" then prebuilt."nixling-activation-helper" else nixlingActivationHelperSourcePackage;
 
+  nixlingGatewayRuntimeSourcePackage = pkgs.rustPlatform.buildRustPackage {
+    pname = "nixling-gateway-runtime";
+    version = "0.0.0-bootstrap";
+    src = packagesSrc;
+    inherit cargoLock;
+    cargoBuildFlags = [ "--package" "nixling-gateway-runtime" ];
+    doCheck = false;
+    postPatch = ''
+      mkdir -p .cargo
+      cat > .cargo/config.toml <<EOF
+[build]
+rustc-wrapper = ""
+EOF
+      rm -f .cargo/rustc-wrapper.sh
+    '';
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 target/x86_64-unknown-linux-gnu/release/nixling-gateway-enroll $out/bin/nixling-gateway-enroll 2>/dev/null \
+        || install -Dm755 target/release/nixling-gateway-enroll $out/bin/nixling-gateway-enroll
+      install -Dm755 target/x86_64-unknown-linux-gnu/release/nixling-gateway-relay $out/bin/nixling-gateway-relay 2>/dev/null \
+        || install -Dm755 target/release/nixling-gateway-relay $out/bin/nixling-gateway-relay
+      runHook postInstall
+    '';
+  };
+  nixlingGatewayRuntimePackage = if prebuilt ? "nixling-gateway-runtime" then prebuilt."nixling-gateway-runtime" else nixlingGatewayRuntimeSourcePackage;
+
   nixlingCliShellArtifactsPackage = pkgs.runCommand "nixling-cli-shell-artifacts" { } ''
     install -Dm644 ${../docs/manpages/nixling.1} "$out/share/man/man1/nixling.1"
     ${pkgs.gzip}/bin/gzip -n -c ${../docs/manpages/nixling.1} > "$out/share/man/man1/nixling.1.gz"
@@ -225,6 +251,7 @@ in
     nixling._hostToolPackages = {
       nixling = nixlingCliPackage;
       nixlingd = nixlingdPackage;
+      nixlingGatewayRuntime = nixlingGatewayRuntimePackage;
     };
 
     environment.systemPackages = [

--- a/nixos-modules/options-gateway.nix
+++ b/nixos-modules/options-gateway.nix
@@ -20,6 +20,13 @@ in
       internal = true;
       description = "Internal: resolved host nixlingd package.";
     };
+
+    nixlingGatewayRuntime = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      internal = true;
+      description = "Internal: resolved gateway runtime helper package.";
+    };
   };
 
   options.nixling.gateways = lib.mkOption {
@@ -92,12 +99,23 @@ in
 
         credentialPath = lib.mkOption {
           type = lib.types.str;
-          default = "/var/lib/nixling/gateways/${name}/credential.json";
+          default = "/var/lib/nixling/gateways/${name}/credential.sealed.json";
           description = ''
-            Host path for the sealed gateway credential envelope. This is a
-            runtime state path, not plaintext Nix data. Assertions require it to
+            Guest runtime path for the sealed gateway credential envelope. This
+            is not plaintext Nix data. Assertions require it to
             live under this gateway's `stateDir` and reject `/nix/store`,
             path-traversal, trailing-slash, or secret-looking values.
+          '';
+        };
+
+        sealKeyPath = lib.mkOption {
+          type = lib.types.str;
+          default = "/var/lib/nixling/gateways/${name}/seal.key";
+          description = ''
+            Guest-local sealing key path for the encrypted gateway credential
+            envelope. The key is created by the in-guest enrollment flow with
+            mode `0600`; it is a runtime state path and must live under this
+            gateway's `stateDir`.
           '';
         };
 
@@ -105,10 +123,9 @@ in
           type = lib.types.bool;
           default = false;
           description = ''
-            Transitional P0 escape hatch that lets the host daemon read the
-            gateway credential envelope and mint short-lived Relay Send bearers.
-            This must stay disabled for production realm rollout; Wave 12
-            removes or fail-closes the host-resident credential path.
+            Retired compatibility option. Host-side gateway credential reads
+            and Relay Send bearer minting are rejected; enroll credentials
+            inside the gateway guest instead.
           '';
         };
 

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1728,16 +1728,21 @@ dependencies = [
  "async-trait",
  "azure_core",
  "base64",
+ "chacha20poly1305",
+ "getrandom 0.2.17",
+ "libc",
  "nixling-constellation-core",
  "nixling-constellation-provider",
  "nixling-gateway",
  "nixling-provider-aca",
  "nixling-provider-relay",
+ "serde",
  "serde_json",
  "sha2",
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/packages/nixling-gateway-runtime/Cargo.toml
+++ b/packages/nixling-gateway-runtime/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 [lints]
 workspace = true
 
-# Top-level gateway composition (ADR 0032, P0): ties the codec-neutral
+# Top-level gateway composition (ADR 0032): ties the codec-neutral
 # nixling-gateway orchestrator/handshake to the concrete Azure Relay transport
 # (nixling-provider-relay) and the ACA workload provider (nixling-provider-aca).
 # This is the only crate that depends on both the gateway and the providers; it
@@ -27,9 +27,14 @@ nixling-constellation-provider = { path = "../nixling-constellation-provider", v
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 base64 = "0.22"
+chacha20poly1305 = "0.10"
+getrandom = "0.2"
+libc = "0.2"
+serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 azure_core = "1.0.0"

--- a/packages/nixling-gateway-runtime/src/bin/nixling-gateway-enroll.rs
+++ b/packages/nixling-gateway-runtime/src/bin/nixling-gateway-enroll.rs
@@ -1,0 +1,118 @@
+//! In-guest gateway credential enrollment helper.
+//!
+//! Secrets are read from stdin and sealed into the gateway runtime state. They
+//! are never accepted as command-line arguments.
+
+use std::io::Read;
+use std::path::PathBuf;
+
+use nixling_gateway_runtime::{
+    CredentialEnvelopeMeta, CredentialError, CredentialFilePolicy, GatewayCredential, SealingKey,
+};
+
+type Err = Box<dyn std::error::Error>;
+
+fn usage() -> Err {
+    "usage: nixling-gateway-enroll <enroll|rotate> <credential-path> <seal-key-path> [not-after-unix]"
+        .into()
+}
+
+fn not_after(raw: Option<String>) -> Result<Option<u64>, Err> {
+    raw.map(|value| value.parse().map_err(Into::into))
+        .transpose()
+}
+
+fn read_material() -> Result<nixling_gateway_runtime::GatewayCredentialMaterial, Err> {
+    let mut raw = String::new();
+    std::io::stdin().read_to_string(&mut raw)?;
+    Ok(GatewayCredential::material_from_json(&raw)?)
+}
+
+fn validate_paths(credential_path: &PathBuf, seal_key_path: &PathBuf) -> Result<(), Err> {
+    let state_dir = std::env::var("NIXLING_GATEWAY_STATE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/var/lib/nixling/gateways"));
+    for path in [credential_path, seal_key_path] {
+        if !path.is_absolute()
+            || path.starts_with("/nix/store")
+            || path
+                .components()
+                .any(|component| matches!(component, std::path::Component::ParentDir))
+            || !path.starts_with(&state_dir)
+        {
+            return Err(
+                "credential and seal key must be absolute runtime paths under the gateway state directory"
+                    .into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), Err> {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .try_init();
+    let mut args = std::env::args().skip(1);
+    let op = args.next().ok_or_else(usage)?;
+    let credential_path = PathBuf::from(args.next().ok_or_else(usage)?);
+    let seal_key_path = PathBuf::from(args.next().ok_or_else(usage)?);
+    let not_after = not_after(args.next())?;
+    if args.next().is_some() {
+        return Err(usage());
+    }
+    validate_paths(&credential_path, &seal_key_path)?;
+
+    let policy = CredentialFilePolicy::default();
+    let material = read_material()?;
+    let now = now_unix();
+    let generation = match op.as_str() {
+        "enroll" => {
+            let key = SealingKey::load_or_generate(&seal_key_path, &policy)?;
+            match GatewayCredential::enroll_sealed(
+                &credential_path,
+                &key,
+                material,
+                CredentialEnvelopeMeta::first(not_after),
+                now,
+            ) {
+                Ok(()) => 1,
+                Err(CredentialError::AlreadyExists) => {
+                    GatewayCredential::load_sealed(&credential_path, &key, &policy, now)?
+                        .generation()
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+        "rotate" => {
+            let key = SealingKey::load(&seal_key_path, &policy)?;
+            GatewayCredential::rotate_sealed(
+                &credential_path,
+                &key,
+                material,
+                &policy,
+                now,
+                not_after,
+            )?
+        }
+        _ => return Err(usage()),
+    };
+
+    tracing::info!(action = %op, generation, "gateway credential lifecycle updated");
+    println!(
+        "{}",
+        serde_json::json!({
+            "status": op,
+            "generation": generation,
+        })
+    );
+    Ok(())
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}

--- a/packages/nixling-gateway-runtime/src/bin/nixling-gateway-relay.rs
+++ b/packages/nixling-gateway-runtime/src/bin/nixling-gateway-relay.rs
@@ -1,4 +1,4 @@
-//! `nixling-gateway-relay` — the handshake-gated relay endpoint (ADR 0032 P0).
+//! `nixling-gateway-relay` — the handshake-gated relay endpoint (ADR 0032).
 //!
 //! Unlike the plain `nixling-relay` byte tunnel, this endpoint carries the
 //! per-session credential as the relay prologue:
@@ -24,7 +24,7 @@
 //!   NL_SESSION_NOT_AFTER    unix-seconds expiry (u64)
 //!
 //!   NIXLING_RELAY_NAMESPACE / NIXLING_RELAY_ENTITY / NIXLING_RELAY_TARGET
-//!   NIXLING_RELAY_SAS_TOKEN    short-lived Send bearer, preferred for P0
+//!   NIXLING_RELAY_SAS_TOKEN    short-lived Send bearer
 //!   NIXLING_RELAY_ENTRA_TOKEN  Entra bearer, or key envs for tools/tests
 //!   NIXLING_RELAY_KEY_NAME / NIXLING_RELAY_KEY
 //!   NIXLING_RELAY_CA_FILE      (optional, sandbox egress-proxy CA)

--- a/packages/nixling-gateway-runtime/src/credential.rs
+++ b/packages/nixling-gateway-runtime/src/credential.rs
@@ -5,22 +5,35 @@
 //! gateway principal uid, redacts all key/token debug output, and mints
 //! short-lived Relay Send tokens from a least-privilege send rule.
 
-use std::fs;
-use std::os::unix::fs::MetadataExt;
-use std::path::Path;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 
+use base64::Engine;
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use nixling_provider_relay::{
     MAX_SAS_TTL_SECS, RelayCredential, RelayEndpoint, RelayError, mint_sas,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Required file mode for gateway credential envelopes.
 pub const GATEWAY_CREDENTIAL_MODE: u32 = 0o600;
+/// Required file mode for the in-guest sealing key.
+pub const GATEWAY_SEAL_KEY_MODE: u32 = 0o600;
+/// Current sealed credential envelope schema.
+pub const GATEWAY_CREDENTIAL_SCHEMA_VERSION: u32 = 1;
+/// ChaCha20-Poly1305 key length.
+pub const GATEWAY_SEAL_KEY_LEN: usize = 32;
+const GATEWAY_CREDENTIAL_NONCE_LEN: usize = 12;
+const SEALING_AAD_PREFIX: &[u8] = b"nixling-gateway-credential-v1";
 
-/// Maximum lifetime for gateway-minted Relay Send SAS bearers in the P0 path.
+/// Maximum lifetime for gateway-minted Relay Send SAS bearers.
 pub const MAX_RELAY_SEND_TOKEN_TTL_SECS: u64 = MAX_SAS_TTL_SECS;
 
-/// Default lifetime for gateway-minted Relay Send SAS bearers in the P0 path.
+/// Default lifetime for gateway-minted Relay Send SAS bearers.
 pub const DEFAULT_RELAY_SEND_TOKEN_TTL_SECS: u64 = MAX_RELAY_SEND_TOKEN_TTL_SECS;
 
 /// Runtime credential file policy.
@@ -30,6 +43,97 @@ pub struct CredentialFilePolicy {
     pub required_uid: Option<u32>,
 }
 
+/// The in-guest sealing key used to encrypt the gateway credential envelope.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SealingKey([u8; GATEWAY_SEAL_KEY_LEN]);
+
+impl SealingKey {
+    /// Wrap raw key bytes.
+    pub fn from_bytes(bytes: [u8; GATEWAY_SEAL_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    /// Load an existing sealing key, enforcing runtime-file policy.
+    pub fn load(
+        path: impl AsRef<Path>,
+        policy: &CredentialFilePolicy,
+    ) -> Result<Self, CredentialError> {
+        let bytes = read_policy_file(path.as_ref(), GATEWAY_SEAL_KEY_MODE, policy)?;
+        let key: [u8; GATEWAY_SEAL_KEY_LEN] = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| CredentialError::BadSealKey)?;
+        Ok(Self(key))
+    }
+
+    /// Load an existing key or create a new guest-local key with `0600` mode.
+    pub fn load_or_generate(
+        path: impl AsRef<Path>,
+        policy: &CredentialFilePolicy,
+    ) -> Result<Self, CredentialError> {
+        let path = path.as_ref();
+        if path.exists() {
+            return Self::load(path, policy);
+        }
+        let mut bytes = [0_u8; GATEWAY_SEAL_KEY_LEN];
+        getrandom::getrandom(&mut bytes).map_err(|_| CredentialError::Crypto)?;
+        match write_runtime_file(path, &bytes, GATEWAY_SEAL_KEY_MODE, false) {
+            Ok(()) | Err(CredentialError::AlreadyExists) => {}
+            Err(err) => return Err(err),
+        }
+        Self::load(path, policy)
+    }
+}
+
+impl core::fmt::Debug for SealingKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("SealingKey(<redacted>)")
+    }
+}
+
+/// Plaintext credential material accepted by the in-guest enrollment flow.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GatewayCredentialMaterial {
+    /// Relay Listen rule name.
+    pub listen_key_name: String,
+    /// Relay Listen rule key.
+    pub listen_key: String,
+    /// Relay Send rule name.
+    pub send_key_name: String,
+    /// Relay Send rule key.
+    pub send_key: String,
+}
+
+impl core::fmt::Debug for GatewayCredentialMaterial {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GatewayCredentialMaterial")
+            .field("listen_key_name", &self.listen_key_name)
+            .field("listen_key", &"<redacted>")
+            .field("send_key_name", &self.send_key_name)
+            .field("send_key", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Metadata attached to a sealed gateway credential envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CredentialEnvelopeMeta {
+    /// Gateway credential generation. Rotation must increase it.
+    pub generation: u64,
+    /// Optional Unix-seconds expiry for the envelope.
+    pub not_after: Option<u64>,
+}
+
+impl CredentialEnvelopeMeta {
+    /// First enrollment generation.
+    pub fn first(not_after: Option<u64>) -> Self {
+        Self {
+            generation: 1,
+            not_after,
+        }
+    }
+}
+
 /// A loaded gateway credential envelope. `Debug` redacts all secret material.
 #[derive(Clone)]
 pub struct GatewayCredential {
@@ -37,6 +141,8 @@ pub struct GatewayCredential {
     listen_key: String,
     send_key_name: String,
     send_key: String,
+    generation: u64,
+    not_after: Option<u64>,
 }
 
 impl core::fmt::Debug for GatewayCredential {
@@ -46,31 +152,144 @@ impl core::fmt::Debug for GatewayCredential {
             .field("listen_key", &"<redacted>")
             .field("send_key_name", &self.send_key_name)
             .field("send_key", &"<redacted>")
+            .field("generation", &self.generation)
+            .field("not_after", &self.not_after)
             .finish()
     }
 }
 
 impl GatewayCredential {
-    /// Load and validate the credential envelope at `path`.
+    /// Load and validate the legacy plaintext credential envelope at `path`.
+    ///
+    /// New gateway-owned credential state should use
+    /// [`GatewayCredential::load_sealed`]. This loader exists only for parsing
+    /// transition fixtures and for explicitly-guarded development paths.
     pub fn load(
         path: impl AsRef<Path>,
         policy: &CredentialFilePolicy,
     ) -> Result<Self, CredentialError> {
         let path = path.as_ref();
-        if path.starts_with("/nix/store") {
-            return Err(CredentialError::NixStorePath);
+        let raw = read_policy_file(path, GATEWAY_CREDENTIAL_MODE, policy)?;
+        let raw = std::str::from_utf8(&raw).map_err(|_| CredentialError::Malformed)?;
+        Self::from_material(
+            Self::parse_material_json(raw)?,
+            CredentialEnvelopeMeta {
+                generation: 0,
+                not_after: None,
+            },
+        )
+    }
+
+    /// Load and unseal the gateway-owned credential envelope.
+    pub fn load_sealed(
+        path: impl AsRef<Path>,
+        sealing_key: &SealingKey,
+        policy: &CredentialFilePolicy,
+        now_unix: u64,
+    ) -> Result<Self, CredentialError> {
+        Self::load_sealed_inner(path.as_ref(), sealing_key, policy, Some(now_unix))
+    }
+
+    fn load_sealed_inner(
+        path: &Path,
+        sealing_key: &SealingKey,
+        policy: &CredentialFilePolicy,
+        now_unix: Option<u64>,
+    ) -> Result<Self, CredentialError> {
+        let raw = read_policy_file(path, GATEWAY_CREDENTIAL_MODE, policy)?;
+        let envelope: SealedCredentialFile =
+            serde_json::from_slice(&raw).map_err(|_| CredentialError::Malformed)?;
+        if envelope.schema_version != GATEWAY_CREDENTIAL_SCHEMA_VERSION {
+            return Err(CredentialError::BadSchemaVersion(envelope.schema_version));
         }
-        let meta = fs::metadata(path).map_err(|_| CredentialError::Unreadable)?;
-        if meta.mode() & 0o777 != GATEWAY_CREDENTIAL_MODE {
-            return Err(CredentialError::BadMode(meta.mode() & 0o777));
-        }
-        if let Some(uid) = policy.required_uid
-            && meta.uid() != uid
+        if let (Some(now_unix), Some(not_after)) = (now_unix, envelope.not_after)
+            && now_unix >= not_after
         {
-            return Err(CredentialError::BadOwner(meta.uid()));
+            return Err(CredentialError::Expired);
         }
-        let raw = fs::read_to_string(path).map_err(|_| CredentialError::Unreadable)?;
-        Self::parse_json(&raw)
+        let nonce = decode_fixed::<GATEWAY_CREDENTIAL_NONCE_LEN>(&envelope.nonce)?;
+        let ciphertext = base64::engine::general_purpose::STANDARD
+            .decode(envelope.ciphertext.as_bytes())
+            .map_err(|_| CredentialError::Malformed)?;
+        let aad = credential_aad(envelope.generation, envelope.not_after);
+        let plaintext = cipher(sealing_key)
+            .decrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: &ciphertext,
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| CredentialError::Crypto)?;
+        let plaintext = std::str::from_utf8(&plaintext).map_err(|_| CredentialError::Malformed)?;
+        Self::from_material(
+            Self::parse_material_json(plaintext)?,
+            CredentialEnvelopeMeta {
+                generation: envelope.generation,
+                not_after: envelope.not_after,
+            },
+        )
+    }
+
+    /// Enroll a new sealed credential envelope. Existing envelopes are refused.
+    pub fn enroll_sealed(
+        path: impl AsRef<Path>,
+        sealing_key: &SealingKey,
+        material: GatewayCredentialMaterial,
+        meta: CredentialEnvelopeMeta,
+        now_unix: u64,
+    ) -> Result<(), CredentialError> {
+        if meta.generation == 0 {
+            return Err(CredentialError::GenerationNotAdvanced);
+        }
+        validate_not_after(meta.not_after, now_unix)?;
+        if path.as_ref().exists() {
+            return Err(CredentialError::AlreadyExists);
+        }
+        write_sealed(path.as_ref(), sealing_key, material, meta, false)
+    }
+
+    /// Rotate an existing sealed envelope and return the new generation.
+    pub fn rotate_sealed(
+        path: impl AsRef<Path>,
+        sealing_key: &SealingKey,
+        material: GatewayCredentialMaterial,
+        policy: &CredentialFilePolicy,
+        now_unix: u64,
+        not_after: Option<u64>,
+    ) -> Result<u64, CredentialError> {
+        let current = Self::load_sealed_inner(path.as_ref(), sealing_key, policy, None)?;
+        let generation = current.generation.saturating_add(1);
+        if generation <= current.generation {
+            return Err(CredentialError::GenerationNotAdvanced);
+        }
+        validate_not_after(not_after, now_unix)?;
+        write_sealed(
+            path.as_ref(),
+            sealing_key,
+            material,
+            CredentialEnvelopeMeta {
+                generation,
+                not_after,
+            },
+            true,
+        )?;
+        Ok(generation)
+    }
+
+    /// Parse plaintext enrollment JSON into secret material.
+    pub fn material_from_json(raw: &str) -> Result<GatewayCredentialMaterial, CredentialError> {
+        Self::parse_material_json(raw)
+    }
+
+    /// Credential generation.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Optional Unix-seconds expiry for the sealed envelope.
+    pub fn not_after(&self) -> Option<u64> {
+        self.not_after
     }
 
     /// Build the gateway listener credential (Listen rule).
@@ -103,13 +322,27 @@ impl GatewayCredential {
         )?))
     }
 
-    fn parse_json(raw: &str) -> Result<Self, CredentialError> {
+    fn parse_material_json(raw: &str) -> Result<GatewayCredentialMaterial, CredentialError> {
         let v: Value = serde_json::from_str(raw).map_err(|_| CredentialError::Malformed)?;
-        Ok(Self {
+        Ok(GatewayCredentialMaterial {
             listen_key_name: required_str(&v, &["relayListen", "keyName"])?,
             listen_key: required_str(&v, &["relayListen", "key"])?,
             send_key_name: required_str(&v, &["relaySend", "keyName"])?,
             send_key: required_str(&v, &["relaySend", "key"])?,
+        })
+    }
+
+    fn from_material(
+        material: GatewayCredentialMaterial,
+        meta: CredentialEnvelopeMeta,
+    ) -> Result<Self, CredentialError> {
+        Ok(Self {
+            listen_key_name: material.listen_key_name,
+            listen_key: material.listen_key,
+            send_key_name: material.send_key_name,
+            send_key: material.send_key,
+            generation: meta.generation,
+            not_after: meta.not_after,
         })
     }
 }
@@ -131,6 +364,17 @@ impl core::fmt::Debug for MintedRelaySendToken {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SealedCredentialFile {
+    schema_version: u32,
+    generation: u64,
+    #[serde(default)]
+    not_after: Option<u64>,
+    nonce: String,
+    ciphertext: String,
+}
+
 /// Credential load/validation failures.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CredentialError {
@@ -144,6 +388,20 @@ pub enum CredentialError {
     BadOwner(u32),
     /// JSON shape was malformed or missing a required field.
     Malformed,
+    /// Runtime credential path was not a regular file.
+    BadFileType,
+    /// Sealed envelope schema is unsupported.
+    BadSchemaVersion(u32),
+    /// Sealing key was malformed.
+    BadSealKey,
+    /// Sealed envelope could not be decrypted or random bytes could not be generated.
+    Crypto,
+    /// Sealed envelope expired.
+    Expired,
+    /// Enrollment target already exists.
+    AlreadyExists,
+    /// Credential generation did not advance.
+    GenerationNotAdvanced,
 }
 
 impl core::fmt::Display for CredentialError {
@@ -160,11 +418,232 @@ impl core::fmt::Display for CredentialError {
                 write!(f, "gateway credential owner uid mismatch: {uid}")
             }
             CredentialError::Malformed => f.write_str("gateway credential JSON is malformed"),
+            CredentialError::BadFileType => {
+                f.write_str("gateway credential must be a regular file")
+            }
+            CredentialError::BadSchemaVersion(version) => {
+                write!(
+                    f,
+                    "gateway credential schema version {version} is unsupported"
+                )
+            }
+            CredentialError::BadSealKey => f.write_str("gateway sealing key is malformed"),
+            CredentialError::Crypto => {
+                f.write_str("gateway credential envelope cannot be unsealed")
+            }
+            CredentialError::Expired => f.write_str("gateway credential envelope expired"),
+            CredentialError::AlreadyExists => {
+                f.write_str("gateway credential envelope already exists")
+            }
+            CredentialError::GenerationNotAdvanced => {
+                f.write_str("gateway credential generation did not advance")
+            }
         }
     }
 }
 
 impl std::error::Error for CredentialError {}
+
+fn validate_not_after(not_after: Option<u64>, now_unix: u64) -> Result<(), CredentialError> {
+    if let Some(not_after) = not_after
+        && not_after <= now_unix
+    {
+        return Err(CredentialError::Expired);
+    }
+    Ok(())
+}
+
+fn read_policy_file(
+    path: &Path,
+    required_mode: u32,
+    policy: &CredentialFilePolicy,
+) -> Result<Vec<u8>, CredentialError> {
+    if path.starts_with("/nix/store") {
+        return Err(CredentialError::NixStorePath);
+    }
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|_| CredentialError::Unreadable)?;
+    let meta = file.metadata().map_err(|_| CredentialError::Unreadable)?;
+    if !meta.file_type().is_file() {
+        return Err(CredentialError::BadFileType);
+    }
+    if meta.mode() & 0o777 != required_mode {
+        return Err(CredentialError::BadMode(meta.mode() & 0o777));
+    }
+    if let Some(uid) = policy.required_uid
+        && meta.uid() != uid
+    {
+        return Err(CredentialError::BadOwner(meta.uid()));
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|_| CredentialError::Unreadable)?;
+    Ok(bytes)
+}
+
+fn write_runtime_file(
+    path: &Path,
+    bytes: &[u8],
+    mode: u32,
+    replace_existing: bool,
+) -> Result<(), CredentialError> {
+    if path.starts_with("/nix/store") {
+        return Err(CredentialError::NixStorePath);
+    }
+    let parent = path.parent().ok_or(CredentialError::Unreadable)?;
+    fs::create_dir_all(parent).map_err(|_| CredentialError::Unreadable)?;
+    if !replace_existing {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(path)
+            .map_err(|err| {
+                if err.kind() == std::io::ErrorKind::AlreadyExists {
+                    CredentialError::AlreadyExists
+                } else {
+                    CredentialError::Unreadable
+                }
+            })?;
+        if file
+            .write_all(bytes)
+            .and_then(|_| file.set_permissions(fs::Permissions::from_mode(mode)))
+            .and_then(|_| file.sync_all())
+            .is_err()
+        {
+            let _ = fs::remove_file(path);
+            return Err(CredentialError::Unreadable);
+        }
+        sync_parent_dir(parent)?;
+        return Ok(());
+    }
+    let tmp = temp_path(path);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(mode)
+        .open(&tmp)
+        .map_err(|_| CredentialError::Unreadable)?;
+    if file
+        .write_all(bytes)
+        .and_then(|_| file.set_permissions(fs::Permissions::from_mode(mode)))
+        .and_then(|_| file.sync_all())
+        .is_err()
+    {
+        let _ = fs::remove_file(&tmp);
+        return Err(CredentialError::Unreadable);
+    }
+    fs::rename(&tmp, path).map_err(|_| {
+        let _ = fs::remove_file(&tmp);
+        CredentialError::Unreadable
+    })?;
+    sync_parent_dir(parent)?;
+    Ok(())
+}
+
+fn sync_parent_dir(parent: &Path) -> Result<(), CredentialError> {
+    fs::File::open(parent)
+        .and_then(|dir| dir.sync_all())
+        .map_err(|_| CredentialError::Unreadable)
+}
+
+fn write_sealed(
+    path: &Path,
+    sealing_key: &SealingKey,
+    material: GatewayCredentialMaterial,
+    meta: CredentialEnvelopeMeta,
+    replace_existing: bool,
+) -> Result<(), CredentialError> {
+    let plaintext =
+        serde_json::to_vec(&material_json(material)).map_err(|_| CredentialError::Malformed)?;
+    let mut nonce = [0_u8; GATEWAY_CREDENTIAL_NONCE_LEN];
+    getrandom::getrandom(&mut nonce).map_err(|_| CredentialError::Crypto)?;
+    let aad = credential_aad(meta.generation, meta.not_after);
+    let ciphertext = cipher(sealing_key)
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: &plaintext,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| CredentialError::Crypto)?;
+    let envelope = SealedCredentialFile {
+        schema_version: GATEWAY_CREDENTIAL_SCHEMA_VERSION,
+        generation: meta.generation,
+        not_after: meta.not_after,
+        nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
+        ciphertext: base64::engine::general_purpose::STANDARD.encode(ciphertext),
+    };
+    let body = serde_json::to_vec(&envelope).map_err(|_| CredentialError::Malformed)?;
+    write_runtime_file(path, &body, GATEWAY_CREDENTIAL_MODE, replace_existing)
+}
+
+fn material_json(material: GatewayCredentialMaterial) -> Value {
+    serde_json::json!({
+        "relayListen": {
+            "keyName": material.listen_key_name,
+            "key": material.listen_key,
+        },
+        "relaySend": {
+            "keyName": material.send_key_name,
+            "key": material.send_key,
+        },
+    })
+}
+
+fn temp_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("credential");
+    path.with_file_name(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        monotonic_nanos()
+    ))
+}
+
+fn monotonic_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+
+fn cipher(sealing_key: &SealingKey) -> ChaCha20Poly1305 {
+    ChaCha20Poly1305::new(Key::from_slice(&sealing_key.0))
+}
+
+fn credential_aad(generation: u64, not_after: Option<u64>) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(SEALING_AAD_PREFIX.len() + 24);
+    aad.extend_from_slice(SEALING_AAD_PREFIX);
+    aad.extend_from_slice(&generation.to_be_bytes());
+    match not_after {
+        Some(not_after) => {
+            aad.push(1);
+            aad.extend_from_slice(&not_after.to_be_bytes());
+        }
+        None => {
+            aad.push(0);
+            aad.extend_from_slice(&0_u64.to_be_bytes());
+        }
+    }
+    aad
+}
+
+fn decode_fixed<const N: usize>(encoded: &str) -> Result<[u8; N], CredentialError> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded.as_bytes())
+        .map_err(|_| CredentialError::Malformed)?;
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| CredentialError::Malformed)
+}
 
 fn required_str(v: &Value, path: &[&str]) -> Result<String, CredentialError> {
     let mut cur = v;
@@ -195,6 +674,19 @@ mod tests {
         .unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
         path
+    }
+
+    fn material() -> GatewayCredentialMaterial {
+        GatewayCredentialMaterial {
+            listen_key_name: "gateway-listen".to_owned(),
+            listen_key: "listen-secret".to_owned(),
+            send_key_name: "gateway-send".to_owned(),
+            send_key: "send-secret".to_owned(),
+        }
+    }
+
+    fn sealing_key() -> SealingKey {
+        SealingKey::from_bytes([9_u8; GATEWAY_SEAL_KEY_LEN])
     }
 
     fn endpoint() -> RelayEndpoint {
@@ -270,6 +762,224 @@ mod tests {
             ),
             Err(CredentialError::BadOwner(_))
         ));
+    }
+
+    #[test]
+    fn sealing_key_load_or_generate_creates_guest_local_0600_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seal.key");
+        let key = SealingKey::load_or_generate(&path, &CredentialFilePolicy::default()).unwrap();
+        assert_eq!(format!("{key:?}"), "SealingKey(<redacted>)");
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o600);
+        let again = SealingKey::load(&path, &CredentialFilePolicy::default()).unwrap();
+        assert_eq!(key, again);
+    }
+
+    #[test]
+    fn enrolls_and_unseals_gateway_owned_credential_envelope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credential.sealed.json");
+        GatewayCredential::enroll_sealed(
+            &path,
+            &sealing_key(),
+            material(),
+            CredentialEnvelopeMeta::first(Some(2_000)),
+            1_000,
+        )
+        .unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o600);
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("listen-secret"));
+        assert!(!raw.contains("send-secret"));
+
+        let cred = GatewayCredential::load_sealed(
+            &path,
+            &sealing_key(),
+            &CredentialFilePolicy::default(),
+            1_000,
+        )
+        .unwrap();
+        assert_eq!(cred.generation(), 1);
+        assert_eq!(cred.not_after(), Some(2_000));
+        let dbg = format!("{cred:?}");
+        assert!(!dbg.contains("listen-secret"));
+        assert!(!dbg.contains("send-secret"));
+    }
+
+    #[test]
+    fn sealed_gateway_credential_expiry_is_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credential.sealed.json");
+        GatewayCredential::enroll_sealed(
+            &path,
+            &sealing_key(),
+            material(),
+            CredentialEnvelopeMeta::first(Some(10)),
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            GatewayCredential::load_sealed(
+                &path,
+                &sealing_key(),
+                &CredentialFilePolicy::default(),
+                10,
+            )
+            .unwrap_err(),
+            CredentialError::Expired
+        );
+    }
+
+    #[test]
+    fn enrollment_rejects_immediately_expired_envelope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credential.sealed.json");
+        assert_eq!(
+            GatewayCredential::enroll_sealed(
+                &path,
+                &sealing_key(),
+                material(),
+                CredentialEnvelopeMeta::first(Some(10)),
+                10,
+            )
+            .unwrap_err(),
+            CredentialError::Expired
+        );
+    }
+
+    #[test]
+    fn rotation_advances_generation_and_invalidates_old_key_material() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credential.sealed.json");
+        GatewayCredential::enroll_sealed(
+            &path,
+            &sealing_key(),
+            material(),
+            CredentialEnvelopeMeta::first(None),
+            1,
+        )
+        .unwrap();
+        let mut rotated = material();
+        rotated.send_key = "new-send-secret".to_owned();
+        let next = GatewayCredential::rotate_sealed(
+            &path,
+            &sealing_key(),
+            rotated,
+            &CredentialFilePolicy::default(),
+            1,
+            Some(3_000),
+        )
+        .unwrap();
+        assert_eq!(next, 2);
+        let cred = GatewayCredential::load_sealed(
+            &path,
+            &sealing_key(),
+            &CredentialFilePolicy::default(),
+            2,
+        )
+        .unwrap();
+        assert_eq!(cred.generation(), 2);
+        assert_eq!(cred.not_after(), Some(3_000));
+        let token = cred.mint_send_token(&endpoint(), 60).unwrap();
+        assert_eq!(sas_param(token.expose(), "skn"), "gateway-send");
+        assert!(!token.expose().contains("new-send-secret"));
+    }
+
+    #[test]
+    fn rotation_can_recover_expired_envelope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credential.sealed.json");
+        GatewayCredential::enroll_sealed(
+            &path,
+            &sealing_key(),
+            material(),
+            CredentialEnvelopeMeta::first(Some(10)),
+            1,
+        )
+        .unwrap();
+        let next = GatewayCredential::rotate_sealed(
+            &path,
+            &sealing_key(),
+            material(),
+            &CredentialFilePolicy::default(),
+            20,
+            Some(40),
+        )
+        .unwrap();
+        assert_eq!(next, 2);
+        assert_eq!(
+            GatewayCredential::load_sealed(
+                &path,
+                &sealing_key(),
+                &CredentialFilePolicy::default(),
+                20,
+            )
+            .unwrap()
+            .not_after(),
+            Some(40)
+        );
+    }
+
+    #[test]
+    fn rotation_rejects_new_expired_deadline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credential.sealed.json");
+        GatewayCredential::enroll_sealed(
+            &path,
+            &sealing_key(),
+            material(),
+            CredentialEnvelopeMeta::first(None),
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            GatewayCredential::rotate_sealed(
+                &path,
+                &sealing_key(),
+                material(),
+                &CredentialFilePolicy::default(),
+                20,
+                Some(20),
+            )
+            .unwrap_err(),
+            CredentialError::Expired
+        );
+    }
+
+    #[test]
+    fn credential_aad_distinguishes_absent_and_zero_expiry() {
+        assert_ne!(credential_aad(1, None), credential_aad(1, Some(0)));
+    }
+
+    #[test]
+    fn sealed_envelope_rejects_wrong_key_and_duplicate_enrollment() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credential.sealed.json");
+        GatewayCredential::enroll_sealed(
+            &path,
+            &sealing_key(),
+            material(),
+            CredentialEnvelopeMeta::first(None),
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            GatewayCredential::enroll_sealed(
+                &path,
+                &sealing_key(),
+                material(),
+                CredentialEnvelopeMeta::first(None),
+                1,
+            )
+            .unwrap_err(),
+            CredentialError::AlreadyExists
+        );
+        let wrong = SealingKey::from_bytes([8_u8; GATEWAY_SEAL_KEY_LEN]);
+        assert_eq!(
+            GatewayCredential::load_sealed(&path, &wrong, &CredentialFilePolicy::default(), 1,)
+                .unwrap_err(),
+            CredentialError::Crypto
+        );
     }
 
     #[test]

--- a/packages/nixling-gateway-runtime/src/lib.rs
+++ b/packages/nixling-gateway-runtime/src/lib.rs
@@ -1,6 +1,6 @@
 //! `nixling-gateway-runtime` — the composition root that ties the
 //! `nixling-gateway` per-session handshake to the `nixling-provider-relay`
-//! prologue gate (ADR 0032, P0). It provides the **matched pair** that makes
+//! prologue gate (ADR 0032). It provides the **matched pair** that makes
 //! the session credential gate the display byte stream over Azure Relay:
 //!
 //! - [`agent_prologue`] — built by the in-sandbox agent from the secret + the
@@ -29,8 +29,9 @@ pub use aca_workload::{
 };
 pub use audit_jsonl::{DEFAULT_GATEWAY_AUDIT_RETENTION_DAYS, JsonlGatewayAudit};
 pub use credential::{
-    CredentialError, CredentialFilePolicy, GATEWAY_CREDENTIAL_MODE, GatewayCredential,
-    MintedRelaySendToken,
+    CredentialEnvelopeMeta, CredentialError, CredentialFilePolicy, GATEWAY_CREDENTIAL_MODE,
+    GATEWAY_CREDENTIAL_SCHEMA_VERSION, GATEWAY_SEAL_KEY_LEN, GATEWAY_SEAL_KEY_MODE,
+    GatewayCredential, GatewayCredentialMaterial, MintedRelaySendToken, SealingKey,
 };
 pub use display_listener::{RelayDisplayListener, notifying_verifier};
 pub use production::production_deps_with_audit;

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -48,7 +48,8 @@ use nixling_gateway::{
 };
 use nixling_gateway_runtime::{
     AcaGatewayWorkload, AgentBinaries, CredentialFilePolicy, GatewayCredential, RelayCoords,
-    RelayDisplayListener, production_deps, relay_sas_token_snippet, system_now_fn,
+    RelayDisplayListener, SealingKey, production_deps, relay_sas_token_snippet, system_now_fn,
+    system_now_unix,
 };
 use nixling_host::ssh_keygen;
 use nixling_ipc::{
@@ -344,6 +345,8 @@ pub struct GatewayFileConfig {
     state_dir: Option<PathBuf>,
     #[serde(default)]
     credential_path: Option<PathBuf>,
+    #[serde(default)]
+    seal_key_path: Option<PathBuf>,
     #[serde(default)]
     allow_host_relay_credentials: bool,
     #[serde(default)]
@@ -750,11 +753,11 @@ fn validate_gateway_host_relay_transition_guard(
     config: &GatewayFileConfig,
 ) -> Result<(), TypedError> {
     if config.allow_host_relay_credentials {
-        Ok(())
-    } else {
         Err(gateway_display_config_error(
-            "host-held gateway credentials and relay send-bearer minting are disabled by default; set allowHostRelayCredentials=true in the gateway config only for transition/dev hosts, or move relay credentials into the gateway guest",
+            "host-held gateway credentials and relay send-bearer minting are retired; enroll inside gateway then retry",
         ))
+    } else {
+        Ok(())
     }
 }
 
@@ -2749,6 +2752,7 @@ fn validate_gateway_display_open_preflight(state: &ServerState) -> Result<(), Ty
             realm: String::new(),
             state_dir: None,
             credential_path: None,
+            seal_key_path: None,
             allow_host_relay_credentials: preflight.allow_host_relay_credentials,
             relay: GatewayRelayFileConfig::default(),
             aca: GatewayAcaFileConfig::default(),
@@ -2936,15 +2940,26 @@ fn agent_bins_from_config(config: &GatewayFileConfig) -> AgentBinaries {
     bins
 }
 
-fn relay_auth_snippet_from_config(config: &GatewayFileConfig) -> Result<String, GatewayError> {
-    validate_gateway_host_relay_transition_guard(config)
-        .map_err(|_| GatewayError::ProviderAllocationFailed)?;
+fn gateway_credential_from_config(
+    config: &GatewayFileConfig,
+) -> Result<GatewayCredential, GatewayError> {
     let credential_path = config
         .credential_path
         .as_ref()
         .ok_or(GatewayError::ProviderAllocationFailed)?;
-    let credential = GatewayCredential::load(credential_path, &CredentialFilePolicy::default())
+    let seal_key_path = config
+        .seal_key_path
+        .as_ref()
+        .ok_or(GatewayError::ProviderAllocationFailed)?;
+    let policy = CredentialFilePolicy::default();
+    let key = SealingKey::load(seal_key_path, &policy)
         .map_err(|_| GatewayError::ProviderAllocationFailed)?;
+    GatewayCredential::load_sealed(credential_path, &key, &policy, system_now_unix())
+        .map_err(|_| GatewayError::ProviderAllocationFailed)
+}
+
+fn relay_auth_snippet_from_config(config: &GatewayFileConfig) -> Result<String, GatewayError> {
+    let credential = gateway_credential_from_config(config)?;
     let token = credential
         .mint_send_token(
             &relay_endpoint_from_config(config)?,
@@ -2957,14 +2972,7 @@ fn relay_auth_snippet_from_config(config: &GatewayFileConfig) -> Result<String, 
 fn display_listener_from_config(
     config: &GatewayFileConfig,
 ) -> Result<RelayDisplayListener, GatewayError> {
-    validate_gateway_host_relay_transition_guard(config)
-        .map_err(|_| GatewayError::ProviderAllocationFailed)?;
-    let credential_path = config
-        .credential_path
-        .as_ref()
-        .ok_or(GatewayError::ProviderAllocationFailed)?;
-    let credential = GatewayCredential::load(credential_path, &CredentialFilePolicy::default())
-        .map_err(|_| GatewayError::ProviderAllocationFailed)?;
+    let credential = gateway_credential_from_config(config)?;
     let waypipe_socket = required_gateway_field(&config.display.waypipe_socket)?;
     let validated = match validate_waypipe_receiver_socket(Path::new(&waypipe_socket)) {
         Ok(validated) => validated,
@@ -11266,6 +11274,7 @@ mod public_status_tests {
             realm: "demo".to_owned(),
             state_dir: None,
             credential_path: Some(PathBuf::from("/run/nixling/test-gateway-credential.json")),
+            seal_key_path: Some(PathBuf::from("/run/nixling/test-gateway-seal.key")),
             allow_host_relay_credentials,
             relay: GatewayRelayFileConfig {
                 namespace: Some("relay.example.invalid".to_owned()),
@@ -11297,22 +11306,16 @@ mod public_status_tests {
     }
 
     #[test]
-    fn gateway_host_relay_guard_defaults_closed() {
+    fn gateway_host_relay_guard_accepts_default_guest_owned_store() {
         let dir = tempfile::tempdir().expect("gateway guard dir");
         let socket_path = bind_test_waypipe_socket(dir.path(), "waypipe.sock", 0o600);
         let config = gateway_config_for_waypipe(&socket_path, false);
-        let err = validate_gateway_host_relay_transition_guard(&config)
-            .expect_err("host relay credentials require explicit guard");
-        let detail = gateway_unavailable_detail(&err);
-        assert!(detail.contains("disabled by default"));
-        assert!(detail.contains("allowHostRelayCredentials=true"));
+        validate_gateway_host_relay_transition_guard(&config)
+            .expect("default guest-owned credential store is accepted");
     }
 
     #[test]
-    fn gateway_host_relay_guard_accepts_explicit_unprivileged_socket() {
-        if Uid::effective().is_root() {
-            return;
-        }
+    fn gateway_host_relay_guard_rejects_retired_escape_hatch() {
         let dir = tempfile::tempdir().expect("gateway guard dir");
         let socket_path = bind_test_waypipe_socket(dir.path(), "waypipe.sock", 0o600);
         let config = gateway_config_for_waypipe(&socket_path, true);
@@ -11320,8 +11323,10 @@ mod public_status_tests {
             .expect("display preflight stores config without touching the user-session socket");
         assert_eq!(preflight.waypipe_socket_path.as_ref(), Some(&socket_path));
         assert!(preflight.allow_host_relay_credentials);
-        validate_waypipe_receiver_socket(&socket_path)
-            .expect("explicit guard and valid waypipe socket are accepted");
+        let err = validate_gateway_host_relay_transition_guard(&config)
+            .expect_err("retired escape hatch is rejected");
+        assert!(gateway_unavailable_detail(&err).contains("retired"));
+        assert!(gateway_unavailable_detail(&err).contains("enroll inside gateway then retry"));
     }
 
     #[test]
@@ -11345,10 +11350,10 @@ mod public_status_tests {
     }
 
     #[test]
-    fn gateway_display_open_validates_waypipe_socket_before_orchestrator() {
+    fn gateway_display_open_refuses_retired_host_relay_before_orchestrator() {
         let (mut state, _dir) = test_state();
         let dir = tempfile::tempdir().expect("waypipe dispatch dir");
-        let socket_path = bind_test_waypipe_socket(dir.path(), "waypipe.sock", 0o660);
+        let socket_path = bind_test_waypipe_socket(dir.path(), "waypipe.sock", 0o600);
         state.gateway_display = Arc::new(GatewayDisplayRuntime {
             orchestrator: GatewayOrchestrator::new(
                 daemon_gateway_deps(),
@@ -11376,8 +11381,9 @@ mod public_status_tests {
                 },
             )),
         )
-        .expect_err("invalid waypipe socket blocks gateway open");
-        assert!(gateway_unavailable_detail(&err).contains("mode 0600"));
+        .expect_err("retired host relay credential path blocks gateway open");
+        assert!(gateway_unavailable_detail(&err).contains("retired"));
+        assert!(gateway_unavailable_detail(&err).contains("enroll inside gateway then retry"));
         assert!(state.gateway_display.sessions.lock().unwrap().is_empty());
     }
 
@@ -15233,7 +15239,8 @@ mod broker_dispatch_tests {
             "authz-audit-requires-admin",
         ];
         for kind in &kinds {
-            let (summary, remediation) = redact_broker_error_for_launcher("Op", Some("W15"), kind);
+            let (summary, remediation) =
+                redact_broker_error_for_launcher("Op", Some("op-15"), kind);
             assert!(!summary.is_empty(), "kind={kind} summary empty");
             assert!(!remediation.is_empty(), "kind={kind} remediation empty");
             for forbidden in &["/etc/", "/var/lib/", "systemctl", "execve", "Caused by"] {
@@ -17805,8 +17812,6 @@ mod broker_dispatch_tests {
             "stateless guest-control readiness MUST be a loud Err so a routing regression cannot masquerade as a benign never-ready"
         );
     }
-
-    // --- fix2a: readiness-loop liveness fast-fail ( W1 ) -----------------
 
     /// Scripted observe-only liveness fake driving the readiness loop
     /// through the same call site as production. Pops the next scripted

--- a/packages/nixlingd/src/typed_error.rs
+++ b/packages/nixlingd/src/typed_error.rs
@@ -676,8 +676,8 @@ impl TypedError {
             }
             Self::GatewayDisplayUnavailable { detail } => {
                 let redacted = redact_path_like_tokens(detail);
-                if detail.contains("allowHostRelayCredentials") {
-                    "set allowHostRelayCredentials=true only on an explicit transition/dev host, or move relay credentials into the gateway guest before retrying".to_owned()
+                if detail.contains("host-held gateway credentials") {
+                    "enroll inside gateway then retry".to_owned()
                 } else if detail.contains("mode 0600") {
                     format!("repair the operator Waypipe receiver socket permissions and retry: {redacted}")
                 } else if detail.contains("waypipeSocket") {

--- a/tests/unit/nix/cases/gateway-vm.nix
+++ b/tests/unit/nix/cases/gateway-vm.nix
@@ -74,7 +74,8 @@ let
     "nixling-wayland-mi"
     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/nixling"
     "11111111-1111-1111-1111-111111111111"
-    "/var/lib/nixling/gateways/work/credential.json"
+    "/var/lib/nixling/gateways/work/credential.sealed.json"
+    "/var/lib/nixling/gateways/work/seal.key"
   ];
   forbiddenRemoteRegistryMarkers = [
     "\"remoteNodes\""
@@ -123,6 +124,11 @@ let
   badCredentialOutsideStateMessages = failureMessages ((mkEval [
     (lib.recursiveUpdate base {
       nixling.gateways.work.credentialPath = "/var/lib/nixling/other/credential.json";
+    })
+  ]).config);
+  badSealKeyOutsideStateMessages = failureMessages ((mkEval [
+    (lib.recursiveUpdate base {
+      nixling.gateways.work.sealKeyPath = "/var/lib/nixling/other/seal.key";
     })
   ]).config);
   badTraversalMessages = failureMessages ((mkEval [
@@ -199,6 +205,11 @@ let
       nixling.gateways.work.realm = "local";
     })
   ]).config);
+  retiredHostRelayCredentialMessages = failureMessages ((mkEval [
+    (lib.recursiveUpdate base {
+      nixling.gateways.work.allowHostRelayCredentials = true;
+    })
+  ]).config);
   sourceToolsCfg = (mkEval [
     (lib.recursiveUpdate base {
       nixling.site.usePrebuiltHostTools = false;
@@ -254,6 +265,13 @@ in
     expected = true;
   };
 
+  "gateway-vm/rejects-seal-key-path-outside-gateway-state" = {
+    expr = lib.any
+      (m: lib.hasInfix "nixling.gateways.work.sealKeyPath must live under" m)
+      badSealKeyOutsideStateMessages;
+    expected = true;
+  };
+
   "gateway-vm/rejects-parent-traversal-in-state-paths" = {
     expr = lib.any
       (m: lib.hasInfix "must not contain `..` path" m)
@@ -300,6 +318,9 @@ in
       };
 
       hasWaypipeSocket = gatewayJson.display ? waypipeSocket;
+      sealKeyPath = gatewayJson.sealKeyPath;
+      credentialPath = gatewayJson.credentialPath;
+      hasEnrollmentHelper = builtins.elem "nixling-gateway-runtime" packageNames;
       hasWaypipeClient = builtins.hasAttr "nixling-gateway-waypipe-client" gatewayGuestCfg.systemd.services;
       hasWaypipeServer = builtins.hasAttr "nixling-gateway-waypipe-server" gatewayGuestCfg.systemd.services;
     };
@@ -319,6 +340,9 @@ in
         memory = "2048Mi";
         autoSuspendIntervalSecs = 600;
       };
+      sealKeyPath = "/var/lib/nixling/gateways/work/seal.key";
+      credentialPath = "/var/lib/nixling/gateways/work/credential.sealed.json";
+      hasEnrollmentHelper = true;
       hasWaypipeSocket = false;
       hasWaypipeClient = false;
       hasWaypipeServer = false;
@@ -370,7 +394,7 @@ in
       gatewayUserCanReachPublicSocket = builtins.elem "nixling" gatewayGuestCfg.users.users.gateway.extraGroups;
     };
     expected = {
-      hostStateDir = true;
+      hostStateDir = false;
       guestStateDir = true;
       guestDaemonStateDir = true;
       guestLockFile = true;
@@ -564,6 +588,13 @@ in
       inherit hostGatewayJsonPresent;
       guest = gatewayJson.allowHostRelayCredentials;
     };
+
+    "gateway-vm/rejects-retired-host-relay-credential-escape-hatch" = {
+      expr = lib.any
+        (m: lib.hasInfix "allowHostRelayCredentials has been retired" m)
+        retiredHostRelayCredentialMessages;
+      expected = true;
+    };
     expected = {
       hostGatewayJsonPresent = false;
       guest = false;
@@ -638,7 +669,7 @@ in
       noSystemPackagesScan = !(lib.hasInfix "config.environment.systemPackages" gatewayModuleSource);
       hasNixling = builtins.elem "nixling" packageNames;
       hasNixlingd = builtins.elem "nixlingd" packageNames;
-      hasGatewayRelaySourceBuild = builtins.elem "nixling-gateway-relay" packageNames;
+      hasGatewayRuntime = builtins.elem "nixling-gateway-runtime" packageNames;
     };
     expected = {
       noInlineBuildRustPackage = true;
@@ -646,7 +677,7 @@ in
       noSystemPackagesScan = true;
       hasNixling = true;
       hasNixlingd = true;
-      hasGatewayRelaySourceBuild = false;
+      hasGatewayRuntime = true;
     };
   };
 }


### PR DESCRIPTION
## Summary
- add in-guest gateway credential enrollment and rotation with sealed runtime envelopes
- install nixling-gateway-enroll in gateway guests and keep secrets on stdin, not argv
- retire host-side gateway credential reads / Relay Send bearer minting in generated config
- add Nix assertions and eval coverage for sealed credential paths and host/guest boundaries

## Validation
- cargo test -p nixling-gateway-runtime --all-targets --quiet
- cargo test -p nixlingd gateway --quiet
- cargo check -p xtask --quiet
- bash tests/test-nix-unit.sh gateway-vm
- make test-drift
- cargo clippy -p nixling-gateway-runtime --all-targets -- -D warnings
- cargo clippy -p nixlingd --all-targets -- -D warnings
- git diff --check && git diff --cached --check
- process-marker scan over changed shipped files

## Panel
Gemini 3.1 Pro end-of-wave panel reached unanimous signoff after R4. Reviewers were instructed not to rerun tests; raw panel output remains in session context.