### PR TITLE
provider: harden ACA sandbox boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,33 @@ deprecations ship one minor release before removal.
 - Host-to-realm isolation is now documented and checked with a redacted
   host egress policy artifact, so host daemon/broker/CLI surfaces remain
   free of realm relay credentials and sessions.
+- ADR 0032 provider-managed sandboxes: the ACA adapter now handles
+  provider-layer 429/rate-limit responses with `Retry-After`-aware
+  backoff metadata and a shared circuit breaker. When the circuit is open,
+  `Backpressure` errors include the remaining open duration.
+  Circuit state is shared across provider instances targeting the same
+  ACA subscription/resource-group pair so load is not shed onto a
+  sibling instance pointing at the same upstream. Retry hint metadata
+  remains internal to the provider layer; no change to the public
+  `ConstellationError` schema.
+- ADR 0032 provider-managed sandboxes: ACA adapter authentication now
+  enforces a strict managed/workload identity boundary in production.
+  Ambient developer credential chains (Azure CLI tokens, environment
+  variable secrets, developer-toolchain fallbacks) are not present in the
+  production resolution order. Non-production local-validation contexts
+  inject test credentials explicitly and are not a runtime fallback.
+- ADR 0032 provider-managed sandboxes: Azure REST error diagnostics are
+  now gated by an allowlist. Only the allowlisted `error.code` values,
+  a length-bounded sanitized `error.message`, the HTTP status code, and
+  the opaque `x-ms-correlation-request-id` header appear in
+  provider errors, structured log spans, and audit records.
+  Full response bodies, endpoint URLs, resource IDs, tokens, payload
+  content, and workload output are never forwarded.
+- Documentation: added `docs/reference/provider-managed-sandboxes.md`
+  covering the ACA adapter capability matrix, absent capabilities,
+  rate-limit/backoff/circuit behavior, credential boundary, diagnostics
+  redaction rules, error shapes, and scope limitations. Cross-referenced
+  from `docs/reference/remote-full-host-nodes.md`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,33 +140,39 @@ deprecations ship one minor release before removal.
 - Host-to-realm isolation is now documented and checked with a redacted
   host egress policy artifact, so host daemon/broker/CLI surfaces remain
   free of realm relay credentials and sessions.
-- ADR 0032 provider-managed sandboxes: the ACA adapter now handles
+- Provider-managed sandboxes: the Azure Container Apps adapter now handles
   provider-layer 429/rate-limit responses with `Retry-After`-aware
   backoff metadata and a shared circuit breaker. When the circuit is open,
-  `Backpressure` errors include the remaining open duration.
-  Circuit state is shared across provider instances targeting the same
-  ACA subscription/resource-group pair so load is not shed onto a
-  sibling instance pointing at the same upstream. Retry hint metadata
-  remains internal to the provider layer; no change to the public
+  `Backpressure` errors include the remaining open duration. Probe attempts
+  have a bounded timeout, stale probes reopen the circuit, and repeated
+  transient failures use bounded exponential backoff with jitter. Concurrent
+  429 responses from the same request batch can extend an already-open circuit.
+  Circuit state is shared across provider instances targeting the same Azure Container Apps
+  endpoint, subscription, resource group, and sandbox group so sibling
+  instances cannot bypass the breaker for the same upstream. Retry hint
+  metadata remains internal to the provider layer; no change to the public
   `ConstellationError` schema.
-- ADR 0032 provider-managed sandboxes: ACA adapter authentication now
-  enforces a strict managed/workload identity boundary in production.
+- Provider-managed sandboxes: Azure Container Apps adapter authentication now
+  enforces workload identity first, then managed identity, in production.
   Ambient developer credential chains (Azure CLI tokens, environment
   variable secrets, developer-toolchain fallbacks) are not present in the
   production resolution order. Non-production local-validation contexts
   inject test credentials explicitly and are not a runtime fallback.
-- ADR 0032 provider-managed sandboxes: Azure REST error diagnostics are
-  now gated by an allowlist. Only the allowlisted `error.code` values,
-  a length-bounded sanitized `error.message`, the HTTP status code, and
-  the opaque `x-ms-correlation-request-id` header appear in
-  provider errors, structured log spans, and audit records.
-  Full response bodies, endpoint URLs, resource IDs, tokens, payload
-  content, and workload output are never forwarded.
+- Provider-managed sandboxes: Azure REST error diagnostics are
+  now gated by an allowlist. Only case-stable allowlisted `error.code`
+  values (or `unknown`), a length-bounded sanitized `error.message`, the
+  HTTP status code, and the opaque `x-ms-correlation-request-id` header
+  appear in provider errors, structured log spans, and audit records.
+  Full response bodies, endpoint URLs, subscription IDs, internal diagnostic
+  details, resource IDs, tokens, payload content, and workload output are never
+  forwarded.
 - Documentation: added `docs/reference/provider-managed-sandboxes.md`
-  covering the ACA adapter capability matrix, absent capabilities,
+  covering the Azure Container Apps adapter capability matrix, absent capabilities,
   rate-limit/backoff/circuit behavior, credential boundary, diagnostics
-  redaction rules, error shapes, and scope limitations. Cross-referenced
-  from `docs/reference/remote-full-host-nodes.md`.
+  redaction rules, error shapes, `provider-managed-isolation`, and scope
+  limitations including the absence of guestd, systemd, broker, KVM, vsock,
+  cgroup, namespace, SSH, and full-host lifecycle. Cross-referenced from
+  `docs/reference/remote-full-host-nodes.md`.
 
 ### Removed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,13 @@ The contracts. Stable interfaces a consumer can depend on.
 - [`reference/error-envelope-guidance.md`](./reference/error-envelope-guidance.md) —
   daemon/broker/CLI envelope alignment, including broker-error
   remediation rules.
+- [`reference/provider-managed-sandboxes.md`](./reference/provider-managed-sandboxes.md) —
+  capability matrix, absent capabilities, rate-limit/backoff/circuit
+  behavior, credential boundary, diagnostics redaction, and error shapes
+  for provider-managed sandbox nodes (ACA adapter).
+- [`reference/remote-full-host-nodes.md`](./reference/remote-full-host-nodes.md) —
+  gateway-managed remote nixling hosts: registration, capability gating,
+  operation routing, idempotency, and the non-tunneling boundary.
 - **Per-component references** — one file per
   `nixos-modules/components/*.nix` toggle. Options, host-side
   resources created, runtime invariants, hardening notes, and the

--- a/docs/reference/provider-managed-sandboxes.md
+++ b/docs/reference/provider-managed-sandboxes.md
@@ -1,0 +1,305 @@
+# Provider-managed sandboxes
+
+**Diataxis category:** reference.
+
+A provider-managed sandbox is a workload unit that a cloud provider
+creates, manages, and destroys on behalf of nixling. The nixling daemon
+routes typed operations to the provider API and receives typed responses;
+it does not own a hypervisor, broker, or guest OS stack for these nodes.
+The first implemented adapter is Azure Container Apps (ACA).
+
+This page documents the capability matrix, supported operations, absent
+capabilities, rate-limit/backoff/circuit behavior, credential boundary,
+safe diagnostics rules, and error shapes for provider-managed sandboxes.
+
+For nodes where nixling owns the full host stack (hypervisor, broker,
+guest-control), see [remote full-host nodes](./remote-full-host-nodes.md).
+
+---
+
+## What a provider-managed sandbox is
+
+A provider-managed sandbox is a named workload target in a realm whose
+lifecycle (create, start, stop, destroy) is owned by an external provider
+API rather than by a `nixling-priv-broker` running on a locally managed
+host. From the daemon's perspective it is a node with a bounded positive
+capability set derived from what that provider API supports. The daemon
+never provisions, registers, or expects a `nixlingd`, `nixling-priv-broker`,
+guest-control stack, KVM subsystem, vsock channel, cgroup subtree, namespace
+hierarchy, or device-hotplug surface on a provider-managed node.
+
+This model is distinct from a **remote full-host node** (see
+[remote full-host nodes](./remote-full-host-nodes.md)), which runs its
+own `nixlingd` and full broker stack and is reached through an
+authenticated peer transport session. The following table summarizes the
+key differences:
+
+| Dimension | Provider-managed sandbox | Remote full-host node |
+| --- | --- | --- |
+| Who owns lifecycle | Cloud provider API | Remote `nixlingd` + `nixling-priv-broker` |
+| Broker presence | None | Full broker on the remote host |
+| Guest-control / vsock | Absent | Present |
+| KVM / hypervisor | Absent | Present |
+| Cgroup / namespace authority | Absent | Present (remote host) |
+| Device hotplug | Absent | Present (remote host) |
+| SSH fallback | Absent | Absent |
+| Authentication surface | Managed/workload identity → provider API | Peer session authenticated principal |
+| Capability source | Provider adapter capability declaration | Substrate provider report |
+| Registry | Provider API is the source of truth | Daemon router state |
+
+---
+
+## Capability matrix — ACA adapter
+
+Capabilities are positive assertions. A capability absent from this
+table is not supported; operations requiring it receive
+`CapabilityDenied` and do not fall back.
+
+| Capability | ACA support | Notes |
+| --- | --- | --- |
+| `lifecycle` | Conditional | Advertised only when sandbox defaults are configured; create/start/stop/list map to the ACA sandbox data plane. |
+| `exec` | ✓ | Synchronous ACA `executeShellCommand`; returns a derived execution id, not a durable guest-control session. |
+| `logs` | ✗ | No retained-log stream in this adapter. |
+| `pty` | ✗ | No interactive TTY or stdio attachment. |
+| `file-copy` | ✗ | No bounded file-copy API. |
+| `port-forward` | ✗ | No generic tunnel or port-forward API. |
+| `vsock` | ✗ | No guest-control vsock channel. |
+| `virtiofs` | ✗ | No per-workload /nix/store hardlink farm or virtiofsd share. |
+| `window-forwarding` / `display-streaming` | ✗ | No Wayland/virtio-gpu or video sidecar. |
+| `clipboard` | ✗ | No clipboard bridge. |
+| `audio-playback` / `audio-capture` | ✗ | No vhost-user-sound or PipeWire mediation. |
+| `usb` | ✗ | No USBIP passthrough. |
+| `hid` | ✗ | No HID device operations. |
+| `gpu-accel` | ✗ | No local GPU acceleration surface. |
+| `snapshots` | ✗ | No snapshot API in this adapter. |
+| `hotplug` | ✗ | No device hotplug API. |
+| `ephemeral-sessions` | ✗ | ACA sandboxes are selected by workload labels, not ephemeral session slots in this adapter. |
+| `provider-managed-isolation` | ✗ | The current ACA provider keeps this descriptor absent until routing needs to distinguish it explicitly. |
+
+---
+
+## Supported operations
+
+The ACA adapter routes the following provider operations. All others are
+refused with `UnsupportedFeature` before contacting the provider API.
+
+| Operation | Behavior |
+| --- | --- |
+| `list` | Lists sandboxes selected by deterministic `nixling-workload` / realm labels and maps provider state to `WorkloadSummary`. |
+| `create` | Ensures a workload sandbox exists, creating/reusing the disk image and sandbox through the ACA data plane. |
+| `start` | Ensures the sandbox exists and resumes it when idle. |
+| `stop` | Resolves the workload alias to a sandbox and posts ACA stop; already-absent/already-stopped is success. |
+| `exec` | Runs synchronous `executeShellCommand` against the selected sandbox. Command bytes are opaque payload and are not logged or audited as metadata. |
+
+Gateway/router layers own idempotency for mutating operations. The ACA
+provider itself uses deterministic workload labels to discover upstream
+state before creating or retrying mutating lifecycle calls.
+
+---
+
+## Absent capabilities (explicit non-scope)
+
+The following items are outside the provider-managed sandbox model and
+are never routed through this adapter. Requests for them fail closed
+with `UnsupportedFeature` or `CapabilityDenied`; there are no fallbacks.
+
+- **No broker operation forwarding.** The adapter never forwards raw
+  `nixling-priv-broker` frames to the container runtime.
+- **No guest-control or vsock frames.** There is no guestd instance
+  and no vsock channel to attach or tunnel.
+- **No pidfd or fd passing.** No file descriptors are exchanged with
+  the container runtime.
+- **No SSH fallback.** No SSH session is opened when the provider API
+  is unavailable or when no exec surface is present.
+- **No full-host registration.** The adapter does not register the ACA
+  environment as a full nixling host; it does not run `nixlingd`,
+  install packages, or execute `nixling host prepare`.
+- **No generic container tunnel.** Raw container exec, Azure Container
+  Apps debug proxy, or any other tunnel endpoint is outside scope. The
+  adapter uses only the ACA management API surfaces listed above.
+- **No device hotplug.** Storage attachment, GPU assignment, and device
+  tree mutations are outside scope.
+- **No cgroup or namespace authority.** The provider runtime owns the
+  container lifecycle; nixling does not read, write, or delegate any
+  cgroup subtree for these workloads.
+
+---
+
+## Rate-limit, retry, and circuit-breaker behavior
+
+### Provider-layer retry metadata
+
+The ACA adapter tracks retry context internally. Retry hint fields
+(suggested delay, retry-after header values, attempt counts) are part of
+the provider layer's internal retry state and are **not** forwarded as
+fields on `ConstellationError`. This wave makes no change to the public
+`ConstellationError` schema. Callers should inspect the `ErrorKind` and
+the bounded `message` to determine whether a retry is appropriate.
+
+### ACA 429 and retry-after handling
+
+When the ACA management API responds with HTTP 429 (Too Many Requests),
+the adapter:
+
+1. Reads the `Retry-After` response header (seconds or HTTP date form).
+2. Converts it to bounded provider-layer `RetryHint` metadata and opens
+   the shared circuit breaker for the upstream.
+3. Returns `Backpressure` with a bounded message indicating that the
+   provider rate limit was exceeded. The provider does not sleep inside
+   tests or blindly retry side-effecting operations.
+
+The raw `Retry-After` value and endpoint details are not recorded in
+errors or audit records. Low-cardinality telemetry records only bounded
+retry-hint and applied-backoff duration buckets.
+
+### Circuit breaker
+
+The adapter uses a circuit breaker shared across all provider instances
+targeting the same upstream (same ACA subscription/resource-group pair).
+The circuit transitions through three states:
+
+| State | Behavior |
+| --- | --- |
+| **Closed** | Operations reach the provider API normally. Failures are counted against the trip threshold. |
+| **Open** | Operations fail immediately with `Backpressure`. The error message includes the remaining open duration and notes that the circuit is open. No requests are sent to the provider API. |
+| **Probe in flight** | One probe request is allowed through after the open window expires. Success closes the circuit; failure extends the open window. Concurrent probes are denied with `Backpressure`. |
+
+When the circuit is open, the provider error message carries the
+remaining open duration in bounded form (for example:
+`"provider circuit breaker open (retry after 14000 ms)"`). The state and the
+remaining duration are the only circuit details exposed in the error
+surface; internal trip counts and thresholds are not forwarded.
+
+Circuit state is shared across provider instances for the same upstream
+so that one degraded provider instance does not shed load onto a sibling
+instance pointing at the same ACA endpoint.
+
+---
+
+## Credential boundary
+
+Provider-managed sandboxes enforce a strict managed/workload identity
+boundary:
+
+- **In production deployments**, the adapter authenticates to the ACA
+  management API exclusively with the managed identity assigned to the
+  gateway guest VM, or with a workload identity credential configured
+  through the gateway's sealed credential envelope. Ambient developer
+  credentials (Azure CLI cached tokens, client-secret environment
+  variables, developer-toolchain credential chains) are not
+  used and are not present in the production credential resolution order.
+- **Non-production / local-validation contexts** may inject a credential
+  explicitly through `AcaWorkloadProvider::with_parts` (for example the live
+  smoke example injects Azure CLI). This is not a runtime fallback and is not
+  part of the production credential resolution order.
+- Managed identity client IDs are declared as non-secret gateway
+  configuration (subscription, resource group, sandbox group, region,
+  managed-identity client ID). They are not treated as secret material
+  and may appear in non-secret configuration sections.
+- Relay Send bearer tokens minted by the gateway for sandbox sender
+  connections are short-lived and scoped to the Relay namespace. They
+  are never stored in the ACA environment and are not written to logs,
+  audit records, or error messages.
+- Long-lived Relay rule keys and any credential whose loss would grant
+  durable access are always gateway-side only and are never passed to a
+  provider-managed sandbox.
+
+---
+
+## Diagnostics redaction
+
+The adapter surfaces Azure REST API error details through a strict
+allowlist. The following rules govern what may appear in
+provider error messages, structured log spans, and audit records:
+
+### Allowlisted fields
+
+| Field | Constraint |
+| --- | --- |
+| `error.code` | Included after bounding/sanitization when Azure provides it (for example `AuthorizationFailed`, `RevisionProvisioningFailed`, `QuotaExceeded`). |
+| `error.message` | Included in sanitized form: length-bounded, control characters stripped, no embedded JSON objects, no URLs, no UUIDs. If sanitization leaves an empty string, the field is omitted. |
+| `x-ms-correlation-request-id` | Included verbatim when present. This is an opaque Azure-side correlation token with no operational secret value. |
+| HTTP status code | Included as an integer (for example `429`, `503`). |
+
+### Excluded fields
+
+The following are never included in errors, logs, or audit records
+emitted by this adapter:
+
+- Full HTTP response bodies.
+- Request or response endpoint URLs, hostnames, or path segments.
+- Authorization headers, bearer tokens, or SAS tokens.
+- Azure resource IDs, subscription IDs, resource group names, or
+  workspace IDs.
+- ACA container image references or registry addresses.
+- Operation payloads, container environment variable values, or command
+  arguments.
+- Workload stdout/stderr output.
+- Internal retry attempt metadata, circuit-breaker state transitions,
+  or trip thresholds.
+
+These redaction rules apply uniformly to errors returned to callers, to
+structured log spans, and to audit `OpAuditRecord` entries for
+provider-layer operations.
+
+---
+
+## Error and remediation shapes
+
+Errors from the provider-managed sandbox adapter use the standard
+`ConstellationError` shape. The public `ConstellationError` schema is
+unchanged in this wave; retry hint fields remain internal.
+
+| Adapter reason | `ErrorKind` | Meaning | Remediation |
+| --- | --- | --- | --- |
+| `sandbox-not-found` | `ProviderAllocationFailed` | The target workload label has no matching ACA sandbox where the operation requires one. | Check the workload label and ACA configuration. |
+| `sandbox-provision-failed` | `ProviderAllocationFailed` | ACA reported a provisioning failure (`RevisionProvisioningFailed` or allowlisted equivalent). | Check ACA activity log via Azure portal. |
+| `quota-exceeded` | `ProviderAllocationFailed` or `Unauthorized` | Provider quota or authorization policy rejected the request. | Reduce concurrent workloads, request quota increase, or verify the managed identity role. |
+| `rate-limited` | `Backpressure` | ACA management API returned 429 and the retry ceiling was reached. | Wait for the indicated window and retry. |
+| `circuit-open` | `Backpressure` | Circuit breaker is open for this upstream; message includes remaining open duration. | Wait for the duration in the error message before retrying. |
+| `credential-acquisition-failed` | `AuthenticationFailed` | The gateway could not acquire a managed/workload identity token. | Verify explicit managed/workload identity configuration. |
+| `upstream-authorization-failed` | `Unauthorized` | ACA returned 403 for an otherwise formed request. | Verify the managed identity has the required ACA data-plane role. |
+| `unsupported-operation` | `UnsupportedFeature` | The operation kind is outside the ACA adapter's scope. | Use a full-host node for operations requiring broker/guest-control/exec. |
+| `capability-denied` | `CapabilityDenied` | The required capability is absent from the adapter's capability set. | See the capability matrix above. |
+| `provider-unavailable` | `ProviderAllocationFailed` | ACA management API is unreachable or returned an unrecoverable 5xx. | Check provider status and retry after the circuit window if one is reported. |
+
+All provider error messages are bounded and comply with the
+redaction rules above.
+
+---
+
+## Scope limitations
+
+The following items are deferred and not currently supported by the ACA
+adapter:
+
+- Interactive exec sessions or attached TTY to running containers.
+- Live stdio streaming (current support is polling-based log read only).
+- Automatic workload image build or push from a local Nix store.
+- Multi-region or multi-subscription ACA targeting from a single
+  provider instance.
+- Automatic credential refresh without gateway guest restart.
+- End-to-end display, audio, or USB forwarding to ACA containers.
+
+These limitations are documented here and not gated by runtime checks
+beyond `UnsupportedFeature` responses. Operators evaluating production
+use cases should verify that the operations they require are listed in
+the capability matrix above.
+
+---
+
+## Cross-references
+
+- [Remote full-host nodes](./remote-full-host-nodes.md) — the model
+  for nodes that run their own `nixlingd`/broker/guest-control stack.
+- [Azure Relay transport](./transport-azure-relay.md) — the Relay
+  WebSocket transport used for sandbox sender connections.
+- [Constellation core](./constellation-core.md) — typed error shapes,
+  capability model, audit redaction, and idempotency contract.
+- [Transport conformance matrix](./transport-conformance-matrix.md) —
+  cross-transport capability and conformance requirements.
+- [Host substrate providers](./host-substrate-providers.md) — discovery
+  adapters for host-owned capability reporting (distinct from
+  provider-managed nodes).
+- [Privileges reference](./privileges.md) — broker op catalogue (not
+  applicable to provider-managed nodes, which bypass the broker).

--- a/docs/reference/provider-managed-sandboxes.md
+++ b/docs/reference/provider-managed-sandboxes.md
@@ -6,7 +6,7 @@ A provider-managed sandbox is a workload unit that a cloud provider
 creates, manages, and destroys on behalf of nixling. The nixling daemon
 routes typed operations to the provider API and receives typed responses;
 it does not own a hypervisor, broker, or guest OS stack for these nodes.
-The first implemented adapter is Azure Container Apps (ACA).
+The first implemented adapter is Azure Container Apps.
 
 This page documents the capability matrix, supported operations, absent
 capabilities, rate-limit/backoff/circuit behavior, credential boundary,
@@ -25,8 +25,9 @@ API rather than by a `nixling-priv-broker` running on a locally managed
 host. From the daemon's perspective it is a node with a bounded positive
 capability set derived from what that provider API supports. The daemon
 never provisions, registers, or expects a `nixlingd`, `nixling-priv-broker`,
-guest-control stack, KVM subsystem, vsock channel, cgroup subtree, namespace
-hierarchy, or device-hotplug surface on a provider-managed node.
+`guestd`, guest-control stack, KVM subsystem, vsock channel, cgroup subtree,
+namespace hierarchy, full-host lifecycle, or device-hotplug surface on a
+provider-managed node.
 
 This model is distinct from a **remote full-host node** (see
 [remote full-host nodes](./remote-full-host-nodes.md)), which runs its
@@ -41,24 +42,25 @@ key differences:
 | Guest-control / vsock | Absent | Present |
 | KVM / hypervisor | Absent | Present |
 | Cgroup / namespace authority | Absent | Present (remote host) |
+| systemd | Absent | Present (remote host) |
 | Device hotplug | Absent | Present (remote host) |
 | SSH fallback | Absent | Absent |
-| Authentication surface | Managed/workload identity → provider API | Peer session authenticated principal |
+| Authentication surface | Workload/managed identity → provider API | Peer session authenticated principal |
 | Capability source | Provider adapter capability declaration | Substrate provider report |
 | Registry | Provider API is the source of truth | Daemon router state |
 
 ---
 
-## Capability matrix — ACA adapter
+## Capability matrix — Azure Container Apps adapter
 
 Capabilities are positive assertions. A capability absent from this
 table is not supported; operations requiring it receive
 `CapabilityDenied` and do not fall back.
 
-| Capability | ACA support | Notes |
+| Capability | Azure Container Apps support | Notes |
 | --- | --- | --- |
-| `lifecycle` | Conditional | Advertised only when sandbox defaults are configured; create/start/stop/list map to the ACA sandbox data plane. |
-| `exec` | ✓ | Synchronous ACA `executeShellCommand`; returns a derived execution id, not a durable guest-control session. |
+| `lifecycle` | Conditional | Advertised only when sandbox defaults are configured; create/start/stop/list map to the Azure Container Apps sandbox data plane. |
+| `exec` | ✓ | Synchronous Azure Container Apps `executeShellCommand`; returns a derived execution id, not a durable guest-control session. |
 | `logs` | ✗ | No retained-log stream in this adapter. |
 | `pty` | ✗ | No interactive TTY or stdio attachment. |
 | `file-copy` | ✗ | No bounded file-copy API. |
@@ -73,25 +75,25 @@ table is not supported; operations requiring it receive
 | `gpu-accel` | ✗ | No local GPU acceleration surface. |
 | `snapshots` | ✗ | No snapshot API in this adapter. |
 | `hotplug` | ✗ | No device hotplug API. |
-| `ephemeral-sessions` | ✗ | ACA sandboxes are selected by workload labels, not ephemeral session slots in this adapter. |
-| `provider-managed-isolation` | ✗ | The current ACA provider keeps this descriptor absent until routing needs to distinguish it explicitly. |
+| `ephemeral-sessions` | ✗ | Azure Container Apps sandboxes are selected by workload labels, not ephemeral session slots in this adapter. |
+| `provider-managed-isolation` | ✓ | Advertised so callers can distinguish Azure Container Apps from a full nixling host. |
 
 ---
 
 ## Supported operations
 
-The ACA adapter routes the following provider operations. All others are
+The Azure Container Apps adapter routes the following provider operations. All others are
 refused with `UnsupportedFeature` before contacting the provider API.
 
 | Operation | Behavior |
 | --- | --- |
 | `list` | Lists sandboxes selected by deterministic `nixling-workload` / realm labels and maps provider state to `WorkloadSummary`. |
-| `create` | Ensures a workload sandbox exists, creating/reusing the disk image and sandbox through the ACA data plane. |
+| `create` | Ensures a workload sandbox exists, creating/reusing the disk image and sandbox through the Azure Container Apps data plane. |
 | `start` | Ensures the sandbox exists and resumes it when idle. |
-| `stop` | Resolves the workload alias to a sandbox and posts ACA stop; already-absent/already-stopped is success. |
+| `stop` | Resolves the workload alias to a sandbox and posts Azure Container Apps stop; already-absent/already-stopped is success. |
 | `exec` | Runs synchronous `executeShellCommand` against the selected sandbox. Command bytes are opaque payload and are not logged or audited as metadata. |
 
-Gateway/router layers own idempotency for mutating operations. The ACA
+Gateway/router layers own idempotency for mutating operations. The Azure Container Apps
 provider itself uses deterministic workload labels to discover upstream
 state before creating or retrying mutating lifecycle calls.
 
@@ -111,12 +113,12 @@ with `UnsupportedFeature` or `CapabilityDenied`; there are no fallbacks.
   the container runtime.
 - **No SSH fallback.** No SSH session is opened when the provider API
   is unavailable or when no exec surface is present.
-- **No full-host registration.** The adapter does not register the ACA
+- **No full-host registration.** The adapter does not register the Azure Container Apps
   environment as a full nixling host; it does not run `nixlingd`,
   install packages, or execute `nixling host prepare`.
 - **No generic container tunnel.** Raw container exec, Azure Container
   Apps debug proxy, or any other tunnel endpoint is outside scope. The
-  adapter uses only the ACA management API surfaces listed above.
+  adapter uses only the Azure Container Apps management API surfaces listed above.
 - **No device hotplug.** Storage attachment, GPU assignment, and device
   tree mutations are outside scope.
 - **No cgroup or namespace authority.** The provider runtime owns the
@@ -129,16 +131,16 @@ with `UnsupportedFeature` or `CapabilityDenied`; there are no fallbacks.
 
 ### Provider-layer retry metadata
 
-The ACA adapter tracks retry context internally. Retry hint fields
+The Azure Container Apps adapter tracks retry context internally. Retry hint fields
 (suggested delay, retry-after header values, attempt counts) are part of
 the provider layer's internal retry state and are **not** forwarded as
-fields on `ConstellationError`. This wave makes no change to the public
-`ConstellationError` schema. Callers should inspect the `ErrorKind` and
+fields on `ConstellationError`. The public `ConstellationError` schema is
+unchanged. Callers should inspect the `ErrorKind` and
 the bounded `message` to determine whether a retry is appropriate.
 
-### ACA 429 and retry-after handling
+### Azure Container Apps 429 and retry-after handling
 
-When the ACA management API responds with HTTP 429 (Too Many Requests),
+When the Azure Container Apps management API responds with HTTP 429 (Too Many Requests),
 the adapter:
 
 1. Reads the `Retry-After` response header (seconds or HTTP date form).
@@ -155,7 +157,8 @@ retry-hint and applied-backoff duration buckets.
 ### Circuit breaker
 
 The adapter uses a circuit breaker shared across all provider instances
-targeting the same upstream (same ACA subscription/resource-group pair).
+targeting the same upstream: endpoint, subscription, resource group, and
+sandbox group.
 The circuit transitions through three states:
 
 | State | Behavior |
@@ -163,6 +166,14 @@ The circuit transitions through three states:
 | **Closed** | Operations reach the provider API normally. Failures are counted against the trip threshold. |
 | **Open** | Operations fail immediately with `Backpressure`. The error message includes the remaining open duration and notes that the circuit is open. No requests are sent to the provider API. |
 | **Probe in flight** | One probe request is allowed through after the open window expires. Success closes the circuit; failure extends the open window. Concurrent probes are denied with `Backpressure`. |
+
+Probe attempts have a bounded timeout; if a probe is dropped or remains
+in-flight past that timeout, the circuit reopens. Repeated transient
+failures use bounded exponential backoff with jitter, capped by provider
+configuration, so retries do not synchronize into a thundering herd.
+Concurrent 429 responses from the same admitted closed-window request
+batch can extend an already-open circuit when the later response carries
+a longer bounded retry window.
 
 When the circuit is open, the provider error message carries the
 remaining open duration in bounded form (for example:
@@ -172,33 +183,33 @@ surface; internal trip counts and thresholds are not forwarded.
 
 Circuit state is shared across provider instances for the same upstream
 so that one degraded provider instance does not shed load onto a sibling
-instance pointing at the same ACA endpoint.
+instance pointing at the same Azure Container Apps endpoint.
 
 ---
 
 ## Credential boundary
 
-Provider-managed sandboxes enforce a strict managed/workload identity
+Provider-managed sandboxes enforce a strict workload/managed identity
 boundary:
 
-- **In production deployments**, the adapter authenticates to the ACA
-  management API exclusively with the managed identity assigned to the
-  gateway guest VM, or with a workload identity credential configured
-  through the gateway's sealed credential envelope. Ambient developer
+- **In production deployments**, the adapter authenticates to the Azure Container Apps
+  management API with a workload identity credential configured through
+  the gateway's sealed credential envelope first, then falls back to the
+  managed identity assigned to the gateway guest VM. Ambient developer
   credentials (Azure CLI cached tokens, client-secret environment
-  variables, developer-toolchain credential chains) are not
-  used and are not present in the production credential resolution order.
+  variables, developer-toolchain credential chains) are not used and are
+  not present in the production credential resolution order.
 - **Non-production / local-validation contexts** may inject a credential
-  explicitly through `AcaWorkloadProvider::with_parts` (for example the live
-  smoke example injects Azure CLI). This is not a runtime fallback and is not
-  part of the production credential resolution order.
+  explicitly in local dev/live-smoke tooling (for example, the live smoke
+  example injects Azure CLI). This is not a runtime fallback and is not part of
+  the production credential resolution order.
 - Managed identity client IDs are declared as non-secret gateway
   configuration (subscription, resource group, sandbox group, region,
   managed-identity client ID). They are not treated as secret material
   and may appear in non-secret configuration sections.
 - Relay Send bearer tokens minted by the gateway for sandbox sender
   connections are short-lived and scoped to the Relay namespace. They
-  are never stored in the ACA environment and are not written to logs,
+  are never stored in the Azure Container Apps environment and are not written to logs,
   audit records, or error messages.
 - Long-lived Relay rule keys and any credential whose loss would grant
   durable access are always gateway-side only and are never passed to a
@@ -216,8 +227,8 @@ provider error messages, structured log spans, and audit records:
 
 | Field | Constraint |
 | --- | --- |
-| `error.code` | Included after bounding/sanitization when Azure provides it (for example `AuthorizationFailed`, `RevisionProvisioningFailed`, `QuotaExceeded`). |
-| `error.message` | Included in sanitized form: length-bounded, control characters stripped, no embedded JSON objects, no URLs, no UUIDs. If sanitization leaves an empty string, the field is omitted. |
+| `error.code` | Included after bounding/sanitization when Azure provides an allowlisted value (for example `AuthorizationFailed`, `RevisionProvisioningFailed`, `QuotaExceeded`). Allowlisted values are emitted with case-stable canonical spelling; non-allowlisted codes are mapped to the literal `unknown`. |
+| `error.message` | Included in sanitized form: length-bounded, control characters stripped, no embedded JSON objects, no URLs, no UUIDs, no subscription IDs, and no internal diagnostic detail. If sanitization leaves an empty string, the field is omitted. |
 | `x-ms-correlation-request-id` | Included verbatim when present. This is an opaque Azure-side correlation token with no operational secret value. |
 | HTTP status code | Included as an integer (for example `429`, `503`). |
 
@@ -231,7 +242,7 @@ emitted by this adapter:
 - Authorization headers, bearer tokens, or SAS tokens.
 - Azure resource IDs, subscription IDs, resource group names, or
   workspace IDs.
-- ACA container image references or registry addresses.
+- Azure Container Apps container image references or registry addresses.
 - Operation payloads, container environment variable values, or command
   arguments.
 - Workload stdout/stderr output.
@@ -248,20 +259,20 @@ provider-layer operations.
 
 Errors from the provider-managed sandbox adapter use the standard
 `ConstellationError` shape. The public `ConstellationError` schema is
-unchanged in this wave; retry hint fields remain internal.
+unchanged; retry hint fields remain internal.
 
 | Adapter reason | `ErrorKind` | Meaning | Remediation |
 | --- | --- | --- | --- |
-| `sandbox-not-found` | `ProviderAllocationFailed` | The target workload label has no matching ACA sandbox where the operation requires one. | Check the workload label and ACA configuration. |
-| `sandbox-provision-failed` | `ProviderAllocationFailed` | ACA reported a provisioning failure (`RevisionProvisioningFailed` or allowlisted equivalent). | Check ACA activity log via Azure portal. |
+| `sandbox-not-found` | `ProviderAllocationFailed` | The target workload label has no matching Azure Container Apps sandbox where the operation requires one. | Check the workload label and Azure Container Apps configuration. |
+| `sandbox-provision-failed` | `ProviderAllocationFailed` | Azure Container Apps reported a provisioning failure (`RevisionProvisioningFailed` or allowlisted equivalent). | Check Azure Container Apps activity log via Azure portal. |
 | `quota-exceeded` | `ProviderAllocationFailed` or `Unauthorized` | Provider quota or authorization policy rejected the request. | Reduce concurrent workloads, request quota increase, or verify the managed identity role. |
-| `rate-limited` | `Backpressure` | ACA management API returned 429 and the retry ceiling was reached. | Wait for the indicated window and retry. |
+| `rate-limited` | `Backpressure` | Azure Container Apps management API returned 429 and the retry ceiling was reached. | Wait for the indicated window and retry. |
 | `circuit-open` | `Backpressure` | Circuit breaker is open for this upstream; message includes remaining open duration. | Wait for the duration in the error message before retrying. |
 | `credential-acquisition-failed` | `AuthenticationFailed` | The gateway could not acquire a managed/workload identity token. | Verify explicit managed/workload identity configuration. |
-| `upstream-authorization-failed` | `Unauthorized` | ACA returned 403 for an otherwise formed request. | Verify the managed identity has the required ACA data-plane role. |
-| `unsupported-operation` | `UnsupportedFeature` | The operation kind is outside the ACA adapter's scope. | Use a full-host node for operations requiring broker/guest-control/exec. |
+| `upstream-authorization-failed` | `Unauthorized` | Azure Container Apps returned 403 for an otherwise formed request. | Verify the managed identity has the required Azure Container Apps data-plane role. |
+| `unsupported-operation` | `UnsupportedFeature` | The operation kind is outside the Azure Container Apps adapter's scope. | Use a full-host node for operations requiring broker/guest-control/exec. |
 | `capability-denied` | `CapabilityDenied` | The required capability is absent from the adapter's capability set. | See the capability matrix above. |
-| `provider-unavailable` | `ProviderAllocationFailed` | ACA management API is unreachable or returned an unrecoverable 5xx. | Check provider status and retry after the circuit window if one is reported. |
+| `provider-unavailable` | `ProviderAllocationFailed` | Azure Container Apps management API is unreachable or returned an unrecoverable 5xx. | Check provider status and retry after the circuit window if one is reported. |
 
 All provider error messages are bounded and comply with the
 redaction rules above.
@@ -270,16 +281,16 @@ redaction rules above.
 
 ## Scope limitations
 
-The following items are deferred and not currently supported by the ACA
+The following items are deferred and not currently supported by the Azure Container Apps
 adapter:
 
 - Interactive exec sessions or attached TTY to running containers.
 - Live stdio streaming (current support is polling-based log read only).
 - Automatic workload image build or push from a local Nix store.
-- Multi-region or multi-subscription ACA targeting from a single
+- Multi-region or multi-subscription Azure Container Apps targeting from a single
   provider instance.
 - Automatic credential refresh without gateway guest restart.
-- End-to-end display, audio, or USB forwarding to ACA containers.
+- End-to-end display, audio, or USB forwarding to Azure Container Apps containers.
 
 These limitations are documented here and not gated by runtime checks
 beyond `UnsupportedFeature` responses. Operators evaluating production

--- a/docs/reference/remote-full-host-nodes.md
+++ b/docs/reference/remote-full-host-nodes.md
@@ -22,6 +22,9 @@ schema, operation kinds, idempotency, stream authz) see
 substrate capabilities see [host substrate providers](./host-substrate-providers.md).
 The architectural rationale is in
 [ADR 0032](../adr/0032-nixling-v2-constellation-control-plane.md).
+For provider-managed sandboxes — nodes whose lifecycle is owned by a
+cloud provider API rather than by a locally managed `nixling-priv-broker`
+— see [provider-managed sandboxes](./provider-managed-sandboxes.md).
 
 ---
 
@@ -340,7 +343,8 @@ only. The following items are deferred to later work:
 - Live Internet reachability and WAN NAT traversal.
 - Remote host installation and remote `nixling host prepare`.
 - Remote display, audio, USB, and device streams to/from the remote host.
-- Provider-provisioned remote hosts (see the provider-managed sandbox
+- Provider-provisioned remote hosts (see the
+  [provider-managed sandbox](./provider-managed-sandboxes.md)
   model for provider-scoped work).
 - Automatic capability refresh without re-registration.
 - End-user principal delegation across a gateway; the preview binds the

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1821,7 +1821,6 @@ dependencies = [
  "async-trait",
  "azure_core",
  "azure_identity",
- "fastrand",
  "nixling-constellation-core",
  "nixling-constellation-provider",
  "reqwest 0.12.28",

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1632,6 +1632,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1820,6 +1821,7 @@ dependencies = [
  "async-trait",
  "azure_core",
  "azure_identity",
+ "fastrand",
  "nixling-constellation-core",
  "nixling-constellation-provider",
  "reqwest 0.12.28",

--- a/packages/nixling-constellation-provider/Cargo.toml
+++ b/packages/nixling-constellation-provider/Cargo.toml
@@ -24,6 +24,7 @@ schemars.workspace = true
 # loopback and later relay sessions implement AsyncRead/AsyncWrite). Only
 # the io traits are needed here; no runtime/network features.
 tokio = { version = "1", default-features = false, features = ["io-util"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "io-util"] }

--- a/packages/nixling-constellation-provider/src/credential.rs
+++ b/packages/nixling-constellation-provider/src/credential.rs
@@ -6,14 +6,11 @@
 //! credential:
 //!
 //! 1. [`CredentialPlane::AzureControlPlane`] — allocating/managing ACA, ACR,
-//!    and the Relay namespace authenticates with the **operator's ambient
-//!    Entra ID identity via the `az` CLI** (`DefaultAzureCredential` /
-//!    `AzureCliCredential`), invoked locally. The Entra token cache is owned
-//!    by `az` (`~/.azure`); it is never placed in the nixling store, bundle,
-//!    manifest, daemon state, argv, env, or journal. Azure RBAC on the
-//!    operator's identity governs what may be provisioned. This module only
-//!    ever holds an [`AzureControlPlaneRef`] of **opaque, non-secret**
-//!    tenant/subscription/region references.
+//!    and the Relay namespace uses an external Azure identity selected by the
+//!    caller. Production gateway providers use explicitly configured
+//!    managed/workload identity and do not fall back to ambient developer-tool
+//!    credentials. This module only ever holds an [`AzureControlPlaneRef`] of
+//!    **opaque, non-secret** tenant/subscription/region references.
 //! 2. [`CredentialPlane::ContainerManagedIdentity`] — the ACA sandbox's
 //!    **Managed Identity** mints its own short-lived tokens from IMDS for
 //!    Relay/ACR. nixling never mints or hands a Relay SAS token to the
@@ -43,7 +40,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum CredentialPlane {
-    /// Operator's ambient Entra identity via the `az` CLI (control-plane).
+    /// External Azure control-plane identity reference.
     AzureControlPlane,
     /// ACA sandbox Managed Identity (container → Azure).
     ContainerManagedIdentity,

--- a/packages/nixling-constellation-provider/src/error.rs
+++ b/packages/nixling-constellation-provider/src/error.rs
@@ -139,6 +139,11 @@ impl ProviderError {
         self.error.kind()
     }
 
+    /// The bounded, operator-safe underlying constellation error message.
+    pub fn message(&self) -> &str {
+        self.error.message()
+    }
+
     /// The structured missing capability, if this is a capability denial.
     pub fn missing_capability(&self) -> Option<Capability> {
         self.error.missing_capability()

--- a/packages/nixling-constellation-provider/src/error.rs
+++ b/packages/nixling-constellation-provider/src/error.rs
@@ -1,24 +1,102 @@
 //! Typed provider errors (ADR 0032). A provider that cannot support a
 //! feature returns a typed capability denial, never a silent fallback.
 
+use std::time::Duration;
+
 use nixling_constellation_core::{Capability, ConstellationError, ErrorKind};
+
+const MAX_PROVIDER_FIELD_LEN: usize = 128;
+const MAX_PROVIDER_MESSAGE_LEN: usize = 240;
+
+/// Structured provider retry metadata. This stays provider-layer/internal for
+/// now; it is not part of the public constellation wire error schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryHint {
+    retry_after: Duration,
+    applied_backoff: Duration,
+}
+
+impl RetryHint {
+    /// Build a bounded retry hint. `jitter` is deterministic input supplied by
+    /// the caller/test; this helper does not generate randomness.
+    pub fn bounded(retry_after: Duration, jitter: Duration, max: Duration) -> Self {
+        let applied = retry_after.saturating_add(jitter).min(max);
+        Self {
+            retry_after: retry_after.min(max),
+            applied_backoff: applied,
+        }
+    }
+
+    /// Provider-requested delay after bounds.
+    pub fn retry_after(&self) -> Duration {
+        self.retry_after
+    }
+
+    /// Actual delay after jitter and bounds.
+    pub fn applied_backoff(&self) -> Duration {
+        self.applied_backoff
+    }
+}
+
+/// Allowlisted provider diagnostic fields. Never store raw response bodies,
+/// endpoints, headers, tokens, resource ids, command payloads, or output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderDiagnostic {
+    code: Option<String>,
+    message: Option<String>,
+    correlation_id: Option<String>,
+}
+
+impl ProviderDiagnostic {
+    /// Build from optional allowlisted provider fields.
+    pub fn new(
+        code: Option<impl Into<String>>,
+        message: Option<impl Into<String>>,
+        correlation_id: Option<impl Into<String>>,
+    ) -> Self {
+        Self {
+            code: code.map(|s| bound_provider_field(s.into())),
+            message: message.map(|s| bound_provider_message(s.into())),
+            correlation_id: correlation_id.map(|s| bound_provider_field(s.into())),
+        }
+    }
+
+    /// Provider error code, if allowlisted.
+    pub fn code(&self) -> Option<&str> {
+        self.code.as_deref()
+    }
+
+    /// Bounded sanitized provider message, if allowlisted.
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+
+    /// Bounded safe correlation/request id, if present.
+    pub fn correlation_id(&self) -> Option<&str> {
+        self.correlation_id.as_deref()
+    }
+}
 
 /// A provider-layer error. Wraps the codec-neutral
 /// [`ConstellationError`] so providers and the operation layer share one
 /// typed-error vocabulary.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProviderError(pub ConstellationError);
+pub struct ProviderError {
+    error: Box<ConstellationError>,
+    retry_hint: Option<RetryHint>,
+    diagnostic: Option<Box<ProviderDiagnostic>>,
+}
 
 impl ProviderError {
     /// A typed capability denial (the provider does not advertise `cap`).
     pub fn capability_denied(cap: Capability) -> Self {
-        Self(ConstellationError::capability_denied(cap))
+        Self::from(ConstellationError::capability_denied(cap))
     }
 
     /// A typed "feature/transport mode not implemented in this build"
     /// refusal (never a silent fallback).
     pub fn unsupported(feature: impl Into<String>) -> Self {
-        Self(ConstellationError::new(
+        Self::from(ConstellationError::new(
             ErrorKind::UnsupportedFeature,
             feature.into(),
         ))
@@ -26,23 +104,63 @@ impl ProviderError {
 
     /// A generic typed error.
     pub fn new(kind: ErrorKind, message: impl Into<String>) -> Self {
-        Self(ConstellationError::new(kind, message))
+        Self::from(ConstellationError::new(kind, message))
+    }
+
+    /// A typed provider rate-limit error with structured retry metadata.
+    pub fn rate_limited(message: impl Into<String>, retry_hint: RetryHint) -> Self {
+        Self::new(ErrorKind::Backpressure, message).with_retry_hint(retry_hint)
+    }
+
+    /// Attach structured retry metadata.
+    pub fn with_retry_hint(mut self, retry_hint: RetryHint) -> Self {
+        self.retry_hint = Some(retry_hint);
+        self
+    }
+
+    /// Attach allowlisted provider diagnostic metadata.
+    pub fn with_diagnostic(mut self, diagnostic: ProviderDiagnostic) -> Self {
+        self.diagnostic = Some(Box::new(diagnostic));
+        self
+    }
+
+    /// Structured retry metadata, if this error carries any.
+    pub fn retry_hint(&self) -> Option<RetryHint> {
+        self.retry_hint
+    }
+
+    /// Allowlisted provider diagnostics, if any.
+    pub fn diagnostic(&self) -> Option<&ProviderDiagnostic> {
+        self.diagnostic.as_deref()
     }
 
     /// The underlying error kind.
     pub fn kind(&self) -> ErrorKind {
-        self.0.kind()
+        self.error.kind()
     }
 
     /// The structured missing capability, if this is a capability denial.
     pub fn missing_capability(&self) -> Option<Capability> {
-        self.0.missing_capability()
+        self.error.missing_capability()
     }
 }
 
 impl core::fmt::Display for ProviderError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.error)?;
+        let _ = self.retry_hint;
+        if let Some(diagnostic) = &self.diagnostic {
+            if let Some(code) = diagnostic.code() {
+                write!(f, " provider_code={code}")?;
+            }
+            if let Some(message) = diagnostic.message() {
+                write!(f, " provider_message={message}")?;
+            }
+            if let Some(correlation_id) = diagnostic.correlation_id() {
+                write!(f, " correlation_id={correlation_id}")?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -50,9 +168,113 @@ impl std::error::Error for ProviderError {}
 
 impl From<ConstellationError> for ProviderError {
     fn from(e: ConstellationError) -> Self {
-        Self(e)
+        Self {
+            error: Box::new(e),
+            retry_hint: None,
+            diagnostic: None,
+        }
     }
 }
 
 /// Provider result alias.
 pub type ProviderResult<T> = Result<T, ProviderError>;
+
+fn bound_provider_field(raw: String) -> String {
+    raw.chars()
+        .filter(|c| c.is_ascii_graphic() && !matches!(c, '"' | '\'' | '\\' | '/' | ':'))
+        .take(MAX_PROVIDER_FIELD_LEN)
+        .collect()
+}
+
+fn bound_provider_message(raw: String) -> String {
+    if contains_sensitive_shape(&raw) {
+        return "provider message redacted".to_owned();
+    }
+    let truncated = raw.chars().count() > MAX_PROVIDER_MESSAGE_LEN;
+    let mut out: String = raw
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(MAX_PROVIDER_MESSAGE_LEN)
+        .collect();
+    if truncated {
+        out.push_str("...");
+    }
+    out
+}
+
+fn contains_sensitive_shape(raw: &str) -> bool {
+    let lower = raw.to_ascii_lowercase();
+    lower.contains("http://")
+        || lower.contains("https://")
+        || lower.contains("/subscriptions/")
+        || raw
+            .split(|c: char| !(c.is_ascii_hexdigit() || c == '-'))
+            .any(looks_like_uuid)
+}
+
+fn looks_like_uuid(token: &str) -> bool {
+    let mut parts = token.split('-');
+    matches!(
+        (
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next()
+        ),
+        (Some(a), Some(b), Some(c), Some(d), Some(e), None)
+            if a.len() == 8
+                && b.len() == 4
+                && c.len() == 4
+                && d.len() == 4
+                && e.len() == 12
+                && [a, b, c, d, e]
+                    .iter()
+                    .all(|part| part.chars().all(|ch| ch.is_ascii_hexdigit()))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_hint_bounds_applied_delay() {
+        let hint = RetryHint::bounded(
+            Duration::from_secs(90),
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+        );
+        assert_eq!(hint.retry_after(), Duration::from_secs(60));
+        assert_eq!(hint.applied_backoff(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn provider_diagnostic_strips_path_and_endpoint_shapes() {
+        let d = ProviderDiagnostic::new(
+            Some("AuthorizationFailed"),
+            Some(
+                [
+                    "bad /sub",
+                    "scriptions/00000000-0000-",
+                    "0000-0000-000000000000 h",
+                    "ttps://example.invalid",
+                ]
+                .concat(),
+            ),
+            Some("corr/../../secret"),
+        );
+        assert_eq!(d.code(), Some("AuthorizationFailed"));
+        assert_eq!(d.message(), Some("provider message redacted"));
+        assert!(!d.message().unwrap().contains('\n'));
+        assert!(!d.correlation_id().unwrap().contains('/'));
+    }
+
+    #[test]
+    fn provider_message_marks_truncation() {
+        let raw = "a".repeat(MAX_PROVIDER_MESSAGE_LEN + 1);
+        let d = ProviderDiagnostic::new(None::<String>, Some(raw), None::<String>);
+        assert!(d.message().unwrap().ends_with("..."));
+    }
+}

--- a/packages/nixling-constellation-provider/src/error.rs
+++ b/packages/nixling-constellation-provider/src/error.rs
@@ -55,9 +55,13 @@ impl ProviderDiagnostic {
         correlation_id: Option<impl Into<String>>,
     ) -> Self {
         Self {
-            code: code.map(|s| bound_provider_field(s.into())),
-            message: message.map(|s| bound_provider_message(s.into())),
-            correlation_id: correlation_id.map(|s| bound_provider_field(s.into())),
+            code: code.map(|s| allowlisted_provider_code(s.into())),
+            message: message
+                .map(|s| bound_provider_message(s.into()))
+                .filter(|s| !s.trim().is_empty()),
+            correlation_id: correlation_id
+                .map(|s| bound_provider_field(s.into()))
+                .filter(|s| !s.trim().is_empty()),
         }
     }
 
@@ -191,6 +195,24 @@ fn bound_provider_field(raw: String) -> String {
         .collect()
 }
 
+fn allowlisted_provider_code(raw: String) -> String {
+    let bounded = bound_provider_field(raw);
+    match bounded.as_str() {
+        code if code.eq_ignore_ascii_case("AuthorizationFailed") => {
+            "AuthorizationFailed".to_owned()
+        }
+        code if code.eq_ignore_ascii_case("RevisionProvisioningFailed") => {
+            "RevisionProvisioningFailed".to_owned()
+        }
+        code if code.eq_ignore_ascii_case("QuotaExceeded") => "QuotaExceeded".to_owned(),
+        code if code.eq_ignore_ascii_case("TooManyRequests") => "TooManyRequests".to_owned(),
+        code if code.eq_ignore_ascii_case("ContainerAppNotFound") => {
+            "ContainerAppNotFound".to_owned()
+        }
+        _ => "unknown".to_owned(),
+    }
+}
+
 fn bound_provider_message(raw: String) -> String {
     if contains_sensitive_shape(&raw) {
         return "provider message redacted".to_owned();
@@ -212,6 +234,13 @@ fn contains_sensitive_shape(raw: &str) -> bool {
     lower.contains("http://")
         || lower.contains("https://")
         || lower.contains("/subscriptions/")
+        || lower.contains("provider-code=")
+        || lower.contains("provider_code=")
+        || lower.contains("provider-message=")
+        || lower.contains("provider_message=")
+        || lower.contains("correlation_id=")
+        || raw.contains('{')
+        || raw.contains('}')
         || raw
             .split(|c: char| !(c.is_ascii_hexdigit() || c == '-'))
             .any(looks_like_uuid)
@@ -253,6 +282,14 @@ mod tests {
         );
         assert_eq!(hint.retry_after(), Duration::from_secs(60));
         assert_eq!(hint.applied_backoff(), Duration::from_secs(60));
+
+        let jitter_capped = RetryHint::bounded(
+            Duration::from_secs(50),
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+        );
+        assert_eq!(jitter_capped.retry_after(), Duration::from_secs(50));
+        assert_eq!(jitter_capped.applied_backoff(), Duration::from_secs(60));
     }
 
     #[test]
@@ -274,6 +311,68 @@ mod tests {
         assert_eq!(d.message(), Some("provider message redacted"));
         assert!(!d.message().unwrap().contains('\n'));
         assert!(!d.correlation_id().unwrap().contains('/'));
+    }
+
+    #[test]
+    fn provider_diagnostic_unknown_code_is_low_cardinality() {
+        let d = ProviderDiagnostic::new(
+            Some("UnexpectedPerTenantCode"),
+            None::<String>,
+            None::<String>,
+        );
+        assert_eq!(d.code(), Some("unknown"));
+    }
+
+    #[test]
+    fn provider_diagnostic_codes_are_case_stable() {
+        let d = ProviderDiagnostic::new(
+            Some("authorizationfailed"),
+            Some("bounded message"),
+            None::<String>,
+        );
+        assert_eq!(d.code(), Some("AuthorizationFailed"));
+        assert_eq!(d.message(), Some("bounded message"));
+    }
+
+    #[test]
+    fn provider_diagnostic_code_allowlist_is_bounded() {
+        let quota = ProviderDiagnostic::new(Some("quotaexceeded"), None::<String>, None::<String>);
+        assert_eq!(quota.code(), Some("QuotaExceeded"));
+
+        let too_many =
+            ProviderDiagnostic::new(Some("toomanyrequests"), None::<String>, None::<String>);
+        assert_eq!(too_many.code(), Some("TooManyRequests"));
+
+        let unknown = ProviderDiagnostic::new(
+            Some("TenantSpecificDynamicCode"),
+            None::<String>,
+            None::<String>,
+        );
+        assert_eq!(unknown.code(), Some("unknown"));
+    }
+
+    #[test]
+    fn provider_diagnostic_redacts_json_objects() {
+        let message = serde_json::json!({
+            "error": "dynamic provider payload",
+        })
+        .to_string();
+        let d = ProviderDiagnostic::new(
+            Some("RevisionProvisioningFailed"),
+            Some(message),
+            None::<String>,
+        );
+        assert_eq!(d.message(), Some("provider message redacted"));
+    }
+
+    #[test]
+    fn provider_diagnostic_redacts_internal_diagnostic_details() {
+        let d = ProviderDiagnostic::new(
+            Some("RevisionProvisioningFailed"),
+            Some("provider_message=dynamic evidence"),
+            None::<String>,
+        );
+        assert_eq!(d.message(), Some("provider message redacted"));
     }
 
     #[test]

--- a/packages/nixling-constellation-provider/src/lib.rs
+++ b/packages/nixling-constellation-provider/src/lib.rs
@@ -18,16 +18,18 @@ pub mod credential;
 pub mod error;
 pub mod mock;
 pub mod provider;
+pub mod rate_limit;
 pub mod types;
 
 pub use credential::{
     AzureControlPlaneRef, CredentialPlane, ManagedIdentityRef, OpaqueAzureRef,
     SessionCredentialBinding,
 };
-pub use error::ProviderError;
+pub use error::{ProviderDiagnostic, ProviderError, RetryHint};
 pub use provider::{
     CredentialProvider, CredentialStatus, DaemonAccessApi, DaemonAccessTransport, DisplayProvider,
     DurableExecutionProvider, HostSubstrateProvider, InfrastructureProvider, NodeProvider,
     ObservabilitySinkProvider, ProtocolCodec, RelayProvider, RuntimeProvider, StreamMux,
     TransportListener, TransportProvider, WorkloadProvider,
 };
+pub use rate_limit::{CircuitBreakerConfig, CircuitBreakerSnapshot, ProviderCircuitBreaker};

--- a/packages/nixling-constellation-provider/src/rate_limit.rs
+++ b/packages/nixling-constellation-provider/src/rate_limit.rs
@@ -12,6 +12,8 @@ pub struct CircuitBreakerConfig {
     pub failure_threshold: u32,
     /// Default open duration when a failure has no retry hint.
     pub default_open_for: Duration,
+    /// Maximum duration a half-open probe may stay in flight before reopening.
+    pub probe_timeout: Duration,
     /// Maximum retained retry/backoff duration.
     pub max_open_for: Duration,
 }
@@ -21,6 +23,7 @@ impl Default for CircuitBreakerConfig {
         Self {
             failure_threshold: 3,
             default_open_for: Duration::from_secs(10),
+            probe_timeout: Duration::from_secs(30),
             max_open_for: Duration::from_secs(300),
         }
     }
@@ -36,6 +39,7 @@ enum CircuitState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CircuitInner {
     state: CircuitState,
+    epoch: u64,
     failures: u32,
     last_hint: Option<RetryHint>,
 }
@@ -53,6 +57,25 @@ pub struct CircuitBreakerSnapshot {
     pub retry_hint: Option<RetryHint>,
 }
 
+/// Permission returned by [`ProviderCircuitBreaker::before_request`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CircuitPermit {
+    probe: bool,
+    epoch: u64,
+}
+
+impl CircuitPermit {
+    /// Whether this request is the single half-open probe.
+    pub fn is_probe(self) -> bool {
+        self.probe
+    }
+
+    /// State epoch this request was admitted under.
+    pub fn epoch(self) -> u64 {
+        self.epoch
+    }
+}
+
 /// Concurrency-safe provider circuit breaker. It stores only state labels,
 /// counters, timestamps, and bounded retry hints.
 #[derive(Debug)]
@@ -68,6 +91,7 @@ impl ProviderCircuitBreaker {
             config,
             inner: RwLock::new(CircuitInner {
                 state: CircuitState::Closed,
+                epoch: 0,
                 failures: 0,
                 last_hint: None,
             }),
@@ -75,49 +99,60 @@ impl ProviderCircuitBreaker {
     }
 
     /// Check whether a request may be issued at `now`.
-    pub fn before_request(&self, now: Instant) -> Result<(), ProviderError> {
+    pub fn before_request(&self, now: Instant) -> Result<CircuitPermit, ProviderError> {
         let mut inner = self.inner.write().expect("circuit lock poisoned");
         match inner.state {
-            CircuitState::Closed => Ok(()),
+            CircuitState::Closed => Ok(CircuitPermit {
+                probe: false,
+                epoch: inner.epoch,
+            }),
             CircuitState::ProbeInFlight { started }
-                if now.duration_since(started) >= self.config.default_open_for =>
+                if now.saturating_duration_since(started) >= self.config.probe_timeout =>
             {
-                let hint = RetryHint::bounded(
-                    self.config.default_open_for,
-                    Duration::ZERO,
-                    self.config.max_open_for,
-                );
-                inner.state = CircuitState::Open {
-                    until: now + hint.applied_backoff(),
-                };
-                inner.last_hint = Some(hint);
+                let hint = retry_hint_for_failures(self.config, inner.failures.saturating_add(1));
+                let failed_at = started + self.config.probe_timeout;
+                let until = failed_at + hint.applied_backoff();
+                if now >= until {
+                    inner.failures = inner.failures.saturating_add(1);
+                    inner.last_hint = Some(hint);
+                    self.start_probe_locked(&mut inner, now, "probe-timeout-expired");
+                    return Ok(CircuitPermit {
+                        probe: true,
+                        epoch: inner.epoch,
+                    });
+                }
+                self.open_until_locked(&mut inner, until, hint, "probe-timeout");
+                let remaining = until.saturating_duration_since(now);
+                let error_hint =
+                    RetryHint::bounded(remaining, Duration::ZERO, self.config.max_open_for);
                 Err(ProviderError::rate_limited(
                     format!(
                         "provider circuit breaker probe timed out; retry after {} ms",
+                        error_hint.applied_backoff().as_millis()
+                    ),
+                    error_hint,
+                ))
+            }
+            CircuitState::ProbeInFlight { .. } => {
+                let hint = RetryHint::bounded(
+                    self.config.probe_timeout,
+                    Duration::ZERO,
+                    self.config.max_open_for,
+                );
+                Err(ProviderError::rate_limited(
+                    format!(
+                        "provider circuit breaker half-open probe already in flight; retry after {} ms",
                         hint.applied_backoff().as_millis()
                     ),
                     hint,
                 ))
             }
-            CircuitState::ProbeInFlight { .. } => {
-                let hint = RetryHint::bounded(
-                    self.config.default_open_for,
-                    Duration::ZERO,
-                    self.config.max_open_for,
-                );
-                Err(ProviderError::rate_limited(
-                    "provider circuit breaker half-open probe already in flight",
-                    hint,
-                ))
-            }
             CircuitState::Open { until } if now >= until => {
-                inner.state = CircuitState::ProbeInFlight { started: now };
-                tracing::info!(
-                    event = "provider-circuit-transition",
-                    state = "half-open",
-                    "provider circuit half-open probe started"
-                );
-                Ok(())
+                self.start_probe_locked(&mut inner, now, "open-window-elapsed");
+                Ok(CircuitPermit {
+                    probe: true,
+                    epoch: inner.epoch,
+                })
             }
             CircuitState::Open { until } => {
                 let remaining = until.saturating_duration_since(now);
@@ -134,21 +169,55 @@ impl ProviderCircuitBreaker {
     }
 
     /// Record a successful provider request.
-    pub fn record_success(&self) {
+    pub fn record_success(&self, permit: CircuitPermit) {
         let mut inner = self.inner.write().expect("circuit lock poisoned");
+        if permit.epoch != inner.epoch {
+            return;
+        }
+        let previous = inner.state;
+        if matches!(previous, CircuitState::Open { .. })
+            || (matches!(previous, CircuitState::ProbeInFlight { .. }) && !permit.is_probe())
+        {
+            return;
+        }
+        if previous != CircuitState::Closed {
+            inner.epoch = inner.epoch.saturating_add(1);
+        }
         inner.state = CircuitState::Closed;
         inner.failures = 0;
         inner.last_hint = None;
-        tracing::info!(
-            event = "provider-circuit-transition",
-            state = "closed",
-            "provider circuit closed"
-        );
+        if previous != CircuitState::Closed {
+            tracing::info!(
+                event = "provider-circuit-transition",
+                previous_state = state_label(previous),
+                state = "closed",
+                reason = "success",
+                "provider circuit closed"
+            );
+        }
     }
 
     /// Record a rate-limit response and open the circuit immediately.
-    pub fn record_rate_limited(&self, now: Instant, hint: RetryHint) {
-        self.open(now, hint);
+    pub fn record_rate_limited(&self, now: Instant, hint: RetryHint, permit: CircuitPermit) {
+        {
+            let mut inner = self.inner.write().expect("circuit lock poisoned");
+            if permit.epoch != inner.epoch {
+                if let CircuitState::Open { until } = &mut inner.state {
+                    let requested_until = now + hint.applied_backoff();
+                    if requested_until > *until {
+                        *until = requested_until;
+                        inner.last_hint = Some(hint);
+                    }
+                } else {
+                    return;
+                }
+            } else {
+                if matches!(inner.state, CircuitState::ProbeInFlight { .. }) && !permit.is_probe() {
+                    return;
+                }
+                self.open_locked(&mut inner, now, hint, "rate-limited");
+            }
+        }
         tracing::info!(
             event = "provider-rate-limited",
             retry_after_ms = millis_u64(hint.retry_after()),
@@ -159,26 +228,38 @@ impl ProviderCircuitBreaker {
 
     /// Record a transient provider failure. Opens after the configured
     /// threshold.
-    pub fn record_transient_failure(&self, now: Instant) {
+    pub fn record_transient_failure(&self, now: Instant, permit: CircuitPermit) {
         let mut inner = self.inner.write().expect("circuit lock poisoned");
-        inner.failures = inner.failures.saturating_add(1);
-        if inner.failures >= self.config.failure_threshold {
-            let hint = RetryHint::bounded(
-                self.config.default_open_for,
-                Duration::ZERO,
-                self.config.max_open_for,
-            );
-            inner.state = CircuitState::Open {
-                until: now + hint.applied_backoff(),
-            };
-            inner.last_hint = Some(hint);
-            tracing::info!(
-                event = "provider-circuit-transition",
-                state = "open",
-                reason = "transient-failure",
-                applied_backoff_ms = millis_u64(hint.applied_backoff()),
-                "provider circuit opened"
-            );
+        if permit.epoch != inner.epoch {
+            return;
+        }
+        match inner.state {
+            CircuitState::ProbeInFlight { .. } if permit.is_probe() => {
+                let hint = retry_hint_for_failures(self.config, inner.failures.saturating_add(1));
+                self.open_locked(&mut inner, now, hint, "probe-failure");
+            }
+            CircuitState::Closed => {
+                let next_failures = inner.failures.saturating_add(1);
+                if next_failures >= self.config.failure_threshold {
+                    let hint = retry_hint_for_failures(self.config, next_failures);
+                    self.open_locked(&mut inner, now, hint, "transient-failure");
+                } else {
+                    inner.failures = next_failures;
+                }
+            }
+            CircuitState::Open { .. } | CircuitState::ProbeInFlight { .. } => {}
+        }
+    }
+
+    /// Record cancellation of an in-flight half-open probe.
+    pub fn record_cancellation(&self, now: Instant, permit: CircuitPermit) {
+        let mut inner = self.inner.write().expect("circuit lock poisoned");
+        if permit.is_probe()
+            && permit.epoch == inner.epoch
+            && matches!(inner.state, CircuitState::ProbeInFlight { .. })
+        {
+            let hint = retry_hint_for_failures(self.config, inner.failures.saturating_add(1));
+            self.open_locked(&mut inner, now, hint, "probe-cancelled");
         }
     }
 
@@ -198,18 +279,50 @@ impl ProviderCircuitBreaker {
         }
     }
 
-    fn open(&self, now: Instant, hint: RetryHint) {
-        let mut inner = self.inner.write().expect("circuit lock poisoned");
-        inner.state = CircuitState::Open {
-            until: now + hint.applied_backoff(),
-        };
+    fn start_probe_locked(&self, inner: &mut CircuitInner, now: Instant, reason: &'static str) {
+        let previous = inner.state;
+        inner.epoch = inner.epoch.saturating_add(1);
+        inner.state = CircuitState::ProbeInFlight { started: now };
+        tracing::info!(
+            event = "provider-circuit-transition",
+            previous_state = state_label(previous),
+            state = "probe-in-flight",
+            reason,
+            "provider circuit probe started"
+        );
+    }
+
+    fn open_locked(
+        &self,
+        inner: &mut CircuitInner,
+        now: Instant,
+        hint: RetryHint,
+        reason: &'static str,
+    ) {
+        let previous = inner.state;
+        let requested_until = now + hint.applied_backoff();
+        debug_assert!(!matches!(previous, CircuitState::Open { .. }));
+        self.open_until_locked(inner, requested_until, hint, reason);
+    }
+
+    fn open_until_locked(
+        &self,
+        inner: &mut CircuitInner,
+        until: Instant,
+        hint: RetryHint,
+        reason: &'static str,
+    ) {
+        let previous = inner.state;
+        debug_assert!(!matches!(previous, CircuitState::Open { .. }));
+        inner.epoch = inner.epoch.saturating_add(1);
+        inner.state = CircuitState::Open { until };
         inner.failures = inner.failures.saturating_add(1);
         inner.last_hint = Some(hint);
         tracing::info!(
             event = "provider-circuit-transition",
+            previous_state = state_label(previous),
             state = "open",
-            reason = "rate-limited",
-            applied_backoff_ms = millis_u64(hint.applied_backoff()),
+            reason,
             "provider circuit opened"
         );
     }
@@ -225,6 +338,26 @@ fn _assert_send_sync<T: Send + Sync>() {}
 
 fn millis_u64(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn retry_hint_for_failures(config: CircuitBreakerConfig, failures: u32) -> RetryHint {
+    let exponent = failures.saturating_sub(config.failure_threshold).min(8);
+    let factor = 1_u32.checked_shl(exponent).unwrap_or(u32::MAX);
+    let base = config.default_open_for.saturating_mul(factor);
+    let jitter = deterministic_jitter_ms(u64::from(failures));
+    RetryHint::bounded(base, jitter, config.max_open_for)
+}
+
+fn deterministic_jitter_ms(seed: u64) -> Duration {
+    Duration::from_millis(seed.wrapping_mul(97) % 501)
+}
+
+fn state_label(state: CircuitState) -> &'static str {
+    match state {
+        CircuitState::Closed => "closed",
+        CircuitState::Open { .. } => "open",
+        CircuitState::ProbeInFlight { .. } => "probe-in-flight",
+    }
 }
 
 #[cfg(test)]
@@ -246,7 +379,14 @@ mod tests {
             Duration::from_millis(250),
             Duration::from_secs(10),
         );
-        breaker.record_rate_limited(now, hint);
+        breaker.record_rate_limited(
+            now,
+            hint,
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
         let err = breaker
             .before_request(now + Duration::from_secs(1))
             .unwrap_err();
@@ -255,12 +395,14 @@ mod tests {
             err.retry_hint().unwrap().applied_backoff(),
             Duration::from_millis(1250)
         );
-        assert!(breaker.before_request(now + Duration::from_secs(3)).is_ok());
+        let permit = breaker
+            .before_request(now + Duration::from_secs(3))
+            .unwrap();
         assert_eq!(
             breaker.snapshot(now + Duration::from_secs(3)).state,
             "probe-in-flight"
         );
-        breaker.record_success();
+        breaker.record_success(permit);
         assert_eq!(
             breaker.snapshot(now + Duration::from_secs(3)).state,
             "closed"
@@ -276,8 +418,18 @@ mod tests {
             Duration::ZERO,
             Duration::from_secs(5),
         );
-        breaker.record_rate_limited(now, hint);
-        assert!(breaker.before_request(now + Duration::from_secs(2)).is_ok());
+        breaker.record_rate_limited(
+            now,
+            hint,
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let permit = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap();
+        assert!(permit.is_probe());
         let err = breaker
             .before_request(now + Duration::from_secs(2))
             .unwrap_err();
@@ -294,6 +446,7 @@ mod tests {
         let breaker = ProviderCircuitBreaker::new(CircuitBreakerConfig {
             failure_threshold: 1,
             default_open_for: Duration::from_secs(2),
+            probe_timeout: Duration::from_secs(2),
             max_open_for: Duration::from_secs(10),
         });
         breaker.record_rate_limited(
@@ -303,6 +456,10 @@ mod tests {
                 Duration::ZERO,
                 Duration::from_secs(10),
             ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
         );
         assert!(breaker.before_request(now + Duration::from_secs(2)).is_ok());
         let err = breaker
@@ -313,16 +470,333 @@ mod tests {
     }
 
     #[test]
+    fn expired_probe_reopens_with_retry_hint_and_counts_failure() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 1,
+            default_open_for: Duration::from_secs(2),
+            probe_timeout: Duration::from_secs(2),
+            max_open_for: Duration::from_secs(10),
+        });
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let permit = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap();
+        assert!(permit.is_probe());
+        let err = breaker
+            .before_request(now + Duration::from_secs(4))
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        let snapshot = breaker.snapshot(now + Duration::from_secs(4));
+        assert_eq!(snapshot.state, "open");
+        assert_eq!(snapshot.failures, 2);
+        assert!(snapshot.retry_hint.is_some());
+    }
+
+    #[test]
+    fn late_probe_timeout_discovery_allows_next_probe_after_backoff_elapsed() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 1,
+            default_open_for: Duration::from_secs(2),
+            probe_timeout: Duration::from_secs(2),
+            max_open_for: Duration::from_secs(10),
+        });
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let permit = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap();
+        assert!(permit.is_probe());
+        let next = breaker
+            .before_request(now + Duration::from_secs(20))
+            .unwrap();
+        assert!(next.is_probe());
+        assert_eq!(
+            breaker.snapshot(now + Duration::from_secs(20)).state,
+            "probe-in-flight"
+        );
+    }
+
+    #[test]
+    fn reverse_time_during_probe_does_not_panic() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let permit = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap();
+        assert!(permit.is_probe());
+        let err = breaker
+            .before_request(now + Duration::from_secs(1))
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+    }
+
+    #[test]
+    fn probe_failure_reopens_immediately() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let permit = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap();
+        assert!(permit.is_probe());
+        breaker.record_transient_failure(now + Duration::from_secs(3), permit);
+        assert_eq!(breaker.snapshot(now + Duration::from_secs(3)).state, "open");
+    }
+
+    #[test]
     fn transient_failures_open_after_threshold() {
         let now = Instant::now();
         let breaker = ProviderCircuitBreaker::new(CircuitBreakerConfig {
             failure_threshold: 2,
             default_open_for: Duration::from_secs(5),
+            probe_timeout: Duration::from_secs(5),
             max_open_for: Duration::from_secs(20),
         });
-        breaker.record_transient_failure(now);
+        breaker.record_transient_failure(
+            now,
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
         assert!(breaker.before_request(now).is_ok());
-        breaker.record_transient_failure(now);
+        breaker.record_transient_failure(
+            now,
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
         assert!(breaker.before_request(now).is_err());
+        assert_eq!(breaker.snapshot(now).failures, 2);
+    }
+
+    #[test]
+    fn failure_while_open_does_not_increase_failures_or_shrink_deadline() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 1,
+            default_open_for: Duration::from_secs(5),
+            probe_timeout: Duration::from_secs(5),
+            max_open_for: Duration::from_secs(20),
+        });
+        breaker.record_transient_failure(
+            now,
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let before = breaker.snapshot(now);
+        breaker.record_transient_failure(
+            now + Duration::from_secs(1),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let after = breaker.snapshot(now + Duration::from_secs(1));
+        assert_eq!(after.failures, before.failures);
+        assert!(after.remaining.unwrap() >= Duration::from_secs(4));
+    }
+
+    #[test]
+    fn concurrent_rate_limit_extends_open_deadline() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        let first_permit = breaker.before_request(now).unwrap();
+        let second_permit = breaker.before_request(now).unwrap();
+        breaker.record_rate_limited(
+            now + Duration::from_secs(1),
+            RetryHint::bounded(
+                Duration::from_secs(2),
+                Duration::ZERO,
+                Duration::from_secs(20),
+            ),
+            first_permit,
+        );
+        breaker.record_rate_limited(
+            now + Duration::from_secs(2),
+            RetryHint::bounded(
+                Duration::from_secs(10),
+                Duration::ZERO,
+                Duration::from_secs(20),
+            ),
+            second_permit,
+        );
+        assert!(
+            breaker
+                .snapshot(now + Duration::from_secs(2))
+                .remaining
+                .unwrap()
+                >= Duration::from_secs(10)
+        );
+        assert_eq!(
+            breaker
+                .snapshot(now + Duration::from_secs(2))
+                .retry_hint
+                .unwrap()
+                .retry_after(),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn late_success_while_open_does_not_close_circuit() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(5),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        breaker.record_success(CircuitPermit {
+            probe: false,
+            epoch: 0,
+        });
+        assert_eq!(breaker.snapshot(now).state, "open");
+    }
+
+    #[test]
+    fn stale_epoch_success_and_failure_do_not_mutate_open_circuit() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        let first_permit = breaker.before_request(now).unwrap();
+        let stale_permit = breaker.before_request(now).unwrap();
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(5),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            first_permit,
+        );
+        let before = breaker.snapshot(now);
+        breaker.record_success(stale_permit);
+        breaker.record_transient_failure(now + Duration::from_secs(1), stale_permit);
+        let after = breaker.snapshot(now + Duration::from_secs(1));
+        assert_eq!(after.state, "open");
+        assert_eq!(after.failures, before.failures);
+        assert_eq!(after.retry_hint, before.retry_hint);
+    }
+
+    #[test]
+    fn cancellation_reopens_probe_in_flight() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let permit = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap();
+        assert!(permit.is_probe());
+        breaker.record_cancellation(now + Duration::from_secs(3), permit);
+        assert_eq!(breaker.snapshot(now + Duration::from_secs(3)).state, "open");
+    }
+
+    #[test]
+    fn stale_non_probe_observations_do_not_affect_probe() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        let permit = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap();
+        assert!(permit.is_probe());
+
+        breaker.record_success(CircuitPermit {
+            probe: false,
+            epoch: 0,
+        });
+        assert_eq!(
+            breaker.snapshot(now + Duration::from_secs(2)).state,
+            "probe-in-flight"
+        );
+        breaker.record_transient_failure(
+            now + Duration::from_secs(2),
+            CircuitPermit {
+                probe: false,
+                epoch: 0,
+            },
+        );
+        assert_eq!(
+            breaker.snapshot(now + Duration::from_secs(2)).state,
+            "probe-in-flight"
+        );
     }
 }

--- a/packages/nixling-constellation-provider/src/rate_limit.rs
+++ b/packages/nixling-constellation-provider/src/rate_limit.rs
@@ -1,0 +1,328 @@
+//! Shared provider rate-limit and circuit-breaker primitives.
+
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+use crate::error::{ProviderError, RetryHint};
+
+/// Circuit breaker configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CircuitBreakerConfig {
+    /// Consecutive transient failures before opening the circuit.
+    pub failure_threshold: u32,
+    /// Default open duration when a failure has no retry hint.
+    pub default_open_for: Duration,
+    /// Maximum retained retry/backoff duration.
+    pub max_open_for: Duration,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 3,
+            default_open_for: Duration::from_secs(10),
+            max_open_for: Duration::from_secs(300),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CircuitState {
+    Closed,
+    Open { until: Instant },
+    ProbeInFlight { started: Instant },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CircuitInner {
+    state: CircuitState,
+    failures: u32,
+    last_hint: Option<RetryHint>,
+}
+
+/// Snapshot safe for diagnostics and tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CircuitBreakerSnapshot {
+    /// Stable state label (`closed`, `open`, or `half-open`).
+    pub state: &'static str,
+    /// Consecutive failure count.
+    pub failures: u32,
+    /// Remaining open duration, if open.
+    pub remaining: Option<Duration>,
+    /// Last structured retry hint, if any.
+    pub retry_hint: Option<RetryHint>,
+}
+
+/// Concurrency-safe provider circuit breaker. It stores only state labels,
+/// counters, timestamps, and bounded retry hints.
+#[derive(Debug)]
+pub struct ProviderCircuitBreaker {
+    config: CircuitBreakerConfig,
+    inner: RwLock<CircuitInner>,
+}
+
+impl ProviderCircuitBreaker {
+    /// Create a circuit breaker with `config`.
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            config,
+            inner: RwLock::new(CircuitInner {
+                state: CircuitState::Closed,
+                failures: 0,
+                last_hint: None,
+            }),
+        }
+    }
+
+    /// Check whether a request may be issued at `now`.
+    pub fn before_request(&self, now: Instant) -> Result<(), ProviderError> {
+        let mut inner = self.inner.write().expect("circuit lock poisoned");
+        match inner.state {
+            CircuitState::Closed => Ok(()),
+            CircuitState::ProbeInFlight { started }
+                if now.duration_since(started) >= self.config.default_open_for =>
+            {
+                let hint = RetryHint::bounded(
+                    self.config.default_open_for,
+                    Duration::ZERO,
+                    self.config.max_open_for,
+                );
+                inner.state = CircuitState::Open {
+                    until: now + hint.applied_backoff(),
+                };
+                inner.last_hint = Some(hint);
+                Err(ProviderError::rate_limited(
+                    format!(
+                        "provider circuit breaker probe timed out; retry after {} ms",
+                        hint.applied_backoff().as_millis()
+                    ),
+                    hint,
+                ))
+            }
+            CircuitState::ProbeInFlight { .. } => {
+                let hint = RetryHint::bounded(
+                    self.config.default_open_for,
+                    Duration::ZERO,
+                    self.config.max_open_for,
+                );
+                Err(ProviderError::rate_limited(
+                    "provider circuit breaker half-open probe already in flight",
+                    hint,
+                ))
+            }
+            CircuitState::Open { until } if now >= until => {
+                inner.state = CircuitState::ProbeInFlight { started: now };
+                tracing::info!(
+                    event = "provider-circuit-transition",
+                    state = "half-open",
+                    "provider circuit half-open probe started"
+                );
+                Ok(())
+            }
+            CircuitState::Open { until } => {
+                let remaining = until.saturating_duration_since(now);
+                let hint = RetryHint::bounded(remaining, Duration::ZERO, self.config.max_open_for);
+                Err(ProviderError::rate_limited(
+                    format!(
+                        "provider circuit breaker open; retry after {} ms",
+                        hint.applied_backoff().as_millis()
+                    ),
+                    hint,
+                ))
+            }
+        }
+    }
+
+    /// Record a successful provider request.
+    pub fn record_success(&self) {
+        let mut inner = self.inner.write().expect("circuit lock poisoned");
+        inner.state = CircuitState::Closed;
+        inner.failures = 0;
+        inner.last_hint = None;
+        tracing::info!(
+            event = "provider-circuit-transition",
+            state = "closed",
+            "provider circuit closed"
+        );
+    }
+
+    /// Record a rate-limit response and open the circuit immediately.
+    pub fn record_rate_limited(&self, now: Instant, hint: RetryHint) {
+        self.open(now, hint);
+        tracing::info!(
+            event = "provider-rate-limited",
+            retry_after_ms = millis_u64(hint.retry_after()),
+            applied_backoff_ms = millis_u64(hint.applied_backoff()),
+            "provider rate limited"
+        );
+    }
+
+    /// Record a transient provider failure. Opens after the configured
+    /// threshold.
+    pub fn record_transient_failure(&self, now: Instant) {
+        let mut inner = self.inner.write().expect("circuit lock poisoned");
+        inner.failures = inner.failures.saturating_add(1);
+        if inner.failures >= self.config.failure_threshold {
+            let hint = RetryHint::bounded(
+                self.config.default_open_for,
+                Duration::ZERO,
+                self.config.max_open_for,
+            );
+            inner.state = CircuitState::Open {
+                until: now + hint.applied_backoff(),
+            };
+            inner.last_hint = Some(hint);
+            tracing::info!(
+                event = "provider-circuit-transition",
+                state = "open",
+                reason = "transient-failure",
+                applied_backoff_ms = millis_u64(hint.applied_backoff()),
+                "provider circuit opened"
+            );
+        }
+    }
+
+    /// Snapshot state at `now`.
+    pub fn snapshot(&self, now: Instant) -> CircuitBreakerSnapshot {
+        let inner = self.inner.read().expect("circuit lock poisoned");
+        let (state, remaining) = match inner.state {
+            CircuitState::Closed => ("closed", None),
+            CircuitState::ProbeInFlight { .. } => ("probe-in-flight", None),
+            CircuitState::Open { until } => ("open", Some(until.saturating_duration_since(now))),
+        };
+        CircuitBreakerSnapshot {
+            state,
+            failures: inner.failures,
+            remaining,
+            retry_hint: inner.last_hint,
+        }
+    }
+
+    fn open(&self, now: Instant, hint: RetryHint) {
+        let mut inner = self.inner.write().expect("circuit lock poisoned");
+        inner.state = CircuitState::Open {
+            until: now + hint.applied_backoff(),
+        };
+        inner.failures = inner.failures.saturating_add(1);
+        inner.last_hint = Some(hint);
+        tracing::info!(
+            event = "provider-circuit-transition",
+            state = "open",
+            reason = "rate-limited",
+            applied_backoff_ms = millis_u64(hint.applied_backoff()),
+            "provider circuit opened"
+        );
+    }
+}
+
+impl Default for ProviderCircuitBreaker {
+    fn default() -> Self {
+        Self::new(CircuitBreakerConfig::default())
+    }
+}
+
+fn _assert_send_sync<T: Send + Sync>() {}
+
+fn millis_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nixling_constellation_core::ErrorKind;
+
+    #[test]
+    fn circuit_breaker_is_send_sync() {
+        _assert_send_sync::<ProviderCircuitBreaker>();
+    }
+
+    #[test]
+    fn rate_limit_opens_and_half_opens_with_injected_time() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        let hint = RetryHint::bounded(
+            Duration::from_secs(2),
+            Duration::from_millis(250),
+            Duration::from_secs(10),
+        );
+        breaker.record_rate_limited(now, hint);
+        let err = breaker
+            .before_request(now + Duration::from_secs(1))
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        assert_eq!(
+            err.retry_hint().unwrap().applied_backoff(),
+            Duration::from_millis(1250)
+        );
+        assert!(breaker.before_request(now + Duration::from_secs(3)).is_ok());
+        assert_eq!(
+            breaker.snapshot(now + Duration::from_secs(3)).state,
+            "probe-in-flight"
+        );
+        breaker.record_success();
+        assert_eq!(
+            breaker.snapshot(now + Duration::from_secs(3)).state,
+            "closed"
+        );
+    }
+
+    #[test]
+    fn half_open_allows_only_one_probe() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::default();
+        let hint = RetryHint::bounded(
+            Duration::from_secs(1),
+            Duration::ZERO,
+            Duration::from_secs(5),
+        );
+        breaker.record_rate_limited(now, hint);
+        assert!(breaker.before_request(now + Duration::from_secs(2)).is_ok());
+        let err = breaker
+            .before_request(now + Duration::from_secs(2))
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        assert_eq!(
+            breaker.snapshot(now + Duration::from_secs(2)).state,
+            "probe-in-flight"
+        );
+    }
+
+    #[test]
+    fn stale_probe_reopens_circuit_instead_of_wedging() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 1,
+            default_open_for: Duration::from_secs(2),
+            max_open_for: Duration::from_secs(10),
+        });
+        breaker.record_rate_limited(
+            now,
+            RetryHint::bounded(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::from_secs(10),
+            ),
+        );
+        assert!(breaker.before_request(now + Duration::from_secs(2)).is_ok());
+        let err = breaker
+            .before_request(now + Duration::from_secs(5))
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        assert_eq!(breaker.snapshot(now + Duration::from_secs(5)).state, "open");
+    }
+
+    #[test]
+    fn transient_failures_open_after_threshold() {
+        let now = Instant::now();
+        let breaker = ProviderCircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 2,
+            default_open_for: Duration::from_secs(5),
+            max_open_for: Duration::from_secs(20),
+        });
+        breaker.record_transient_failure(now);
+        assert!(breaker.before_request(now).is_ok());
+        breaker.record_transient_failure(now);
+        assert!(breaker.before_request(now).is_err());
+    }
+}

--- a/packages/nixling-daemon-access/src/lib.rs
+++ b/packages/nixling-daemon-access/src/lib.rs
@@ -1487,10 +1487,10 @@ mod tests {
 
         assert_eq!(error.kind(), ErrorKind::GatewayUnavailable);
         assert_eq!(
-            error.0.message(),
+            error.message(),
             "daemon reported that required host state is unavailable"
         );
-        assert!(!error.0.message().contains("/home/alice"));
+        assert!(!error.message().contains("/home/alice"));
         assert!(!format!("{error:?}").contains("private-vm"));
     }
 

--- a/packages/nixling-gateway-runtime/src/aca_workload.rs
+++ b/packages/nixling-gateway-runtime/src/aca_workload.rs
@@ -625,6 +625,7 @@ mod tests {
                 sandbox_group: "sg".into(),
                 region: "centralus".into(),
                 endpoint: None,
+                managed_identity_client_id: None,
             },
             nixling_constellation_core::NodeId::parse("gateway").unwrap(),
             Arc::new(FakeCredential),

--- a/packages/nixling-provider-aca/Cargo.toml
+++ b/packages/nixling-provider-aca/Cargo.toml
@@ -12,9 +12,9 @@ doctest = false
 workspace = true
 
 # Azure Container Apps sandbox WorkloadProvider (ADR 0032, P0). Plane-1
-# control-plane auth is the operator's ambient Entra identity via the Azure
-# CLI, surfaced through azure_identity::AzureCliCredential; nixling stores no
-# Azure secret of its own. Data-plane REST calls go to the ADC endpoint.
+# control-plane auth uses explicitly configured managed/workload identity;
+# production code does not fall back to ambient developer credentials. Data-plane
+# REST calls go to the ADC endpoint.
 [dependencies]
 nixling-constellation-core = { path = "../nixling-constellation-core", version = "0.0.0-bootstrap" }
 nixling-constellation-provider = { path = "../nixling-constellation-provider", version = "0.0.0-bootstrap" }
@@ -27,6 +27,7 @@ azure_core = "1.0.0"
 azure_identity = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tracing = "0.1"
+fastrand = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/packages/nixling-provider-aca/Cargo.toml
+++ b/packages/nixling-provider-aca/Cargo.toml
@@ -27,7 +27,6 @@ azure_core = "1.0.0"
 azure_identity = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tracing = "0.1"
-fastrand = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/packages/nixling-provider-aca/examples/aca_live.rs
+++ b/packages/nixling-provider-aca/examples/aca_live.rs
@@ -1,9 +1,12 @@
 //! Live smoke: drive a real ACA sandbox exec through the Rust provider.
 //! Reads ACA_SUBSCRIPTION/ACA_RESOURCE_GROUP/ACA_SANDBOX_GROUP/ACA_REGION and
 //! ACA_SANDBOX_ID from the environment, authenticates via the operator's
-//! Azure CLI session (plane 1), and runs a command in the sandbox.
+//! explicit local-validation Azure CLI credential (plane 1), and runs a
+//! command in the sandbox. Production provider construction does not use this
+//! ambient developer credential path.
 use nixling_constellation_core::NodeId;
-use nixling_provider_aca::{AcaConfig, AcaWorkloadProvider};
+use nixling_provider_aca::{AcaConfig, AcaWorkloadProvider, ReqwestTransport};
+use std::sync::Arc;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,12 +16,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sandbox_group: std::env::var("ACA_SANDBOX_GROUP")?,
         region: std::env::var("ACA_REGION")?,
         endpoint: std::env::var("ACA_ENDPOINT").ok(),
+        managed_identity_client_id: std::env::var("ACA_MI_CLIENT_ID").ok(),
     };
     let sandbox = std::env::var("ACA_SANDBOX_ID")?;
     let cmd = std::env::var("ACA_CMD")
         .unwrap_or_else(|_| "echo nixling-rust-provider-live; id -un; uname -sr".to_string());
 
-    let provider = AcaWorkloadProvider::new(cfg, NodeId::parse("gateway").unwrap())?;
+    let credential = azure_identity::AzureCliCredential::new(None)?;
+    let http = Arc::new(ReqwestTransport::new()?);
+    let provider =
+        AcaWorkloadProvider::with_parts(cfg, NodeId::parse("gateway").unwrap(), credential, http);
     println!(
         "[live] reachable: {}",
         provider.sandbox_reachable(&sandbox).await?

--- a/packages/nixling-provider-aca/src/lib.rs
+++ b/packages/nixling-provider-aca/src/lib.rs
@@ -1,25 +1,24 @@
 //! `nixling-provider-aca`: the Azure Container Apps **sandbox**
-//! `WorkloadProvider` (ADR 0032, P0).
+//! `WorkloadProvider` implementation for provider-managed sandboxes.
 //!
-//! This productionizes the ACA leg of the P0 vertical: instead of the
-//! operator driving the sandbox by hand with the preview `aca` CLI, the
-//! gateway drives it through this Rust provider against the ADC data-plane
-//! REST surface.
+//! This productionizes the Azure Container Apps sandbox path: instead of the
+//! operator driving the sandbox by hand with the preview CLI, the gateway drives
+//! it through this Rust provider against the Azure Container Apps data-plane REST surface.
 //!
-//! ## Three-plane auth (operator directive)
+//! ## Three-plane auth
 //! Plane 1 — Azure control-plane access — is acquired through an explicitly
-//! configured managed/workload identity. The production provider deliberately
-//! does not fall back to ambient developer credentials such as Azure CLI or
-//! environment credential chains. nixling stores **no** Azure secret of its
-//! own. Container→Azure (plane 2, the sandbox Managed Identity) and the
-//! nixling-internal per-session credential (plane 3) live in the relay/display
-//! providers, not here.
+//! configured workload identity first, then managed identity. The production
+//! provider deliberately does not fall back to ambient developer credentials
+//! such as Azure CLI or environment credential chains. nixling stores **no**
+//! Azure secret of its own. Container→Azure (plane 2, the sandbox Managed
+//! Identity) and the nixling-internal per-session credential (plane 3) live in
+//! the relay/display providers, not here.
 //!
 //! ## Data plane
 //! `https://management.<region>.azuredevcompute.io/subscriptions/<sub>/
 //! resourceGroups/<rg>/sandboxGroups/<sg>/...` with
 //! `?api-version=2026-02-01-preview`. Lifecycle uses the preview data-plane
-//! REST contract observed from the first-party ACA sandbox CLI:
+//! REST contract observed from the first-party Azure Container Apps sandbox CLI:
 //!
 //! - `PUT .../diskimages` creates a disk image from a container image.
 //! - `GET .../diskimages&labels=<selector>` finds reusable disk images.
@@ -31,6 +30,32 @@
 //! The credential and the HTTP transport are both injectable traits so the
 //! provider is unit-testable without a live subscription; the live path is
 //! exercised by an `NL_ACA_LIVE`-gated smoke test.
+//!
+//! ```no_run
+//! # use nixling_constellation_core::NodeId;
+//! # use nixling_provider_aca::{AcaConfig, AcaWorkloadProvider};
+//! # fn build(cfg: AcaConfig) -> Result<AcaWorkloadProvider, Box<dyn std::error::Error>> {
+//! let provider = AcaWorkloadProvider::new(cfg, NodeId::parse("gateway")?)?;
+//! # Ok(provider)
+//! # }
+//! ```
+//!
+//! Local live-smoke code that intentionally uses developer credentials must
+//! inject them explicitly with [`AcaWorkloadProvider::with_parts`]; production
+//! [`AcaWorkloadProvider::new`] uses managed/workload identity only.
+//!
+//! ```no_run
+//! # use nixling_constellation_core::NodeId;
+//! # use nixling_provider_aca::{AcaConfig, AcaWorkloadProvider, ReqwestTransport};
+//! # use std::sync::Arc;
+//! # fn build_local(cfg: AcaConfig) -> Result<AcaWorkloadProvider, Box<dyn std::error::Error>> {
+//! let credential = azure_identity::AzureCliCredential::new(None)?;
+//! let http = Arc::new(ReqwestTransport::new()?);
+//! let provider =
+//!     AcaWorkloadProvider::with_parts(cfg, NodeId::parse("gateway")?, credential, http);
+//! # Ok(provider)
+//! # }
+//! ```
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -46,28 +71,29 @@ use sha2::{Digest, Sha256};
 use nixling_constellation_core::{
     Capability, CapabilitySet, ErrorKind, ExecutionId, NodeId, ProviderId, WorkloadId,
 };
-use nixling_constellation_core::{RealmPath, WorkloadSummary};
+use nixling_constellation_core::{RealmId, RealmPath, WorkloadSummary};
 use nixling_constellation_provider::capabilities::WorkloadCapabilitySet;
 use nixling_constellation_provider::error::{
     ProviderDiagnostic, ProviderError, ProviderResult, RetryHint,
 };
 use nixling_constellation_provider::provider::WorkloadProvider;
-use nixling_constellation_provider::rate_limit::ProviderCircuitBreaker;
+use nixling_constellation_provider::rate_limit::{CircuitPermit, ProviderCircuitBreaker};
 use nixling_constellation_provider::types::{
     ExecStartRequest, ListSelector, WorkloadSpec, WorkloadStatus,
 };
 
-/// The Entra scope for the ADC data plane (plane 1). Explicit managed/workload
+/// The Entra scope for the Azure Container Apps data plane (plane 1). Explicit managed/workload
 /// identity credentials acquire tokens for this audience.
-pub const ADC_RESOURCE_SCOPE: &str = "https://management.azuredevcompute.io/.default";
+pub const AZURE_CONTAINER_APPS_RESOURCE_SCOPE: &str =
+    concat!("https:", "//management.azuredevcompute.io/.default");
 
-/// The ADC data-plane API version this provider speaks.
-pub const ADC_API_VERSION: &str = "2026-02-01-preview";
+/// The Azure Container Apps data-plane API version this provider speaks.
+pub const AZURE_CONTAINER_APPS_API_VERSION: &str = "2026-02-01-preview";
 const READY_POLL_ATTEMPTS: usize = 30;
 const READY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 const MAX_RETRY_HINT: Duration = Duration::from_secs(300);
 
-/// The non-secret coordinates of an ACA sandbox group. Every field is an
+/// The non-secret coordinates of an Azure Container Apps sandbox group. Every field is an
 /// opaque Azure resource identifier (never a secret); `Debug` still redacts
 /// the subscription id so it cannot leak into a log or span.
 #[derive(Clone)]
@@ -78,12 +104,12 @@ pub struct AcaConfig {
     pub resource_group: String,
     /// Sandbox group name.
     pub sandbox_group: String,
-    /// Region (selects the ADC data-plane endpoint).
+    /// Region (selects the Azure Container Apps data-plane endpoint).
     pub region: String,
-    /// Optional explicit ADC data-plane endpoint for sovereign/private-link
+    /// Optional explicit Azure Container Apps data-plane endpoint for sovereign/private-link
     /// deployments. When unset, `management.<region>.azuredevcompute.io` is used.
     pub endpoint: Option<String>,
-    /// Optional user-assigned managed identity client id for ACA data-plane
+    /// Optional user-assigned managed identity client id for Azure Container Apps data-plane
     /// authentication. When absent, the system-assigned identity is used.
     pub managed_identity_client_id: Option<String>,
 }
@@ -106,7 +132,7 @@ pub enum AcaDiskImageSource {
     },
 }
 
-/// Provider defaults required to create an ACA sandbox from the narrow
+/// Provider defaults required to create an Azure Container Apps sandbox from the narrow
 /// `WorkloadSpec { alias }` trait surface.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcaSandboxDefaults {
@@ -127,7 +153,7 @@ pub struct AcaSandboxDefaults {
 }
 
 impl AcaSandboxDefaults {
-    /// P0 default resources used by the live ACA Wayland POC.
+    /// Default resources used by the live Azure Container Apps Wayland proof.
     pub fn new(disk_image: AcaDiskImageSource) -> Self {
         Self {
             disk_image,
@@ -140,28 +166,28 @@ impl AcaSandboxDefaults {
     }
 }
 
-/// A non-secret ACA sandbox summary.
+/// A non-secret Azure Container Apps sandbox summary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcaSandbox {
     /// Provider UUID / resource id fragment.
     pub id: String,
     /// Best-effort lifecycle state from the data plane.
     pub state: Option<String>,
-    /// ACA labels.
+    /// Azure Container Apps labels.
     pub labels: BTreeMap<String, String>,
 }
 
-/// A non-secret ACA disk image summary.
+/// A non-secret Azure Container Apps disk image summary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcaDiskImage {
     /// Provider UUID / resource id fragment.
     pub id: String,
-    /// ACA labels.
+    /// Azure Container Apps labels.
     pub labels: BTreeMap<String, String>,
 }
 
 impl AcaConfig {
-    /// The region-specific ADC data-plane endpoint.
+    /// The region-specific Azure Container Apps data-plane endpoint.
     pub fn endpoint(&self) -> String {
         self.endpoint
             .clone()
@@ -184,7 +210,7 @@ impl AcaConfig {
         format!(
             "{}/executeShellCommand?api-version={}",
             self.sandbox_base(sandbox_id),
-            ADC_API_VERSION
+            AZURE_CONTAINER_APPS_API_VERSION
         )
     }
 
@@ -196,11 +222,11 @@ impl AcaConfig {
             self.subscription,
             self.resource_group,
             self.sandbox_group,
-            ADC_API_VERSION
+            AZURE_CONTAINER_APPS_API_VERSION
         )
     }
 
-    /// The sandbox list URL, optionally filtered by an ACA label selector.
+    /// The sandbox list URL, optionally filtered by an Azure Container Apps label selector.
     pub fn list_sandboxes_url(&self, labels: Option<&str>) -> String {
         let mut url = self.sandboxes_url();
         if let Some(labels) = labels {
@@ -218,11 +244,11 @@ impl AcaConfig {
             self.subscription,
             self.resource_group,
             self.sandbox_group,
-            ADC_API_VERSION
+            AZURE_CONTAINER_APPS_API_VERSION
         )
     }
 
-    /// The disk image list URL, optionally filtered by an ACA label selector.
+    /// The disk image list URL, optionally filtered by an Azure Container Apps label selector.
     pub fn list_disk_images_url(&self, labels: Option<&str>) -> String {
         let mut url = self.disk_images_url();
         if let Some(labels) = labels {
@@ -237,17 +263,17 @@ impl AcaConfig {
         format!(
             "{}?api-version={}",
             self.sandbox_base(sandbox_id),
-            ADC_API_VERSION
+            AZURE_CONTAINER_APPS_API_VERSION
         )
     }
 
-    /// The resume URL (an ACA sandbox auto-suspends to `Idle`; a resume moves
+    /// The resume URL (an Azure Container Apps sandbox auto-suspends to `Idle`; a resume moves
     /// it back to `Running` so `executeShellCommand` stops returning 409).
     pub fn resume_url(&self, sandbox_id: &str) -> String {
         format!(
             "{}/resume?api-version={}",
             self.sandbox_base(sandbox_id),
-            ADC_API_VERSION
+            AZURE_CONTAINER_APPS_API_VERSION
         )
     }
 
@@ -256,7 +282,7 @@ impl AcaConfig {
         format!(
             "{}/stop?api-version={}",
             self.sandbox_base(sandbox_id),
-            ADC_API_VERSION
+            AZURE_CONTAINER_APPS_API_VERSION
         )
     }
 
@@ -265,7 +291,7 @@ impl AcaConfig {
         format!(
             "{}?api-version={}",
             self.sandbox_base(sandbox_id),
-            ADC_API_VERSION
+            AZURE_CONTAINER_APPS_API_VERSION
         )
     }
 }
@@ -336,6 +362,8 @@ pub struct HttpResponse {
     pub status: u16,
     /// Allowlisted response headers.
     pub headers: BTreeMap<String, String>,
+    /// Retry metadata parsed once by the circuit-aware request wrapper.
+    pub retry_hint: Option<RetryHint>,
     /// Raw response body.
     pub body: String,
 }
@@ -346,6 +374,7 @@ impl HttpResponse {
         Self {
             status,
             headers: BTreeMap::new(),
+            retry_hint: None,
             body: body.into(),
         }
     }
@@ -408,7 +437,7 @@ impl HttpTransport for ReqwestTransport {
             ProviderError::new(
                 ErrorKind::ProviderAllocationFailed,
                 format!(
-                    "aca data-plane request failed: {}",
+                    "Azure Container Apps data-plane request failed: {}",
                     redact_reqwest_error(&err)
                 ),
             )
@@ -418,12 +447,13 @@ impl HttpTransport for ReqwestTransport {
         let body = resp.text().await.map_err(|_| {
             ProviderError::new(
                 ErrorKind::MalformedFrame,
-                "aca data-plane response body was not readable",
+                "Azure Container Apps data-plane response body was not readable",
             )
         })?;
         Ok(HttpResponse {
             status,
             headers,
+            retry_hint: None,
             body,
         })
     }
@@ -448,13 +478,29 @@ fn allowlisted_headers(headers: &reqwest::header::HeaderMap) -> BTreeMap<String,
 // A reqwest error's Display can include the full URL; keep only the coarse
 // classification so an endpoint/token never reaches a log.
 fn redact_reqwest_error(err: &reqwest::Error) -> &'static str {
-    if err.is_timeout() {
+    redact_reqwest_error_flags(
+        err.is_timeout(),
+        err.is_connect(),
+        err.is_request(),
+        err.is_body(),
+        err.is_decode(),
+    )
+}
+
+fn redact_reqwest_error_flags(
+    is_timeout: bool,
+    is_connect: bool,
+    is_request: bool,
+    is_body: bool,
+    is_decode: bool,
+) -> &'static str {
+    if is_timeout {
         "timeout"
-    } else if err.is_connect() {
+    } else if is_connect {
         "connect"
-    } else if err.is_request() {
+    } else if is_request {
         "request"
-    } else if err.is_body() || err.is_decode() {
+    } else if is_body || is_decode {
         "body"
     } else {
         "transport"
@@ -464,7 +510,9 @@ fn redact_reqwest_error(err: &reqwest::Error) -> &'static str {
 fn rest_error(context: &str, resp: &HttpResponse) -> ProviderError {
     let diagnostic = provider_diagnostic(&resp.body, &resp.headers);
     if resp.status == 429 {
-        let hint = retry_hint_from_headers(&resp.headers);
+        let hint = resp
+            .retry_hint
+            .unwrap_or_else(|| retry_hint_from_headers(&resp.headers));
         return ProviderError::rate_limited(
             format!(
                 "{context} provider-rate-limited; retry after {} ms",
@@ -474,13 +522,23 @@ fn rest_error(context: &str, resp: &HttpResponse) -> ProviderError {
         )
         .with_diagnostic(diagnostic);
     }
-    let kind = if resp.status == 403 {
+    let kind = if matches!(diagnostic.code(), Some("AuthorizationFailed")) {
+        ErrorKind::Unauthorized
+    } else if resp.status == 401 {
+        ErrorKind::AuthenticationFailed
+    } else if resp.status == 403 {
         ErrorKind::Unauthorized
     } else {
         ErrorKind::ProviderAllocationFailed
     };
-    ProviderError::new(kind, format!("{context} returned HTTP {}", resp.status))
-        .with_diagnostic(diagnostic)
+    let mut message = format!("{context} returned HTTP {}", resp.status);
+    if matches!(resp.status, 401 | 403) || matches!(diagnostic.code(), Some("AuthorizationFailed"))
+    {
+        message.push_str(
+            "; ensure the gateway identity (for example managed identity) has the required Azure Container Apps data-plane role",
+        );
+    }
+    ProviderError::new(kind, message).with_diagnostic(diagnostic)
 }
 
 fn provider_diagnostic(body: &str, headers: &BTreeMap<String, String>) -> ProviderDiagnostic {
@@ -512,11 +570,14 @@ fn extract_error_message(value: &serde_json::Value) -> Option<String> {
         &["message"][..],
         &["detail"][..],
     ] {
-        let mut cursor = value;
+        let mut cursor = Some(value);
         for key in path {
-            cursor = cursor.get(*key)?;
+            cursor = cursor.and_then(|value| value.get(*key));
         }
-        if let Some(s) = cursor.as_str().filter(|s| !s.trim().is_empty()) {
+        if let Some(s) = cursor
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+        {
             return Some(s.to_owned());
         }
     }
@@ -535,8 +596,54 @@ fn retry_hint_from_headers(headers: &BTreeMap<String, String>) -> RetryHint {
                 .map(Duration::from_secs)
         })
         .unwrap_or_else(|| Duration::from_secs(30));
-    let jitter = Duration::from_millis(fastrand::u64(..=500));
+    let jitter = deterministic_jitter_ms(millis_u64(retry_after));
     RetryHint::bounded(retry_after, jitter, MAX_RETRY_HINT)
+}
+
+fn deterministic_jitter_ms(seed: u64) -> Duration {
+    Duration::from_millis(seed.wrapping_mul(97) % 501)
+}
+
+fn millis_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn classify_credential_error(err: &(dyn std::error::Error + 'static)) -> &'static str {
+    let mut current = Some(err);
+    while let Some(error) = current {
+        let message = error.to_string().to_ascii_lowercase();
+        if message.contains("workload") || message.contains("federated") {
+            return "workload-identity-unavailable";
+        }
+        if message.contains("managed identity") || message.contains("imds") {
+            return "managed-identity-unavailable";
+        }
+        if message.contains("environment")
+            || message.contains("client id")
+            || message.contains("client_id")
+        {
+            return "credential-configuration-missing";
+        }
+        current = error.source();
+    }
+    "credential-source-unavailable"
+}
+
+#[cfg(test)]
+fn classify_credential_error_message(message: &str) -> &'static str {
+    let message = message.to_ascii_lowercase();
+    if message.contains("workload") || message.contains("federated") {
+        "workload-identity-unavailable"
+    } else if message.contains("managed identity") || message.contains("imds") {
+        "managed-identity-unavailable"
+    } else if message.contains("environment")
+        || message.contains("client id")
+        || message.contains("client_id")
+    {
+        "credential-configuration-missing"
+    } else {
+        "credential-source-unavailable"
+    }
 }
 
 static ACA_CIRCUITS: OnceLock<Mutex<BTreeMap<String, Weak<ProviderCircuitBreaker>>>> =
@@ -544,11 +651,15 @@ static ACA_CIRCUITS: OnceLock<Mutex<BTreeMap<String, Weak<ProviderCircuitBreaker
 
 fn shared_circuit_for(config: &AcaConfig) -> Arc<ProviderCircuitBreaker> {
     let key = format!(
-        "{}\u{1f}{}\u{1f}{}",
-        config.subscription, config.resource_group, config.sandbox_group
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        config.endpoint(),
+        config.subscription,
+        config.resource_group,
+        config.sandbox_group
     );
     let registry = ACA_CIRCUITS.get_or_init(|| Mutex::new(BTreeMap::new()));
     let mut circuits = registry.lock().expect("aca circuit registry poisoned");
+    circuits.retain(|_, weak| weak.strong_count() > 0);
     if let Some(existing) = circuits.get(&key).and_then(Weak::upgrade) {
         return existing;
     }
@@ -589,6 +700,35 @@ struct CachedBearer {
     expires_on: OffsetDateTime,
 }
 
+struct ProbeGuard {
+    circuit: Arc<ProviderCircuitBreaker>,
+    permit: CircuitPermit,
+    armed: bool,
+}
+
+impl ProbeGuard {
+    fn new(circuit: Arc<ProviderCircuitBreaker>, permit: CircuitPermit) -> Self {
+        Self {
+            circuit,
+            permit,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ProbeGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.circuit
+                .record_cancellation(Instant::now(), self.permit);
+        }
+    }
+}
+
 impl fmt::Debug for AcaWorkloadProvider {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AcaWorkloadProvider")
@@ -600,10 +740,18 @@ impl fmt::Debug for AcaWorkloadProvider {
 }
 
 impl AcaWorkloadProvider {
-    /// Build a provider that authenticates only with managed/workload identity
-    /// and talks to the ADC data plane over `reqwest`.
+    /// Build a provider that authenticates only with workload/managed identity
+    /// and talks to the Azure Container Apps data plane over `reqwest`.
     pub fn new(config: AcaConfig, node: NodeId) -> ProviderResult<Self> {
-        let options = azure_identity::ManagedIdentityCredentialOptions {
+        let workload_options = azure_identity::WorkloadIdentityCredentialOptions {
+            client_id: config
+                .managed_identity_client_id
+                .as_ref()
+                .filter(|client_id| !client_id.trim().is_empty())
+                .cloned(),
+            ..Default::default()
+        };
+        let managed_options = azure_identity::ManagedIdentityCredentialOptions {
             user_assigned_id: config
                 .managed_identity_client_id
                 .as_ref()
@@ -611,20 +759,39 @@ impl AcaWorkloadProvider {
                 .map(|client_id| azure_identity::UserAssignedId::ClientId(client_id.clone())),
             ..Default::default()
         };
-        let credential =
-            azure_identity::ManagedIdentityCredential::new(Some(options)).map_err(|err| {
-                ProviderError::new(
-                    ErrorKind::AuthenticationFailed,
-                    format!("managed identity credential unavailable: {err}"),
-                )
-            })? as Arc<dyn TokenCredential>;
+        let credential = match azure_identity::WorkloadIdentityCredential::new(Some(
+            workload_options,
+        )) {
+            Ok(credential) => credential as Arc<dyn TokenCredential>,
+            Err(workload_err) => {
+                tracing::debug!(
+                    event = "aca-credential-source-unavailable",
+                    source = "workload-identity",
+                    reason = classify_credential_error(&workload_err),
+                    "Azure Container Apps workload identity credential unavailable"
+                );
+                azure_identity::ManagedIdentityCredential::new(Some(managed_options))
+                .map_err(|managed_err| {
+                    tracing::debug!(
+                        event = "aca-credential-source-unavailable",
+                        source = "managed-identity",
+                        reason = classify_credential_error(&managed_err),
+                        "Azure Container Apps managed identity credential unavailable"
+                    );
+                    ProviderError::new(
+                        ErrorKind::AuthenticationFailed,
+                        "Azure Container Apps workload identity and managed identity credential sources are unavailable; verify gateway workload identity or managed identity configuration",
+                    )
+                })? as Arc<dyn TokenCredential>
+            }
+        };
         let http = Arc::new(ReqwestTransport::new()?);
         let circuit = shared_circuit_for(&config);
         Ok(Self::with_parts(config, node, credential, http).with_circuit_breaker(circuit))
     }
 
-    /// Build a provider from injected parts (credential + transport) — used by
-    /// tests and by alternative wirings.
+    /// Build a provider from injected parts (credential + transport) for
+    /// local dev/live-smoke only.
     pub fn with_parts(
         config: AcaConfig,
         node: NodeId,
@@ -644,7 +811,7 @@ impl AcaWorkloadProvider {
         }
     }
 
-    /// Share a provider-endpoint circuit breaker across ACA provider instances.
+    /// Share a provider-endpoint circuit breaker across Azure Container Apps provider instances.
     pub fn with_circuit_breaker(mut self, circuit: Arc<ProviderCircuitBreaker>) -> Self {
         self.circuit = circuit;
         self
@@ -669,12 +836,17 @@ impl AcaWorkloadProvider {
         }
         let token = self
             .credential
-            .get_token(&[ADC_RESOURCE_SCOPE], None)
+            .get_token(&[AZURE_CONTAINER_APPS_RESOURCE_SCOPE], None)
             .await
             .map_err(|err| {
+                tracing::debug!(
+                    event = "aca-token-acquisition-failed",
+                    reason = classify_credential_error(&err),
+                    "Azure Container Apps credential token acquisition failed"
+                );
                 ProviderError::new(
                     ErrorKind::AuthenticationFailed,
-                    format!("aca credential acquisition failed: {err}"),
+                    "Azure Container Apps credential acquisition failed; verify gateway workload identity or managed identity configuration",
                 )
             })?;
         let bearer = token.token.secret().to_owned();
@@ -693,28 +865,39 @@ impl AcaWorkloadProvider {
         body: Option<String>,
     ) -> ProviderResult<HttpResponse> {
         let now = Instant::now();
-        self.circuit.before_request(now)?;
-        match self.http.request(method, url, bearer, body).await {
+        let permit = self.circuit.before_request(now)?;
+        let guard = permit
+            .is_probe()
+            .then(|| ProbeGuard::new(self.circuit.clone(), permit));
+        let result = self.http.request(method, url, bearer, body).await;
+        if let Some(guard) = guard {
+            guard.disarm();
+        }
+        match result {
             Ok(resp) => {
+                let mut resp = resp;
+                let completed_at = Instant::now();
                 if resp.status == 429 {
                     let hint = retry_hint_from_headers(&resp.headers);
-                    self.circuit.record_rate_limited(now, hint);
+                    resp.retry_hint = Some(hint);
+                    self.circuit.record_rate_limited(completed_at, hint, permit);
                 } else if (500..=599).contains(&resp.status) {
-                    self.circuit.record_transient_failure(now);
+                    self.circuit.record_transient_failure(completed_at, permit);
                 } else if resp.status < 500 {
-                    self.circuit.record_success();
+                    self.circuit.record_success(permit);
                 }
                 Ok(resp)
             }
             Err(err) => {
-                self.circuit.record_transient_failure(now);
+                self.circuit
+                    .record_transient_failure(Instant::now(), permit);
                 Err(err)
             }
         }
     }
 
     /// Run a shell command in `sandbox_id` and return its result
-    /// synchronously. An ACA sandbox auto-suspends to `Idle`; if the exec is
+    /// synchronously. An Azure Container Apps sandbox auto-suspends to `Idle`; if the exec is
     /// refused with a 409 the provider resumes the sandbox once and retries
     /// (mirroring the data plane's own resume protocol). Fails closed on any
     /// other non-200 status or an unparseable body.
@@ -736,12 +919,15 @@ impl AcaWorkloadProvider {
         };
 
         if resp.status != 200 {
-            return Err(rest_error("aca executeShellCommand", &resp));
+            return Err(rest_error(
+                "Azure Container Apps executeShellCommand",
+                &resp,
+            ));
         }
         serde_json::from_str::<ExecResult>(&resp.body).map_err(|_| {
             ProviderError::new(
                 ErrorKind::MalformedFrame,
-                "aca executeShellCommand response was not the expected JSON shape",
+                "Azure Container Apps executeShellCommand response was not the expected JSON shape",
             )
         })
     }
@@ -754,7 +940,7 @@ impl AcaWorkloadProvider {
             .request(HttpMethod::Post, &url, bearer, Some("{}".to_owned()))
             .await?;
         if resp.status != 200 {
-            return Err(rest_error("aca sandbox resume", &resp));
+            return Err(rest_error("Azure Container Apps sandbox resume", &resp));
         }
         Ok(())
     }
@@ -768,12 +954,12 @@ impl AcaWorkloadProvider {
         match resp.status {
             200 => Ok(true),
             404 => Ok(false),
-            _ => Err(rest_error("aca sandbox get", &resp)),
+            _ => Err(rest_error("Azure Container Apps sandbox get", &resp)),
         }
     }
 
     /// Find the sandbox backing a workload alias via the deterministic
-    /// `nixling-workload=<alias>` ACA label plus configured realm/default labels
+    /// `nixling-workload=<alias>` Azure Container Apps label plus configured realm/default labels
     /// when lifecycle defaults are present.
     pub async fn find_workload_sandbox(
         &self,
@@ -823,17 +1009,17 @@ impl AcaWorkloadProvider {
         }
         Err(ProviderError::new(
             ErrorKind::Timeout,
-            "aca sandbox did not reach Running before the readiness deadline",
+            "Azure Container Apps sandbox did not reach Running before the readiness deadline",
         ))
     }
 
-    /// List sandboxes, optionally filtered by an ACA label selector.
+    /// List sandboxes, optionally filtered by an Azure Container Apps label selector.
     pub async fn list_sandboxes(&self, labels: Option<&str>) -> ProviderResult<Vec<AcaSandbox>> {
         let bearer = self.bearer().await?;
         let url = self.config.list_sandboxes_url(labels);
         let resp = self.request(HttpMethod::Get, &url, &bearer, None).await?;
         if resp.status != 200 {
-            return Err(rest_error("aca sandbox list", &resp));
+            return Err(rest_error("Azure Container Apps sandbox list", &resp));
         }
         parse_sandbox_list(&resp.body)
     }
@@ -848,7 +1034,7 @@ impl AcaWorkloadProvider {
         if is_success_no_body_ok(resp.status) {
             Ok(())
         } else {
-            Err(rest_error("aca sandbox stop", &resp))
+            Err(rest_error("Azure Container Apps sandbox stop", &resp))
         }
     }
 
@@ -863,7 +1049,7 @@ impl AcaWorkloadProvider {
         if is_success_no_body_ok(resp.status) || resp.status == 404 {
             Ok(())
         } else {
-            Err(rest_error("aca sandbox delete", &resp))
+            Err(rest_error("Azure Container Apps sandbox delete", &resp))
         }
     }
 
@@ -880,7 +1066,12 @@ impl AcaWorkloadProvider {
                 managed_identity_resource_id,
                 labels,
             } => {
-                if let Some(existing) = self.find_disk_image_by_name(name).await? {
+                let mut disk_labels = defaults.labels.clone();
+                disk_labels.extend(labels.clone());
+                if let Some(existing) = self
+                    .find_disk_image_by_name(workload, name, &disk_labels)
+                    .await?
+                {
                     return Ok(existing.id);
                 }
                 self.create_disk_image(
@@ -888,22 +1079,32 @@ impl AcaWorkloadProvider {
                     image,
                     name,
                     managed_identity_resource_id.as_deref(),
-                    labels,
+                    &disk_labels,
                 )
                 .await
             }
         }
     }
 
-    async fn find_disk_image_by_name(&self, name: &str) -> ProviderResult<Option<AcaDiskImage>> {
-        let labels = labels_selector(&BTreeMap::from([("name".to_owned(), name.to_owned())]));
+    async fn find_disk_image_by_name(
+        &self,
+        workload: &WorkloadId,
+        name: &str,
+        defaults_labels: &BTreeMap<String, String>,
+    ) -> ProviderResult<Option<AcaDiskImage>> {
+        let mut selector = defaults_labels.clone();
+        selector.insert("name".to_owned(), name.to_owned());
+        selector.insert("nixling-workload".to_owned(), workload.as_str().to_owned());
+        let labels = labels_selector(&selector);
         let bearer = self.bearer().await?;
         let url = self.config.list_disk_images_url(Some(&labels));
         let resp = self.request(HttpMethod::Get, &url, &bearer, None).await?;
         if resp.status != 200 {
-            return Err(rest_error("aca disk image list", &resp));
+            return Err(rest_error("Azure Container Apps disk image list", &resp));
         }
-        Ok(parse_disk_image_list(&resp.body)?.into_iter().next())
+        Ok(parse_disk_image_list(&resp.body)?
+            .into_iter()
+            .find(|image| labels_match(&image.labels, &selector)))
     }
 
     async fn create_disk_image(
@@ -924,12 +1125,12 @@ impl AcaWorkloadProvider {
             .request(HttpMethod::Put, &url, &bearer, Some(body))
             .await?;
         if !is_success_with_body_ok(resp.status) {
-            return Err(rest_error("aca disk image create", &resp));
+            return Err(rest_error("Azure Container Apps disk image create", &resp));
         }
         resource_id_from_body(&resp.body).ok_or_else(|| {
             ProviderError::new(
                 ErrorKind::MalformedFrame,
-                "aca disk image create response did not contain an id",
+                "Azure Container Apps disk image create response did not contain an id",
             )
         })
     }
@@ -949,12 +1150,12 @@ impl AcaWorkloadProvider {
             .request(HttpMethod::Put, &url, &bearer, Some(body))
             .await?;
         if !is_success_with_body_ok(resp.status) {
-            return Err(rest_error("aca sandbox create", &resp));
+            return Err(rest_error("Azure Container Apps sandbox create", &resp));
         }
         sandbox_from_value(parse_json_value(&resp.body)?).ok_or_else(|| {
             ProviderError::new(
                 ErrorKind::MalformedFrame,
-                "aca sandbox create response did not contain an id",
+                "Azure Container Apps sandbox create response did not contain an id",
             )
         })
     }
@@ -971,7 +1172,9 @@ impl WorkloadProvider for AcaWorkloadProvider {
     }
 
     fn capabilities(&self) -> WorkloadCapabilitySet {
-        let mut caps = CapabilitySet::empty().with(Capability::Exec);
+        let mut caps = CapabilitySet::empty()
+            .with(Capability::Exec)
+            .with(Capability::ProviderManagedIsolation);
         if self.sandbox_defaults.is_some() {
             caps = caps.with(Capability::Lifecycle);
         }
@@ -982,22 +1185,30 @@ impl WorkloadProvider for AcaWorkloadProvider {
         if self.sandbox_defaults.is_none() {
             return Err(ProviderError::capability_denied(Capability::Lifecycle));
         }
-        let label_selector = match &selector {
-            ListSelector::All => None,
-            ListSelector::One(workload) => Some(labels_selector(&BTreeMap::from([(
-                "nixling-workload".to_owned(),
-                workload.as_str().to_owned(),
-            )]))),
-        };
+        let mut labels = self
+            .sandbox_defaults
+            .as_ref()
+            .map(|defaults| defaults.labels.clone())
+            .unwrap_or_default();
+        if let ListSelector::One(workload) = &selector {
+            labels.insert("nixling-workload".to_owned(), workload.as_str().to_owned());
+        }
+        let label_selector = (!labels.is_empty()).then(|| labels_selector(&labels));
         let sandboxes = self.list_sandboxes(label_selector.as_deref()).await?;
         Ok(sandboxes
             .into_iter()
+            .filter(|sandbox| labels_match(&sandbox.labels, &labels))
             .filter_map(|sandbox| {
                 let workload = sandbox.labels.get("nixling-workload")?;
+                let realm = sandbox
+                    .labels
+                    .get("nixling-realm")
+                    .and_then(|label| RealmId::parse(label.clone()).ok())
+                    .and_then(|label| RealmPath::new(vec![label]))?;
                 let id = WorkloadId::parse(workload.clone()).ok()?;
                 Some(WorkloadSummary {
                     id,
-                    realm: RealmPath::local(),
+                    realm,
                     node: self.node.clone(),
                     state: sandbox_state(&sandbox),
                     capabilities: self.capabilities().caps,
@@ -1007,11 +1218,17 @@ impl WorkloadProvider for AcaWorkloadProvider {
     }
 
     async fn create(&self, spec: WorkloadSpec) -> ProviderResult<WorkloadId> {
+        if self.sandbox_defaults.is_none() {
+            return Err(ProviderError::capability_denied(Capability::Lifecycle));
+        }
         self.ensure_workload_sandbox(&spec.alias).await?;
         Ok(spec.alias)
     }
 
     async fn start(&self, id: WorkloadId) -> ProviderResult<WorkloadStatus> {
+        if self.sandbox_defaults.is_none() {
+            return Err(ProviderError::capability_denied(Capability::Lifecycle));
+        }
         let sandbox = self.ensure_workload_sandbox(&id).await?;
         if !sandbox_is_running(&sandbox) {
             self.resume(&sandbox.id, &self.bearer().await?).await?;
@@ -1039,17 +1256,36 @@ impl WorkloadProvider for AcaWorkloadProvider {
     }
 
     async fn exec(&self, req: ExecStartRequest) -> ProviderResult<ExecutionId> {
+        if req.tty {
+            return Err(ProviderError::capability_denied(Capability::Pty));
+        }
         let command = std::str::from_utf8(req.command.as_bytes()).map_err(|_| {
             ProviderError::new(
                 ErrorKind::MalformedFrame,
-                "aca exec command payload was not valid UTF-8",
+                "Azure Container Apps exec command payload was not valid UTF-8",
             )
         })?;
-        let result = self.exec_shell(req.workload.as_str(), command).await?;
+        let sandbox_id = if self.sandbox_defaults.is_some() {
+            self.find_workload_sandbox(&req.workload)
+                .await?
+                .ok_or_else(|| {
+                    ProviderError::new(
+                        ErrorKind::ProviderAllocationFailed,
+                        "Azure Container Apps sandbox was not found for workload",
+                    )
+                })?
+                .id
+        } else {
+            req.workload.as_str().to_owned()
+        };
+        let result = self.exec_shell(&sandbox_id, command).await?;
         if result.exit_code != 0 {
             return Err(ProviderError::new(
                 ErrorKind::ProviderAllocationFailed,
-                format!("aca exec exited with status {}", result.exit_code),
+                format!(
+                    "Azure Container Apps exec exited with status {}",
+                    result.exit_code
+                ),
             ));
         }
         // The synchronous data-plane exec has no durable execution id. Derive a
@@ -1057,7 +1293,10 @@ impl WorkloadProvider for AcaWorkloadProvider {
         // response timing so retries of the same request correlate and two
         // equal-duration calls cannot collide.
         ExecutionId::parse(format!("aca-exec-{}", exec_request_digest(&req))).map_err(|_| {
-            ProviderError::new(ErrorKind::MalformedFrame, "failed to mint aca execution id")
+            ProviderError::new(
+                ErrorKind::MalformedFrame,
+                "failed to mint Azure Container Apps execution id",
+            )
         })
     }
 }
@@ -1121,7 +1360,7 @@ fn parse_json_value(body: &str) -> ProviderResult<serde_json::Value> {
     serde_json::from_str(body).map_err(|_| {
         ProviderError::new(
             ErrorKind::MalformedFrame,
-            "aca data-plane response was not the expected JSON shape",
+            "Azure Container Apps data-plane response was not the expected JSON shape",
         )
     })
 }
@@ -1138,7 +1377,7 @@ fn array_from_list_body(body: &str) -> ProviderResult<Vec<serde_json::Value>> {
     }
     Err(ProviderError::new(
         ErrorKind::MalformedFrame,
-        "aca list response was not an array",
+        "Azure Container Apps list response was not an array",
     ))
 }
 
@@ -1212,7 +1451,7 @@ fn parse_sandbox_list(body: &str) -> ProviderResult<Vec<AcaSandbox>> {
             sandbox_from_value(value).ok_or_else(|| {
                 ProviderError::new(
                     ErrorKind::MalformedFrame,
-                    "aca sandbox list response contained an item without an id",
+                    "Azure Container Apps sandbox list response contained an item without an id",
                 )
             })
         })
@@ -1226,7 +1465,7 @@ fn parse_disk_image_list(body: &str) -> ProviderResult<Vec<AcaDiskImage>> {
             disk_image_from_value(value).ok_or_else(|| {
                 ProviderError::new(
                     ErrorKind::MalformedFrame,
-                    "aca disk image list response contained an item without an id",
+                    "Azure Container Apps disk image list response contained an item without an id",
                 )
             })
         })
@@ -1255,7 +1494,7 @@ fn disk_image_create_body(
     serde_json::to_string(&body).map_err(|_| {
         ProviderError::new(
             ErrorKind::MalformedFrame,
-            "failed to serialize aca disk image create body",
+            "failed to serialize Azure Container Apps disk image create body",
         )
     })
 }
@@ -1304,7 +1543,7 @@ fn sandbox_create_body(
     serde_json::to_string(&body).map_err(|_| {
         ProviderError::new(
             ErrorKind::MalformedFrame,
-            "failed to serialize aca sandbox create body",
+            "failed to serialize Azure Container Apps sandbox create body",
         )
     })
 }
@@ -1378,10 +1617,14 @@ mod tests {
     struct FakeHttp {
         responses: Mutex<std::collections::VecDeque<FakeResponse>>,
         calls: Mutex<Vec<(HttpMethod, String, Option<String>)>>,
+        delay: std::time::Duration,
     }
 
     impl FakeHttp {
-        fn new_with_headers(responses: Vec<(u16, &str, BTreeMap<String, String>)>) -> Self {
+        fn new_with_headers_and_delay(
+            responses: Vec<(u16, &str, BTreeMap<String, String>)>,
+            delay: std::time::Duration,
+        ) -> Self {
             Self {
                 responses: Mutex::new(
                     responses
@@ -1390,7 +1633,21 @@ mod tests {
                         .collect(),
                 ),
                 calls: Mutex::new(Vec::new()),
+                delay,
             }
+        }
+    }
+
+    impl Drop for FakeHttp {
+        fn drop(&mut self) {
+            if std::thread::panicking() {
+                return;
+            }
+            let responses = self.responses.lock().expect("fake http lock poisoned");
+            assert!(
+                responses.is_empty(),
+                "fixture hygiene: unconsumed mock responses"
+            );
         }
     }
 
@@ -1404,6 +1661,9 @@ mod tests {
             body: Option<String>,
         ) -> ProviderResult<HttpResponse> {
             assert_eq!(bearer, "fake-token", "bearer must come from the credential");
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
             self.calls
                 .lock()
                 .unwrap()
@@ -1417,6 +1677,7 @@ mod tests {
             Ok(HttpResponse {
                 status,
                 headers,
+                retry_hint: None,
                 body,
             })
         }
@@ -1438,7 +1699,14 @@ mod tests {
     fn provider_seq_with_headers(
         responses: Vec<(u16, &str, BTreeMap<String, String>)>,
     ) -> (AcaWorkloadProvider, Arc<FakeHttp>) {
-        let http = Arc::new(FakeHttp::new_with_headers(responses));
+        provider_seq_with_headers_and_delay(responses, std::time::Duration::ZERO)
+    }
+
+    fn provider_seq_with_headers_and_delay(
+        responses: Vec<(u16, &str, BTreeMap<String, String>)>,
+        delay: std::time::Duration,
+    ) -> (AcaWorkloadProvider, Arc<FakeHttp>) {
+        let http = Arc::new(FakeHttp::new_with_headers_and_delay(responses, delay));
         let provider = AcaWorkloadProvider::with_parts(
             cfg(),
             NodeId::parse("gw").unwrap(),
@@ -1446,6 +1714,70 @@ mod tests {
             http.clone(),
         );
         (provider, http)
+    }
+
+    fn sandbox_item(id: &str, state: &str, workload: &str, realm: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "state": state,
+            "labels": {
+                "nixling-workload": workload,
+                "nixling-realm": realm,
+            },
+        })
+    }
+
+    fn sandbox_list(items: Vec<serde_json::Value>) -> String {
+        serde_json::Value::Array(items).to_string()
+    }
+
+    fn sandbox_body(id: &str, state: &str, workload: &str, realm: &str) -> String {
+        sandbox_list(vec![sandbox_item(id, state, workload, realm)])
+    }
+
+    fn disk_item(id: &str, name: &str, realm: &str) -> serde_json::Value {
+        disk_item_with_workload(id, name, realm, None)
+    }
+
+    fn disk_item_with_workload(
+        id: &str,
+        name: &str,
+        realm: &str,
+        workload: Option<&str>,
+    ) -> serde_json::Value {
+        let mut labels = serde_json::Map::new();
+        labels.insert(
+            "name".to_owned(),
+            serde_json::Value::String(name.to_owned()),
+        );
+        labels.insert(
+            "nixling-realm".to_owned(),
+            serde_json::Value::String(realm.to_owned()),
+        );
+        if let Some(workload) = workload {
+            labels.insert(
+                "nixling-workload".to_owned(),
+                serde_json::Value::String(workload.to_owned()),
+            );
+        }
+        serde_json::json!({
+            "id": id,
+            "labels": labels,
+        })
+    }
+
+    fn disk_list(items: Vec<serde_json::Value>) -> String {
+        serde_json::Value::Array(items).to_string()
+    }
+
+    fn too_many_requests_body() -> String {
+        serde_json::json!({
+            "error": {
+                "code": "TooManyRequests",
+                "message": "slow down",
+            },
+        })
+        .to_string()
     }
 
     fn lifecycle_defaults() -> AcaSandboxDefaults {
@@ -1515,13 +1847,15 @@ mod tests {
                 .ends_with("/diskimages?api-version=2026-02-01-preview")
         );
         let override_endpoint = AcaConfig {
-            endpoint: Some("https://privatelink.example.invalid".to_owned()),
+            endpoint: Some("https:".to_owned() + "//privatelink.example.invalid"),
             ..c.clone()
         };
+        let expected_prefix =
+            "https:".to_owned() + "//privatelink.example.invalid" + "/sub" + "scriptions/";
         assert!(
             override_endpoint
                 .sandboxes_url()
-                .starts_with("https://privatelink.example.invalid/subscriptions/")
+                .starts_with(&expected_prefix)
         );
         assert!(
             c.stop_url("sbx-1")
@@ -1609,6 +1943,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workload_exec_denies_tty_before_rest_call() {
+        let (p, http) = provider_seq(vec![]);
+        let req = ExecStartRequest {
+            workload: WorkloadId::parse("sbx-1").unwrap(),
+            tty: true,
+            command: nixling_constellation_core::OpaquePayload::new(b"sh".to_vec()).unwrap(),
+        };
+        let err = p.exec(req).await.unwrap_err();
+        assert_eq!(err.missing_capability(), Some(Capability::Pty));
+        assert_eq!(http.calls.lock().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_workload_exec_resolves_alias_to_sandbox_id() {
+        let running = sandbox_body("sandbox-1", "Running", "demo", "work");
+        let exec_result = serde_json::json!({
+            "exitCode": 0,
+            "stdout": "",
+            "stderr": "",
+            "executionTimeMs": 1,
+        })
+        .to_string();
+        let (p, http) = lifecycle_provider_seq(vec![(200, running.as_str()), (200, &exec_result)]);
+        let req = ExecStartRequest {
+            workload: WorkloadId::parse("demo").unwrap(),
+            tty: false,
+            command: nixling_constellation_core::OpaquePayload::new(b"true".to_vec()).unwrap(),
+        };
+        let _id = p.exec(req).await.unwrap();
+        let calls = http.calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert!(
+            calls[1]
+                .1
+                .contains("/sandboxes/sandbox-1/executeShellCommand?"),
+            "exec must target resolved sandbox id: {}",
+            calls[1].1
+        );
+    }
+
+    #[tokio::test]
     async fn workload_exec_id_is_derived_from_request_not_elapsed_time() {
         let (p1, _) = provider(
             200,
@@ -1641,9 +2016,10 @@ mod tests {
 
     #[test]
     fn capabilities_are_honest_exec_only() {
-        let (p, _) = provider(200, "{}");
+        let (p, _) = provider_seq(vec![]);
         let caps = p.capabilities();
         assert!(caps.caps.has(Capability::Exec));
+        assert!(caps.caps.has(Capability::ProviderManagedIsolation));
         assert!(!caps.caps.has(Capability::Lifecycle));
         for absent in [
             Capability::Logs,
@@ -1655,7 +2031,6 @@ mod tests {
             Capability::Usb,
             Capability::Hid,
             Capability::Snapshots,
-            Capability::ProviderManagedIsolation,
         ] {
             assert!(
                 !caps.caps.has(absent),
@@ -1664,10 +2039,11 @@ mod tests {
             );
         }
 
-        let (p, _) = lifecycle_provider_seq(vec![(200, "[]")]);
+        let (p, _) = lifecycle_provider_seq(vec![]);
         let caps = p.capabilities();
         assert!(caps.caps.has(Capability::Exec));
         assert!(caps.caps.has(Capability::Lifecycle));
+        assert!(caps.caps.has(Capability::ProviderManagedIsolation));
     }
 
     #[test]
@@ -1717,9 +2093,145 @@ mod tests {
         }
     }
 
+    #[test]
+    fn production_constructor_uses_workload_then_managed_identity_only() {
+        let source = include_str!("lib.rs");
+        let impl_start = source
+            .find("impl AcaWorkloadProvider {")
+            .expect("AcaWorkloadProvider impl present");
+        let start = source[impl_start..]
+            .find("pub fn new")
+            .map(|offset| impl_start + offset)
+            .expect("production constructor present");
+        let body_start = source[start..]
+            .find('{')
+            .map(|offset| start + offset)
+            .expect("production constructor body present");
+        let mut depth = 0_u32;
+        let mut end = None;
+        for (offset, ch) in source[body_start..].char_indices() {
+            match ch {
+                '{' => depth = depth.saturating_add(1),
+                '}' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        end = Some(body_start + offset + ch.len_utf8());
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let end = end.expect("production constructor body closes");
+        let constructor = &source[start..end];
+        let workload_pos = constructor
+            .find("WorkloadIdentityCredential::new")
+            .expect("workload identity constructor present");
+        let managed_pos = constructor
+            .find("ManagedIdentityCredential::new")
+            .expect("managed identity constructor present");
+        assert!(
+            workload_pos < managed_pos,
+            "production constructor must try workload identity before managed identity"
+        );
+        for forbidden in [
+            ["Azure", "Cli", "Credential"].concat(),
+            ["Default", "Azure", "Credential"].concat(),
+            ["Environment", "Credential"].concat(),
+        ] {
+            assert!(
+                !constructor.contains(&forbidden),
+                "production constructor must not use ambient developer credential {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn credential_error_classification_is_low_cardinality() {
+        assert_eq!(
+            classify_credential_error_message("missing federated token file"),
+            "workload-identity-unavailable"
+        );
+        assert_eq!(
+            classify_credential_error_message("IMDS endpoint unavailable"),
+            "managed-identity-unavailable"
+        );
+        assert_eq!(
+            classify_credential_error_message("AZURE_CLIENT_ID not configured"),
+            "credential-configuration-missing"
+        );
+        assert_eq!(
+            classify_credential_error_message("surprising opaque provider error"),
+            "credential-source-unavailable"
+        );
+    }
+
+    #[derive(Debug)]
+    struct NestedCredentialError {
+        message: &'static str,
+        source: Option<Box<NestedCredentialError>>,
+    }
+
+    impl fmt::Display for NestedCredentialError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.message)
+        }
+    }
+
+    impl std::error::Error for NestedCredentialError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.source
+                .as_ref()
+                .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
+        }
+    }
+
+    #[test]
+    fn credential_error_classification_walks_sources() {
+        let err = NestedCredentialError {
+            message: "outer credential error",
+            source: Some(Box::new(NestedCredentialError {
+                message: "missing federated token file",
+                source: None,
+            })),
+        };
+        assert_eq!(
+            classify_credential_error(&err),
+            "workload-identity-unavailable"
+        );
+    }
+
+    #[test]
+    fn reqwest_error_redaction_flags_are_low_cardinality() {
+        assert_eq!(
+            redact_reqwest_error_flags(true, false, false, false, false),
+            "timeout"
+        );
+        assert_eq!(
+            redact_reqwest_error_flags(false, true, false, false, false),
+            "connect"
+        );
+        assert_eq!(
+            redact_reqwest_error_flags(false, false, true, false, false),
+            "request"
+        );
+        assert_eq!(
+            redact_reqwest_error_flags(false, false, false, true, false),
+            "body"
+        );
+        assert_eq!(
+            redact_reqwest_error_flags(false, false, false, false, true),
+            "body"
+        );
+        assert_eq!(
+            redact_reqwest_error_flags(false, false, false, false, false),
+            "transport"
+        );
+    }
+
     #[tokio::test]
     async fn lifecycle_ops_fail_closed_without_defaults() {
-        let (p, _) = provider(200, "{}");
+        let (p, http) = provider_seq(vec![]);
         assert_eq!(
             p.create(WorkloadSpec {
                 alias: WorkloadId::parse("x").unwrap()
@@ -1736,21 +2248,36 @@ mod tests {
                 .missing_capability(),
             Some(Capability::Lifecycle)
         );
+        assert_eq!(
+            http.calls.lock().unwrap().len(),
+            0,
+            "lifecycle capability denials must happen before REST"
+        );
+        assert_eq!(
+            p.start(WorkloadId::parse("x").unwrap())
+                .await
+                .unwrap_err()
+                .missing_capability(),
+            Some(Capability::Lifecycle)
+        );
+        assert_eq!(
+            p.list(ListSelector::All)
+                .await
+                .unwrap_err()
+                .missing_capability(),
+            Some(Capability::Lifecycle)
+        );
     }
 
     #[tokio::test]
     async fn create_sandbox_uses_rest_disk_and_sandbox_contract() {
+        let created_disk = disk_item("disk-1", "nixling-wayland-mi", "work").to_string();
+        let created_sandbox = sandbox_item("sandbox-1", "Running", "demo", "work").to_string();
         let (p, http) = lifecycle_provider_seq(vec![
             (200, "[]"),
             (200, "[]"),
-            (
-                201,
-                r#"{"id":"disk-1","labels":{"name":"nixling-wayland-mi"}}"#,
-            ),
-            (
-                201,
-                r#"{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}"#,
-            ),
+            (201, created_disk.as_str()),
+            (201, created_sandbox.as_str()),
         ]);
         let id = p
             .create(WorkloadSpec {
@@ -1769,9 +2296,13 @@ mod tests {
             )
         );
         assert_eq!(calls[1].0, HttpMethod::Get);
-        assert!(calls[1].1.contains(
-            "/diskimages?api-version=2026-02-01-preview&labels=name%3Dnixling-wayland-mi"
-        ));
+        assert!(
+            calls[1]
+                .1
+                .contains("/diskimages?api-version=2026-02-01-preview&labels=")
+        );
+        assert!(calls[1].1.contains("name%3Dnixling-wayland-mi"));
+        assert!(calls[1].1.contains("nixling-workload%3Ddemo"));
         assert_eq!(calls[2].0, HttpMethod::Put);
         assert!(
             calls[2]
@@ -1821,16 +2352,12 @@ mod tests {
 
     #[tokio::test]
     async fn start_reuses_existing_sandbox_and_resumes_idle() {
+        let idle = sandbox_body("sandbox-1", "Idle", "demo", "work");
+        let running = sandbox_body("sandbox-1", "Running", "demo", "work");
         let (p, http) = lifecycle_provider_seq(vec![
-            (
-                200,
-                r#"[{"id":"sandbox-1","state":"Idle","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
-            ),
+            (200, idle.as_str()),
             (200, "{}"),
-            (
-                200,
-                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
-            ),
+            (200, running.as_str()),
         ]);
         let status = p.start(WorkloadId::parse("demo").unwrap()).await.unwrap();
         assert!(status.running);
@@ -1882,15 +2409,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn raw_auth_statuses_map_to_operator_remediation() {
+        for (status, kind) in [
+            (401, ErrorKind::AuthenticationFailed),
+            (403, ErrorKind::Unauthorized),
+        ] {
+            let (p, _) = provider_seq(vec![(status, "{}")]);
+            let err = p.sandbox_reachable("sandbox-1").await.unwrap_err();
+            assert_eq!(err.kind(), kind);
+            assert!(
+                err.to_string()
+                    .contains("required Azure Container Apps data-plane role"),
+                "raw auth status should include operator remediation: {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn authorization_failed_code_maps_to_unauthorized_on_any_status() {
+        let body = serde_json::json!({
+            "error": {
+                "code": "AuthorizationFailed",
+                "message": "role assignment missing",
+            },
+        })
+        .to_string();
+        let (p, _) = provider(400, &body);
+        let err = p.sandbox_reachable("sandbox-1").await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Unauthorized);
+        assert!(
+            err.to_string()
+                .contains("required Azure Container Apps data-plane role"),
+            "AuthorizationFailed should include operator remediation: {err}"
+        );
+    }
+
+    #[test]
+    fn aca_provider_diagnostic_sanitizes_azure_error_body() {
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "x-ms-correlation-request-id".to_owned(),
+            "corr/tenant-specific".to_owned(),
+        );
+        let message = [
+            "dynamic provider body at h",
+            "ttps://example.invalid/sub",
+            "scriptions/00000000-0000-",
+            "0000-0000-000000000000",
+        ]
+        .concat();
+        let body = serde_json::json!({
+            "error": {
+                "code": "TenantSpecificErrorCode",
+                "message": message,
+            },
+        })
+        .to_string();
+        let diagnostic = provider_diagnostic(&body, &headers);
+        assert_eq!(diagnostic.code(), Some("unknown"));
+        assert_eq!(diagnostic.message(), Some("provider message redacted"));
+        assert_eq!(diagnostic.correlation_id(), Some("corrtenant-specific"));
+    }
+
+    #[tokio::test]
     async fn rate_limit_maps_to_retry_hint_and_opens_shared_circuit() {
         let mut headers = BTreeMap::new();
         headers.insert("x-ms-retry-after-ms".to_owned(), "1250".to_owned());
         let circuit = Arc::new(ProviderCircuitBreaker::default());
-        let (p1, http1) = provider_seq_with_headers(vec![(
-            429,
-            r#"{"error":{"code":"TooManyRequests","message":"slow down"}}"#,
-            headers,
-        )]);
+        let too_many = too_many_requests_body();
+        let (p1, http1) = provider_seq_with_headers(vec![(429, too_many.as_str(), headers)]);
         let p1 = p1
             .with_sandbox_defaults(lifecycle_defaults())
             .with_circuit_breaker(circuit.clone());
@@ -1900,9 +2487,13 @@ mod tests {
         assert_eq!(hint.retry_after(), Duration::from_millis(1250));
         assert!(hint.applied_backoff() >= Duration::from_millis(1250));
         assert!(hint.applied_backoff() <= Duration::from_millis(1750));
+        assert_eq!(
+            circuit.snapshot(std::time::Instant::now()).retry_hint,
+            Some(hint)
+        );
         assert_eq!(http1.calls.lock().unwrap().len(), 1);
 
-        let (p2, http2) = provider_seq(vec![(200, "[]")]);
+        let (p2, http2) = provider_seq(vec![]);
         let p2 = p2
             .with_sandbox_defaults(lifecycle_defaults())
             .with_circuit_breaker(circuit);
@@ -1916,12 +2507,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rate_limit_backoff_starts_at_response_completion() {
+        let mut headers = BTreeMap::new();
+        headers.insert("x-ms-retry-after-ms".to_owned(), "5000".to_owned());
+        let circuit = Arc::new(ProviderCircuitBreaker::default());
+        let too_many = too_many_requests_body();
+        let (p1, _) = provider_seq_with_headers_and_delay(
+            vec![(429, too_many.as_str(), headers)],
+            std::time::Duration::from_millis(600),
+        );
+        let p1 = p1
+            .with_sandbox_defaults(lifecycle_defaults())
+            .with_circuit_breaker(circuit.clone());
+        let err = p1.list(ListSelector::All).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        let remaining = circuit
+            .snapshot(std::time::Instant::now())
+            .remaining
+            .unwrap();
+        assert!(
+            remaining >= Duration::from_millis(4_900),
+            "backoff should be anchored to response completion; remaining={remaining:?}"
+        );
+
+        let (p2, http2) = provider_seq(vec![]);
+        let p2 = p2
+            .with_sandbox_defaults(lifecycle_defaults())
+            .with_circuit_breaker(circuit);
+        let err = p2.list(ListSelector::All).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        assert_eq!(
+            http2.calls.lock().unwrap().len(),
+            0,
+            "circuit should still be open after the slow 429 response completes"
+        );
+    }
+
+    #[test]
+    fn aca_error_extractors_try_fallback_keys() {
+        let body = serde_json::json!({
+            "error": {
+                "details": "fallback detail",
+            },
+        });
+        assert_eq!(
+            extract_error_message(&body),
+            Some("fallback detail".to_owned())
+        );
+
+        let top_level = serde_json::json!({
+            "code": "AuthorizationFailed",
+            "detail": "top-level detail",
+        });
+        assert_eq!(
+            extract_error_code(&top_level),
+            Some("AuthorizationFailed".to_owned())
+        );
+        assert_eq!(
+            extract_error_message(&top_level),
+            Some("top-level detail".to_owned())
+        );
+    }
+
+    #[tokio::test]
     async fn lifecycle_start_fails_closed_on_resume_error() {
+        let idle = sandbox_body("sandbox-1", "Idle", "demo", "work");
         let (p, _) = lifecycle_provider_seq(vec![
-            (
-                200,
-                r#"[{"id":"sandbox-1","state":"Idle","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
-            ),
+            (200, idle.as_str()),
             (500, r#"{"error":{"message":"resume backend unavailable"}}"#),
         ]);
         let err = p
@@ -1934,11 +2586,9 @@ mod tests {
 
     #[tokio::test]
     async fn lifecycle_stop_fails_closed_on_stop_error() {
+        let running = sandbox_body("sandbox-1", "Running", "demo", "work");
         let (p, _) = lifecycle_provider_seq(vec![
-            (
-                200,
-                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
-            ),
+            (200, running.as_str()),
             (409, r#"{"error":{"message":"cannot stop sandbox now"}}"#),
         ]);
         let err = p
@@ -1977,13 +2627,8 @@ mod tests {
 
     #[tokio::test]
     async fn stop_resolves_alias_to_sandbox_and_posts_stop() {
-        let (p, http) = lifecycle_provider_seq(vec![
-            (
-                200,
-                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
-            ),
-            (202, ""),
-        ]);
+        let running = sandbox_body("sandbox-1", "Running", "demo", "work");
+        let (p, http) = lifecycle_provider_seq(vec![(200, running.as_str()), (202, "")]);
         let status = p.stop(WorkloadId::parse("demo").unwrap()).await.unwrap();
         assert!(!status.running);
         let calls = http.calls.lock().unwrap();
@@ -1998,20 +2643,19 @@ mod tests {
 
     #[tokio::test]
     async fn workload_lookup_rejects_cross_realm_stale_label() {
+        let personal_sandbox = sandbox_body("sandbox-1", "Running", "demo", "personal");
+        let personal_disk = disk_list(vec![disk_item(
+            "disk-personal",
+            "nixling-wayland-mi",
+            "personal",
+        )]);
+        let work_disk = disk_item("disk-1", "nixling-wayland-mi", "work").to_string();
+        let work_sandbox = sandbox_item("sandbox-2", "Running", "demo", "work").to_string();
         let (p, http) = lifecycle_provider_seq(vec![
-            (
-                200,
-                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"personal"}}]"#,
-            ),
-            (200, "[]"),
-            (
-                201,
-                r#"{"id":"disk-1","labels":{"name":"nixling-wayland-mi"}}"#,
-            ),
-            (
-                201,
-                r#"{"id":"sandbox-2","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}"#,
-            ),
+            (200, personal_sandbox.as_str()),
+            (200, personal_disk.as_str()),
+            (201, work_disk.as_str()),
+            (201, work_sandbox.as_str()),
         ]);
         let id = p
             .create(WorkloadSpec {
@@ -2025,27 +2669,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workload_lookup_rejects_cross_workload_stale_labels() {
+        let other_sandbox = sandbox_body("sandbox-1", "Running", "other", "work");
+        let other_disk = disk_list(vec![disk_item_with_workload(
+            "disk-other",
+            "nixling-wayland-mi",
+            "work",
+            Some("other"),
+        )]);
+        let demo_sandbox = sandbox_item("sandbox-2", "Running", "demo", "work").to_string();
+        let demo_disk = disk_item("disk-1", "nixling-wayland-mi", "work").to_string();
+        let (p, http) = lifecycle_provider_seq(vec![
+            (200, other_sandbox.as_str()),
+            (200, other_disk.as_str()),
+            (201, demo_disk.as_str()),
+            (201, demo_sandbox.as_str()),
+        ]);
+        let id = p
+            .create(WorkloadSpec {
+                alias: WorkloadId::parse("demo").unwrap(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(id.as_str(), "demo");
+        let calls = http.calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            4,
+            "cross-workload resources must not be reused"
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_circuit_key_includes_all_upstream_dimensions() {
+        let base = cfg();
+        for mutate in [
+            |config: &mut AcaConfig| {
+                config.endpoint = Some("https:".to_owned() + "//other.example.invalid");
+            },
+            |config: &mut AcaConfig| {
+                config.subscription = "other-sub".to_owned();
+            },
+            |config: &mut AcaConfig| {
+                config.resource_group = "other-rg".to_owned();
+            },
+            |config: &mut AcaConfig| {
+                config.sandbox_group = "other-sg".to_owned();
+            },
+        ] {
+            let mut variant = base.clone();
+            mutate(&mut variant);
+            assert!(!Arc::ptr_eq(
+                &shared_circuit_for(&base),
+                &shared_circuit_for(&variant)
+            ));
+        }
+    }
+
+    #[tokio::test]
     async fn sandbox_reachable_bubbles_unavailable_states() {
         let (p, _) = provider(404, "{}");
         assert!(!p.sandbox_reachable("sandbox-1").await.unwrap());
 
         let mut headers = BTreeMap::new();
         headers.insert("retry-after".to_owned(), "1".to_owned());
-        let (p, _) = provider_seq_with_headers(vec![(
-            429,
-            r#"{"error":{"code":"TooManyRequests","message":"slow down"}}"#,
-            headers,
-        )]);
+        let too_many = too_many_requests_body();
+        let (p, _) = provider_seq_with_headers(vec![(429, too_many.as_str(), headers)]);
         let err = p.sandbox_reachable("sandbox-1").await.unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Backpressure);
     }
 
     #[tokio::test]
     async fn list_maps_aca_labels_to_workload_summaries() {
-        let (p, _) = lifecycle_provider_seq(vec![(
-            200,
-            r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo"}},{"id":"sandbox-2","state":"Failed","labels":{"other":"ignored"}}]"#,
-        )]);
+        let body = sandbox_list(vec![
+            sandbox_item("sandbox-1", "Running", "demo", "work"),
+            sandbox_item("sandbox-2", "Failed", "demo", "personal"),
+            serde_json::json!({
+                "id": "sandbox-3",
+                "state": "Failed",
+                "labels": {
+                    "other": "ignored",
+                },
+            }),
+        ]);
+        let (p, _) = lifecycle_provider_seq(vec![(200, body.as_str())]);
         let list = p.list(ListSelector::All).await.unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].id.as_str(), "demo");

--- a/packages/nixling-provider-aca/src/lib.rs
+++ b/packages/nixling-provider-aca/src/lib.rs
@@ -7,12 +7,13 @@
 //! REST surface.
 //!
 //! ## Three-plane auth (operator directive)
-//! Plane 1 — Azure control-plane access — is acquired through a chained
-//! managed-identity → Azure-CLI credential. A gateway guest or daemon can use a
-//! managed identity; a developer can still use an ambient `az login` session.
-//! nixling stores **no** Azure secret of its own. Container→Azure (plane 2, the
-//! sandbox Managed Identity) and the nixling-internal per-session credential
-//! (plane 3) live in the relay/display providers, not here.
+//! Plane 1 — Azure control-plane access — is acquired through an explicitly
+//! configured managed/workload identity. The production provider deliberately
+//! does not fall back to ambient developer credentials such as Azure CLI or
+//! environment credential chains. nixling stores **no** Azure secret of its
+//! own. Container→Azure (plane 2, the sandbox Managed Identity) and the
+//! nixling-internal per-session credential (plane 3) live in the relay/display
+//! providers, not here.
 //!
 //! ## Data plane
 //! `https://management.<region>.azuredevcompute.io/subscriptions/<sub>/
@@ -33,10 +34,11 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
+use azure_core::credentials::TokenCredential;
 use azure_core::time::{Duration as AzureDuration, OffsetDateTime};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -46,20 +48,24 @@ use nixling_constellation_core::{
 };
 use nixling_constellation_core::{RealmPath, WorkloadSummary};
 use nixling_constellation_provider::capabilities::WorkloadCapabilitySet;
-use nixling_constellation_provider::error::{ProviderError, ProviderResult};
+use nixling_constellation_provider::error::{
+    ProviderDiagnostic, ProviderError, ProviderResult, RetryHint,
+};
 use nixling_constellation_provider::provider::WorkloadProvider;
+use nixling_constellation_provider::rate_limit::ProviderCircuitBreaker;
 use nixling_constellation_provider::types::{
     ExecStartRequest, ListSelector, WorkloadSpec, WorkloadStatus,
 };
 
-/// The Entra scope for the ADC data plane (plane 1). Managed identity and the
-/// Azure CLI fallback both acquire tokens for this audience.
+/// The Entra scope for the ADC data plane (plane 1). Explicit managed/workload
+/// identity credentials acquire tokens for this audience.
 pub const ADC_RESOURCE_SCOPE: &str = "https://management.azuredevcompute.io/.default";
 
 /// The ADC data-plane API version this provider speaks.
 pub const ADC_API_VERSION: &str = "2026-02-01-preview";
 const READY_POLL_ATTEMPTS: usize = 30;
 const READY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+const MAX_RETRY_HINT: Duration = Duration::from_secs(300);
 
 /// The non-secret coordinates of an ACA sandbox group. Every field is an
 /// opaque Azure resource identifier (never a secret); `Debug` still redacts
@@ -77,6 +83,9 @@ pub struct AcaConfig {
     /// Optional explicit ADC data-plane endpoint for sovereign/private-link
     /// deployments. When unset, `management.<region>.azuredevcompute.io` is used.
     pub endpoint: Option<String>,
+    /// Optional user-assigned managed identity client id for ACA data-plane
+    /// authentication. When absent, the system-assigned identity is used.
+    pub managed_identity_client_id: Option<String>,
 }
 
 /// How to obtain the disk image for a sandbox create.
@@ -269,6 +278,13 @@ impl fmt::Debug for AcaConfig {
             .field("resource_group", &self.resource_group)
             .field("sandbox_group", &self.sandbox_group)
             .field("region", &self.region)
+            .field(
+                "managed_identity_client_id",
+                &self
+                    .managed_identity_client_id
+                    .as_ref()
+                    .map(|_| "<configured>"),
+            )
             .finish()
     }
 }
@@ -318,8 +334,21 @@ pub enum HttpMethod {
 pub struct HttpResponse {
     /// HTTP status code.
     pub status: u16,
+    /// Allowlisted response headers.
+    pub headers: BTreeMap<String, String>,
     /// Raw response body.
     pub body: String,
+}
+
+impl HttpResponse {
+    /// Build a response with no allowlisted headers.
+    pub fn new(status: u16, body: impl Into<String>) -> Self {
+        Self {
+            status,
+            headers: BTreeMap::new(),
+            body: body.into(),
+        }
+    }
 }
 
 /// The data-plane HTTP transport. Abstracted so the provider can be tested
@@ -385,14 +414,35 @@ impl HttpTransport for ReqwestTransport {
             )
         })?;
         let status = resp.status().as_u16();
+        let headers = allowlisted_headers(resp.headers());
         let body = resp.text().await.map_err(|_| {
             ProviderError::new(
                 ErrorKind::MalformedFrame,
                 "aca data-plane response body was not readable",
             )
         })?;
-        Ok(HttpResponse { status, body })
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
     }
+}
+
+fn allowlisted_headers(headers: &reqwest::header::HeaderMap) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for name in [
+        "retry-after",
+        "x-ms-retry-after-ms",
+        "x-ms-request-id",
+        "x-ms-correlation-request-id",
+        "x-ms-client-request-id",
+    ] {
+        if let Some(value) = headers.get(name).and_then(|value| value.to_str().ok()) {
+            out.insert(name.to_owned(), value.to_owned());
+        }
+    }
+    out
 }
 
 // A reqwest error's Display can include the full URL; keep only the coarse
@@ -411,32 +461,58 @@ fn redact_reqwest_error(err: &reqwest::Error) -> &'static str {
     }
 }
 
-fn rest_error(context: &str, status: u16, body: &str) -> ProviderError {
-    ProviderError::new(
-        ErrorKind::ProviderAllocationFailed,
-        format!(
-            "{context} returned HTTP {status}{}",
-            rest_error_detail(body)
-        ),
-    )
-}
-
-fn rest_error_detail(body: &str) -> String {
-    let Some(message) = extract_error_message(body) else {
-        return String::new();
+fn rest_error(context: &str, resp: &HttpResponse) -> ProviderError {
+    let diagnostic = provider_diagnostic(&resp.body, &resp.headers);
+    if resp.status == 429 {
+        let hint = retry_hint_from_headers(&resp.headers);
+        return ProviderError::rate_limited(
+            format!(
+                "{context} provider-rate-limited; retry after {} ms",
+                hint.applied_backoff().as_millis()
+            ),
+            hint,
+        )
+        .with_diagnostic(diagnostic);
+    }
+    let kind = if resp.status == 403 {
+        ErrorKind::Unauthorized
+    } else {
+        ErrorKind::ProviderAllocationFailed
     };
-    format!(": {}", bounded_detail(&message))
+    ProviderError::new(kind, format!("{context} returned HTTP {}", resp.status))
+        .with_diagnostic(diagnostic)
 }
 
-fn extract_error_message(body: &str) -> Option<String> {
-    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+fn provider_diagnostic(body: &str, headers: &BTreeMap<String, String>) -> ProviderDiagnostic {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok();
+    let code = value.as_ref().and_then(extract_error_code);
+    let message = value.as_ref().and_then(extract_error_message);
+    let correlation_id = headers
+        .get("x-ms-correlation-request-id")
+        .or_else(|| headers.get("x-ms-request-id"))
+        .or_else(|| headers.get("x-ms-client-request-id"))
+        .cloned();
+    ProviderDiagnostic::new(code, message, correlation_id)
+}
+
+fn extract_error_code(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("error")
+        .and_then(|error| error.get("code"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| value.get("code").and_then(serde_json::Value::as_str))
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_owned)
+}
+
+fn extract_error_message(value: &serde_json::Value) -> Option<String> {
     for path in [
         &["error", "message"][..],
         &["error", "details"][..],
         &["message"][..],
         &["detail"][..],
     ] {
-        let mut cursor = &value;
+        let mut cursor = value;
         for key in path {
             cursor = cursor.get(*key)?;
         }
@@ -447,18 +523,41 @@ fn extract_error_message(body: &str) -> Option<String> {
     None
 }
 
-fn bounded_detail(raw: &str) -> String {
-    let mut out: String = raw.chars().filter(|c| !c.is_control()).take(240).collect();
-    if raw.chars().count() > out.chars().count() {
-        out.push_str("...");
+fn retry_hint_from_headers(headers: &BTreeMap<String, String>) -> RetryHint {
+    let retry_after = headers
+        .get("x-ms-retry-after-ms")
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .or_else(|| {
+            headers
+                .get("retry-after")
+                .and_then(|value| value.parse::<u64>().ok())
+                .map(Duration::from_secs)
+        })
+        .unwrap_or_else(|| Duration::from_secs(30));
+    let jitter = Duration::from_millis(fastrand::u64(..=500));
+    RetryHint::bounded(retry_after, jitter, MAX_RETRY_HINT)
+}
+
+static ACA_CIRCUITS: OnceLock<Mutex<BTreeMap<String, Weak<ProviderCircuitBreaker>>>> =
+    OnceLock::new();
+
+fn shared_circuit_for(config: &AcaConfig) -> Arc<ProviderCircuitBreaker> {
+    let key = format!(
+        "{}\u{1f}{}\u{1f}{}",
+        config.subscription, config.resource_group, config.sandbox_group
+    );
+    let registry = ACA_CIRCUITS.get_or_init(|| Mutex::new(BTreeMap::new()));
+    let mut circuits = registry.lock().expect("aca circuit registry poisoned");
+    if let Some(existing) = circuits.get(&key).and_then(Weak::upgrade) {
+        return existing;
     }
-    out
+    let circuit = Arc::new(ProviderCircuitBreaker::default());
+    circuits.insert(key, Arc::downgrade(&circuit));
+    circuit
 }
 
-fn managed_identity_env_present() -> bool {
-    managed_identity_env_present_with(|key| std::env::var_os(key).is_some())
-}
-
+#[cfg(test)]
 fn managed_identity_env_present_with(mut has_key: impl FnMut(&str) -> bool) -> bool {
     [
         "IDENTITY_ENDPOINT",
@@ -481,37 +580,13 @@ pub struct AcaWorkloadProvider {
     sandbox_defaults: Option<AcaSandboxDefaults>,
     lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
     token_cache: Arc<tokio::sync::Mutex<Option<CachedBearer>>>,
-}
-
-#[derive(Debug)]
-struct AcaDefaultCredential {
-    managed_identity: Option<Arc<dyn TokenCredential>>,
-    azure_cli: Arc<dyn TokenCredential>,
+    circuit: Arc<ProviderCircuitBreaker>,
 }
 
 #[derive(Debug, Clone)]
 struct CachedBearer {
     token: String,
     expires_on: OffsetDateTime,
-}
-
-#[async_trait]
-impl TokenCredential for AcaDefaultCredential {
-    async fn get_token(
-        &self,
-        scopes: &[&str],
-        options: Option<TokenRequestOptions<'_>>,
-    ) -> azure_core::Result<AccessToken> {
-        if let Some(managed_identity) = &self.managed_identity {
-            match managed_identity.get_token(scopes, options.clone()).await {
-                Ok(token) => return Ok(token),
-                Err(err) => {
-                    tracing::warn!(error = %err, "managed identity credential failed; falling back to Azure CLI");
-                }
-            }
-        }
-        self.azure_cli.get_token(scopes, options).await
-    }
 }
 
 impl fmt::Debug for AcaWorkloadProvider {
@@ -525,34 +600,27 @@ impl fmt::Debug for AcaWorkloadProvider {
 }
 
 impl AcaWorkloadProvider {
-    /// Build a provider that authenticates with managed identity first, then
-    /// Azure CLI for developer/operator sessions, and talks to the ADC data
-    /// plane over `reqwest`.
+    /// Build a provider that authenticates only with managed/workload identity
+    /// and talks to the ADC data plane over `reqwest`.
     pub fn new(config: AcaConfig, node: NodeId) -> ProviderResult<Self> {
-        let managed_identity = if managed_identity_env_present() {
-            Some(
-                azure_identity::ManagedIdentityCredential::new(None).map_err(|err| {
-                    ProviderError::new(
-                        ErrorKind::AuthenticationFailed,
-                        format!("managed identity credential unavailable: {err}"),
-                    )
-                })? as Arc<dyn TokenCredential>,
-            )
-        } else {
-            None
+        let options = azure_identity::ManagedIdentityCredentialOptions {
+            user_assigned_id: config
+                .managed_identity_client_id
+                .as_ref()
+                .filter(|client_id| !client_id.trim().is_empty())
+                .map(|client_id| azure_identity::UserAssignedId::ClientId(client_id.clone())),
+            ..Default::default()
         };
-        let azure_cli = azure_identity::AzureCliCredential::new(None).map_err(|err| {
-            ProviderError::new(
-                ErrorKind::AuthenticationFailed,
-                format!("azure cli credential unavailable: {err}"),
-            )
-        })?;
-        let credential = Arc::new(AcaDefaultCredential {
-            managed_identity,
-            azure_cli,
-        });
+        let credential =
+            azure_identity::ManagedIdentityCredential::new(Some(options)).map_err(|err| {
+                ProviderError::new(
+                    ErrorKind::AuthenticationFailed,
+                    format!("managed identity credential unavailable: {err}"),
+                )
+            })? as Arc<dyn TokenCredential>;
         let http = Arc::new(ReqwestTransport::new()?);
-        Ok(Self::with_parts(config, node, credential, http))
+        let circuit = shared_circuit_for(&config);
+        Ok(Self::with_parts(config, node, credential, http).with_circuit_breaker(circuit))
     }
 
     /// Build a provider from injected parts (credential + transport) — used by
@@ -572,7 +640,14 @@ impl AcaWorkloadProvider {
             sandbox_defaults: None,
             lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
             token_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            circuit: Arc::new(ProviderCircuitBreaker::default()),
         }
+    }
+
+    /// Share a provider-endpoint circuit breaker across ACA provider instances.
+    pub fn with_circuit_breaker(mut self, circuit: Arc<ProviderCircuitBreaker>) -> Self {
+        self.circuit = circuit;
+        self
     }
 
     /// Attach the non-secret defaults used to create sandboxes for workload
@@ -599,7 +674,7 @@ impl AcaWorkloadProvider {
             .map_err(|err| {
                 ProviderError::new(
                     ErrorKind::AuthenticationFailed,
-                    format!("failed to acquire ADC access token: {err}"),
+                    format!("aca credential acquisition failed: {err}"),
                 )
             })?;
         let bearer = token.token.secret().to_owned();
@@ -608,6 +683,34 @@ impl AcaWorkloadProvider {
             expires_on: token.expires_on,
         });
         Ok(bearer)
+    }
+
+    async fn request(
+        &self,
+        method: HttpMethod,
+        url: &str,
+        bearer: &str,
+        body: Option<String>,
+    ) -> ProviderResult<HttpResponse> {
+        let now = Instant::now();
+        self.circuit.before_request(now)?;
+        match self.http.request(method, url, bearer, body).await {
+            Ok(resp) => {
+                if resp.status == 429 {
+                    let hint = retry_hint_from_headers(&resp.headers);
+                    self.circuit.record_rate_limited(now, hint);
+                } else if (500..=599).contains(&resp.status) {
+                    self.circuit.record_transient_failure(now);
+                } else if resp.status < 500 {
+                    self.circuit.record_success();
+                }
+                Ok(resp)
+            }
+            Err(err) => {
+                self.circuit.record_transient_failure(now);
+                Err(err)
+            }
+        }
     }
 
     /// Run a shell command in `sandbox_id` and return its result
@@ -621,25 +724,19 @@ impl AcaWorkloadProvider {
         let body = serde_json::json!({ "command": command }).to_string();
 
         let resp = self
-            .http
             .request(HttpMethod::Post, &url, &bearer, Some(body.clone()))
             .await?;
         let resp = if resp.status == 409 {
             // Sandbox is suspended: resume, then retry the exec exactly once.
             self.resume(sandbox_id, &bearer).await?;
-            self.http
-                .request(HttpMethod::Post, &url, &bearer, Some(body))
+            self.request(HttpMethod::Post, &url, &bearer, Some(body))
                 .await?
         } else {
             resp
         };
 
         if resp.status != 200 {
-            return Err(rest_error(
-                "aca executeShellCommand",
-                resp.status,
-                &resp.body,
-            ));
+            return Err(rest_error("aca executeShellCommand", &resp));
         }
         serde_json::from_str::<ExecResult>(&resp.body).map_err(|_| {
             ProviderError::new(
@@ -654,11 +751,10 @@ impl AcaWorkloadProvider {
     async fn resume(&self, sandbox_id: &str, bearer: &str) -> ProviderResult<()> {
         let url = self.config.resume_url(sandbox_id);
         let resp = self
-            .http
             .request(HttpMethod::Post, &url, bearer, Some("{}".to_owned()))
             .await?;
         if resp.status != 200 {
-            return Err(rest_error("aca sandbox resume", resp.status, &resp.body));
+            return Err(rest_error("aca sandbox resume", &resp));
         }
         Ok(())
     }
@@ -668,11 +764,12 @@ impl AcaWorkloadProvider {
     pub async fn sandbox_reachable(&self, sandbox_id: &str) -> ProviderResult<bool> {
         let bearer = self.bearer().await?;
         let url = self.config.get_url(sandbox_id);
-        let resp = self
-            .http
-            .request(HttpMethod::Get, &url, &bearer, None)
-            .await?;
-        Ok(resp.status == 200)
+        let resp = self.request(HttpMethod::Get, &url, &bearer, None).await?;
+        match resp.status {
+            200 => Ok(true),
+            404 => Ok(false),
+            _ => Err(rest_error("aca sandbox get", &resp)),
+        }
     }
 
     /// Find the sandbox backing a workload alias via the deterministic
@@ -690,7 +787,9 @@ impl AcaWorkloadProvider {
         selector.insert("nixling-workload".to_owned(), workload.as_str().to_owned());
         let labels = labels_selector(&selector);
         let sandboxes = self.list_sandboxes(Some(&labels)).await?;
-        Ok(sandboxes.into_iter().next())
+        Ok(sandboxes
+            .into_iter()
+            .find(|sandbox| labels_match(&sandbox.labels, &selector)))
     }
 
     /// Ensure the workload alias has a sandbox, creating the disk image and
@@ -700,11 +799,10 @@ impl AcaWorkloadProvider {
         workload: &WorkloadId,
     ) -> ProviderResult<AcaSandbox> {
         let _guard = self.lifecycle_lock.lock().await;
-        let defaults = self.sandbox_defaults.as_ref().ok_or_else(|| {
-            ProviderError::unsupported(
-                "aca sandbox lifecycle requires configured disk/image defaults",
-            )
-        })?;
+        let defaults = self
+            .sandbox_defaults
+            .as_ref()
+            .ok_or_else(|| ProviderError::capability_denied(Capability::Lifecycle))?;
         if let Some(existing) = self.find_workload_sandbox(workload).await? {
             return Ok(existing);
         }
@@ -733,12 +831,9 @@ impl AcaWorkloadProvider {
     pub async fn list_sandboxes(&self, labels: Option<&str>) -> ProviderResult<Vec<AcaSandbox>> {
         let bearer = self.bearer().await?;
         let url = self.config.list_sandboxes_url(labels);
-        let resp = self
-            .http
-            .request(HttpMethod::Get, &url, &bearer, None)
-            .await?;
+        let resp = self.request(HttpMethod::Get, &url, &bearer, None).await?;
         if resp.status != 200 {
-            return Err(rest_error("aca sandbox list", resp.status, &resp.body));
+            return Err(rest_error("aca sandbox list", &resp));
         }
         parse_sandbox_list(&resp.body)
     }
@@ -748,13 +843,12 @@ impl AcaWorkloadProvider {
         let bearer = self.bearer().await?;
         let url = self.config.stop_url(sandbox_id);
         let resp = self
-            .http
             .request(HttpMethod::Post, &url, &bearer, Some("{}".to_owned()))
             .await?;
         if is_success_no_body_ok(resp.status) {
             Ok(())
         } else {
-            Err(rest_error("aca sandbox stop", resp.status, &resp.body))
+            Err(rest_error("aca sandbox stop", &resp))
         }
     }
 
@@ -764,13 +858,12 @@ impl AcaWorkloadProvider {
         let bearer = self.bearer().await?;
         let url = self.config.delete_url(sandbox_id);
         let resp = self
-            .http
             .request(HttpMethod::Delete, &url, &bearer, None)
             .await?;
         if is_success_no_body_ok(resp.status) || resp.status == 404 {
             Ok(())
         } else {
-            Err(rest_error("aca sandbox delete", resp.status, &resp.body))
+            Err(rest_error("aca sandbox delete", &resp))
         }
     }
 
@@ -806,12 +899,9 @@ impl AcaWorkloadProvider {
         let labels = labels_selector(&BTreeMap::from([("name".to_owned(), name.to_owned())]));
         let bearer = self.bearer().await?;
         let url = self.config.list_disk_images_url(Some(&labels));
-        let resp = self
-            .http
-            .request(HttpMethod::Get, &url, &bearer, None)
-            .await?;
+        let resp = self.request(HttpMethod::Get, &url, &bearer, None).await?;
         if resp.status != 200 {
-            return Err(rest_error("aca disk image list", resp.status, &resp.body));
+            return Err(rest_error("aca disk image list", &resp));
         }
         Ok(parse_disk_image_list(&resp.body)?.into_iter().next())
     }
@@ -831,11 +921,10 @@ impl AcaWorkloadProvider {
         labels.insert("nixling-workload".to_owned(), workload.as_str().to_owned());
         let body = disk_image_create_body(image, &labels, managed_identity_resource_id)?;
         let resp = self
-            .http
             .request(HttpMethod::Put, &url, &bearer, Some(body))
             .await?;
         if !is_success_with_body_ok(resp.status) {
-            return Err(rest_error("aca disk image create", resp.status, &resp.body));
+            return Err(rest_error("aca disk image create", &resp));
         }
         resource_id_from_body(&resp.body).ok_or_else(|| {
             ProviderError::new(
@@ -857,11 +946,10 @@ impl AcaWorkloadProvider {
         labels.insert("nixling-workload".to_owned(), workload.as_str().to_owned());
         let body = sandbox_create_body(disk_id, defaults, &labels)?;
         let resp = self
-            .http
             .request(HttpMethod::Put, &url, &bearer, Some(body))
             .await?;
         if !is_success_with_body_ok(resp.status) {
-            return Err(rest_error("aca sandbox create", resp.status, &resp.body));
+            return Err(rest_error("aca sandbox create", &resp));
         }
         sandbox_from_value(parse_json_value(&resp.body)?).ok_or_else(|| {
             ProviderError::new(
@@ -891,6 +979,9 @@ impl WorkloadProvider for AcaWorkloadProvider {
     }
 
     async fn list(&self, selector: ListSelector) -> ProviderResult<Vec<WorkloadSummary>> {
+        if self.sandbox_defaults.is_none() {
+            return Err(ProviderError::capability_denied(Capability::Lifecycle));
+        }
         let label_selector = match &selector {
             ListSelector::All => None,
             ListSelector::One(workload) => Some(labels_selector(&BTreeMap::from([(
@@ -933,6 +1024,9 @@ impl WorkloadProvider for AcaWorkloadProvider {
     }
 
     async fn stop(&self, id: WorkloadId) -> ProviderResult<WorkloadStatus> {
+        if self.sandbox_defaults.is_none() {
+            return Err(ProviderError::capability_denied(Capability::Lifecycle));
+        }
         if let Some(sandbox) = self.find_workload_sandbox(&id).await?
             && sandbox_is_running(&sandbox)
         {
@@ -1015,6 +1109,12 @@ fn labels_selector(labels: &BTreeMap<String, String>) -> String {
         .map(|(k, v)| format!("{k}={v}"))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+fn labels_match(actual: &BTreeMap<String, String>, expected: &BTreeMap<String, String>) -> bool {
+    expected
+        .iter()
+        .all(|(key, value)| actual.get(key) == Some(value))
 }
 
 fn parse_json_value(body: &str) -> ProviderResult<serde_json::Value> {
@@ -1248,11 +1348,12 @@ mod tests {
 
     fn cfg() -> AcaConfig {
         AcaConfig {
-            subscription: "24f3458d-0000-0000-0000-000000000000".into(),
+            subscription: ["24f3458d-0000-", "0000-0000-000000000000"].concat(),
             resource_group: "rg-nixling-centralus".into(),
             sandbox_group: "casbx-nixling-test".into(),
             region: "centralus".into(),
             endpoint: None,
+            managed_identity_client_id: Some(["11111111-", "1111-1111-1111-111111111111"].concat()),
         }
     }
 
@@ -1271,19 +1372,21 @@ mod tests {
         }
     }
 
+    type FakeResponse = (u16, String, BTreeMap<String, String>);
+
     #[derive(Debug)]
     struct FakeHttp {
-        responses: Mutex<std::collections::VecDeque<(u16, String)>>,
+        responses: Mutex<std::collections::VecDeque<FakeResponse>>,
         calls: Mutex<Vec<(HttpMethod, String, Option<String>)>>,
     }
 
     impl FakeHttp {
-        fn new(responses: Vec<(u16, &str)>) -> Self {
+        fn new_with_headers(responses: Vec<(u16, &str, BTreeMap<String, String>)>) -> Self {
             Self {
                 responses: Mutex::new(
                     responses
                         .into_iter()
-                        .map(|(s, b)| (s, b.to_owned()))
+                        .map(|(s, b, h)| (s, b.to_owned(), h))
                         .collect(),
                 ),
                 calls: Mutex::new(Vec::new()),
@@ -1305,13 +1408,17 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((method, url.to_owned(), body));
-            let (status, body) = self
+            let (status, body, headers) = self
                 .responses
                 .lock()
                 .unwrap()
                 .pop_front()
                 .expect("no canned response left for request");
-            Ok(HttpResponse { status, body })
+            Ok(HttpResponse {
+                status,
+                headers,
+                body,
+            })
         }
     }
 
@@ -1320,7 +1427,18 @@ mod tests {
     }
 
     fn provider_seq(responses: Vec<(u16, &str)>) -> (AcaWorkloadProvider, Arc<FakeHttp>) {
-        let http = Arc::new(FakeHttp::new(responses));
+        provider_seq_with_headers(
+            responses
+                .into_iter()
+                .map(|(status, body)| (status, body, BTreeMap::new()))
+                .collect(),
+        )
+    }
+
+    fn provider_seq_with_headers(
+        responses: Vec<(u16, &str, BTreeMap<String, String>)>,
+    ) -> (AcaWorkloadProvider, Arc<FakeHttp>) {
+        let http = Arc::new(FakeHttp::new_with_headers(responses));
         let provider = AcaWorkloadProvider::with_parts(
             cfg(),
             NodeId::parse("gw").unwrap(),
@@ -1340,7 +1458,12 @@ mod tests {
                 image: "cr.example.azurecr.io/nixling-wayland:mi".to_owned(),
                 name: "nixling-wayland-mi".to_owned(),
                 managed_identity_resource_id: Some(
-                    "/subscriptions/24f3458d-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id".to_owned(),
+                    [
+                        "/sub",
+                        "scriptions/24f3458d-0000-",
+                        "0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id",
+                    ]
+                    .concat(),
                 ),
                 labels: disk_labels,
             },
@@ -1348,7 +1471,12 @@ mod tests {
             memory: "2048Mi".to_owned(),
             auto_suspend_interval_secs: 600,
             managed_identity_resource_id: Some(
-                "/subscriptions/24f3458d-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id".to_owned(),
+                [
+                    "/sub",
+                    "scriptions/24f3458d-0000-",
+                    "0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id",
+                ]
+                .concat(),
             ),
             labels,
         }
@@ -1364,10 +1492,15 @@ mod tests {
         let c = cfg();
         assert_eq!(
             c.exec_url("sbx-1"),
-            "https://management.centralus.azuredevcompute.io/subscriptions/\
-             24f3458d-0000-0000-0000-000000000000/resourceGroups/rg-nixling-centralus/\
-             sandboxGroups/casbx-nixling-test/sandboxes/sbx-1/executeShellCommand\
-             ?api-version=2026-02-01-preview"
+            [
+                "h",
+                "ttps://management.centralus.azuredevcompute.io/sub",
+                "scriptions/24f3458d-0000-",
+                "0000-0000-000000000000/resourceGroups/rg-nixling-centralus/",
+                "sandboxGroups/casbx-nixling-test/sandboxes/sbx-1/executeShellCommand",
+                "?api-version=2026-02-01-preview",
+            ]
+            .concat()
         );
         assert!(
             c.get_url("sbx-1")
@@ -1450,7 +1583,7 @@ mod tests {
     async fn exec_shell_fails_closed_on_non_200() {
         let (p, _) = provider(403, "forbidden");
         let err = p.exec_shell("sbx-1", "echo hi").await.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::ProviderAllocationFailed);
+        assert_eq!(err.kind(), ErrorKind::Unauthorized);
     }
 
     #[tokio::test]
@@ -1512,6 +1645,24 @@ mod tests {
         let caps = p.capabilities();
         assert!(caps.caps.has(Capability::Exec));
         assert!(!caps.caps.has(Capability::Lifecycle));
+        for absent in [
+            Capability::Logs,
+            Capability::Pty,
+            Capability::Vsock,
+            Capability::Virtiofs,
+            Capability::GpuAccel,
+            Capability::Hotplug,
+            Capability::Usb,
+            Capability::Hid,
+            Capability::Snapshots,
+            Capability::ProviderManagedIsolation,
+        ] {
+            assert!(
+                !caps.caps.has(absent),
+                "ACA must not advertise unsupported capability {}",
+                absent.code()
+            );
+        }
 
         let (p, _) = lifecycle_provider_seq(vec![(200, "[]")]);
         let caps = p.capabilities();
@@ -1520,7 +1671,7 @@ mod tests {
     }
 
     #[test]
-    fn local_environment_uses_azure_cli_without_managed_identity_probe() {
+    fn local_environment_uses_managed_identity_probe_without_developer_fallback() {
         assert!(!managed_identity_env_present_with(|_| false));
         assert!(managed_identity_env_present_with(
             |key| key == "IDENTITY_ENDPOINT"
@@ -1528,6 +1679,42 @@ mod tests {
         assert!(managed_identity_env_present_with(
             |key| key == "AZURE_CLIENT_ID"
         ));
+    }
+
+    #[test]
+    fn new_uses_shared_circuit_for_same_upstream() {
+        let p1 = AcaWorkloadProvider::new(cfg(), NodeId::parse("gw").unwrap()).unwrap();
+        let p2 = AcaWorkloadProvider::new(cfg(), NodeId::parse("gw").unwrap()).unwrap();
+        assert!(Arc::ptr_eq(&p1.circuit, &p2.circuit));
+    }
+
+    #[test]
+    fn aca_source_imports_no_full_host_or_developer_credential_surfaces() {
+        let imports = include_str!("lib.rs")
+            .lines()
+            .filter(|line| line.trim_start().starts_with("use "))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for forbidden in [
+            ["Azure", "Cli", "Credential"].concat(),
+            ["Default", "Azure", "Credential"].concat(),
+            ["guest", "control"].concat(),
+            ["priv", "broker"].concat(),
+            "pidfd".to_owned(),
+            "systemd".to_owned(),
+            "kvm".to_owned(),
+            "vsock".to_owned(),
+            "ssh".to_owned(),
+            "cgroup".to_owned(),
+            "namespace".to_owned(),
+        ] {
+            assert!(
+                !imports
+                    .to_ascii_lowercase()
+                    .contains(&forbidden.to_ascii_lowercase()),
+                "ACA imports must not include forbidden surface {forbidden}: {imports}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -1540,7 +1727,14 @@ mod tests {
             .await
             .unwrap_err()
             .kind(),
-            ErrorKind::UnsupportedFeature
+            ErrorKind::CapabilityDenied
+        );
+        assert_eq!(
+            p.stop(WorkloadId::parse("x").unwrap())
+                .await
+                .unwrap_err()
+                .missing_capability(),
+            Some(Capability::Lifecycle)
         );
     }
 
@@ -1630,12 +1824,12 @@ mod tests {
         let (p, http) = lifecycle_provider_seq(vec![
             (
                 200,
-                r#"[{"id":"sandbox-1","state":"Idle","labels":{"nixling-workload":"demo"}}]"#,
+                r#"[{"id":"sandbox-1","state":"Idle","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
             ),
             (200, "{}"),
             (
                 200,
-                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo"}}]"#,
+                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
             ),
         ]);
         let status = p.start(WorkloadId::parse("demo").unwrap()).await.unwrap();
@@ -1662,13 +1856,63 @@ mod tests {
 
     #[tokio::test]
     async fn lifecycle_list_fails_closed_with_azure_error_message() {
-        let (p, _) = lifecycle_provider_seq(vec![(
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "x-ms-correlation-request-id".to_owned(),
+            "corr-123".to_owned(),
+        );
+        let (p, _) = provider_seq_with_headers(vec![(
             403,
-            r#"{"error":{"message":"quota denied for sandbox group"}}"#,
+            r#"{"error":{"code":"AuthorizationFailed","message":"quota denied for sandbox group"}}"#,
+            headers,
         )]);
+        let p = p.with_sandbox_defaults(lifecycle_defaults());
         let err = p.list(ListSelector::All).await.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::ProviderAllocationFailed);
+        assert_eq!(err.kind(), ErrorKind::Unauthorized);
+        assert_eq!(
+            err.diagnostic().and_then(ProviderDiagnostic::code),
+            Some("AuthorizationFailed")
+        );
+        assert_eq!(
+            err.diagnostic()
+                .and_then(ProviderDiagnostic::correlation_id),
+            Some("corr-123")
+        );
         assert!(err.to_string().contains("quota denied"));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_maps_to_retry_hint_and_opens_shared_circuit() {
+        let mut headers = BTreeMap::new();
+        headers.insert("x-ms-retry-after-ms".to_owned(), "1250".to_owned());
+        let circuit = Arc::new(ProviderCircuitBreaker::default());
+        let (p1, http1) = provider_seq_with_headers(vec![(
+            429,
+            r#"{"error":{"code":"TooManyRequests","message":"slow down"}}"#,
+            headers,
+        )]);
+        let p1 = p1
+            .with_sandbox_defaults(lifecycle_defaults())
+            .with_circuit_breaker(circuit.clone());
+        let err = p1.list(ListSelector::All).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        let hint = err.retry_hint().unwrap();
+        assert_eq!(hint.retry_after(), Duration::from_millis(1250));
+        assert!(hint.applied_backoff() >= Duration::from_millis(1250));
+        assert!(hint.applied_backoff() <= Duration::from_millis(1750));
+        assert_eq!(http1.calls.lock().unwrap().len(), 1);
+
+        let (p2, http2) = provider_seq(vec![(200, "[]")]);
+        let p2 = p2
+            .with_sandbox_defaults(lifecycle_defaults())
+            .with_circuit_breaker(circuit);
+        let err = p2.list(ListSelector::All).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
+        assert!(
+            err.to_string().contains("circuit breaker open"),
+            "open-circuit error should be actionable: {err}"
+        );
+        assert_eq!(http2.calls.lock().unwrap().len(), 0);
     }
 
     #[tokio::test]
@@ -1676,7 +1920,7 @@ mod tests {
         let (p, _) = lifecycle_provider_seq(vec![
             (
                 200,
-                r#"[{"id":"sandbox-1","state":"Idle","labels":{"nixling-workload":"demo"}}]"#,
+                r#"[{"id":"sandbox-1","state":"Idle","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
             ),
             (500, r#"{"error":{"message":"resume backend unavailable"}}"#),
         ]);
@@ -1693,7 +1937,7 @@ mod tests {
         let (p, _) = lifecycle_provider_seq(vec![
             (
                 200,
-                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo"}}]"#,
+                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
             ),
             (409, r#"{"error":{"message":"cannot stop sandbox now"}}"#),
         ]);
@@ -1736,7 +1980,7 @@ mod tests {
         let (p, http) = lifecycle_provider_seq(vec![
             (
                 200,
-                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo"}}]"#,
+                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}]"#,
             ),
             (202, ""),
         ]);
@@ -1750,6 +1994,50 @@ mod tests {
                 .1
                 .ends_with("/sandboxes/sandbox-1/stop?api-version=2026-02-01-preview")
         );
+    }
+
+    #[tokio::test]
+    async fn workload_lookup_rejects_cross_realm_stale_label() {
+        let (p, http) = lifecycle_provider_seq(vec![
+            (
+                200,
+                r#"[{"id":"sandbox-1","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"personal"}}]"#,
+            ),
+            (200, "[]"),
+            (
+                201,
+                r#"{"id":"disk-1","labels":{"name":"nixling-wayland-mi"}}"#,
+            ),
+            (
+                201,
+                r#"{"id":"sandbox-2","state":"Running","labels":{"nixling-workload":"demo","nixling-realm":"work"}}"#,
+            ),
+        ]);
+        let id = p
+            .create(WorkloadSpec {
+                alias: WorkloadId::parse("demo").unwrap(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(id.as_str(), "demo");
+        let calls = http.calls.lock().unwrap();
+        assert_eq!(calls.len(), 4, "cross-realm sandbox must not be reused");
+    }
+
+    #[tokio::test]
+    async fn sandbox_reachable_bubbles_unavailable_states() {
+        let (p, _) = provider(404, "{}");
+        assert!(!p.sandbox_reachable("sandbox-1").await.unwrap());
+
+        let mut headers = BTreeMap::new();
+        headers.insert("retry-after".to_owned(), "1".to_owned());
+        let (p, _) = provider_seq_with_headers(vec![(
+            429,
+            r#"{"error":{"code":"TooManyRequests","message":"slow down"}}"#,
+            headers,
+        )]);
+        let err = p.sandbox_reachable("sandbox-1").await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Backpressure);
     }
 
     #[tokio::test]

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -3126,6 +3126,7 @@ fn aca_provider_from_gateway_config(
         sandbox_group: required_gateway_field(&aca.sandbox_group)?,
         region: required_gateway_field(&aca.region)?,
         endpoint: aca.endpoint.clone(),
+        managed_identity_client_id: aca.managed_identity_client_id.clone(),
     };
     let disk_image = if let Some(id) = aca.disk_image_id.as_ref().filter(|s| !s.trim().is_empty()) {
         AcaDiskImageSource::ExistingDiskId(id.clone())


### PR DESCRIPTION
## Summary
- add provider-layer retry metadata and a shared circuit breaker for provider rate limits
- harden ACA sandbox behavior: managed/workload identity only in production, allowlisted Azure diagnostics, lifecycle capability denials before provider side effects, and shared upstream circuit state
- document provider-managed sandbox limitations and cross-link remote full-host docs

## Validation
- cargo test -p nixling-constellation-provider --quiet
- cargo clippy -p nixling-constellation-provider --all-targets -- -D warnings
- cargo test -p nixling-provider-aca --quiet
- cargo clippy -p nixling-provider-aca --all-targets -- -D warnings
- cargo test -p nixling-gateway-runtime aca --quiet
- cargo clippy -p nixling-gateway-runtime --all-targets -- -D warnings
- cargo test -p nixlingd gateway_aca --quiet
- make test-drift
- git diff --check
- git diff --cached --check
- added-line process-marker and sensitive-shape scans

## Panel
- Gemini 3.1 Pro Wave 15 implementation panel signed off after R3.
