### PR TITLE
runtime: fix qemu live validation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- CLI/daemon: qemu-media USB attach/detach `--apply --json` now emits a
+  JSON success envelope, and qemu-media list/status service capabilities no
+  longer advertise `virtiofsd`.
 - Proof tests: the Cloud Hypervisor connect proof now binds fixture
   sockets under a short relative target path so long worktree paths do
   not exceed Unix domain socket pathname limits.

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -8941,16 +8941,37 @@ fn broker_error_envelope(
 fn emit_daemon_mutating_outcome(outcome: DaemonVerbOutcome, json: bool) -> Result<i32, CliFailure> {
     match outcome {
         DaemonVerbOutcome::Applied { summary } => {
-            print_stdout(&format!("{summary}\n"));
+            if json {
+                print_json(&serde_json::json!({
+                    "outcome": "applied",
+                    "summary": summary,
+                }))?;
+            } else {
+                print_stdout(&format!("{summary}\n"));
+            }
             Ok(0)
         }
         DaemonVerbOutcome::DryRunPlanned { summary } => {
-            print_stdout(&format!("{summary}\n"));
+            if json {
+                print_json(&serde_json::json!({
+                    "outcome": "dry-run",
+                    "summary": summary,
+                }))?;
+            } else {
+                print_stdout(&format!("{summary}\n"));
+            }
             Ok(0)
         }
         DaemonVerbOutcome::ApiReadyTimeout { summary } => {
             let msg = summary.unwrap_or_else(|| "vm start: api-ready timeout".to_owned());
-            print_stdout(&format!("{msg}\n"));
+            if json {
+                print_json(&serde_json::json!({
+                    "outcome": "api-ready-timeout",
+                    "summary": msg,
+                }))?;
+            } else {
+                print_stdout(&format!("{msg}\n"));
+            }
             Ok(EXIT_API_TIMEOUT)
         }
         DaemonVerbOutcome::InvalidRequest { remediation } => {
@@ -12041,6 +12062,45 @@ mod host_install_dispatch_tests {
         assert!(!rendered.contains("1-2.3"));
         assert!(!rendered.contains("usb-Vendor_SecretSerial"));
         assert!(!rendered.contains("usbip attach"));
+    }
+
+    #[test]
+    fn qemu_media_usb_attach_apply_json_renders_json_envelope() {
+        let _env_lock = ENV_MUTEX.lock().expect("lock env mutex");
+        let vm = "media";
+        let args = UsbAttachArgs {
+            vm: vm.to_owned(),
+            busid: "1-2.3".to_owned(),
+            dry_run: false,
+            apply: true,
+            json: true,
+            human: false,
+        };
+        let (result, _request, stdout) = run_public_command_with_manifest(
+            "qemu-media-usb-attach-json",
+            vm,
+            json!({
+                "type": "mutatingVerbResponse",
+                "verb": "usb attach",
+                "outcome": "applied",
+                "summary": "nixling usb attach --apply: qemu-media attached ref 'installer-usb' in slot 'cdrom' for vm 'media' via QMP (commands=add-fd,blockdev-add:file,blockdev-add:raw,device_add)"
+            }),
+            write_qemu_media_manifest,
+            |context| super::cmd_usb_attach(context, &args),
+        );
+
+        assert_eq!(result.expect("qemu media attach json"), 0);
+        let rendered: Value = serde_json::from_slice(&stdout).expect("json stdout");
+        assert_eq!(
+            rendered.get("outcome").and_then(Value::as_str),
+            Some("applied")
+        );
+        assert!(
+            rendered
+                .get("summary")
+                .and_then(Value::as_str)
+                .is_some_and(|summary| summary.contains("qemu-media attached ref"))
+        );
     }
 
     #[test]

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -11160,7 +11160,11 @@ fn public_service_states(
         },
         "qemuMedia": public_is_qemu_media(manifest_entry)
             .then(|| public_pidfd_role_state(state, vm, RunnerRole::QemuMedia.as_str())),
-        "virtiofsd": public_pidfd_role_prefix_state(state, vm, "virtiofsd"),
+        "virtiofsd": if public_is_qemu_media(manifest_entry) {
+            "unsupported".to_owned()
+        } else {
+            public_pidfd_role_prefix_state(state, vm, "virtiofsd")
+        },
         "gpu": gpu_role_id.map(|role| public_pidfd_role_state(state, vm, role)),
         "video": has_role(ProcessRole::Video).then(|| public_pidfd_role_state(state, vm, "video")),
         "snd": (has_role(ProcessRole::Audio)
@@ -12003,6 +12007,14 @@ mod public_status_tests {
         assert_eq!(
             services.get("qemuMedia").and_then(Value::as_str),
             Some("running")
+        );
+        assert_eq!(
+            services.get("virtiofsd").and_then(Value::as_str),
+            Some("unsupported")
+        );
+        assert_eq!(
+            public_service_capabilities(&services),
+            vec!["nixling".to_owned(), "qemu-media".to_owned()]
         );
     }
 


### PR DESCRIPTION
## Summary
- emit JSON envelopes for daemon-backed mutating success output when `--json` is requested
- mark virtiofsd unsupported in qemu-media daemon service summaries
- add focused CLI and daemon regression tests

## Validation
- `cargo test -p nixling qemu_media_usb_attach_apply_json_renders_json_envelope --lib`
- `cargo test -p nixling qemu_media_usb_attach_routes_without_guest_usbip_import --lib`
- `cargo test -p nixlingd public_lifecycle_reports_running_for_qemu_media_runner --lib`
- `cargo fmt --all -- --check`
