### PR TITLE
ADR032: add transport conformance matrix

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -170,7 +170,7 @@ jobs:
   flake-eval-x86:
     needs: flake-eval-discover
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ deprecations ship one minor release before removal.
 - Gateway credentials can now be enrolled and rotated inside the gateway
   guest as a sealed runtime envelope, while host-side gateway credential
   reads and Relay Send bearer minting are rejected.
+- Transport conformance now covers loopback session capacity, byte-exact
+  concurrent sessions, shutdown, frame-cap rejection, truncated frames,
+  capability intersection, stream backpressure, and retry-safe stream
+  cancellation.
 
 ### Changed
 

--- a/docs/reference/constellation-protocol.md
+++ b/docs/reference/constellation-protocol.md
@@ -31,6 +31,11 @@ The session layer carries a 4-byte little-endian length followed by one
 codec frame. The frame cap is 1 MiB and is enforced before payload
 allocation or protobuf decode.
 
+Transport adapters must preserve byte-exact delivery, bounded pending
+session queues, typed unavailable/backpressure errors, and explicit
+shutdown behavior. The reusable checks are listed in the
+[transport conformance matrix](./transport-conformance-matrix.md).
+
 The protobuf codec maps bytes to the codec-neutral `ConstellationFrame`.
 The router consumes only semantic frames; it never depends on protobuf
 types. The schema fingerprint for the current protobuf shape is exposed by

--- a/docs/reference/transport-conformance-matrix.md
+++ b/docs/reference/transport-conformance-matrix.md
@@ -1,0 +1,30 @@
+# Transport conformance matrix
+
+**Diataxis category:** reference.
+
+Transport providers give constellation peers a bidirectional byte stream.
+They do not authenticate users, authorize operations, or multiplex named
+streams; those checks happen in the peer-session and stream-mux layers.
+
+Every transport adapter should pass the shared conformance checks in
+`nixling-constellation-transport::conformance` before it is wired into a
+gateway or remote node.
+
+| Behavior | Required result | Loopback status |
+| --- | --- | --- |
+| Listen once | A provider exposes one listener per registration; a duplicate listener is rejected with a typed transport error. | Covered |
+| Connect/accept | A successful connect pairs with one accept and returns two independent bidirectional byte streams. | Covered |
+| Byte exactness | Bytes written in either direction arrive unchanged and never cross into another session. | Covered |
+| Queue capacity | A bounded pending-session queue refuses excess connects instead of allocating unbounded state. | Covered |
+| Concurrent sessions | Multiple accepted sessions remain isolated and can be drained deterministically by callers. | Covered |
+| Shutdown | After shutdown, new connects and accepts return a typed unavailable error. | Covered |
+| Frame cap | Peer sessions reject declared or outbound frames above the 1 MiB cap before allocating payload buffers. | Covered |
+| Truncated frames | A short read after a valid length prefix is reported as a malformed frame. | Covered |
+| Capability negotiation | Peers select the intersection of advertised capabilities, including the empty set. | Covered |
+| Stream backpressure | A sender without outbound credit receives a typed backpressure error before bytes are sent. | Covered |
+| Cancellation retry | Repeated cancel of the same stream is idempotent and not treated as a protocol violation. | Covered |
+
+Future transports can add adapter-specific tests, but they must preserve
+the same external behavior: bounded memory, typed refusal on unavailable
+or overloaded paths, no byte corruption, and no implicit fallback to a
+different transport.

--- a/packages/nixling-constellation-router/src/mux_session.rs
+++ b/packages/nixling-constellation-router/src/mux_session.rs
@@ -306,4 +306,76 @@ mod tests {
             nixling_constellation_core::ErrorKind::Backpressure
         );
     }
+
+    #[tokio::test]
+    async fn send_data_without_outbound_credit_is_rejected() {
+        let (client_s, server_s) = connected_pair().await;
+        let server = tokio::spawn(async move {
+            let peer = PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                display_caps(),
+            )
+            .await
+            .unwrap();
+            let mut s = MuxSession::new(peer);
+            let _ = s.recv().await.unwrap();
+        });
+
+        let peer =
+            PeerSession::connect_with_capabilities(client_s, ProtobufCodec::new(), display_caps())
+                .await
+                .unwrap();
+        let mut client = MuxSession::new(peer);
+        client.open_stream(display_open()).await.unwrap();
+        let err = client
+            .send_data(
+                &stream_id(),
+                StreamChannel::Primary,
+                OpaquePayload::new(b"without-credit".to_vec()).unwrap(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.kind(),
+            nixling_constellation_core::ErrorKind::Backpressure
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_stream_is_idempotent() {
+        let (client_s, server_s) = connected_pair().await;
+        let server = tokio::spawn(async move {
+            let peer = PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                display_caps(),
+            )
+            .await
+            .unwrap();
+            let mut s = MuxSession::new(peer);
+            assert!(matches!(
+                s.recv().await.unwrap(),
+                ConstellationFrame::StreamOpen(_)
+            ));
+            assert!(matches!(
+                s.recv().await.unwrap(),
+                ConstellationFrame::StreamClose(StreamClose {
+                    reason: StreamCloseReason::Cancelled,
+                    ..
+                })
+            ));
+        });
+
+        let peer =
+            PeerSession::connect_with_capabilities(client_s, ProtobufCodec::new(), display_caps())
+                .await
+                .unwrap();
+        let mut client = MuxSession::new(peer);
+        client.open_stream(display_open()).await.unwrap();
+        assert!(client.cancel_stream(&stream_id()).await.unwrap());
+        assert!(!client.cancel_stream(&stream_id()).await.unwrap());
+        server.await.unwrap();
+    }
 }

--- a/packages/nixling-constellation-router/src/session.rs
+++ b/packages/nixling-constellation-router/src/session.rs
@@ -289,6 +289,7 @@ mod tests {
     use nixling_constellation_provider::types::{NodeRegistration, TransportTarget};
     use nixling_constellation_transport::LoopbackTransport;
     use std::sync::Arc;
+    use tokio::io::AsyncWriteExt;
 
     async fn connected_pair() -> (TransportSession, TransportSession) {
         let transport = Arc::new(LoopbackTransport::new());
@@ -364,6 +365,42 @@ mod tests {
         assert!(selected.has(Capability::Exec));
         assert!(!selected.has(Capability::WindowForwarding));
         assert_eq!(server.await.unwrap(), selected.clone());
+    }
+
+    #[tokio::test]
+    async fn handshake_negotiates_empty_capability_intersection() {
+        let (client_s, server_s) = connected_pair().await;
+        let server = tokio::spawn(async move {
+            PeerSession::accept_with_capabilities(
+                server_s,
+                ProtobufCodec::new(),
+                CapabilitySet::empty(),
+            )
+            .await
+            .unwrap()
+            .negotiated()
+            .capabilities
+            .capabilities
+            .clone()
+        });
+        let client = PeerSession::connect_with_capabilities(
+            client_s,
+            ProtobufCodec::new(),
+            CapabilitySet::empty().with(Capability::Exec),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !client
+                .negotiated()
+                .capabilities
+                .capabilities
+                .has(Capability::Exec)
+        );
+        assert_eq!(
+            server.await.unwrap(),
+            client.negotiated().capabilities.capabilities
+        );
     }
 
     #[tokio::test]
@@ -558,6 +595,37 @@ mod tests {
         let bytes = codec.encode_frame(&frame).unwrap();
         write_frame(client_s.stream_mut(), &bytes).await.unwrap();
         let err = server.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::MalformedFrame);
+    }
+
+    #[tokio::test]
+    async fn write_frame_rejects_payload_above_cap() {
+        let (mut a, _b) = tokio::io::duplex(64);
+        let payload = vec![0_u8; MAX_FRAME_BYTES + 1];
+        let err = write_frame(&mut a, &payload).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::FrameTooLarge);
+    }
+
+    #[tokio::test]
+    async fn read_frame_rejects_declared_length_above_cap() {
+        let (mut writer, mut reader) = tokio::io::duplex(8);
+        writer
+            .write_all(&((MAX_FRAME_BYTES as u32) + 1).to_le_bytes())
+            .await
+            .unwrap();
+        let err = read_frame(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::FrameTooLarge);
+    }
+
+    #[tokio::test]
+    async fn read_frame_rejects_truncated_payload() {
+        let (mut writer, mut reader) = tokio::io::duplex(16);
+        let writer = tokio::spawn(async move {
+            writer.write_all(&5_u32.to_le_bytes()).await.unwrap();
+            writer.write_all(b"ab").await.unwrap();
+        });
+        let err = read_frame(&mut reader).await.unwrap_err();
+        writer.await.unwrap();
         assert_eq!(err.kind(), ErrorKind::MalformedFrame);
     }
 }

--- a/packages/nixling-constellation-transport/Cargo.toml
+++ b/packages/nixling-constellation-transport/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 nixling-constellation-core = { path = "../nixling-constellation-core", version = "0.0.0-bootstrap" }
 nixling-constellation-provider = { path = "../nixling-constellation-provider", version = "0.0.0-bootstrap" }
 async-trait = "0.1"
-tokio = { version = "1", default-features = false, features = ["io-util", "sync"] }
+tokio = { version = "1", default-features = false, features = ["io-util", "rt", "sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "io-util", "sync"] }

--- a/packages/nixling-constellation-transport/src/lib.rs
+++ b/packages/nixling-constellation-transport/src/lib.rs
@@ -18,7 +18,11 @@ use nixling_constellation_provider::provider::{TransportListener, TransportProvi
 use nixling_constellation_provider::types::{
     NodeRegistration, SafeLabel, TransportSession, TransportTarget,
 };
-use tokio::sync::{Mutex, mpsc};
+use std::sync::{
+    Arc, Mutex as StdMutex,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::{Mutex, mpsc, mpsc::error::TrySendError};
 
 /// Default in-memory duplex buffer size for a loopback session.
 const LOOPBACK_BUF: usize = 64 * 1024;
@@ -29,19 +33,41 @@ const LOOPBACK_BUF: usize = 64 * 1024;
 /// supported (each is an independent duplex pair).
 pub struct LoopbackTransport {
     id: ProviderId,
-    tx: mpsc::Sender<TransportSession>,
+    tx: StdMutex<Option<mpsc::Sender<TransportSession>>>,
     rx: Mutex<Option<mpsc::Receiver<TransportSession>>>,
+    closed: Arc<AtomicBool>,
 }
 
 impl LoopbackTransport {
     /// Build a loopback transport.
     pub fn new() -> Self {
-        let (tx, rx) = mpsc::channel(16);
+        Self::with_queue_capacity(16)
+    }
+
+    /// Build a loopback transport with an explicit pending-session queue
+    /// capacity. Capacity zero is rounded up to one so the transport never
+    /// constructs an invalid Tokio channel.
+    pub fn with_queue_capacity(capacity: usize) -> Self {
+        let (tx, rx) = mpsc::channel(capacity.max(1));
         Self {
             id: ProviderId::parse("loopback").expect("valid provider id"),
-            tx,
+            tx: StdMutex::new(Some(tx)),
             rx: Mutex::new(Some(rx)),
+            closed: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Close the in-memory transport. Future connects and accepts report a
+    /// typed relay-unavailable error.
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        if let Ok(mut tx) = self.tx.lock() {
+            tx.take();
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
     }
 }
 
@@ -58,17 +84,38 @@ impl TransportProvider for LoopbackTransport {
     }
 
     async fn connect(&self, _target: TransportTarget) -> ProviderResult<TransportSession> {
+        if self.is_closed() {
+            return Err(ProviderError::new(
+                ErrorKind::RelayUnavailable,
+                "loopback transport is closed",
+            ));
+        }
         let (near, far) = tokio::io::duplex(LOOPBACK_BUF);
         // Queue the far end for the listener; hand the near end to the caller.
-        self.tx
-            .send(TransportSession::new(
-                SafeLabel::new("loopback-accept"),
-                Box::new(far),
-            ))
-            .await
-            .map_err(|_| {
-                ProviderError::new(ErrorKind::RelayUnavailable, "loopback listener is gone")
-            })?;
+        let tx = self
+            .tx
+            .lock()
+            .map_err(|_| ProviderError::new(ErrorKind::RelayUnavailable, "loopback closed"))?
+            .clone()
+            .ok_or_else(|| ProviderError::new(ErrorKind::RelayUnavailable, "loopback closed"))?;
+        match tx.try_send(TransportSession::new(
+            SafeLabel::new("loopback-accept"),
+            Box::new(far),
+        )) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                return Err(ProviderError::new(
+                    ErrorKind::Backpressure,
+                    "loopback pending-session queue is full",
+                ));
+            }
+            Err(TrySendError::Closed(_)) => {
+                return Err(ProviderError::new(
+                    ErrorKind::RelayUnavailable,
+                    "loopback listener is gone",
+                ));
+            }
+        }
         Ok(TransportSession::new(
             SafeLabel::new("loopback-connect"),
             Box::new(near),
@@ -85,6 +132,7 @@ impl TransportProvider for LoopbackTransport {
         Ok(Box::new(LoopbackListener {
             node: registration.node,
             rx: Mutex::new(rx),
+            closed: Arc::clone(&self.closed),
         }))
     }
 }
@@ -93,6 +141,7 @@ impl TransportProvider for LoopbackTransport {
 struct LoopbackListener {
     node: NodeId,
     rx: Mutex<mpsc::Receiver<TransportSession>>,
+    closed: Arc<AtomicBool>,
 }
 
 #[async_trait]
@@ -102,12 +151,142 @@ impl TransportListener for LoopbackListener {
     }
 
     async fn accept(&self) -> ProviderResult<TransportSession> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ProviderError::new(
+                ErrorKind::RelayUnavailable,
+                "loopback closed",
+            ));
+        }
         self.rx
             .lock()
             .await
             .recv()
             .await
             .ok_or_else(|| ProviderError::new(ErrorKind::RelayUnavailable, "loopback closed"))
+    }
+}
+
+/// Reusable transport conformance checks for in-process and future real
+/// transport providers. These are hermetic and assert only the byte/session
+/// contract exposed by [`TransportProvider`].
+pub mod conformance {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn registration() -> NodeRegistration {
+        NodeRegistration {
+            node: NodeId::parse("gw").expect("valid conformance node id"),
+        }
+    }
+
+    fn target() -> TransportTarget {
+        TransportTarget {
+            endpoint: "loopback".to_owned(),
+        }
+    }
+
+    /// Accept/connect one session and prove bytes are bidirectional.
+    pub async fn accepts_and_round_trips(provider: &dyn TransportProvider) -> ProviderResult<()> {
+        let listener = provider.listen(registration()).await?;
+        let (mut sender, mut accepted) =
+            tokio::try_join!(provider.connect(target()), listener.accept())?;
+        sender
+            .stream_mut()
+            .write_all(b"hello")
+            .await
+            .map_err(|err| {
+                ProviderError::new(ErrorKind::RelayUnavailable, format!("write failed: {err}"))
+            })?;
+        let mut buf = [0_u8; 5];
+        accepted
+            .stream_mut()
+            .read_exact(&mut buf)
+            .await
+            .map_err(|err| {
+                ProviderError::new(ErrorKind::RelayUnavailable, format!("read failed: {err}"))
+            })?;
+        if &buf != b"hello" {
+            return Err(ProviderError::new(
+                ErrorKind::MalformedFrame,
+                "transport corrupted forward bytes",
+            ));
+        }
+        accepted
+            .stream_mut()
+            .write_all(b"ack")
+            .await
+            .map_err(|err| {
+                ProviderError::new(ErrorKind::RelayUnavailable, format!("write failed: {err}"))
+            })?;
+        let mut back = [0_u8; 3];
+        sender
+            .stream_mut()
+            .read_exact(&mut back)
+            .await
+            .map_err(|err| {
+                ProviderError::new(ErrorKind::RelayUnavailable, format!("read failed: {err}"))
+            })?;
+        if &back != b"ack" {
+            return Err(ProviderError::new(
+                ErrorKind::MalformedFrame,
+                "transport corrupted reverse bytes",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Open several sessions on one listener and prove they do not cross-talk.
+    pub async fn concurrent_sessions_are_isolated(
+        provider: &dyn TransportProvider,
+        count: usize,
+    ) -> ProviderResult<()> {
+        let listener = provider.listen(registration()).await?;
+        let mut sessions = Vec::with_capacity(count);
+        for index in 0..count {
+            let (sender, accepted) =
+                tokio::try_join!(provider.connect(target()), listener.accept())?;
+            sessions.push((index, sender, accepted));
+        }
+        let mut tasks = Vec::with_capacity(count);
+        for (index, mut sender, mut accepted) in sessions {
+            tasks.push(tokio::spawn(async move {
+                let byte = b'a'.wrapping_add(index as u8);
+                sender
+                    .stream_mut()
+                    .write_all(&[byte])
+                    .await
+                    .map_err(|err| {
+                        ProviderError::new(
+                            ErrorKind::RelayUnavailable,
+                            format!("write failed: {err}"),
+                        )
+                    })?;
+                let mut buf = [0_u8; 1];
+                accepted
+                    .stream_mut()
+                    .read_exact(&mut buf)
+                    .await
+                    .map_err(|err| {
+                        ProviderError::new(
+                            ErrorKind::RelayUnavailable,
+                            format!("read failed: {err}"),
+                        )
+                    })?;
+                if buf[0] != byte {
+                    return Err(ProviderError::new(
+                        ErrorKind::MalformedFrame,
+                        "transport sessions crossed bytes",
+                    ));
+                }
+                Ok(())
+            }));
+        }
+        for task in tasks {
+            task.await.map_err(|err| {
+                ProviderError::new(ErrorKind::RelayUnavailable, format!("task failed: {err}"))
+            })??;
+        }
+        Ok(())
     }
 }
 
@@ -162,5 +341,79 @@ mod tests {
             })
             .await;
         assert!(second.is_err());
+    }
+
+    #[tokio::test]
+    async fn loopback_passes_shared_conformance() {
+        let transport = LoopbackTransport::new();
+        conformance::accepts_and_round_trips(&transport)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn loopback_concurrent_sessions_are_isolated() {
+        let transport = LoopbackTransport::new();
+        conformance::concurrent_sessions_are_isolated(&transport, 4)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn loopback_queue_capacity_is_enforced() {
+        let transport = LoopbackTransport::with_queue_capacity(1);
+        let _listener = transport
+            .listen(NodeRegistration {
+                node: NodeId::parse("gw").unwrap(),
+            })
+            .await
+            .unwrap();
+        let first = transport
+            .connect(TransportTarget {
+                endpoint: "loopback".to_owned(),
+            })
+            .await;
+        assert!(first.is_ok());
+        let second = transport
+            .connect(TransportTarget {
+                endpoint: "loopback".to_owned(),
+            })
+            .await;
+        assert_eq!(second.unwrap_err().kind(), ErrorKind::Backpressure);
+    }
+
+    #[tokio::test]
+    async fn loopback_shutdown_reports_typed_errors() {
+        let transport = LoopbackTransport::new();
+        let listener = transport
+            .listen(NodeRegistration {
+                node: NodeId::parse("gw").unwrap(),
+            })
+            .await
+            .unwrap();
+        transport.close();
+        assert!(listener.accept().await.is_err());
+        assert!(
+            transport
+                .connect(TransportTarget {
+                    endpoint: "loopback".to_owned(),
+                })
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn loopback_shutdown_wakes_pending_accept() {
+        let transport = LoopbackTransport::new();
+        let listener = transport
+            .listen(NodeRegistration {
+                node: NodeId::parse("gw").unwrap(),
+            })
+            .await
+            .unwrap();
+        let accept = tokio::spawn(async move { listener.accept().await });
+        transport.close();
+        assert!(accept.await.unwrap().is_err());
     }
 }


### PR DESCRIPTION
## Summary
- add reusable loopback transport conformance checks for byte-exact delivery and concurrent isolation
- enforce loopback pending-session capacity, typed Backpressure, and shutdown behavior
- add peer-session frame-cap/truncation and mux backpressure/cancel coverage
- document the transport conformance matrix and update the changelog

## Validation
- cargo test -p nixling-constellation-transport --quiet
- cargo test -p nixling-constellation-router --quiet
- cargo clippy -p nixling-constellation-transport --all-targets -- -D warnings
- cargo clippy -p nixling-constellation-router --all-targets -- -D warnings
- make test-drift
- git diff --check && git diff --cached --check
- process-marker scan over changed shipped files

## Panel
Gemini 3.1 Pro end-of-wave panel reached unanimous signoff after R4. Reviewers were instructed not to rerun tests; raw panel output remains in session context.