### PR TITLE
tests: shard nix-unit flake checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ deprecations ship one minor release before removal.
 
 ### Changed
 
+- CI: nix-unit eval coverage is now split into multiple
+  `nix-unit-<shard>` flake checks plus a cheap global `nix-unit`
+  presence/pin check, so PR flake evaluation can fan the slow corpus
+  out across the existing x86 matrix.
 - **Breaking:** VMs with `nixling.vms.<vm>.usbip.yubikey = true` must
   now also enable `nixling.vms.<vm>.guest.control.enable = true`. USBIP
   guest attach/detach is owned by guestd over authenticated

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ test-flake:
 test-flake-list:
 	@bash tests/test-flake-list.sh
 
-## test-nix-unit — build the nix-unit corpus check (focused convenience target;
-## already covered by test-flake, so NOT in test-unit to avoid double work).
+## test-nix-unit — build all sharded nix-unit corpus checks (focused convenience
+## target; already covered by test-flake, so NOT in test-unit to avoid double work).
 test-nix-unit:
 	bash tests/test-nix-unit.sh
 

--- a/flake.nix
+++ b/flake.nix
@@ -575,7 +575,75 @@
         # NO recursive-nix / IFD: each case is compared at flake-eval time
         # and the verdict baked into a tiny runCommand. The same corpus is
         # CLI-compatible with upstream `nix-unit` for local iteration.
-        nixUnitCases = import ./tests/unit/nix {
+        nixUnitShardCaseFiles = {
+          nix-unit-daemon = [
+            "broker-bundle-path.nix"
+            "broker-caps.nix"
+            "broker-socket-activation.nix"
+            "daemon-autostart.nix"
+            "daemon-default-compat.nix"
+            "gateway-vm.nix"
+            "nixlingd-startup-smoke.nix"
+          ];
+          nix-unit-guest = [
+            "guest-config-containment.nix"
+            "guest-control-auth.nix"
+            "guest-control-vsock.nix"
+            "guest-exec-policy.nix"
+          ];
+          nix-unit-misc = [
+            "assertions.nix"
+            "autostart-wiring.nix"
+            "examples-with-observability.nix"
+            "ifname-nix-rust-parity.nix"
+            "observability.nix"
+            "readiness-waves.nix"
+            "restart-policy.nix"
+            "vm-eval-overlays.nix"
+          ];
+          nix-unit-network = [
+            "bridge-ipv6-boot-sysctl.nix"
+            "multi-env-daemon-backed.nix"
+            "net-vm-network.nix"
+            "usbip-gating.nix"
+          ];
+          nix-unit-runtime = [
+            "external-vm-kind.nix"
+            "niri-vm-borders.nix"
+            "requested-vm-config.nix"
+            "video-contract.nix"
+          ];
+          nix-unit-state = [
+            "per-vm-state-ownership.nix"
+            "principal-uid-collision.nix"
+            "store-overlay-emit.nix"
+            "umask-roundtrip.nix"
+            "volume-mounts.nix"
+          ];
+        };
+        nixUnitCaseFileNames =
+          pkgs.lib.filter (n: pkgs.lib.hasSuffix ".nix" n)
+            (pkgs.lib.attrNames (builtins.readDir ./tests/unit/nix/cases));
+        nixUnitShardFiles = pkgs.lib.concatLists (pkgs.lib.attrValues nixUnitShardCaseFiles);
+        nixUnitShardMissingFiles =
+          pkgs.lib.filter (n: !(builtins.elem n nixUnitShardFiles)) nixUnitCaseFileNames;
+        nixUnitShardUnknownFiles =
+          pkgs.lib.filter (n: !(builtins.elem n nixUnitCaseFileNames)) nixUnitShardFiles;
+        nixUnitShardDuplicateFiles =
+          let
+            count = needle: pkgs.lib.length (pkgs.lib.filter (n: n == needle) nixUnitShardFiles);
+          in
+          pkgs.lib.filter (n: count n > 1) (pkgs.lib.unique nixUnitShardFiles);
+        nixUnitShardCoverageOk =
+          nixUnitShardMissingFiles == [ ]
+          && nixUnitShardUnknownFiles == [ ]
+          && nixUnitShardDuplicateFiles == [ ];
+        nixUnitShardCoverageReport = builtins.toJSON {
+          missing = nixUnitShardMissingFiles;
+          unknown = nixUnitShardUnknownFiles;
+          duplicate = nixUnitShardDuplicateFiles;
+        };
+        nixUnitCasesFor = caseFileNames: import ./tests/unit/nix {
           lib = pkgs.lib;
           inherit pkgs system;
           flakeRoot = ./.;
@@ -587,7 +655,9 @@
           # (which would resolve to a non-git store path inside the flake).
           nixpkgsFlake = nixpkgs;
           inherit nixlingModule;
+          inherit caseFileNames;
         };
+        nixUnitCases = nixUnitCasesFor null;
         nixUnitEval = name: case:
           let
             r = builtins.tryEval (let v = case.expr; in builtins.deepSeq v v);
@@ -622,11 +692,29 @@
                 if !r.success then "eval threw; expected a value"
                 else "got=${builtins.toJSON r.value} expected=${builtins.toJSON case.expected}";
             };
-        nixUnitResults = pkgs.lib.mapAttrsToList nixUnitEval nixUnitCases;
-        nixUnitFailures = pkgs.lib.filter (x: !x.ok) nixUnitResults;
-        nixUnitReport = pkgs.lib.concatMapStringsSep "\n"
-          (x: "FAIL ${x.name}: ${x.detail}") nixUnitFailures;
-        nixUnitTotal = pkgs.lib.length nixUnitResults;
+        nixUnitResultsFor = cases: pkgs.lib.mapAttrsToList nixUnitEval cases;
+        nixUnitShardCheck = checkName: caseFileNames:
+          let
+            cases = nixUnitCasesFor caseFileNames;
+            results = nixUnitResultsFor cases;
+            failures = pkgs.lib.filter (x: !x.ok) results;
+            report = pkgs.lib.concatMapStringsSep "\n"
+              (x: "FAIL ${x.name}: ${x.detail}") failures;
+            total = pkgs.lib.length results;
+          in
+          if failures != [ ] then
+            throw ''
+              ${checkName} gate FAILED (${toString (pkgs.lib.length failures)}/${toString total} cases failed) for ${system}:
+              ${report}
+            ''
+          else
+            pkgs.runCommand "nixling-${checkName}" { } ''
+              echo "${checkName}: ${toString total} cases passed"
+              mkdir -p "$out"
+              echo ok > "$out/${checkName}"
+            '';
+        nixUnitShardChecks =
+          pkgs.lib.mapAttrs nixUnitShardCheck nixUnitShardCaseFiles;
 
         # Fail-closed case-PRESENCE gate (mirrors tests/tools/assert-pinned-tests.sh
         # for the Rust layer): every pinned case name MUST still exist in the
@@ -697,14 +785,14 @@
         # Throwing here forces the gate to fail during `--no-build`
         # evaluation, on BOTH systems (aarch64 included on an x86 runner).
         nix-unit =
-          if nixUnitFailures != [ ] || nixUnitMissingPins != [ ] then
+          if !nixUnitShardCoverageOk || nixUnitMissingPins != [ ] then
             throw ''
-              nix-unit gate FAILED (${toString (pkgs.lib.length nixUnitFailures)}/${toString nixUnitTotal} cases failed, ${toString (pkgs.lib.length nixUnitMissingPins)} pinned cases missing) for ${system}:
-              ${nixUnitReport}${pkgs.lib.optionalString (nixUnitMissingPins != [ ]) "\n${nixUnitMissingReport}"}
+              nix-unit presence gate FAILED (${toString (pkgs.lib.length nixUnitMissingPins)} pinned cases missing) for ${system}:
+              shardCoverage=${nixUnitShardCoverageReport}${pkgs.lib.optionalString (nixUnitMissingPins != [ ]) "\n${nixUnitMissingReport}"}
             ''
           else
             pkgs.runCommand "nixling-nix-unit" { } ''
-              echo "nix-unit: ${toString nixUnitTotal} cases passed (${toString (pkgs.lib.length nixUnitPinned)} pinned present)"
+              echo "nix-unit: ${toString (pkgs.lib.length nixUnitCaseNames)} pinned case names present; ${toString (pkgs.lib.length (pkgs.lib.attrNames nixUnitShardCaseFiles))} shards cover ${toString (pkgs.lib.length nixUnitCaseFileNames)} case files"
               mkdir -p "$out"
               echo ok > "$out/nix-unit"
             '';
@@ -1032,7 +1120,7 @@
             };
           })
         ]);
-      } // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+      } // nixUnitShardChecks // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
         # graphics-workstation transitively depends on x86_64-only
         # packages (spectrum-ch, crosvm-patched, vhost-device-sound)
         # and the framework's `checkVmPlatform` gate refuses to

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -49,7 +49,9 @@ files: **drift gates** (`tests/unit/gates/` — `xtask gen-* + git diff`) and
 1. **Asserting a Nix module value / option / eval-rejection?** → type 1, a
    nix-unit case in `tests/unit/nix/cases/`. Add a case file (it is
    auto-discovered; do not edit `default.nix`), then regenerate the pin list
-   (`tests/tools/gen-nix-unit-pins.sh`).
+   (`tests/tools/gen-nix-unit-pins.sh`). CI evaluates the corpus through
+   sharded `nix-unit-<shard>` flake checks; add new cases to the existing
+   topical file whose shard already owns that behavior.
 2. **Asserting Rust logic?** → type 2, a `#[test]` in that crate's `src`.
 3. **Asserting the real binary's wire/CLI behaviour?** → type 3, a test in
    `packages/<crate>/tests/*.rs` against `CARGO_BIN_EXE_*`. Spawn hermetically —

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,7 +55,7 @@ Rust tests (types 2–5: unit, integration, contract, policy-lint) live under
 | `make test-proofs` | standalone proofs/ crates | local + CI |
 | `make test-flake` | `nix flake check --no-build` (native system); `NL_FLAKE_CHECK=<name>` instantiates one check, `NL_FLAKE_OUTPUTS=1` sweeps non-`checks` outputs | local + CI (x86 sharded per-check matrix; aarch64 PR job runs a lightweight smoke eval) |
 | `make test-flake-list` | emit native-system flake check names as JSON (CI matrix plumbing) | CI (dynamic matrix) |
-| `make test-nix-unit` | nix-unit corpus (already covered by test-flake; focused convenience target) | local |
+| `make test-nix-unit` | sharded nix-unit corpus checks (already covered by test-flake; focused convenience target) | local |
 | `make test-drift` | drift-check + vms-json-parity + flake-check-matrix-sync | local + CI |
 | `make test-policy` | meta gates (ci-coverage, ci-uses-make, adr-index, etc.) | local + CI |
 | `make test-integration` | type-9 podman container tests | **local host/manual pre-PR** (podman; not the PR pipeline) |

--- a/tests/golden/flake-check-matrix/x86_64-linux.txt
+++ b/tests/golden/flake-check-matrix/x86_64-linux.txt
@@ -18,6 +18,12 @@ guest-static-elf
 harness-ubuntu-skeleton
 module-helper-wiring
 nix-unit
+nix-unit-daemon
+nix-unit-guest
+nix-unit-misc
+nix-unit-network
+nix-unit-runtime
+nix-unit-state
 rust-audit
 rust-build
 rust-clippy

--- a/tests/test-nix-unit.sh
+++ b/tests/test-nix-unit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# tests/test-nix-unit.sh — `make test-nix-unit`: build the nix-unit corpus check
-# (flake.checks.<system>.nix-unit) for the native system.
+# tests/test-nix-unit.sh — `make test-nix-unit`: build the nix-unit corpus checks
+# (`flake.checks.<system>.nix-unit*`) for the native system.
 #
 # This is a FOCUSED convenience target for iterating on the declarative
 # value/throw corpus under tests/unit/nix/. It is NOT part of `make test-unit`,
@@ -21,12 +21,29 @@ export NIX_CONFIG="${NIX_CONFIG:-experimental-features = nix-command flakes}"
 cd "$ROOT"
 
 system=$(nix eval --raw --impure --expr builtins.currentSystem)
-log "--> nix build .#checks.$system.nix-unit"
-if nix build --no-link --print-out-paths ".#checks.$system.nix-unit"; then
-  ok "nix-unit corpus ($system)"
-else
-  fail "nix-unit corpus ($system)"
+mapfile -t checks < <(
+  nix eval --raw ".#checks.$system" --apply '
+    cs:
+      builtins.concatStringsSep "\n"
+        (builtins.filter
+          (name: name == "nix-unit" || builtins.substring 0 9 name == "nix-unit-")
+          (builtins.sort builtins.lessThan (builtins.attrNames cs)))
+  '
+)
+
+if [ "${#checks[@]}" -eq 0 ]; then
+  fail "nix-unit corpus ($system): no nix-unit* checks found"
   exit 1
 fi
+
+for check in "${checks[@]}"; do
+  log "--> nix build .#checks.$system.$check"
+  if nix build --no-link --print-out-paths ".#checks.$system.$check"; then
+    ok "nix-unit check $check ($system)"
+  else
+    fail "nix-unit check $check ($system)"
+    exit 1
+  fi
+done
 
 log "test-nix-unit OK"

--- a/tests/unit/nix/default.nix
+++ b/tests/unit/nix/default.nix
@@ -20,7 +20,16 @@
 # `ctx` carries everything any case might need; cases destructure only what
 # they use:
 #   { lib, pkgs, system, flakeRoot, nl, mkEval }
-{ lib, pkgs, system, flakeRoot, nl, mkEval ? null, nixpkgsFlake ? null, nixlingModule ? null }:
+{ lib
+, pkgs
+, system
+, flakeRoot
+, nl
+, mkEval ? null
+, nixpkgsFlake ? null
+, nixlingModule ? null
+, caseFileNames ? null
+}:
 
 let
   ctx = { inherit lib pkgs system flakeRoot nl mkEval nixpkgsFlake nixlingModule; };
@@ -31,9 +40,20 @@ let
   # its case file + its migration-state.d row + deletes its legacy `.sh`;
   # it never touches default.nix.
   casesDir = ./cases;
-  caseFiles = map (n: casesDir + "/${n}")
+  allCaseFileNames =
     (lib.filter (n: lib.hasSuffix ".nix" n)
       (lib.attrNames (builtins.readDir casesDir)));
+  selectedCaseFileNames =
+    if caseFileNames == null
+    then allCaseFileNames
+    else caseFileNames;
+  missingCaseFileNames =
+    lib.filter (n: !(builtins.elem n allCaseFileNames)) selectedCaseFileNames;
+  caseFiles =
+    if missingCaseFileNames != [ ] then
+      throw "nix-unit: requested missing case file(s): ${lib.concatStringsSep ", " missingCaseFileNames}"
+    else
+      map (n: casesDir + "/${n}") selectedCaseFileNames;
 
   merge = acc: f:
     let cases = import f ctx;


### PR DESCRIPTION
## Summary

Splits the slow monolithic nix-unit flake check into named `nix-unit-<shard>` checks while keeping `nix-unit` as a cheap global presence/pin/shard-coverage check.

Updates `make test-nix-unit` to build all nix-unit shard checks, refreshes the flake-check matrix pin, and documents the sharded nix-unit behavior.

## Testing checklist (mandatory)

- [ ] **`make check` passes locally**: long local validation is running in parallel with PR CI per operator direction.
- [ ] **`make test-integration` passes on the host before PR creation**: running in the parallel local validation batch for this task.
- [ ] **`make test-host-integration` passes on the host before PR creation**: running in the parallel local validation batch for this task.
- [x] **Manual `make test-hardware` run** on a NixOS host **with the real devices**: N/A; no hardware passthrough behavior changed.
- [x] **New/changed tests are wired into a `make` target**: nix-unit shards are discovered by `make test-flake-list`, gated by `test-flake-x86`, and `make test-nix-unit` builds all `nix-unit*` checks.
- [x] **Docs + CI updated in lockstep**: updated flake matrix pin, Makefile comments, tests docs, and changelog.

## Notes

Focused sanity completed before PR creation:

- `bash -n tests/test-nix-unit.sh tests/test-flake.sh`
- `make -s test-flake-list` includes `nix-unit-network` and `nix-unit-state`
- `bash tests/tools/gen-flake-check-matrix-pin.sh --check`
- `NL_FLAKE_CHECK=nix-unit make test-flake`
- `NL_FLAKE_CHECK=nix-unit-network make test-flake`
