### PR TITLE
router: add remote full-host preview adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Constellation: added a preview remote full-host node adapter. A gateway
+  guest can now register a remote nixling host as a named node in a realm,
+  route typed lifecycle and exec/logs operations to it, and receive typed
+  responses through the remote host's own `nixlingd`/broker/guest-control
+  stack. The adapter validates registration (node id, realm path, schema
+  shape, capability set, authenticated gateway principal), tracks heartbeat/liveness,
+  gates every routed operation against the node's declared capabilities, and
+  enforces the non-tunneling boundary (no raw broker frames, no guest-control
+  frame forwarding, no fd/pidfd transfer, no host path or credential
+  exposure across the transport session). Remote-side idempotency deduplication
+  is layered on top of the gateway-level dedup so reconnect recovery queries
+  remote state before retrying side effects. Peer disconnect marks the node
+  unavailable immediately, and new-generation re-registration makes
+  old-generation operations fail stale. Relay identity remains reachability only
+  and is never mapped to a local or realm principal. This adapter is
+  **experimental/preview**: it is validated with mock and loopback peer clients
+  only. Production transports (Azure Relay over a live WAN, QUIC, SSH),
+  remote host install, remote host prepare, and network mutation are not yet
+  supported. See `docs/reference/remote-full-host-nodes.md` for the full
+  reference.
+
 - Bundle: the private manifest bundle now emits `storage.json` and
   `sync.json` contracts for managed paths, process restart/adoption
   policies, degraded-state taxonomy, and lock/lease synchronization

--- a/docs/reference/remote-full-host-nodes.md
+++ b/docs/reference/remote-full-host-nodes.md
@@ -1,0 +1,354 @@
+# Remote full-host nodes
+
+**Diataxis category:** reference.
+
+**Status: experimental / preview.** The remote full-host node adapter
+proves gateway-managed registration and routing semantics with
+mock and loopback peer clients only. Production transports (QUIC, SSH,
+Azure Relay over a live WAN, remote host install, and remote host
+prepare) are not yet supported. Do not depend on this interface for
+production workloads.
+
+This page documents the committed adapter model for gateway-managed
+remote nixling hosts: registration, heartbeat/liveness, capability
+gating, operation routing, remote-side deduplication and idempotency,
+disconnect/reconnect, authentication/principal binding, audit shape, and
+the non-tunneling boundary. For the constellation core model (frame
+schema, operation kinds, idempotency, stream authz) see
+[constellation core](./constellation-core.md). For the transport layer
+(loopback, local TCP, Azure Relay) see the
+[transport conformance matrix](./transport-conformance-matrix.md) and the
+[transport support policy](./transport-support-policy.md). For host
+substrate capabilities see [host substrate providers](./host-substrate-providers.md).
+The architectural rationale is in
+[ADR 0032](../adr/0032-nixling-v2-constellation-control-plane.md).
+
+---
+
+## What a remote full-host node is
+
+A remote full-host node is a host running its own `nixlingd`,
+`nixling-priv-broker`, and guest-control stack that a gateway guest
+can reach through a transport peer session. From the gateway's point
+of view, the remote host appears as a named `NodeId` in a realm with
+a declared capability set. All lifecycle, broker, and guest-control
+work executes on the remote host itself; the gateway routes typed
+operation requests and receives typed responses.
+
+This model is distinct from a provider-managed sandbox (which has no
+local broker or systemd) and from a gateway guest VM (which runs inside
+the gateway host's hypervisor). Remote full-host nodes are
+substrate-independent once the host's substrate provider has advertised
+the required capabilities.
+
+---
+
+## Registration
+
+A remote host registers with the gateway by opening an authenticated peer
+session over a supported transport and presenting a bounded registration
+record. The preview adapter keeps this record in router state rather than
+adding a public registration frame shape. The registration payload carries:
+
+| Field | Constraint |
+| --- | --- |
+| `node_id` | Stable, operator-assigned label (`^[a-z][a-z0-9-]*$`). Must be unique within the realm. |
+| `realm_path` | The realm the node is joining. Must match the realm the gateway is managing. |
+| `capabilities` | Positive-assertion capability set derived from the host's substrate provider report. No missing capabilities appear in this set. |
+| `substrate_adapter` | Opaque identifier for the host substrate adapter (`nixos-host-substrate` or `generic-linux-host-substrate`). |
+| `gateway_principal` | Authenticated gateway principal bound to the peer session. |
+| `gateway_node` | Authenticated gateway node bound to the peer session, distinct from the registered full-host node. |
+| `generation` | Bounded non-secret token for the remote node's current boot/generation. |
+
+The gateway rejects registration if:
+
+- the `node_id` conflicts with an existing active node in the realm;
+- the `realm_path` does not match the gateway's managed realm;
+- the node kind is not `NodeKind::FullHost`;
+- the authenticated gateway principal is not authorized for the realm/node
+  (see [Authentication and principal binding](#authentication-and-principal-binding));
+- the transport session fails frame-cap or codec/version negotiation.
+
+A rejected registration produces a `ConstellationError` with
+the closest existing `ErrorKind` (`InvalidTarget`, `Unauthorized`,
+`Backpressure`, or `CapabilityDenied`), a bounded human-readable message,
+and a `missing_capability` field when the denial is capability-driven. No
+registration state is persisted on rejection.
+
+Successful registration is idempotent for the same (`node_id`,
+`realm_path`, `generation`) tuple. A same-node registration with a new
+generation supersedes the old generation and marks old-generation pending
+operations stale before they can reach the new generation.
+
+---
+
+## Heartbeat and liveness
+
+After registration, the remote node sends periodic heartbeat frames to
+signal liveness. The gateway treats a node as degraded when no heartbeat
+arrives within the configured liveness window and as disconnected when
+the transport peer session closes or is lost.
+
+| State | Gateway behavior |
+| --- | --- |
+| Registered, heartbeats arriving | Node is eligible for operation routing. |
+| Degraded (missed heartbeats, transport still open) | New routing requests for this node receive `ErrorKind::GatewayUnavailable` with reason `remote-node-unavailable`. In-flight operations reconcile through idempotency before retry. |
+| Disconnected (transport closed) | Node transitions to unavailable immediately. Pending mutating operations stay unknown-result until reconnect can query remote idempotency/durable state. |
+
+Heartbeat metadata carries only the bounded generation token and local
+monotonic time in router state. It does not carry credentials, paths, host
+metrics, or topology data.
+
+---
+
+## Capability gating
+
+Every operation routed to a remote node is validated against the node's
+registered capability set before the gateway sends the request. The
+gateway derives the required capability from the `OperationKind` in
+trusted code; remote nodes never provide the required capability as a
+wire field.
+
+If a required capability is absent from the node's registered set, the
+gateway returns `ErrorKind::CapabilityDenied` with a
+`missing_capability` field to the requesting peer. The operation request
+is never forwarded to the remote node.
+
+Capabilities are positive assertions. A node that has not advertised
+`lifecycle` cannot receive workload list/start/stop requests. A node that
+has not advertised `exec` cannot receive exec start/attach/cancel requests.
+A node that has not advertised `logs` cannot receive retained-log requests.
+
+Capability sets are fixed at registration time for a given transport
+session. A node that gains or loses a substrate capability must
+disconnect and re-register to update its advertised set.
+
+---
+
+## Operation routing
+
+The gateway routes `OperationRequest` frames to the remote node over the
+established transport session. Routing proceeds as follows:
+
+1. The gateway validates the authenticated gateway principal against the
+   operation kind and realm policy (see
+   [Authentication and principal binding](#authentication-and-principal-binding)).
+2. The gateway checks the node's capability set (see
+   [Capability gating](#capability-gating)).
+3. The gateway routes through its shared operation router and preserves the
+   idempotency key for mutating operations.
+4. The gateway sends the semantic `OperationRequest` to the remote peer
+   client. The adapter never exposes a raw byte/frame tunnel to callers.
+5. The remote node's local `nixlingd` receives the operation request,
+   enforces its own realm/capability policy, and invokes the local
+   broker or guest-control path.
+6. The remote node returns a semantic response to the gateway.
+7. The gateway records the result in dedup state and returns the response to
+   the requesting peer.
+
+The gateway never forwards:
+
+- raw broker operation frames or payloads;
+- guest-control frames or vsock data;
+- pidfds or file descriptors;
+- host paths, endpoint strings, or socket addresses;
+- relay, provider, or realm credentials;
+- command arguments, environment, cwd, or stdio bytes as routing
+  metadata (these remain opaque operation/stream payloads);
+- authentication tokens or principal assertions beyond the constellation
+  authz envelope.
+
+The remote host re-originates all side effects through its own
+`nixlingd`/broker/guest-control stack. The gateway is a routing
+intermediary, not an execution proxy.
+
+---
+
+## Remote-side deduplication and idempotency
+
+Mutating operation kinds carry a required `IdempotencyKey` (see
+[constellation core — operation authorization and idempotency](./constellation-core.md#operation-authorization-and-idempotency)).
+The gateway deduplicates at-least-once delivery before forwarding. The
+remote node performs a second deduplication layer against its own
+in-memory idempotency store:
+
+- A same-key same-operation request within the dedup window returns the
+  retained `OperationResponse` without re-executing the side effect.
+- A same-key request with different operation fields (`kind`, `realm`,
+  `node`, `workload`, `principal`, or body) fails closed with
+  `ErrorKind::IdempotencyKeyConflict`.
+- Dedup entries are retained for the duration of the transport session
+  plus a bounded grace window. They are not persisted across remote node
+  restarts.
+
+Non-mutating operations (read, inspect, list) are not idempotency-keyed
+and may be retried freely.
+
+---
+
+## Disconnect and reconnect
+
+When a transport peer session is lost the remote node is marked
+unavailable immediately; the heartbeat timeout is only a fallback for
+silent peers. New routing requests for the node receive
+`ErrorKind::GatewayUnavailable` with reason `remote-node-unavailable`.
+
+For unacknowledged mutating operations, reconnect recovery first queries
+the remote node's idempotency or durable-exec state with the same
+idempotency key and generation. The gateway never blindly resends a
+side-effecting operation that may have already started. Same-node
+re-registration with a new generation supersedes the old generation; old
+generation pending operations fail with reason `stale-node-generation`
+before they can reach the new generation.
+
+---
+
+## Authentication and principal binding
+
+The gateway authenticates the transport peer session using the
+peer-session handshake mechanism described in
+[constellation core — peer protocol handshake](./constellation-core.md#peer-protocol-handshake).
+For the preview adapter, the authenticated principal is obtained from the
+`PeerContext` established during handshake, or from an injected test
+equivalent in hermetic test environments.
+
+Key invariants:
+
+- **Relay identity is reachability only.** A relay-authenticated peer is
+  a transport endpoint. Relay credentials never map to a constellation
+  principal and never authorize nixling lifecycle or broker operations.
+  Relay transport grants only the ability to reach the gateway's relay
+  rendezvous point; all operation authorization is based on the
+  `OperationRequest`'s authenticated principal and realm policy.
+- **Principal binding is per operation.** For the preview adapter,
+  `OperationRequest.principal` is the authenticated gateway principal
+  derived from the handshake context and must match the peer-session
+  principal under the router invariant. End-user impersonation/delegation
+  is out of scope until a typed delegated-principal field and policy model
+  land. A long-lived transport session does not cache authorization
+  decisions.
+- **No local `Admin` promotion.** A relay-authenticated or
+  constellation-authenticated principal is never mapped to the local
+  `nixling` group or to the broker's `Admin` peer credential. Local
+  lifecycle authorization remains `SO_PEERCRED` + `nixling` group
+  membership on `public.sock`. Remote principals may hold constellation
+  enrollment, lifecycle, exec, logs, or other realm-scoped authorization;
+  they do not inherit host-local privileges.
+- **Node agent service principals.** A remote node may register using a
+  dedicated node-agent service principal rather than a user principal.
+  The principal identity is carried in the constellation authz/audit
+  envelope and does not replace the local peer identity used for
+  `SO_PEERCRED` authorization on the remote host's `public.sock`.
+
+In hermetic test environments the `PeerContext` is supplied by an
+injected test authenticator that binds a fixed principal to the session
+without opening a real relay or network connection.
+
+---
+
+## Audit shape
+
+Every mutating operation routed through the gateway produces an
+`AuditEnvelope` on the gateway and a corresponding `OpAuditRecord` on
+the remote host. The two records share a `trace_id` for correlation.
+
+The preview implementation exposes `RemoteRoute` / `RemoteNodeError`
+metadata that is safe to feed into gateway and remote audit records:
+
+| Field | Value |
+| --- | --- |
+| `node_id` | The registered node label. |
+| `realm_path` | The target realm. |
+| `principal` | The authenticated gateway principal (bounded, redacted). |
+| `operation_kind` | The closed `OperationKind` enum variant. |
+| `capability_fingerprint` | Bounded fingerprint of the registered capability set. |
+| `outcome` | Low-cardinality result kind such as `accepted`, `remote-node-unavailable`, `capability-denied`, or `stale-node-generation`. |
+| `trace_id` / `span_id` | From the bounded `TraceContext`, when present. |
+
+The remote host continues to record its own broker and daemon audit records
+for locally re-originated side effects. Gateway and remote records correlate
+through the operation id and trace context; the gateway does not write remote
+host audit files.
+
+Audit records never include:
+
+- relay or provider credentials;
+- transport endpoint addresses or socket paths;
+- operation payloads, command arguments, environment, or stdio;
+- host paths, closures, or store hashes.
+
+The `AuditChainRecord` / `AuditChainLink` tamper-evident chain covers
+both the gateway and remote-node audit streams (see
+[constellation core — audit and error redaction](./constellation-core.md#audit-and-error-redaction)).
+
+---
+
+## Error and remediation shapes
+
+Errors from the remote full-host node adapter use the standard
+`ConstellationError` shape:
+
+| Adapter reason | `ErrorKind` | Meaning | Remediation hint |
+| --- | --- | --- |
+| `wrong-realm` / `wrong-node` | `InvalidTarget` | Request targets a node outside the registered realm/node. | Check the target realm and node enrollment. |
+| `not-full-host` | `InvalidTarget` | Registration used a gateway or provider-managed node kind. | Register only full nixling hosts through this adapter. |
+| `unauthorized-gateway` | `Unauthorized` or `InvalidTarget` | Peer/session principal is not authorized for the realm/node. | Enroll the gateway principal for this realm and node. |
+| `duplicate-registration` | `InvalidTarget` | Same node/generation conflicts with existing metadata. | Re-register with the current generation or remove the conflicting node. |
+| `stale-node-generation` | `InvalidTarget` | Operation or heartbeat targets an old generation. | Refresh remote node registration before retrying. |
+| `registry-capacity-exceeded` / `dedup-capacity-exceeded` | `Backpressure` | Registry or dedup bounds would be exceeded. | Remove stale nodes, wait for in-flight operations, or raise the configured capacity. |
+| `missing-idempotency-key` | `InvalidTarget` | Mutating operation arrived without an idempotency key. | Retry with an idempotency key. |
+| `idempotency-key-conflict` | `IdempotencyKeyConflict` | Same key presented with different operation fields. | Use a fresh idempotency key or retry the original request. |
+| `idempotency-key-expired` | `IdempotencyKeyExpired` | Key was reused after its retention window. | Start a new operation with a fresh idempotency key. |
+| `missing-workload` | `InvalidTarget` | A workload or execution operation omitted the workload target. | Target a workload for workload or execution operations. |
+| `remote-operation-unknown` | `GatewayUnavailable` | Reconnect reconciliation found no matching remote-side operation state. | Retry after the remote node reconciles operation state. |
+| `remote-node-unavailable` | `GatewayUnavailable` | Node is disconnected or stale. | Check the remote daemon peer session and re-register the node. |
+| `capability-denied` | `CapabilityDenied` | Required capability absent from the node's registered set. | Check the substrate provider report and re-register after resolving capability gaps. |
+| `unsupported-operation` | `UnsupportedFeature` | Operation is outside the preview remote full-host adapter scope. | Use a supported operation or wait for later capability support. |
+
+All `ConstellationError` messages are bounded and do not include host
+paths, command output, credential details, or internal identifiers.
+
+---
+
+## Non-tunneling boundaries
+
+The following items are explicitly outside the remote full-host node
+adapter's scope. Requests for these operations fail closed; the adapter
+does not implement fallbacks or workarounds.
+
+| Surface | Boundary |
+| --- | --- |
+| Raw broker operation forwarding | The gateway never forwards raw `nixling-priv-broker` frames. All broker work stays on the remote host. |
+| Guest-control frame tunneling | Guest-control (vsock) frames are not proxied through the gateway. The remote `nixlingd` opens its own guest-control sessions. |
+| Pidfd / fd forwarding | File descriptors, pidfds, and socket handles are never sent across the transport session. |
+| Host path and endpoint exposure | Host-local paths, socket addresses, runner argv, and endpoint strings are not visible in the operation envelope or in gateway audit records. |
+| Provider/relay credential forwarding | Transport and realm credentials remain in the layer that owns them and are never placed in operation payloads. |
+| Remote host install / host prepare | Registration assumes the remote host is already running a compatible `nixlingd`/`nixling-priv-broker` stack. Host installation and host preparation are out of scope for this adapter. |
+| Production WAN transports | The preview is validated with mock and loopback peer clients only. Azure Relay over a live WAN, QUIC, and SSH are not yet connected. See [transport support policy](./transport-support-policy.md). |
+| Network mutation | The adapter does not configure routing, firewall rules, or overlays on the remote host or on the gateway network. |
+| SSH fallback | There is no implicit SSH fallback when the peer session transport is unavailable. Callers receive a typed `GatewayUnavailable` / transport-layer refusal. |
+
+---
+
+## Scope limitations of the preview
+
+The preview adapter is validated against mock and loopback peer clients
+only. The following items are deferred to later work:
+
+- Production transport connectors (Azure Relay rendezvous, QUIC, SSH
+  bootstrap).
+- Live Internet reachability and WAN NAT traversal.
+- Remote host installation and remote `nixling host prepare`.
+- Remote display, audio, USB, and device streams to/from the remote host.
+- Provider-provisioned remote hosts (see the provider-managed sandbox
+  model for provider-scoped work).
+- Automatic capability refresh without re-registration.
+- End-user principal delegation across a gateway; the preview binds the
+  authenticated gateway principal only.
+- Multi-gateway realm federation with remote full-host nodes.
+
+These limitations are documented here and not gated by runtime checks; the
+adapter does not advertise capabilities it has not implemented. Operators
+evaluating production use cases should wait for transport connectors and
+live-host validation to land before relying on remote full-host node
+routing.

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1649,6 +1649,7 @@ dependencies = [
  "sha2",
  "subtle",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/packages/nixling-constellation-router/Cargo.toml
+++ b/packages/nixling-constellation-router/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"
 subtle = "2"
+tracing = "0.1"
 
 [dev-dependencies]
 nixling-constellation-transport = { path = "../nixling-constellation-transport", version = "0.0.0-bootstrap" }

--- a/packages/nixling-constellation-router/src/lib.rs
+++ b/packages/nixling-constellation-router/src/lib.rs
@@ -44,6 +44,7 @@ use nixling_constellation_core::{
 pub mod display_transport;
 pub mod execution;
 pub mod mux_session;
+pub mod remote_node;
 pub mod secure_session;
 pub mod session;
 pub mod session_lifecycle;
@@ -55,6 +56,13 @@ pub use display_transport::{
 };
 pub use execution::{DEFAULT_MAX_EXECUTIONS, DurableExecTable};
 pub use mux_session::MuxSession;
+pub use remote_node::{
+    DEFAULT_HEARTBEAT_TIMEOUT, DEFAULT_MAX_REMOTE_NODES, RemoteDispatchOutcome,
+    RemoteFullHostAdapter, RemoteNodeAuditLabels, RemoteNodeAvailability, RemoteNodeEntry,
+    RemoteNodeError, RemoteNodeErrorKind, RemoteNodeRegistration, RemoteNodeRegistry,
+    RemotePeerClient, RemotePeerStatus, RemoteRetryAction, RemoteRoute,
+    ensure_remote_execution_generation, retry_action_after_disconnect,
+};
 pub use secure_session::{
     NonceReplayGuard, SecurePeerIdentity, SecurePeerSession, SecureSessionKey,
 };

--- a/packages/nixling-constellation-router/src/remote_node.rs
+++ b/packages/nixling-constellation-router/src/remote_node.rs
@@ -1,0 +1,1575 @@
+//! Remote full-host node routing state.
+//!
+//! This module is intentionally pure router state. It tracks enrolled
+//! full-host nodes and prepares semantic remote operation routing decisions;
+//! it never carries transport endpoints, host paths, file descriptors, pidfds,
+//! broker operations, or guest-control frames.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use nixling_constellation_core::{
+    Capability, CapabilitySet, ErrorKind, ExecutionGeneration, NodeId, NodeKind, NodeSummary,
+    OperationKind, OperationRequest, PrincipalId, ProtocolToken, ProviderId, RealmPath,
+    TraceContext,
+};
+
+/// Default maximum number of remote full-host nodes retained by one registry.
+pub const DEFAULT_MAX_REMOTE_NODES: usize = 4096;
+/// Default heartbeat timeout used when a peer disconnect event was not seen.
+pub const DEFAULT_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Lifecycle state for a registered remote full-host node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteNodeAvailability {
+    /// A peer session is registered and not stale.
+    Available,
+    /// The peer session closed; refuse routes immediately.
+    Disconnected,
+    /// The heartbeat fallback elapsed without a refresh.
+    StaleHeartbeat,
+}
+
+/// Why a remote node registration or route was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteNodeErrorKind {
+    WrongRealm,
+    WrongNode,
+    NotFullHost,
+    UnauthorizedGateway,
+    DuplicateRegistration,
+    StaleGeneration,
+    RegistryCapacityExceeded,
+    DedupCapacityExceeded,
+    MissingIdempotencyKey,
+    IdempotencyConflict,
+    IdempotencyExpired,
+    RemoteOperationUnknown,
+    NodeUnavailable,
+    CapabilityDenied,
+    MissingWorkload,
+    UnsupportedOperation,
+}
+
+impl RemoteNodeErrorKind {
+    /// Stable low-cardinality code safe for audit/error labels.
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::WrongRealm => "wrong-realm",
+            Self::WrongNode => "wrong-node",
+            Self::NotFullHost => "not-full-host",
+            Self::UnauthorizedGateway => "unauthorized-gateway",
+            Self::DuplicateRegistration => "duplicate-registration",
+            Self::StaleGeneration => "stale-node-generation",
+            Self::RegistryCapacityExceeded => "registry-capacity-exceeded",
+            Self::DedupCapacityExceeded => "dedup-capacity-exceeded",
+            Self::MissingIdempotencyKey => "missing-idempotency-key",
+            Self::IdempotencyConflict => "idempotency-key-conflict",
+            Self::IdempotencyExpired => "idempotency-key-expired",
+            Self::RemoteOperationUnknown => "remote-operation-unknown",
+            Self::NodeUnavailable => "remote-node-unavailable",
+            Self::CapabilityDenied => "capability-denied",
+            Self::MissingWorkload => "missing-workload",
+            Self::UnsupportedOperation => "unsupported-operation",
+        }
+    }
+
+    /// Map to the existing typed constellation error vocabulary.
+    pub fn error_kind(self) -> ErrorKind {
+        match self {
+            Self::CapabilityDenied => ErrorKind::CapabilityDenied,
+            Self::RegistryCapacityExceeded | Self::DedupCapacityExceeded => ErrorKind::Backpressure,
+            Self::NodeUnavailable => ErrorKind::GatewayUnavailable,
+            Self::RemoteOperationUnknown => ErrorKind::GatewayUnavailable,
+            Self::UnsupportedOperation => ErrorKind::UnsupportedFeature,
+            Self::IdempotencyConflict => ErrorKind::IdempotencyKeyConflict,
+            Self::IdempotencyExpired => ErrorKind::IdempotencyKeyExpired,
+            Self::UnauthorizedGateway => ErrorKind::Unauthorized,
+            Self::WrongRealm
+            | Self::WrongNode
+            | Self::NotFullHost
+            | Self::DuplicateRegistration
+            | Self::StaleGeneration
+            | Self::MissingIdempotencyKey
+            | Self::MissingWorkload => ErrorKind::InvalidTarget,
+        }
+    }
+
+    /// Operator-facing remediation text. This is bounded static prose and
+    /// deliberately avoids endpoints, credentials, paths, and provider data.
+    pub fn remediation(self) -> &'static str {
+        match self {
+            Self::WrongRealm => "check the target realm and remote node enrollment",
+            Self::WrongNode => "check the target node id and remote node enrollment",
+            Self::NotFullHost => "register only full nixling hosts through this adapter",
+            Self::UnauthorizedGateway => "enroll the gateway principal for this realm and node",
+            Self::DuplicateRegistration => {
+                "re-register with the current generation or remove the conflicting node"
+            }
+            Self::StaleGeneration => "refresh remote node registration before retrying",
+            Self::RegistryCapacityExceeded => {
+                "remove stale remote nodes or raise the registry capacity"
+            }
+            Self::DedupCapacityExceeded => {
+                "wait for in-flight operations to finish or raise the dedup capacity"
+            }
+            Self::MissingIdempotencyKey => "retry the mutating operation with an idempotency key",
+            Self::IdempotencyConflict => {
+                "use a fresh idempotency key or retry the original request"
+            }
+            Self::IdempotencyExpired => "start a new operation with a fresh idempotency key",
+            Self::RemoteOperationUnknown => {
+                "retry after the remote node reconciles operation state"
+            }
+            Self::NodeUnavailable => {
+                "check the remote daemon peer session and re-register the node"
+            }
+            Self::CapabilityDenied => {
+                "check the substrate provider report and re-register after resolving capability gaps"
+            }
+            Self::MissingWorkload => "target a workload for workload or execution operations",
+            Self::UnsupportedOperation => "use a supported remote full-host operation",
+        }
+    }
+}
+
+/// A typed refusal from the remote-node registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteNodeError {
+    /// Stable reason.
+    pub kind: RemoteNodeErrorKind,
+    /// Missing capability, when `kind == CapabilityDenied`.
+    pub missing_capability: Option<Capability>,
+    /// Bounded capability fingerprint of the registered node.
+    pub capability_fingerprint: Option<String>,
+}
+
+impl RemoteNodeError {
+    fn new(kind: RemoteNodeErrorKind) -> Self {
+        Self {
+            kind,
+            missing_capability: None,
+            capability_fingerprint: None,
+        }
+    }
+
+    fn capability_denied(capability: Capability, fingerprint: String) -> Self {
+        Self {
+            kind: RemoteNodeErrorKind::CapabilityDenied,
+            missing_capability: Some(capability),
+            capability_fingerprint: Some(fingerprint),
+        }
+    }
+
+    /// Stable reason code.
+    pub fn code(&self) -> &'static str {
+        self.kind.code()
+    }
+
+    /// Operator-safe remediation text.
+    pub fn remediation(&self) -> &'static str {
+        self.kind.remediation()
+    }
+}
+
+impl core::fmt::Display for RemoteNodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}: {}", self.code(), self.remediation())
+    }
+}
+
+impl std::error::Error for RemoteNodeError {}
+
+/// Registration request for one remote full-host node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteNodeRegistration {
+    /// The full-host node summary being registered.
+    pub summary: NodeSummary,
+    /// Authenticated gateway principal for the peer session.
+    pub gateway_principal: PrincipalId,
+    /// Authenticated gateway node for the peer session, when bound.
+    pub gateway_node: NodeId,
+    /// Host substrate adapter id advertised by the remote host.
+    pub substrate_adapter: ProviderId,
+    /// Bounded non-secret remote boot/generation token.
+    pub generation: ProtocolToken,
+}
+
+/// Bounded metadata retained for a registered remote node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteNodeEntry {
+    /// Advertised full-host node summary.
+    pub summary: NodeSummary,
+    /// Gateway principal authenticated on the peer session.
+    pub gateway_principal: PrincipalId,
+    /// Gateway node authenticated on the peer session.
+    pub gateway_node: NodeId,
+    /// Host substrate adapter id advertised by the remote host.
+    pub substrate_adapter: ProviderId,
+    /// Current remote node generation.
+    pub generation: ProtocolToken,
+    /// Capability fingerprint used for low-cardinality audit correlation.
+    pub capability_fingerprint: String,
+    availability: RemoteNodeAvailability,
+    last_heartbeat: Instant,
+}
+
+impl RemoteNodeEntry {
+    /// Current availability.
+    pub fn availability(&self) -> RemoteNodeAvailability {
+        self.availability
+    }
+
+    /// Whether an operation for `generation` is known stale.
+    pub fn is_stale_generation(&self, generation: &ProtocolToken) -> bool {
+        generation != &self.generation
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RemoteNodeKey {
+    realm: RealmPath,
+    node: NodeId,
+}
+
+impl RemoteNodeKey {
+    fn new(realm: RealmPath, node: NodeId) -> Self {
+        Self { realm, node }
+    }
+}
+
+/// Pure registry and route-preflight owner for remote full-host nodes.
+#[derive(Debug, Clone)]
+pub struct RemoteNodeRegistry {
+    managed_realm: RealmPath,
+    nodes: BTreeMap<RemoteNodeKey, RemoteNodeEntry>,
+    max_nodes: usize,
+    heartbeat_timeout: Duration,
+}
+
+impl Default for RemoteNodeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RemoteNodeRegistry {
+    /// Construct with default bounds.
+    pub fn new() -> Self {
+        Self::for_realm(RealmPath::local())
+    }
+
+    /// Construct for a specific gateway-managed realm.
+    pub fn for_realm(managed_realm: RealmPath) -> Self {
+        Self {
+            managed_realm,
+            nodes: BTreeMap::new(),
+            max_nodes: DEFAULT_MAX_REMOTE_NODES,
+            heartbeat_timeout: DEFAULT_HEARTBEAT_TIMEOUT,
+        }
+    }
+
+    /// Override retained node capacity.
+    pub fn with_max_nodes(mut self, max_nodes: usize) -> Self {
+        self.max_nodes = max_nodes;
+        self
+    }
+
+    /// Override heartbeat timeout.
+    pub fn with_heartbeat_timeout(mut self, timeout: Duration) -> Self {
+        self.heartbeat_timeout = timeout;
+        self
+    }
+
+    /// Register or re-register a remote full-host node.
+    pub fn register(
+        &mut self,
+        registration: RemoteNodeRegistration,
+        now: Instant,
+    ) -> Result<RemoteNodeEntry, RemoteNodeError> {
+        let node_label = registration.summary.id.as_str().to_owned();
+        let realm_label = registration.summary.realm.target_form();
+        let substrate_label = registration.substrate_adapter.as_str().to_owned();
+        tracing::info!(
+            event = "remote-node-register",
+            realm = %realm_label,
+            node = %node_label,
+            substrate_adapter = %substrate_label,
+            "remote full-host node registration preflight"
+        );
+        if registration.summary.kind != NodeKind::FullHost {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::NotFullHost));
+        }
+        if registration.summary.realm != self.managed_realm {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::WrongRealm));
+        }
+        if registration.gateway_node == registration.summary.id {
+            return Err(RemoteNodeError::new(
+                RemoteNodeErrorKind::UnauthorizedGateway,
+            ));
+        }
+        let key = RemoteNodeKey::new(
+            registration.summary.realm.clone(),
+            registration.summary.id.clone(),
+        );
+        let fingerprint = registration.summary.capabilities.stable_fingerprint();
+        if let Some(existing) = self.nodes.get_mut(&key) {
+            if existing.gateway_principal != registration.gateway_principal {
+                return Err(RemoteNodeError::new(
+                    RemoteNodeErrorKind::DuplicateRegistration,
+                ));
+            }
+            if existing.generation == registration.generation {
+                if existing.summary != registration.summary
+                    || existing.gateway_node != registration.gateway_node
+                    || existing.substrate_adapter != registration.substrate_adapter
+                {
+                    return Err(RemoteNodeError::new(
+                        RemoteNodeErrorKind::DuplicateRegistration,
+                    ));
+                }
+            } else {
+                existing.generation = registration.generation;
+            }
+            existing.summary = registration.summary;
+            existing.gateway_node = registration.gateway_node;
+            existing.substrate_adapter = registration.substrate_adapter;
+            existing.capability_fingerprint = fingerprint;
+            existing.availability = RemoteNodeAvailability::Available;
+            existing.last_heartbeat = now;
+            return Ok(existing.clone());
+        }
+
+        if self.nodes.len() >= self.max_nodes {
+            return Err(RemoteNodeError::new(
+                RemoteNodeErrorKind::RegistryCapacityExceeded,
+            ));
+        }
+
+        let entry = RemoteNodeEntry {
+            summary: registration.summary,
+            gateway_principal: registration.gateway_principal,
+            gateway_node: registration.gateway_node,
+            substrate_adapter: registration.substrate_adapter,
+            generation: registration.generation,
+            capability_fingerprint: fingerprint,
+            availability: RemoteNodeAvailability::Available,
+            last_heartbeat: now,
+        };
+        self.nodes.insert(key, entry.clone());
+        Ok(entry)
+    }
+
+    /// Refresh heartbeat for the current generation.
+    pub fn heartbeat(
+        &mut self,
+        realm: &RealmPath,
+        node: &NodeId,
+        generation: &ProtocolToken,
+        now: Instant,
+    ) -> Result<RemoteNodeEntry, RemoteNodeError> {
+        tracing::info!(
+            event = "remote-node-heartbeat",
+            realm = %realm.target_form(),
+            node = %node.as_str(),
+            "remote full-host node heartbeat"
+        );
+        let entry = self
+            .entry_mut(realm, node)
+            .ok_or_else(|| RemoteNodeError::new(RemoteNodeErrorKind::WrongNode))?;
+        if &entry.generation != generation {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::StaleGeneration));
+        }
+        if entry.availability == RemoteNodeAvailability::Disconnected {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::NodeUnavailable));
+        }
+        entry.availability = RemoteNodeAvailability::Available;
+        entry.last_heartbeat = now;
+        Ok(entry.clone())
+    }
+
+    /// Mark a peer-session disconnect immediately.
+    pub fn peer_disconnected(&mut self, realm: &RealmPath, node: &NodeId) -> bool {
+        tracing::info!(
+            event = "remote-node-disconnected",
+            realm = %realm.target_form(),
+            node = %node.as_str(),
+            "remote full-host node marked unavailable after peer disconnect"
+        );
+        let Some(entry) = self.entry_mut(realm, node) else {
+            return false;
+        };
+        entry.availability = RemoteNodeAvailability::Disconnected;
+        true
+    }
+
+    /// Mark nodes stale when heartbeat fallback expires.
+    pub fn expire_heartbeats(&mut self, now: Instant) {
+        for entry in self.nodes.values_mut() {
+            if entry.availability == RemoteNodeAvailability::Available
+                && now.duration_since(entry.last_heartbeat) > self.heartbeat_timeout
+            {
+                entry.availability = RemoteNodeAvailability::StaleHeartbeat;
+            }
+        }
+    }
+
+    /// Borrow a registered node.
+    pub fn get(&self, realm: &RealmPath, node: &NodeId) -> Option<&RemoteNodeEntry> {
+        self.nodes
+            .get(&RemoteNodeKey::new(realm.clone(), node.clone()))
+    }
+
+    /// Remove a registered remote node explicitly.
+    pub fn unregister(&mut self, realm: &RealmPath, node: &NodeId) -> Option<RemoteNodeEntry> {
+        self.nodes
+            .remove(&RemoteNodeKey::new(realm.clone(), node.clone()))
+    }
+
+    /// Number of registered nodes.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Check whether a remote operation may be sent.
+    pub fn prepare_route(
+        &self,
+        req: &OperationRequest,
+        generation: &ProtocolToken,
+        gateway_principal: &PrincipalId,
+    ) -> Result<RemoteRoute, RemoteNodeError> {
+        if req.realm != self.managed_realm {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::WrongRealm));
+        }
+        let entry = self
+            .get(&req.realm, &req.node)
+            .ok_or_else(|| RemoteNodeError::new(RemoteNodeErrorKind::WrongNode))?;
+        if req.node != entry.summary.id {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::WrongNode));
+        }
+        if &entry.gateway_principal != gateway_principal {
+            return Err(RemoteNodeError::new(
+                RemoteNodeErrorKind::UnauthorizedGateway,
+            ));
+        }
+        if entry.availability != RemoteNodeAvailability::Available {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::NodeUnavailable));
+        }
+        if entry.is_stale_generation(generation) {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::StaleGeneration));
+        }
+        let required_capability = required_remote_capability(req.kind)?;
+        if let Some(capability) = required_capability
+            && !entry.summary.capabilities.has(capability)
+        {
+            return Err(RemoteNodeError::capability_denied(
+                capability,
+                entry.capability_fingerprint.clone(),
+            ));
+        }
+        if req.workload.is_none() && remote_operation_requires_workload(req.kind) {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::MissingWorkload));
+        }
+        Ok(RemoteRoute {
+            realm: req.realm.clone(),
+            node: req.node.clone(),
+            generation: entry.generation.clone(),
+            operation: req.kind,
+            required_capability,
+            capability_fingerprint: entry.capability_fingerprint.clone(),
+            principal: entry.gateway_principal.clone(),
+            trace: req.trace.clone(),
+            mutating: req.kind.is_mutating(),
+        })
+    }
+
+    fn entry_mut(&mut self, realm: &RealmPath, node: &NodeId) -> Option<&mut RemoteNodeEntry> {
+        self.nodes
+            .get_mut(&RemoteNodeKey::new(realm.clone(), node.clone()))
+    }
+}
+
+/// Route metadata that is safe to audit and pass to a semantic peer client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteRoute {
+    /// Target realm.
+    pub realm: RealmPath,
+    /// Target node.
+    pub node: NodeId,
+    /// Registered node generation.
+    pub generation: ProtocolToken,
+    /// Trusted operation kind.
+    pub operation: OperationKind,
+    /// Capability required by the operation, if any.
+    pub required_capability: Option<Capability>,
+    /// Bounded capability fingerprint.
+    pub capability_fingerprint: String,
+    /// Authenticated gateway principal.
+    pub principal: PrincipalId,
+    /// Bounded trace context propagated for audit correlation.
+    pub trace: Option<TraceContext>,
+    /// Whether this route is for a mutating operation.
+    pub mutating: bool,
+}
+
+impl RemoteRoute {
+    /// Bounded labels safe for audit, traces, and tests.
+    pub fn audit_labels(&self, outcome: &'static str) -> RemoteNodeAuditLabels<'_> {
+        RemoteNodeAuditLabels {
+            realm: self.realm.target_form(),
+            node: self.node.as_str(),
+            operation: self.operation,
+            principal: self.principal.as_str(),
+            capability_fingerprint: &self.capability_fingerprint,
+            trace_id: self.trace.as_ref().map(TraceContext::trace_id),
+            span_id: self.trace.as_ref().map(TraceContext::span_id),
+            outcome,
+        }
+    }
+}
+
+/// Low-cardinality route labels suitable for audit/telemetry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteNodeAuditLabels<'a> {
+    pub realm: String,
+    pub node: &'a str,
+    pub operation: OperationKind,
+    pub principal: &'a str,
+    pub capability_fingerprint: &'a str,
+    pub trace_id: Option<&'a str>,
+    pub span_id: Option<&'a str>,
+    pub outcome: &'static str,
+}
+
+/// Recovering an unacknowledged mutating operation must query remote state
+/// before retrying.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteRetryAction {
+    QueryRemoteState,
+    NoSideEffectToRetry,
+}
+
+/// Decide how to recover after a disconnect.
+pub fn retry_action_after_disconnect(req: &OperationRequest) -> RemoteRetryAction {
+    if req.kind.is_mutating() {
+        RemoteRetryAction::QueryRemoteState
+    } else {
+        RemoteRetryAction::NoSideEffectToRetry
+    }
+}
+
+/// Result from a semantic remote peer client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemotePeerStatus {
+    /// The remote host recorded a completed semantic result.
+    Completed(nixling_constellation_core::OpaquePayload),
+    /// The remote host still has the same operation in progress.
+    InProgress,
+    /// The remote host has no matching side effect for this idempotency key.
+    Unknown,
+}
+
+/// Transport-neutral remote peer seam.
+///
+/// Implementations exchange semantic operation envelopes. They must not expose
+/// bytes, frames, sockets, endpoints, broker ops, guest-control frames, or file
+/// descriptors through this trait.
+pub trait RemotePeerClient: Send {
+    /// Send a newly accepted operation to the remote host.
+    fn send_operation(
+        &mut self,
+        route: &RemoteRoute,
+        req: &OperationRequest,
+    ) -> Result<nixling_constellation_core::OpaquePayload, RemoteNodeError>;
+
+    /// Query remote state for an unacknowledged mutating operation before any
+    /// retry can be considered.
+    fn query_operation(
+        &mut self,
+        route: &RemoteRoute,
+        req: &OperationRequest,
+    ) -> Result<RemotePeerStatus, RemoteNodeError>;
+}
+
+/// Outcome of gateway-side remote full-host dispatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteDispatchOutcome {
+    /// A semantic operation was sent and completed.
+    Sent {
+        route: RemoteRoute,
+        result: nixling_constellation_core::OpaquePayload,
+    },
+    /// A same-request retry was satisfied from gateway-side dedup state.
+    Replayed {
+        result: nixling_constellation_core::OpaquePayload,
+    },
+    /// The operation may have reached the remote host; query remote state
+    /// before retrying.
+    QueryRemoteState { route: RemoteRoute },
+}
+
+/// Gateway-side remote full-host adapter. It gates through the shared router
+/// and registry before a semantic peer client can see an operation.
+pub struct RemoteFullHostAdapter<C = super::SystemClock>
+where
+    C: super::Clock,
+{
+    registry: RemoteNodeRegistry,
+    router: super::OperationRouter<C>,
+    gateway_principal: PrincipalId,
+    negotiated_capabilities: CapabilitySet,
+}
+
+impl RemoteFullHostAdapter<super::SystemClock> {
+    /// Build with default registry/router bounds.
+    pub fn new(gateway_principal: PrincipalId, negotiated_capabilities: CapabilitySet) -> Self {
+        Self::with_router(
+            RemoteNodeRegistry::new(),
+            super::OperationRouter::new(),
+            gateway_principal,
+            negotiated_capabilities,
+        )
+    }
+}
+
+impl<C> RemoteFullHostAdapter<C>
+where
+    C: super::Clock,
+{
+    /// Build with injected state for tests or gateway composition.
+    pub fn with_router(
+        registry: RemoteNodeRegistry,
+        router: super::OperationRouter<C>,
+        gateway_principal: PrincipalId,
+        negotiated_capabilities: CapabilitySet,
+    ) -> Self {
+        Self {
+            registry,
+            router,
+            gateway_principal,
+            negotiated_capabilities,
+        }
+    }
+
+    /// Mutable access to the registry for enrollment/heartbeat paths.
+    pub fn registry_mut(&mut self) -> &mut RemoteNodeRegistry {
+        &mut self.registry
+    }
+
+    /// Borrow registry state.
+    pub fn registry(&self) -> &RemoteNodeRegistry {
+        &self.registry
+    }
+
+    /// Route and send one operation through the semantic peer client.
+    pub fn dispatch(
+        &mut self,
+        req: &OperationRequest,
+        generation: &ProtocolToken,
+        client: &mut dyn RemotePeerClient,
+    ) -> Result<RemoteDispatchOutcome, RemoteNodeError> {
+        let route = self
+            .registry
+            .prepare_route(req, generation, &self.gateway_principal)?;
+        let labels = route.audit_labels("preflight-ok");
+        tracing::info!(
+            event = "remote-node-dispatch",
+            realm = %labels.realm,
+            node = %labels.node,
+            operation_kind = ?labels.operation,
+            principal = %labels.principal,
+            capability_fingerprint = %labels.capability_fingerprint,
+            trace_id = labels.trace_id,
+            span_id = labels.span_id,
+            outcome = labels.outcome,
+            "remote full-host operation dispatch preflight accepted"
+        );
+        match self.router.route_with_capabilities(
+            req,
+            &self.gateway_principal,
+            &self.negotiated_capabilities,
+        ) {
+            super::RouteDecision::Accept { .. } => {
+                let result = match client.send_operation(&route, req) {
+                    Ok(result) => result,
+                    Err(err) => {
+                        if req.kind.is_mutating() {
+                            self.router.mark_failed(req);
+                        }
+                        return Err(err);
+                    }
+                };
+                let labels = route.audit_labels("sent");
+                tracing::info!(
+                    event = "remote-node-dispatch",
+                    realm = %labels.realm,
+                    node = %labels.node,
+                    operation_kind = ?labels.operation,
+                    principal = %labels.principal,
+                    capability_fingerprint = %labels.capability_fingerprint,
+                    trace_id = labels.trace_id,
+                    span_id = labels.span_id,
+                    outcome = labels.outcome,
+                    "remote full-host operation sent"
+                );
+                if req.kind.is_mutating() {
+                    self.router.mark_completed(req, result.clone());
+                }
+                Ok(RemoteDispatchOutcome::Sent { route, result })
+            }
+            super::RouteDecision::Replay { result, .. } => {
+                Ok(RemoteDispatchOutcome::Replayed { result })
+            }
+            super::RouteDecision::InProgress { .. } => match client.query_operation(&route, req) {
+                Err(err) => {
+                    if req.kind.is_mutating() {
+                        self.router.mark_failed(req);
+                    }
+                    Err(err)
+                }
+                Ok(status) => match status {
+                    RemotePeerStatus::Completed(result) => {
+                        self.router.mark_completed(req, result.clone());
+                        Ok(RemoteDispatchOutcome::Replayed { result })
+                    }
+                    RemotePeerStatus::InProgress => {
+                        let labels = route.audit_labels("query-remote-state");
+                        tracing::info!(
+                            event = "remote-node-dispatch",
+                            realm = %labels.realm,
+                            node = %labels.node,
+                            operation_kind = ?labels.operation,
+                            principal = %labels.principal,
+                            capability_fingerprint = %labels.capability_fingerprint,
+                            trace_id = labels.trace_id,
+                            span_id = labels.span_id,
+                            outcome = labels.outcome,
+                            "remote full-host operation requires remote state query"
+                        );
+                        Ok(RemoteDispatchOutcome::QueryRemoteState { route })
+                    }
+                    RemotePeerStatus::Unknown => {
+                        if req.kind.is_mutating() {
+                            self.router.mark_failed(req);
+                        }
+                        Err(RemoteNodeError::new(
+                            RemoteNodeErrorKind::RemoteOperationUnknown,
+                        ))
+                    }
+                },
+            },
+            decision => Err(remote_error_from_route_decision(decision)),
+        }
+    }
+}
+
+fn remote_error_from_route_decision(decision: super::RouteDecision) -> RemoteNodeError {
+    match decision {
+        super::RouteDecision::PrincipalMismatch => {
+            RemoteNodeError::new(RemoteNodeErrorKind::UnauthorizedGateway)
+        }
+        super::RouteDecision::CapabilityDenied {
+            capability,
+            negotiated_fingerprint,
+        } => RemoteNodeError::capability_denied(capability, negotiated_fingerprint),
+        super::RouteDecision::MissingIdempotencyKey => {
+            RemoteNodeError::new(RemoteNodeErrorKind::MissingIdempotencyKey)
+        }
+        super::RouteDecision::IdempotencyKeyConflict => {
+            RemoteNodeError::new(RemoteNodeErrorKind::IdempotencyConflict)
+        }
+        super::RouteDecision::IdempotencyKeyExpired => {
+            RemoteNodeError::new(RemoteNodeErrorKind::IdempotencyExpired)
+        }
+        super::RouteDecision::DedupCapacityExceeded => {
+            RemoteNodeError::new(RemoteNodeErrorKind::DedupCapacityExceeded)
+        }
+        super::RouteDecision::InProgress { .. }
+        | super::RouteDecision::Replay { .. }
+        | super::RouteDecision::Accept { .. } => {
+            RemoteNodeError::new(RemoteNodeErrorKind::UnsupportedOperation)
+        }
+    }
+}
+
+fn required_remote_capability(kind: OperationKind) -> Result<Option<Capability>, RemoteNodeError> {
+    match kind {
+        OperationKind::NodeRegister
+        | OperationKind::NodeHeartbeat
+        | OperationKind::NodeCapabilities
+        | OperationKind::WorkloadList
+        | OperationKind::WorkloadStart
+        | OperationKind::WorkloadStop
+        | OperationKind::ExecStart
+        | OperationKind::ExecAttach
+        | OperationKind::ExecLogs
+        | OperationKind::ExecCancel
+        | OperationKind::GuestHealth => Ok(kind.required_capability()),
+        OperationKind::FileCopyStart
+        | OperationKind::PortForwardOpen
+        | OperationKind::DisplaySessionOpen => Err(RemoteNodeError::new(
+            RemoteNodeErrorKind::UnsupportedOperation,
+        )),
+    }
+}
+
+fn remote_operation_requires_workload(kind: OperationKind) -> bool {
+    matches!(
+        kind,
+        OperationKind::WorkloadStart
+            | OperationKind::WorkloadStop
+            | OperationKind::ExecStart
+            | OperationKind::ExecAttach
+            | OperationKind::ExecLogs
+            | OperationKind::ExecCancel
+    )
+}
+
+/// Validate remote execution generation before opening a stream.
+pub fn ensure_remote_execution_generation(
+    route: &RemoteRoute,
+    generation: &ExecutionGeneration,
+) -> Result<(), RemoteNodeError> {
+    if generation.guest_boot_id == route.generation {
+        Ok(())
+    } else {
+        Err(RemoteNodeError::new(RemoteNodeErrorKind::StaleGeneration))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nixling_constellation_core::{IdempotencyKey, OpaquePayload, OperationId, WorkloadId};
+
+    fn instant(offset: u64) -> Instant {
+        Instant::now() + Duration::from_secs(offset)
+    }
+
+    fn principal() -> PrincipalId {
+        PrincipalId::parse("gateway-principal").unwrap()
+    }
+
+    fn gateway_node() -> NodeId {
+        NodeId::parse("gateway").unwrap()
+    }
+
+    fn full_host_summary(caps: CapabilitySet) -> NodeSummary {
+        NodeSummary {
+            id: NodeId::parse("remote-host").unwrap(),
+            realm: RealmPath::local(),
+            kind: NodeKind::FullHost,
+            capabilities: caps,
+        }
+    }
+
+    fn registration(generation: &str, caps: CapabilitySet) -> RemoteNodeRegistration {
+        RemoteNodeRegistration {
+            summary: full_host_summary(caps),
+            gateway_principal: principal(),
+            gateway_node: gateway_node(),
+            substrate_adapter: ProviderId::parse("nixos-host-substrate").unwrap(),
+            generation: ProtocolToken::parse(generation).unwrap(),
+        }
+    }
+
+    fn req(kind: OperationKind, capability: Capability, key: Option<&str>) -> OperationRequest {
+        req_with_trace(kind, capability, key, None)
+    }
+
+    fn req_with_trace(
+        kind: OperationKind,
+        capability: Capability,
+        key: Option<&str>,
+        trace: Option<TraceContext>,
+    ) -> OperationRequest {
+        OperationRequest {
+            operation_id: OperationId::parse("op-1").unwrap(),
+            idempotency_key: key.map(|raw| IdempotencyKey::parse(raw).unwrap()),
+            realm: RealmPath::local(),
+            node: NodeId::parse("remote-host").unwrap(),
+            workload: Some(WorkloadId::parse("vm-a").unwrap()),
+            principal: principal(),
+            kind,
+            trace,
+            body: OpaquePayload::new(capability.code().as_bytes().to_vec()).unwrap(),
+        }
+    }
+
+    #[test]
+    fn full_host_registers_with_bounded_fingerprint() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut registry = RemoteNodeRegistry::new();
+        let entry = registry
+            .register(registration("gen-1", caps.clone()), instant(0))
+            .unwrap();
+        assert_eq!(entry.summary.kind, NodeKind::FullHost);
+        assert_eq!(entry.capability_fingerprint, caps.stable_fingerprint());
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn provider_managed_node_cannot_register_as_full_host() {
+        let mut reg = registration("gen-1", CapabilitySet::empty());
+        reg.summary.kind = NodeKind::ProviderManaged;
+        let err = RemoteNodeRegistry::new()
+            .register(reg, instant(0))
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::NotFullHost);
+        assert_eq!(err.code(), "not-full-host");
+    }
+
+    #[test]
+    fn gateway_identity_cannot_be_the_registered_full_host() {
+        let mut reg = registration("gen-1", CapabilitySet::empty());
+        reg.gateway_node = reg.summary.id.clone();
+        let err = RemoteNodeRegistry::new()
+            .register(reg, instant(0))
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::UnauthorizedGateway);
+        assert_eq!(err.kind.error_kind(), ErrorKind::Unauthorized);
+    }
+
+    #[test]
+    fn conflicting_duplicate_registration_fails() {
+        let mut registry = RemoteNodeRegistry::new();
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        registry
+            .register(registration("gen-1", caps.clone()), instant(0))
+            .unwrap();
+        let mut conflicting = registration("gen-1", caps);
+        conflicting.gateway_principal = PrincipalId::parse("other-gateway").unwrap();
+        let err = registry.register(conflicting, instant(1)).unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::DuplicateRegistration);
+    }
+
+    #[test]
+    fn wrong_realm_registration_fails_before_state_is_retained() {
+        let mut reg = registration("gen-1", CapabilitySet::empty());
+        reg.summary.realm = RealmPath::new(vec![
+            nixling_constellation_core::RealmId::parse("work").unwrap(),
+        ])
+        .unwrap();
+        let mut registry = RemoteNodeRegistry::new();
+        let err = registry.register(reg, instant(0)).unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::WrongRealm);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn new_generation_supersedes_old_and_old_generation_is_stale() {
+        let mut registry = RemoteNodeRegistry::new();
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        registry
+            .register(registration("gen-1", caps.clone()), instant(0))
+            .unwrap();
+        let entry = registry
+            .register(registration("gen-2", caps), instant(1))
+            .unwrap();
+        assert_eq!(entry.generation, ProtocolToken::parse("gen-2").unwrap());
+
+        let old = ProtocolToken::parse("gen-1").unwrap();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        let err = registry
+            .prepare_route(&request, &old, &principal())
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::StaleGeneration);
+    }
+
+    #[test]
+    fn wrong_realm_route_fails_before_lookup() {
+        let registry = RemoteNodeRegistry::new();
+        let mut request = req(OperationKind::WorkloadList, Capability::Lifecycle, None);
+        request.realm = RealmPath::new(vec![
+            nixling_constellation_core::RealmId::parse("work").unwrap(),
+        ])
+        .unwrap();
+        let err = registry
+            .prepare_route(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &principal(),
+            )
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::WrongRealm);
+    }
+
+    #[test]
+    fn heartbeat_and_disconnect_drive_availability() {
+        let mut registry = RemoteNodeRegistry::new().with_heartbeat_timeout(Duration::from_secs(2));
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        registry
+            .register(registration("gen-1", caps), instant(0))
+            .unwrap();
+        let generation = ProtocolToken::parse("gen-1").unwrap();
+        let node = NodeId::parse("remote-host").unwrap();
+        registry
+            .heartbeat(&RealmPath::local(), &node, &generation, instant(1))
+            .unwrap();
+        assert_eq!(
+            registry
+                .get(&RealmPath::local(), &node)
+                .unwrap()
+                .availability(),
+            RemoteNodeAvailability::Available
+        );
+        assert!(registry.peer_disconnected(&RealmPath::local(), &node));
+        assert_eq!(
+            registry
+                .get(&RealmPath::local(), &node)
+                .unwrap()
+                .availability(),
+            RemoteNodeAvailability::Disconnected
+        );
+        let err = registry
+            .heartbeat(&RealmPath::local(), &node, &generation, instant(2))
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::NodeUnavailable);
+        registry
+            .register(
+                registration("gen-1", CapabilitySet::empty().with(Capability::Lifecycle)),
+                instant(3),
+            )
+            .unwrap();
+        registry.expire_heartbeats(instant(10));
+        assert_eq!(
+            registry
+                .get(&RealmPath::local(), &node)
+                .unwrap()
+                .availability(),
+            RemoteNodeAvailability::StaleHeartbeat
+        );
+    }
+
+    #[test]
+    fn unavailable_node_refuses_before_route() {
+        let mut registry = RemoteNodeRegistry::new();
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        registry
+            .register(registration("gen-1", caps), instant(0))
+            .unwrap();
+        let node = NodeId::parse("remote-host").unwrap();
+        registry.peer_disconnected(&RealmPath::local(), &node);
+        let request = req(OperationKind::WorkloadList, Capability::Lifecycle, None);
+        let err = registry
+            .prepare_route(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &principal(),
+            )
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::NodeUnavailable);
+        assert!(err.remediation().contains("remote daemon"));
+    }
+
+    #[test]
+    fn missing_capability_denies_before_remote_send() {
+        let mut registry = RemoteNodeRegistry::new();
+        registry
+            .register(registration("gen-1", CapabilitySet::empty()), instant(0))
+            .unwrap();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        let err = registry
+            .prepare_route(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &principal(),
+            )
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::CapabilityDenied);
+        assert_eq!(err.missing_capability, Some(Capability::Lifecycle));
+        assert!(err.capability_fingerprint.is_some());
+    }
+
+    #[test]
+    fn remote_operation_maps_existing_kind_and_capability() {
+        let mut registry = RemoteNodeRegistry::new();
+        let caps = CapabilitySet::empty()
+            .with(Capability::Lifecycle)
+            .with(Capability::Exec)
+            .with(Capability::Logs);
+        registry
+            .register(registration("gen-1", caps.clone()), instant(0))
+            .unwrap();
+        for (kind, cap) in [
+            (OperationKind::WorkloadList, Some(Capability::Lifecycle)),
+            (OperationKind::WorkloadStart, Some(Capability::Lifecycle)),
+            (OperationKind::WorkloadStop, Some(Capability::Lifecycle)),
+            (OperationKind::ExecStart, Some(Capability::Exec)),
+            (OperationKind::ExecAttach, Some(Capability::Exec)),
+            (OperationKind::ExecCancel, Some(Capability::Exec)),
+            (OperationKind::ExecLogs, Some(Capability::Logs)),
+        ] {
+            let request = req(kind, cap.unwrap_or(Capability::Lifecycle), Some("idem-1"));
+            let route = registry
+                .prepare_route(
+                    &request,
+                    &ProtocolToken::parse("gen-1").unwrap(),
+                    &principal(),
+                )
+                .unwrap();
+            assert_eq!(route.operation, kind);
+            assert_eq!(route.required_capability, cap);
+            assert_eq!(route.capability_fingerprint, caps.stable_fingerprint());
+        }
+    }
+
+    #[test]
+    fn unsupported_remote_operation_is_refused() {
+        let mut registry = RemoteNodeRegistry::new();
+        registry
+            .register(
+                registration(
+                    "gen-1",
+                    CapabilitySet::empty().with(Capability::PortForward),
+                ),
+                instant(0),
+            )
+            .unwrap();
+        let request = req(
+            OperationKind::PortForwardOpen,
+            Capability::PortForward,
+            Some("idem-1"),
+        );
+        let err = registry
+            .prepare_route(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &principal(),
+            )
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::UnsupportedOperation);
+    }
+
+    #[test]
+    fn unregister_allows_capacity_recovery() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut registry = RemoteNodeRegistry::new().with_max_nodes(1);
+        registry
+            .register(registration("gen-1", caps.clone()), instant(0))
+            .unwrap();
+        let mut second = registration("gen-1", caps.clone());
+        second.summary.id = NodeId::parse("other-host").unwrap();
+        assert_eq!(
+            registry
+                .register(second.clone(), instant(1))
+                .unwrap_err()
+                .kind,
+            RemoteNodeErrorKind::RegistryCapacityExceeded
+        );
+        assert!(
+            registry
+                .unregister(&RealmPath::local(), &NodeId::parse("remote-host").unwrap())
+                .is_some()
+        );
+        assert!(registry.register(second, instant(2)).is_ok());
+    }
+
+    #[test]
+    fn mutating_disconnect_recovery_queries_remote_state() {
+        let start = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        assert_eq!(
+            retry_action_after_disconnect(&start),
+            RemoteRetryAction::QueryRemoteState
+        );
+        let list = req(OperationKind::WorkloadList, Capability::Lifecycle, None);
+        assert_eq!(
+            retry_action_after_disconnect(&list),
+            RemoteRetryAction::NoSideEffectToRetry
+        );
+    }
+
+    #[test]
+    fn remote_execution_generation_is_checked_before_stream_open() {
+        let route = RemoteRoute {
+            realm: RealmPath::local(),
+            node: NodeId::parse("remote-host").unwrap(),
+            generation: ProtocolToken::parse("boot-a").unwrap(),
+            operation: OperationKind::ExecAttach,
+            required_capability: Some(Capability::Exec),
+            capability_fingerprint: CapabilitySet::empty()
+                .with(Capability::Exec)
+                .stable_fingerprint(),
+            principal: principal(),
+            trace: None,
+            mutating: false,
+        };
+        let good = ExecutionGeneration {
+            guest_boot_id: ProtocolToken::parse("boot-a").unwrap(),
+            workload_generation: ProtocolToken::parse("workload-gen").unwrap(),
+        };
+        assert!(ensure_remote_execution_generation(&route, &good).is_ok());
+        let stale = ExecutionGeneration {
+            guest_boot_id: ProtocolToken::parse("boot-b").unwrap(),
+            workload_generation: ProtocolToken::parse("workload-gen").unwrap(),
+        };
+        let err = ensure_remote_execution_generation(&route, &stale).unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::StaleGeneration);
+    }
+
+    #[test]
+    fn debug_output_does_not_expose_forbidden_shapes() {
+        let mut registry = RemoteNodeRegistry::new();
+        registry
+            .register(
+                registration("gen-1", CapabilitySet::empty().with(Capability::Lifecycle)),
+                instant(0),
+            )
+            .unwrap();
+        let debug = format!("{registry:?}");
+        for forbidden in [
+            "TOKEN=",
+            "secret",
+            "/nix/store",
+            "stdout",
+            "pidfd",
+            "fd=",
+            "https://",
+            "ssh://",
+        ] {
+            assert!(
+                !debug.contains(forbidden),
+                "debug output leaked {forbidden}: {debug}"
+            );
+        }
+    }
+
+    #[derive(Default)]
+    struct FakePeer {
+        sends: usize,
+        queries: usize,
+        query_status: Option<RemotePeerStatus>,
+        fail_send: bool,
+        fail_query: bool,
+    }
+
+    impl RemotePeerClient for FakePeer {
+        fn send_operation(
+            &mut self,
+            _route: &RemoteRoute,
+            _req: &OperationRequest,
+        ) -> Result<OpaquePayload, RemoteNodeError> {
+            self.sends += 1;
+            if self.fail_send {
+                return Err(RemoteNodeError::new(RemoteNodeErrorKind::NodeUnavailable));
+            }
+            Ok(OpaquePayload::new(b"remote-ok".to_vec()).unwrap())
+        }
+
+        fn query_operation(
+            &mut self,
+            _route: &RemoteRoute,
+            _req: &OperationRequest,
+        ) -> Result<RemotePeerStatus, RemoteNodeError> {
+            self.queries += 1;
+            if self.fail_query {
+                return Err(RemoteNodeError::new(RemoteNodeErrorKind::NodeUnavailable));
+            }
+            Ok(self
+                .query_status
+                .clone()
+                .unwrap_or(RemotePeerStatus::InProgress))
+        }
+    }
+
+    fn adapter(caps: CapabilitySet) -> RemoteFullHostAdapter {
+        let mut adapter = RemoteFullHostAdapter::new(principal(), caps.clone());
+        adapter
+            .registry_mut()
+            .register(registration("gen-1", caps), instant(0))
+            .unwrap();
+        adapter
+    }
+
+    #[test]
+    fn gateway_adapter_sends_only_after_router_and_registry_accept() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut adapter = adapter(caps);
+        let mut peer = FakePeer::default();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        let outcome = adapter
+            .dispatch(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap();
+        assert!(matches!(outcome, RemoteDispatchOutcome::Sent { .. }));
+        assert_eq!(peer.sends, 1);
+    }
+
+    #[test]
+    fn gateway_adapter_replays_without_second_send() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut adapter = adapter(caps);
+        let mut peer = FakePeer::default();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        adapter
+            .dispatch(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap();
+        let outcome = adapter
+            .dispatch(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap();
+        assert!(matches!(outcome, RemoteDispatchOutcome::Replayed { .. }));
+        assert_eq!(peer.sends, 1);
+        assert_eq!(peer.queries, 0);
+    }
+
+    #[test]
+    fn missing_negotiated_capability_denies_before_remote_send() {
+        let mut adapter = adapter(CapabilitySet::empty().with(Capability::Lifecycle));
+        adapter.negotiated_capabilities = CapabilitySet::empty();
+        let mut peer = FakePeer::default();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        let err = adapter
+            .dispatch(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::CapabilityDenied);
+        assert_eq!(peer.sends, 0);
+    }
+
+    #[test]
+    fn gateway_principal_must_match_remote_registration() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut adapter = adapter(caps);
+        adapter.gateway_principal = PrincipalId::parse("other-gateway").unwrap();
+        let mut peer = FakePeer::default();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        let err = adapter
+            .dispatch(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::UnauthorizedGateway);
+        assert_eq!(peer.sends, 0);
+    }
+
+    #[test]
+    fn unacknowledged_mutation_queries_remote_state_before_retry() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut adapter = RemoteFullHostAdapter::with_router(
+            RemoteNodeRegistry::new(),
+            super::super::OperationRouter::new(),
+            principal(),
+            caps.clone(),
+        );
+        adapter
+            .registry_mut()
+            .register(registration("gen-1", caps), instant(0))
+            .unwrap();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        assert!(matches!(
+            adapter.router.route_with_capabilities(
+                &request,
+                &principal(),
+                &adapter.negotiated_capabilities
+            ),
+            super::super::RouteDecision::Accept { .. }
+        ));
+
+        let mut peer = FakePeer::default();
+        let outcome = adapter
+            .dispatch(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            RemoteDispatchOutcome::QueryRemoteState { .. }
+        ));
+        assert_eq!(peer.sends, 0);
+        assert_eq!(peer.queries, 1);
+    }
+
+    #[test]
+    fn unknown_remote_state_clears_local_lock_and_returns_typed_error() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut adapter = RemoteFullHostAdapter::with_router(
+            RemoteNodeRegistry::new(),
+            super::super::OperationRouter::new(),
+            principal(),
+            caps.clone(),
+        );
+        adapter
+            .registry_mut()
+            .register(registration("gen-1", caps), instant(0))
+            .unwrap();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        assert!(matches!(
+            adapter.router.route_with_capabilities(
+                &request,
+                &principal(),
+                &adapter.negotiated_capabilities
+            ),
+            super::super::RouteDecision::Accept { .. }
+        ));
+        let mut peer = FakePeer {
+            query_status: Some(RemotePeerStatus::Unknown),
+            ..Default::default()
+        };
+        let err = adapter
+            .dispatch(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::RemoteOperationUnknown);
+        let mut next_peer = FakePeer::default();
+        let outcome = adapter
+            .dispatch(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &mut next_peer,
+            )
+            .unwrap();
+        assert!(matches!(outcome, RemoteDispatchOutcome::Sent { .. }));
+        assert_eq!(next_peer.sends, 1);
+    }
+
+    #[test]
+    fn send_error_clears_local_idempotency_lock() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut adapter = adapter(caps);
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        let mut failing_peer = FakePeer {
+            fail_send: true,
+            ..Default::default()
+        };
+        let err = adapter
+            .dispatch(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &mut failing_peer,
+            )
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::NodeUnavailable);
+
+        let mut next_peer = FakePeer::default();
+        let outcome = adapter
+            .dispatch(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &mut next_peer,
+            )
+            .unwrap();
+        assert!(matches!(outcome, RemoteDispatchOutcome::Sent { .. }));
+        assert_eq!(next_peer.sends, 1);
+    }
+
+    #[test]
+    fn query_error_clears_local_idempotency_lock() {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        let mut adapter = RemoteFullHostAdapter::with_router(
+            RemoteNodeRegistry::new(),
+            super::super::OperationRouter::new(),
+            principal(),
+            caps.clone(),
+        );
+        adapter
+            .registry_mut()
+            .register(registration("gen-1", caps), instant(0))
+            .unwrap();
+        let request = req(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+        );
+        assert!(matches!(
+            adapter.router.route_with_capabilities(
+                &request,
+                &principal(),
+                &adapter.negotiated_capabilities
+            ),
+            super::super::RouteDecision::Accept { .. }
+        ));
+
+        let mut failing_peer = FakePeer {
+            fail_query: true,
+            ..Default::default()
+        };
+        let err = adapter
+            .dispatch(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &mut failing_peer,
+            )
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteNodeErrorKind::NodeUnavailable);
+
+        let mut next_peer = FakePeer::default();
+        let outcome = adapter
+            .dispatch(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &mut next_peer,
+            )
+            .unwrap();
+        assert!(matches!(outcome, RemoteDispatchOutcome::Sent { .. }));
+        assert_eq!(next_peer.sends, 1);
+    }
+
+    #[test]
+    fn route_audit_labels_propagate_trace_context() {
+        let mut registry = RemoteNodeRegistry::new();
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        registry
+            .register(registration("gen-1", caps.clone()), instant(0))
+            .unwrap();
+        let trace = TraceContext::new("trace-1", "span-1").unwrap();
+        let request = req_with_trace(
+            OperationKind::WorkloadStart,
+            Capability::Lifecycle,
+            Some("idem-1"),
+            Some(trace),
+        );
+        let route = registry
+            .prepare_route(
+                &request,
+                &ProtocolToken::parse("gen-1").unwrap(),
+                &principal(),
+            )
+            .unwrap();
+        let labels = route.audit_labels("accepted");
+        assert_eq!(labels.realm, "local");
+        assert_eq!(labels.node, "remote-host");
+        assert_eq!(labels.principal, "gateway-principal");
+        assert_eq!(labels.capability_fingerprint, caps.stable_fingerprint());
+        assert_eq!(labels.trace_id, Some("trace-1"));
+        assert_eq!(labels.span_id, Some("span-1"));
+        assert_eq!(labels.outcome, "accepted");
+    }
+}

--- a/packages/nixlingd/src/constellation_stubs.rs
+++ b/packages/nixlingd/src/constellation_stubs.rs
@@ -26,11 +26,14 @@
 
 use std::sync::{Arc, Mutex};
 
-use nixling_constellation_core::{CapabilitySet, OperationRequest, PrincipalId, TargetName};
+use nixling_constellation_core::{
+    CapabilitySet, OperationRequest, PrincipalId, ProtocolToken, TargetName,
+};
 use nixling_constellation_provider::error::ProviderResult;
 use nixling_constellation_provider::provider::{ProtocolCodec, WorkloadProvider};
 use nixling_constellation_router::{
-    DispatchTarget, OperationRouter, RealmEntrypointTable, ResolveError, RouteDecision,
+    DispatchTarget, OperationRouter, RealmEntrypointTable, RemoteDispatchOutcome,
+    RemoteFullHostAdapter, RemoteNodeRegistry, RemotePeerClient, ResolveError, RouteDecision,
 };
 
 /// A node/gateway-scoped [`OperationRouter`] shared across peer sessions.
@@ -182,13 +185,57 @@ impl Default for LocalExecutor {
     }
 }
 
-/// A remote-node peer session (future gateway work). Carries the seam only.
-pub struct PeerDaemon;
+/// Gateway-side remote full-host peer coordinator. It composes the pure remote
+/// node registry, the shared operation router, and a semantic peer-client seam.
+/// It still carries no transport endpoints, broker handles, guest-control
+/// clients, pidfds, file descriptors, or host paths.
+pub struct PeerDaemon {
+    remote_full_hosts: RemoteFullHostAdapter,
+}
 
 impl PeerDaemon {
-    /// Build the peer-daemon skeleton.
+    /// Build with a fixed preview gateway principal and no negotiated
+    /// capabilities. Tests/gateway-mode wiring should prefer
+    /// [`Self::with_gateway_principal`].
     pub fn new() -> Self {
-        Self
+        Self::with_gateway_principal(
+            PrincipalId::parse("gateway").expect("gateway is a valid principal token"),
+            CapabilitySet::empty(),
+        )
+    }
+
+    /// Build a peer daemon with an authenticated gateway principal and the
+    /// negotiated capability set for remote operations.
+    pub fn with_gateway_principal(
+        gateway_principal: PrincipalId,
+        capabilities: CapabilitySet,
+    ) -> Self {
+        Self {
+            remote_full_hosts: RemoteFullHostAdapter::new(gateway_principal, capabilities),
+        }
+    }
+
+    /// Borrow the remote full-host registry.
+    pub fn remote_nodes(&self) -> &RemoteNodeRegistry {
+        self.remote_full_hosts.registry()
+    }
+
+    /// Mutable access to the remote full-host registry for registration and
+    /// heartbeat paths.
+    pub fn remote_nodes_mut(&mut self) -> &mut RemoteNodeRegistry {
+        self.remote_full_hosts.registry_mut()
+    }
+
+    /// Route one already-authenticated semantic operation to a remote full
+    /// host. The adapter gates by principal, capability, generation, and
+    /// idempotency before the peer client sees the request.
+    pub fn dispatch_remote(
+        &mut self,
+        req: &OperationRequest,
+        generation: &ProtocolToken,
+        client: &mut dyn RemotePeerClient,
+    ) -> Result<RemoteDispatchOutcome, nixling_constellation_router::RemoteNodeError> {
+        self.remote_full_hosts.dispatch(req, generation, client)
     }
 }
 
@@ -294,8 +341,10 @@ impl DaemonModeConfig {
 mod tests {
     use super::*;
     use nixling_constellation_core::{
-        IdempotencyKey, NodeId, OpaquePayload, OperationId, OperationKind, RealmPath,
+        Capability, IdempotencyKey, NodeId, NodeKind, NodeSummary, OpaquePayload, OperationId,
+        OperationKind, ProviderId, RealmPath, WorkloadId,
     };
+    use nixling_constellation_router::{RemoteNodeError, RemoteNodeRegistration};
 
     fn list_req(principal: &PrincipalId) -> OperationRequest {
         OperationRequest {
@@ -322,6 +371,60 @@ mod tests {
             kind: OperationKind::WorkloadStart,
             trace: None,
             body: OpaquePayload::new(b"start".to_vec()).unwrap(),
+        }
+    }
+
+    fn remote_start_req(principal: &PrincipalId, op_id: &str, key: &str) -> OperationRequest {
+        OperationRequest {
+            operation_id: OperationId::parse(op_id).unwrap(),
+            idempotency_key: Some(IdempotencyKey::parse(key).unwrap()),
+            realm: RealmPath::local(),
+            node: NodeId::parse("remote-host").unwrap(),
+            workload: Some(WorkloadId::parse("vm-a").unwrap()),
+            principal: principal.clone(),
+            kind: OperationKind::WorkloadStart,
+            trace: None,
+            body: OpaquePayload::new(b"remote-start".to_vec()).unwrap(),
+        }
+    }
+
+    fn remote_registration(principal: &PrincipalId) -> RemoteNodeRegistration {
+        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+        RemoteNodeRegistration {
+            summary: NodeSummary {
+                id: NodeId::parse("remote-host").unwrap(),
+                realm: RealmPath::local(),
+                kind: NodeKind::FullHost,
+                capabilities: caps,
+            },
+            gateway_principal: principal.clone(),
+            gateway_node: NodeId::parse("gateway").unwrap(),
+            substrate_adapter: ProviderId::parse("nixos-host-substrate").unwrap(),
+            generation: ProtocolToken::parse("gen-1").unwrap(),
+        }
+    }
+
+    #[derive(Default)]
+    struct FakePeerClient {
+        sends: usize,
+    }
+
+    impl RemotePeerClient for FakePeerClient {
+        fn send_operation(
+            &mut self,
+            _route: &nixling_constellation_router::RemoteRoute,
+            _req: &OperationRequest,
+        ) -> Result<OpaquePayload, RemoteNodeError> {
+            self.sends += 1;
+            Ok(OpaquePayload::new(b"remote-ok".to_vec()).unwrap())
+        }
+
+        fn query_operation(
+            &mut self,
+            _route: &nixling_constellation_router::RemoteRoute,
+            _req: &OperationRequest,
+        ) -> Result<nixling_constellation_router::RemotePeerStatus, RemoteNodeError> {
+            Ok(nixling_constellation_router::RemotePeerStatus::InProgress)
         }
     }
 
@@ -434,5 +537,65 @@ mod tests {
             cross_wired.validate(),
             Err(DaemonModeError::GatewayCarriesHostLifecycle)
         );
+    }
+
+    #[test]
+    fn peer_daemon_composes_remote_full_host_registry_and_router() {
+        let principal = PrincipalId::parse("gateway-principal").unwrap();
+        let mut daemon = PeerDaemon::with_gateway_principal(
+            principal.clone(),
+            CapabilitySet::empty().with(Capability::Lifecycle),
+        );
+        daemon
+            .remote_nodes_mut()
+            .register(remote_registration(&principal), std::time::Instant::now())
+            .unwrap();
+        assert_eq!(daemon.remote_nodes().len(), 1);
+
+        let mut peer = FakePeerClient::default();
+        let request = remote_start_req(&principal, "op-remote-1", "idem-remote-1");
+        let outcome = daemon
+            .dispatch_remote(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .unwrap();
+        assert!(matches!(outcome, RemoteDispatchOutcome::Sent { .. }));
+        assert_eq!(peer.sends, 1);
+    }
+
+    #[test]
+    fn peer_daemon_remote_path_does_not_change_local_default_resolver() {
+        let principal = PrincipalId::parse("gateway-principal").unwrap();
+        let _daemon = PeerDaemon::with_gateway_principal(
+            principal,
+            CapabilitySet::empty().with(Capability::Lifecycle),
+        );
+        let resolver = TargetResolver::local_only();
+        let target = TargetName::parse("demo.nixling").unwrap();
+        assert!(matches!(
+            resolver.resolve(&target),
+            Ok(DispatchTarget::HostResident { .. })
+        ));
+    }
+
+    #[test]
+    fn constellation_seam_imports_no_broker_guest_control_or_provider_credentials() {
+        let src = include_str!("constellation_stubs.rs");
+        let imports = src
+            .lines()
+            .filter(|line| line.trim_start().starts_with("use "))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for forbidden in [
+            ["nixling", "_ipc"].concat(),
+            ["guest", "_control"].concat(),
+            ["priv", "_broker"].concat(),
+            ["provider", "_relay"].concat(),
+            ["provider", "_aca"].concat(),
+            ["gateway", "_runtime"].concat(),
+        ] {
+            assert!(
+                !imports.contains(&forbidden),
+                "constellation seam import leaked forbidden dependency {forbidden}: {imports}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a preview remote full-host registry and semantic peer-client adapter for gateway-routed full-host nodes
- enforce managed-realm and gateway-principal binding, capability/liveness/generation gates, retry-safe idempotency recovery, and bounded trace/audit labels
- wire the daemon PeerDaemon seam and document the preview non-tunneling contract

## Validation
- cargo test -p nixling-constellation-router --quiet
- cargo clippy -p nixling-constellation-router --all-targets -- -D warnings
- cargo test -p nixlingd constellation_stubs --quiet
- cargo clippy -p nixlingd --all-targets -- -D warnings
- make test-drift
- git diff --check
- git diff --cached --check
- added-line process-marker scan

## Panel
- Gemini 3.1 Pro Wave 14 implementation panel signed off after R3.
