### PR TITLE
ADR032: add local TCP transport proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ deprecations ship one minor release before removal.
 - Azure Relay now has a constellation `TransportProvider` adapter that
   wraps Relay WebSocket rendezvous into bounded transport sessions for
   gateway-owned listeners and sandbox senders.
+- Local TCP test transport support now proves the transport interface is
+  not Azure-specific, with loopback-only binds, explicit URI targets, and
+  redacted typed errors for negative network cases.
 
 ### Changed
 

--- a/docs/reference/constellation-protocol.md
+++ b/docs/reference/constellation-protocol.md
@@ -37,6 +37,8 @@ shutdown behavior. The reusable checks are listed in the
 [transport conformance matrix](./transport-conformance-matrix.md).
 The Azure Relay adapter is documented in
 [transport-azure-relay](./transport-azure-relay.md).
+Supported transport policy, including the no-implicit-SSH-fallback rule,
+is documented in [transport-support-policy](./transport-support-policy.md).
 
 The protobuf codec maps bytes to the codec-neutral `ConstellationFrame`.
 The router consumes only semantic frames; it never depends on protobuf

--- a/docs/reference/transport-conformance-matrix.md
+++ b/docs/reference/transport-conformance-matrix.md
@@ -10,19 +10,19 @@ Every transport adapter should pass the shared conformance checks in
 `nixling-constellation-transport::conformance` before it is wired into a
 gateway or remote node.
 
-| Behavior | Required result | Loopback status |
-| --- | --- | --- |
-| Listen once | A provider exposes one listener per registration; a duplicate listener is rejected with a typed transport error. | Covered |
-| Connect/accept | A successful connect pairs with one accept and returns two independent bidirectional byte streams. | Covered |
-| Byte exactness | Bytes written in either direction arrive unchanged and never cross into another session. | Covered |
-| Queue capacity | A bounded pending-session queue refuses excess connects instead of allocating unbounded state. | Covered |
-| Concurrent sessions | Multiple accepted sessions remain isolated and can be drained deterministically by callers. | Covered |
-| Shutdown | After shutdown, new connects and accepts return a typed unavailable error. | Covered |
-| Frame cap | Peer sessions reject declared or outbound frames above the 1 MiB cap before allocating payload buffers. | Covered |
-| Truncated frames | A short read after a valid length prefix is reported as a malformed frame. | Covered |
-| Capability negotiation | Peers select the intersection of advertised capabilities, including the empty set. | Covered |
-| Stream backpressure | A sender without outbound credit receives a typed backpressure error before bytes are sent. | Covered |
-| Cancellation retry | Repeated cancel of the same stream is idempotent and not treated as a protocol violation. | Covered |
+| Behavior | Required result | Loopback status | Local TCP status |
+| --- | --- | --- | --- |
+| Listen once | A provider exposes one listener per registration; a duplicate listener is rejected with a typed transport error. | Covered | Covered |
+| Connect/accept | A successful connect pairs with one accept and returns two independent bidirectional byte streams. | Covered | Covered |
+| Byte exactness | Bytes written in either direction arrive unchanged and never cross into another session. | Covered | Covered |
+| Queue capacity | A bounded pending-session queue refuses excess connects instead of allocating unbounded state. | Covered | Not applicable: no user-space accept queue. |
+| Concurrent sessions | Multiple accepted sessions remain isolated and can be drained deterministically by callers. | Covered | Covered |
+| Shutdown | After shutdown, new connects and accepts return a typed unavailable error. | Covered | Covered |
+| Frame cap | Peer sessions reject declared or outbound frames above the 1 MiB cap before allocating payload buffers. | Covered | Transport-independent peer-session coverage. |
+| Truncated frames | A short read after a valid length prefix is reported as a malformed frame. | Covered | Transport-independent peer-session coverage. |
+| Capability negotiation | Peers select the intersection of advertised capabilities, including the empty set. | Covered | Transport-independent peer-session coverage. |
+| Stream backpressure | A sender without outbound credit receives a typed backpressure error before bytes are sent. | Covered | Transport-independent stream-mux coverage. |
+| Cancellation retry | Repeated cancel of the same stream is idempotent and not treated as a protocol violation. | Covered | Transport-independent stream-mux coverage. |
 
 Future transports can add adapter-specific tests, but they must preserve
 the same external behavior: bounded memory, typed refusal on unavailable

--- a/docs/reference/transport-support-policy.md
+++ b/docs/reference/transport-support-policy.md
@@ -1,0 +1,19 @@
+# Transport support policy
+
+**Diataxis category:** reference.
+
+Transports provide reachability for constellation peer sessions. They do
+not authenticate local users, authorize operations, or multiplex named
+streams; peer-session and stream-mux layers own those contracts.
+
+| Transport | Status | Notes |
+| --- | --- | --- |
+| Azure Relay | Gateway transport | Uses gateway-owned credentials and Relay rendezvous sessions. |
+| In-memory loopback | Test/conformance only | Hermetic byte transport; opens no sockets. |
+| Local TCP | Test/conformance only | Loopback-only plaintext adapter that proves the transport trait is not Azure-specific. |
+| QUIC | Planned | Must pass the same transport conformance matrix before support. |
+| SSH | Explicit future transport/bootstrap only | There is no implicit fallback to SSH when a target transport is unavailable. |
+
+Transport selection must be explicit. If the requested transport cannot
+connect, listen, or authenticate at its own layer, callers receive a typed
+transport error; nixling does not silently downgrade to another transport.

--- a/packages/nixling-constellation-transport/Cargo.toml
+++ b/packages/nixling-constellation-transport/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 nixling-constellation-core = { path = "../nixling-constellation-core", version = "0.0.0-bootstrap" }
 nixling-constellation-provider = { path = "../nixling-constellation-provider", version = "0.0.0-bootstrap" }
 async-trait = "0.1"
-tokio = { version = "1", default-features = false, features = ["io-util", "rt", "sync"] }
+tokio = { version = "1", default-features = false, features = ["io-util", "net", "rt", "sync", "time"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "io-util", "sync"] }
+tokio = { version = "1", features = ["macros", "rt", "io-util", "net", "sync", "time"] }

--- a/packages/nixling-constellation-transport/src/lib.rs
+++ b/packages/nixling-constellation-transport/src/lib.rs
@@ -10,6 +10,8 @@
 //! broker/daemon internals (enforced by the constellation
 //! dependency-direction CI gate).
 
+mod local_tcp;
+
 use async_trait::async_trait;
 use nixling_constellation_core::ErrorKind;
 use nixling_constellation_core::{NodeId, ProviderId};
@@ -23,6 +25,8 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 use tokio::sync::{Mutex, mpsc, mpsc::error::TrySendError};
+
+pub use local_tcp::LocalTcpTransport;
 
 /// Default in-memory duplex buffer size for a loopback session.
 const LOOPBACK_BUF: usize = 64 * 1024;
@@ -187,9 +191,18 @@ pub mod conformance {
 
     /// Accept/connect one session and prove bytes are bidirectional.
     pub async fn accepts_and_round_trips(provider: &dyn TransportProvider) -> ProviderResult<()> {
+        accepts_and_round_trips_with_target(provider, target()).await
+    }
+
+    /// Accept/connect one session against an explicit target and prove bytes
+    /// are bidirectional.
+    pub async fn accepts_and_round_trips_with_target(
+        provider: &dyn TransportProvider,
+        target: TransportTarget,
+    ) -> ProviderResult<()> {
         let listener = provider.listen(registration()).await?;
         let (mut sender, mut accepted) =
-            tokio::try_join!(provider.connect(target()), listener.accept())?;
+            tokio::try_join!(provider.connect(target), listener.accept())?;
         sender
             .stream_mut()
             .write_all(b"hello")
@@ -240,11 +253,21 @@ pub mod conformance {
         provider: &dyn TransportProvider,
         count: usize,
     ) -> ProviderResult<()> {
+        concurrent_sessions_are_isolated_with_target(provider, target(), count).await
+    }
+
+    /// Open several sessions to an explicit target and prove they do not
+    /// cross-talk while all are alive concurrently.
+    pub async fn concurrent_sessions_are_isolated_with_target(
+        provider: &dyn TransportProvider,
+        target: TransportTarget,
+        count: usize,
+    ) -> ProviderResult<()> {
         let listener = provider.listen(registration()).await?;
         let mut sessions = Vec::with_capacity(count);
         for index in 0..count {
             let (sender, accepted) =
-                tokio::try_join!(provider.connect(target()), listener.accept())?;
+                tokio::try_join!(provider.connect(target.clone()), listener.accept())?;
             sessions.push((index, sender, accepted));
         }
         let mut tasks = Vec::with_capacity(count);

--- a/packages/nixling-constellation-transport/src/local_tcp.rs
+++ b/packages/nixling-constellation-transport/src/local_tcp.rs
@@ -1,0 +1,336 @@
+use async_trait::async_trait;
+use nixling_constellation_core::{ErrorKind, NodeId, ProviderId};
+use nixling_constellation_provider::error::{ProviderError, ProviderResult};
+use nixling_constellation_provider::provider::{TransportListener, TransportProvider};
+use nixling_constellation_provider::types::{
+    NodeRegistration, SafeLabel, TransportSession, TransportTarget,
+};
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex, Notify};
+
+const LOCAL_TCP_SCHEME: &str = "tcp+local://";
+
+/// A loopback-only TCP transport adapter used to prove the transport
+/// abstraction is not Azure-specific. It is intentionally local, plaintext,
+/// credential-free, and safe for hermetic tests.
+pub struct LocalTcpTransport {
+    id: ProviderId,
+    listener: Mutex<Option<TcpListener>>,
+    local_addr: SocketAddr,
+    closed: Arc<AtomicBool>,
+    shutdown: Arc<Notify>,
+}
+
+impl LocalTcpTransport {
+    /// Bind a loopback TCP listener. Use port `0` in tests for an
+    /// OS-assigned ephemeral port.
+    pub async fn bind(bind_addr: SocketAddr) -> ProviderResult<Self> {
+        validate_bind_addr(bind_addr)?;
+        let listener = TcpListener::bind(bind_addr)
+            .await
+            .map_err(|err| local_tcp_io_error("bind", err.kind()))?;
+        let local_addr = listener
+            .local_addr()
+            .map_err(|err| local_tcp_io_error("bind", err.kind()))?;
+        Ok(Self {
+            id: ProviderId::parse("local-tcp").expect("valid provider id"),
+            listener: Mutex::new(Some(listener)),
+            local_addr,
+            closed: Arc::new(AtomicBool::new(false)),
+            shutdown: Arc::new(Notify::new()),
+        })
+    }
+
+    /// Bind `127.0.0.1:0`.
+    pub async fn bind_loopback_v4() -> ProviderResult<Self> {
+        Self::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await
+    }
+
+    /// The OS-selected local address.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// A URI-like transport target for this listener.
+    pub fn target(&self) -> TransportTarget {
+        TransportTarget {
+            endpoint: format!("{LOCAL_TCP_SCHEME}{}", self.local_addr),
+        }
+    }
+
+    /// Close the local TCP listener. Future connects and accepts fail with a
+    /// typed transport error.
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.shutdown.notify_waiters();
+    }
+}
+
+#[async_trait]
+impl TransportProvider for LocalTcpTransport {
+    fn transport_id(&self) -> ProviderId {
+        self.id.clone()
+    }
+
+    async fn connect(&self, target: TransportTarget) -> ProviderResult<TransportSession> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ProviderError::new(
+                ErrorKind::RelayUnavailable,
+                "local-tcp-closed",
+            ));
+        }
+        let addr = parse_target(&target.endpoint)?;
+        let stream = TcpStream::connect(addr)
+            .await
+            .map_err(|err| local_tcp_io_error("connect", err.kind()))?;
+        Ok(TransportSession::new(
+            SafeLabel::new("local-tcp-connect"),
+            Box::new(stream),
+        ))
+    }
+
+    async fn listen(
+        &self,
+        registration: NodeRegistration,
+    ) -> ProviderResult<Box<dyn TransportListener>> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ProviderError::new(
+                ErrorKind::RelayUnavailable,
+                "local-tcp-closed",
+            ));
+        }
+        let listener = self.listener.lock().await.take().ok_or_else(|| {
+            ProviderError::new(ErrorKind::RelayUnavailable, "local-tcp-listener-taken")
+        })?;
+        Ok(Box::new(LocalTcpListener {
+            node: registration.node,
+            listener,
+            closed: Arc::clone(&self.closed),
+            shutdown: Arc::clone(&self.shutdown),
+        }))
+    }
+}
+
+struct LocalTcpListener {
+    node: NodeId,
+    listener: TcpListener,
+    closed: Arc<AtomicBool>,
+    shutdown: Arc<Notify>,
+}
+
+#[async_trait]
+impl TransportListener for LocalTcpListener {
+    fn node(&self) -> NodeId {
+        self.node.clone()
+    }
+
+    async fn accept(&self) -> ProviderResult<TransportSession> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ProviderError::new(
+                ErrorKind::RelayUnavailable,
+                "local-tcp-closed",
+            ));
+        }
+        let accepted = tokio::select! {
+            _ = self.shutdown.notified() => {
+                return Err(ProviderError::new(ErrorKind::RelayUnavailable, "local-tcp-closed"));
+            }
+            accepted = self.listener.accept() => accepted,
+        };
+        let (stream, _) = accepted.map_err(|err| local_tcp_io_error("accept", err.kind()))?;
+        Ok(TransportSession::new(
+            SafeLabel::new("local-tcp-accept"),
+            Box::new(stream),
+        ))
+    }
+}
+
+fn validate_bind_addr(addr: SocketAddr) -> ProviderResult<()> {
+    if !addr.ip().is_loopback() || addr.ip().is_unspecified() {
+        return Err(ProviderError::new(
+            ErrorKind::InvalidTarget,
+            "local-tcp-bind-address-denied",
+        ));
+    }
+    if addr.port() != 0 && addr.port() < 1024 {
+        return Err(ProviderError::new(
+            ErrorKind::InvalidTarget,
+            "local-tcp-privileged-port-denied",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_target(endpoint: &str) -> ProviderResult<SocketAddr> {
+    let raw = endpoint
+        .strip_prefix(LOCAL_TCP_SCHEME)
+        .ok_or_else(|| ProviderError::new(ErrorKind::InvalidTarget, "local-tcp-target-invalid"))?;
+    let addr = raw
+        .parse::<SocketAddr>()
+        .map_err(|_| ProviderError::new(ErrorKind::InvalidTarget, "local-tcp-target-invalid"))?;
+    validate_connect_addr(addr)?;
+    Ok(addr)
+}
+
+fn validate_connect_addr(addr: SocketAddr) -> ProviderResult<()> {
+    if !addr.ip().is_loopback() || addr.ip().is_unspecified() || addr.port() < 1024 {
+        return Err(ProviderError::new(
+            ErrorKind::InvalidTarget,
+            "local-tcp-target-denied",
+        ));
+    }
+    Ok(())
+}
+
+fn local_tcp_io_error(stage: &'static str, kind: std::io::ErrorKind) -> ProviderError {
+    ProviderError::new(
+        ErrorKind::RelayUnavailable,
+        format!("local-tcp-{stage}-failed:{}", io_reason(kind)),
+    )
+}
+
+fn io_reason(kind: std::io::ErrorKind) -> &'static str {
+    match kind {
+        std::io::ErrorKind::AddrInUse => "address-in-use",
+        std::io::ErrorKind::AddrNotAvailable => "address-not-available",
+        std::io::ErrorKind::ConnectionRefused => "connection-refused",
+        std::io::ErrorKind::ConnectionReset => "connection-reset",
+        std::io::ErrorKind::ConnectionAborted => "connection-aborted",
+        std::io::ErrorKind::TimedOut => "timeout",
+        std::io::ErrorKind::PermissionDenied => "permission-denied",
+        std::io::ErrorKind::BrokenPipe => "broken-pipe",
+        std::io::ErrorKind::UnexpectedEof => "unexpected-eof",
+        _ => "io-error",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conformance::{
+        accepts_and_round_trips_with_target, concurrent_sessions_are_isolated_with_target,
+    };
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn local_tcp_passes_round_trip_conformance() {
+        let transport = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        accepts_and_round_trips_with_target(&transport, transport.target())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_tcp_concurrent_sessions_are_isolated() {
+        let transport = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        concurrent_sessions_are_isolated_with_target(&transport, transport.target(), 4)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_tcp_rejects_unsafe_bind_addresses() {
+        for addr in [
+            SocketAddr::from(([0, 0, 0, 0], 0)),
+            SocketAddr::from(([192, 0, 2, 10], 1500)),
+            SocketAddr::from(([127, 0, 0, 1], 22)),
+        ] {
+            let err = match LocalTcpTransport::bind(addr).await {
+                Ok(_) => panic!("unsafe bind address was accepted"),
+                Err(err) => err,
+            };
+            assert_eq!(err.kind(), ErrorKind::InvalidTarget);
+            let rendered = err.to_string();
+            assert!(!rendered.contains(&addr.to_string()));
+        }
+    }
+
+    #[tokio::test]
+    async fn local_tcp_rejects_bad_targets_without_endpoint_leakage() {
+        let transport = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        for endpoint in [
+            "tcp://127.0.0.1:12345",
+            "tcp+local://0.0.0.0:12345",
+            "tcp+local://192.0.2.10:12345",
+            "tcp+local://127.0.0.1:22",
+        ] {
+            let err = transport
+                .connect(TransportTarget {
+                    endpoint: endpoint.to_owned(),
+                })
+                .await
+                .unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InvalidTarget);
+            assert!(!err.to_string().contains(endpoint));
+        }
+    }
+
+    #[tokio::test]
+    async fn local_tcp_connection_refused_is_typed_and_redacted() {
+        let transport = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        let addr = transport.local_addr();
+        drop(transport);
+        let target = TransportTarget {
+            endpoint: format!("{LOCAL_TCP_SCHEME}{addr}"),
+        };
+        let connector = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        let err = connector.connect(target).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::RelayUnavailable);
+        assert!(err.to_string().contains("connection-refused"));
+        assert!(!err.to_string().contains(&addr.to_string()));
+    }
+
+    #[tokio::test]
+    async fn local_tcp_bind_error_is_categorized_and_redacted() {
+        let first = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        let addr = first.local_addr();
+        let err = match LocalTcpTransport::bind(addr).await {
+            Ok(_) => panic!("duplicate bind unexpectedly succeeded"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::RelayUnavailable);
+        assert!(err.to_string().contains("address-in-use"));
+        assert!(!err.to_string().contains(&addr.to_string()));
+    }
+
+    #[tokio::test]
+    async fn local_tcp_shutdown_wakes_pending_accept() {
+        let transport = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        let listener = transport
+            .listen(NodeRegistration {
+                node: NodeId::parse("gw").unwrap(),
+            })
+            .await
+            .unwrap();
+        let accept = tokio::spawn(async move { listener.accept().await });
+        transport.close();
+        let err = tokio::time::timeout(std::time::Duration::from_secs(1), accept)
+            .await
+            .expect("accept should wake")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::RelayUnavailable);
+    }
+
+    #[tokio::test]
+    async fn local_tcp_unexpected_eof_is_observable_to_reader() {
+        let transport = LocalTcpTransport::bind_loopback_v4().await.unwrap();
+        let listener = transport
+            .listen(NodeRegistration {
+                node: NodeId::parse("gw").unwrap(),
+            })
+            .await
+            .unwrap();
+        let (client, accepted) =
+            tokio::try_join!(transport.connect(transport.target()), listener.accept()).unwrap();
+        drop(accepted);
+        let mut stream = client.into_stream();
+        let mut buf = [0_u8; 1];
+        assert_eq!(stream.read(&mut buf).await.unwrap(), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add loopback-only LocalTcpTransport as a non-Azure transport proof
- validate tcp+local targets, reject unsafe binds/targets, and redact raw endpoints in typed errors
- extend transport conformance helpers/docs and add transport support policy with no implicit SSH fallback

## Validation
- cargo test -p nixling-constellation-transport --quiet
- cargo clippy -p nixling-constellation-transport --all-targets -- -D warnings
- make test-drift
- git diff --check && git diff --cached --check
- process-marker scan over changed shipped files

## Panel
Gemini 3.1 Pro plan review reached signoff before implementation, and end-of-wave implementation panel reached unanimous signoff after R4. Reviewers were instructed not to rerun tests; raw panel output remains in session context.