### PR TITLE
runtime: add Cloud Hypervisor provider adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Runtime providers: added the host-side Cloud Hypervisor runtime provider
+  adapter and explicit provider-selection policy. `local-cloud-hypervisor`
+  remains the default VM runtime, plans carry only bounded provider/workload
+  metadata, and crosvm, QEMU, Firecracker, and qemu-media ids fail closed
+  rather than silently falling back. Firecracker-shaped selections refuse
+  desktop, guest-control, virtiofs/store, graphics, audio, and USB workloads
+  before side effects. Added reference documentation for runtime provider
+  selection and cross-links from component/runtime docs.
+
 - Constellation: added a preview remote full-host node adapter. A gateway
   guest can now register a remote nixling host as a named node in a realm,
   route typed lifecycle and exec/logs operations to it, and receive typed

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,10 @@ The contracts. Stable interfaces a consumer can depend on.
   framework-managed SSH identity, trust-state, and audit behavior.
 - [`reference/qemu-media.md`](./reference/qemu-media.md) —
   qemu-media runtime, media-source, CLI, and security contract.
+- [`reference/runtime-provider-selection.md`](./reference/runtime-provider-selection.md) —
+  Cloud Hypervisor default runtime selection, reserved provider ids,
+  capability gating, and why crosvm/QEMU/Firecracker do not silently
+  replace the default VM runtime.
 - [`reference/security-runbook.md`](./reference/security-runbook.md) —
   operator incident-response, USBIP emergency containment, and
   compromise-recovery steps.

--- a/docs/reference/components-audio.md
+++ b/docs/reference/components-audio.md
@@ -13,6 +13,10 @@ session. On the host the sidecar appears as a PipeWire client named
 `nixling-<vm>` (visible in `wpctl status`, plasma-pa, pavucontrol);
 inside the guest, normal PipeWire + ALSA + PulseAudio compat stacks
 work on top of the virtio-snd card.
+Audio-capable VMs use the Cloud Hypervisor runtime provider plus the
+broker-spawned sound sidecar; see
+[runtime provider selection](./runtime-provider-selection.md) for runtime
+provider capability boundaries.
 
 Each VM has independent **mic** and **speaker** grants. The
 host-side state file is `/var/lib/nixling/vms/<vm>/state/audio-state.json`.

--- a/docs/reference/components-graphics.md
+++ b/docs/reference/components-graphics.md
@@ -10,6 +10,10 @@ Exposes a virtio-gpu device to the guest and forwards Wayland clients
 running inside the VM to the host compositor over the virtio-gpu
 cross-domain channel. The guest sees a normal Wayland session
 (`WAYLAND_DISPLAY=wayland-1`, `GDK_BACKEND=wayland`, etc.).
+Graphics-capable VMs use the Cloud Hypervisor runtime provider plus a
+crosvm GPU sidecar; see
+[runtime provider selection](./runtime-provider-selection.md) for the
+runtime capability boundary.
 
 When `graphics.crossDomainTrusted = true` and
 `graphics.waylandFilter.enable = true`, the guest-side

--- a/docs/reference/qemu-media.md
+++ b/docs/reference/qemu-media.md
@@ -7,6 +7,10 @@ for external media workflows. It uses nixling's daemon/broker control
 plane, but not the per-VM NixOS evaluator, Cloud Hypervisor, store
 sync, guest-control, SSH, or in-guest observability paths.
 
+For the general VM runtime selection policy, including why qemu-media is
+not selected as a full VM runtime, see
+[runtime provider selection](./runtime-provider-selection.md).
+
 ## Runtime shape
 
 | Surface | Contract |

--- a/docs/reference/runtime-provider-selection.md
+++ b/docs/reference/runtime-provider-selection.md
@@ -1,0 +1,68 @@
+# Runtime provider selection
+
+**Diataxis category:** reference.
+
+Runtime providers describe the local VM runner family used for a
+workload. They are capability declarations and routing policy, not
+escape hatches around `nixlingd` or `nixling-priv-broker`.
+
+## Default provider
+
+Normal local nixling VMs use the Cloud Hypervisor runtime provider:
+
+| Field | Value |
+| --- | --- |
+| Provider id | `local-cloud-hypervisor` |
+| Provider locality | Local host |
+| Runner authority | `nixlingd` DAG plus broker `SpawnRunner` |
+| Supported baseline | local lifecycle through the daemon, vsock, virtiofs store/share surfaces |
+
+The provider adapter validates the existing typed Cloud Hypervisor input
+shape and delegates argv generation to the existing host-side generator.
+Runtime plans remain opaque and contain only bounded provider/workload
+metadata. They never serialize argv, host paths, store paths, socket paths,
+fd numbers, pidfds, cgroup paths, namespace identifiers, endpoint strings,
+or process output.
+
+## Unsupported provider ids
+
+The following ids are reserved but are not production VM runtimes:
+
+| Provider id | Behavior |
+| --- | --- |
+| `crosvm` | Refuses as unsupported. crosvm is currently used for selected sidecars, not as the full VM runtime. |
+| `qemu` | Refuses as unsupported. General QEMU VM runtime semantics are not implemented. |
+| `qemu-media` | Refuses as a full VM runtime. It remains the dedicated media sidecar runtime documented in [qemu-media](./qemu-media.md). |
+| `firecracker` | Refuses as unsupported and, before any side effect, rejects workloads requiring guest-control, virtiofs/store sync, graphics, audio, USB, or desktop surfaces. |
+
+Unknown provider ids fail closed with `UnsupportedFeature` and a remediation
+that points operators back to `local-cloud-hypervisor`.
+
+## Capability gating
+
+Runtime provider selection is data-driven:
+
+- callers route only to a provider whose advertised capabilities cover the
+  requested workload;
+- unsupported profiles never silently fall back to Cloud Hypervisor, SSH, a
+  raw command tunnel, or qemu-media;
+- a missing capability returns a typed refusal before any runner side effect;
+- provider/debug/error metadata is limited to provider id, capability code,
+  reason, and remediation.
+
+Features that require graphics, audio, USB, virtiofs-backed storage,
+guest-control, or local GPU acceleration should assume the Cloud Hypervisor
+runtime unless a future provider explicitly advertises the needed capability.
+
+## Related component requirements
+
+- [Graphics](./components-graphics.md) depends on the Cloud Hypervisor VM
+  runner plus the crosvm GPU sidecar.
+- [Video](./components-video.md) uses a media sidecar and patched Cloud
+  Hypervisor vhost-user-media support.
+- [Audio](./components-audio.md) uses the Cloud Hypervisor VM runner plus a
+  broker-spawned sound sidecar.
+- [USBIP](./components-usbip.md) is a daemon/broker lifecycle surface, not a
+  generic runtime fallback.
+- [qemu-media](./qemu-media.md) is a separate media workflow and is not a
+  general replacement for the Cloud Hypervisor VM runtime.

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1768,9 +1768,12 @@ dependencies = [
 name = "nixling-host"
 version = "0.0.0-bootstrap"
 dependencies = [
+ "async-trait",
  "libc",
  "miniz_oxide",
  "nix 0.29.0",
+ "nixling-constellation-core",
+ "nixling-constellation-provider",
  "nixling-core",
  "nixling-ipc",
  "rustix 0.38.44",

--- a/packages/nixling-host-providers/src/lib.rs
+++ b/packages/nixling-host-providers/src/lib.rs
@@ -7,26 +7,25 @@
 use async_trait::async_trait;
 use nixling_constellation_core::{Capability, CapabilitySet, ErrorKind, ProviderId};
 use nixling_constellation_provider::{
-    DisplayProvider, HostSubstrateProvider, RuntimeProvider,
-    capabilities::{
-        DisplayCapabilitySet, HostSubstrateKind, NodeCapabilitySet, RuntimeCapabilitySet,
-    },
+    DisplayProvider, HostSubstrateProvider,
+    capabilities::{DisplayCapabilitySet, HostSubstrateKind, NodeCapabilitySet},
     error::{ProviderError, ProviderResult},
-    types::{
-        DisplaySessionHandle, DisplaySessionId, DisplaySessionRequest, RuntimeHandle, RuntimePlan,
-        RuntimeStatus, WorkloadSpec,
-    },
+    types::{DisplaySessionHandle, DisplaySessionId, DisplaySessionRequest},
 };
 use nixling_core::host::HostJson;
 use nixling_core::host_check::{self, HostCheckReport, HostCheckSeverity};
-use nixling_host::{
-    ch_argv::{ChArgvError, generate_ch_argv},
-    wayland_proxy_argv::{WaylandProxyArgvError, generate_wayland_proxy_argv},
+use nixling_host::wayland_proxy_argv::{WaylandProxyArgvError, generate_wayland_proxy_argv};
+
+pub use nixling_host::{
+    ch_argv::ChArgvInput,
+    runtime_provider::{
+        CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID,
+        CloudHypervisorRuntimeProvider as LocalMicroVmProvider, RuntimeWorkloadRequirements,
+        validate_runtime_profile,
+    },
+    wayland_proxy_argv::WaylandProxyArgvInput,
 };
 
-pub use nixling_host::{ch_argv::ChArgvInput, wayland_proxy_argv::WaylandProxyArgvInput};
-
-const LOCAL_MICROVM_PROVIDER_ID: &str = "local-microvm";
 const LOCAL_CROSS_DOMAIN_WAYLAND_PROVIDER_ID: &str = "local-cross-domain-wayland";
 const NIXOS_HOST_SUBSTRATE_PROVIDER_ID: &str = "nixos-host-substrate";
 const GENERIC_LINUX_HOST_SUBSTRATE_PROVIDER_ID: &str = "generic-linux-host-substrate";
@@ -220,97 +219,6 @@ pub fn detect_os_release(contents: &str) -> DetectedHostSubstrate {
     DetectedHostSubstrate { kind, version }
 }
 
-/// RuntimeProvider adapter for the local Cloud Hypervisor microVM path.
-#[derive(Clone)]
-pub struct LocalMicroVmProvider {
-    provider_id: ProviderId,
-    ch_input: ChArgvInput,
-}
-
-impl std::fmt::Debug for LocalMicroVmProvider {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LocalMicroVmProvider")
-            .field("provider_id", &self.provider_id)
-            .finish_non_exhaustive()
-    }
-}
-
-impl LocalMicroVmProvider {
-    /// Construct a local microVM provider using the canonical provider id.
-    pub fn new(ch_input: ChArgvInput) -> Self {
-        Self::with_provider_id(static_provider_id(LOCAL_MICROVM_PROVIDER_ID), ch_input)
-    }
-
-    /// Construct a local microVM provider with an explicit provider id.
-    pub fn with_provider_id(provider_id: ProviderId, ch_input: ChArgvInput) -> Self {
-        Self {
-            provider_id,
-            ch_input,
-        }
-    }
-
-    /// Borrow the Cloud Hypervisor argv generator input this adapter wraps.
-    pub fn ch_input(&self) -> &ChArgvInput {
-        &self.ch_input
-    }
-
-    /// Generate Cloud Hypervisor argv through the existing nixling-host generator.
-    pub async fn cloud_hypervisor_argv(&self) -> ProviderResult<Vec<String>> {
-        render_ch_argv(self.ch_input.clone()).await
-    }
-
-    fn ensure_workload_matches(&self, spec: &WorkloadSpec) -> ProviderResult<()> {
-        if spec.alias.as_str() == self.ch_input.vm_name.as_str() {
-            Ok(())
-        } else {
-            Err(ProviderError::new(
-                ErrorKind::InvalidTarget,
-                "workload alias does not match the local microVM argv input",
-            ))
-        }
-    }
-}
-
-#[async_trait]
-impl RuntimeProvider for LocalMicroVmProvider {
-    fn provider_id(&self) -> ProviderId {
-        self.provider_id.clone()
-    }
-
-    fn capabilities(&self) -> RuntimeCapabilitySet {
-        RuntimeCapabilitySet {
-            caps: CapabilitySet::from_caps([Capability::Vsock, Capability::Virtiofs]),
-        }
-    }
-
-    async fn plan_workload(&self, spec: WorkloadSpec) -> ProviderResult<RuntimePlan> {
-        self.ensure_workload_matches(&spec)?;
-        self.cloud_hypervisor_argv().await?;
-        Ok(RuntimePlan {
-            provider: self.provider_id(),
-            workload: spec.alias,
-        })
-    }
-
-    async fn start(&self, _plan: RuntimePlan) -> ProviderResult<RuntimeHandle> {
-        Err(ProviderError::unsupported(
-            "local microVM start is not wired in this provider adapter",
-        ))
-    }
-
-    async fn stop(&self, _handle: RuntimeHandle) -> ProviderResult<()> {
-        Err(ProviderError::unsupported(
-            "local microVM stop is not wired in this provider adapter",
-        ))
-    }
-
-    async fn inspect(&self, _handle: RuntimeHandle) -> ProviderResult<RuntimeStatus> {
-        Err(ProviderError::unsupported(
-            "local microVM inspect is not wired in this provider adapter",
-        ))
-    }
-}
-
 /// DisplayProvider adapter for the local cross-domain Wayland proxy path.
 #[derive(Clone)]
 pub struct LocalCrossDomainWaylandProvider {
@@ -408,18 +316,6 @@ impl DisplayProvider for LocalCrossDomainWaylandProvider {
     }
 }
 
-async fn render_ch_argv(input: ChArgvInput) -> ProviderResult<Vec<String>> {
-    tokio::task::spawn_blocking(move || generate_ch_argv(&input))
-        .await
-        .map_err(|_| {
-            ProviderError::new(
-                ErrorKind::ProviderAllocationFailed,
-                "blocking task failed while rendering Cloud Hypervisor argv",
-            )
-        })?
-        .map_err(ch_argv_error)
-}
-
 async fn render_wayland_proxy_argv(input: WaylandProxyArgvInput) -> ProviderResult<Vec<String>> {
     tokio::task::spawn_blocking(move || generate_wayland_proxy_argv(&input))
         .await
@@ -430,24 +326,6 @@ async fn render_wayland_proxy_argv(input: WaylandProxyArgvInput) -> ProviderResu
             )
         })?
         .map_err(wayland_proxy_argv_error)
-}
-
-fn ch_argv_error(err: ChArgvError) -> ProviderError {
-    let message = match err {
-        ChArgvError::EmptyVmName => "invalid Cloud Hypervisor argv input: empty VM name",
-        ChArgvError::InvalidChBinaryPath { .. } => {
-            "invalid Cloud Hypervisor argv input: invalid binary path"
-        }
-        ChArgvError::ZeroCpus => "invalid Cloud Hypervisor argv input: zero CPUs",
-        ChArgvError::EmptyKernelPath => "invalid Cloud Hypervisor argv input: empty kernel path",
-        ChArgvError::TapFdMissing { .. } => {
-            "invalid Cloud Hypervisor argv input: missing TAP file descriptor"
-        }
-        ChArgvError::TapIfnameMissing { .. } => {
-            "invalid Cloud Hypervisor argv input: missing TAP interface name"
-        }
-    };
-    ProviderError::new(ErrorKind::ProviderAllocationFailed, message)
 }
 
 fn wayland_proxy_argv_error(err: WaylandProxyArgvError) -> ProviderError {
@@ -468,6 +346,7 @@ fn static_provider_id(id: &'static str) -> ProviderId {
 mod tests {
     use super::*;
     use nixling_constellation_core::{ErrorKind, WorkloadId};
+    use nixling_constellation_provider::RuntimeProvider;
     use nixling_constellation_provider::types::{DisplaySessionRequest, WorkloadSpec};
     use nixling_core::host_check::{
         HostCheckFinding, HostCheckReport, HostCheckSeverity, HostCheckSummary,
@@ -651,7 +530,6 @@ mod tests {
         let adapter = LocalMicroVmProvider::new(input);
         let from_adapter = adapter
             .cloud_hypervisor_argv()
-            .await
             .expect("adapter delegates to CH generator");
 
         assert_eq!(direct, expected_ch_argv());
@@ -690,8 +568,8 @@ mod tests {
         });
 
         let runtime_debug = format!("{:?}", LocalMicroVmProvider::new(ch_input));
-        assert!(runtime_debug.contains("LocalMicroVmProvider"));
-        assert!(runtime_debug.contains(LOCAL_MICROVM_PROVIDER_ID));
+        assert!(runtime_debug.contains("CloudHypervisorRuntimeProvider"));
+        assert!(runtime_debug.contains(CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID));
         for forbidden in [
             "debug-redact-ch-bin",
             "debug-redact-kernel",

--- a/packages/nixling-host/Cargo.toml
+++ b/packages/nixling-host/Cargo.toml
@@ -25,8 +25,11 @@ default = []
 fake-backends = []
 
 [dependencies]
+nixling-constellation-core = { path = "../nixling-constellation-core", version = "0.0.0-bootstrap" }
+nixling-constellation-provider = { path = "../nixling-constellation-provider", version = "0.0.0-bootstrap" }
 nixling-core = { path = "../nixling-core", version = "0.0.0-bootstrap" }
 nixling-ipc = { path = "../nixling-ipc", version = "0.0.0-bootstrap" }
+async-trait = "0.1"
 serde.workspace = true
 serde_json.workspace = true
 schemars.workspace = true

--- a/packages/nixling-host/src/lib.rs
+++ b/packages/nixling-host/src/lib.rs
@@ -97,6 +97,10 @@ pub mod media;
 // swtpm_argv, usbip_argv, video_argv, vsock_relay_argv,
 // otel_host_bridge_argv). See ADR 0018.
 pub mod runner_argv_regenerator;
+// Host-side runtime provider adapters. The concrete Cloud Hypervisor
+// adapter wraps typed CH argv input without serializing argv/paths into
+// provider DTOs.
+pub mod runtime_provider;
 
 // v1.1.1 RenderDnsmasqEnvConf daemon-host-prep DAG op support.
 // Per ADR 0018. Pure-Rust dnsmasq config

--- a/packages/nixling-host/src/runtime_provider.rs
+++ b/packages/nixling-host/src/runtime_provider.rs
@@ -1,0 +1,598 @@
+//! Host-side runtime-provider adapters.
+//!
+//! Runtime plans are intentionally opaque provider DTOs. The Cloud
+//! Hypervisor adapter validates the existing typed argv input through
+//! [`crate::ch_argv::generate_ch_argv`] but never stores argv, host paths,
+//! file descriptors, pidfds, cgroup paths, namespace identifiers, or socket
+//! paths in [`RuntimePlan`], errors, or debug output.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use nixling_constellation_core::{Capability, CapabilitySet, ErrorKind, ProviderId};
+use nixling_constellation_provider::{
+    RuntimeProvider,
+    capabilities::RuntimeCapabilitySet,
+    error::{ProviderError, ProviderResult},
+    types::{RuntimeHandle, RuntimePlan, RuntimeStatus, WorkloadSpec},
+};
+
+use crate::ch_argv::{ChArgvError, ChArgvInput, generate_ch_argv};
+
+/// Default local runtime provider id.
+pub const CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID: &str = "local-cloud-hypervisor";
+/// Reserved crosvm runtime provider id. Not implemented as a full VM runtime.
+pub const CROSVM_RUNTIME_PROVIDER_ID: &str = "crosvm";
+/// Reserved QEMU runtime provider id. Not implemented as a full VM runtime.
+pub const QEMU_RUNTIME_PROVIDER_ID: &str = "qemu";
+/// Reserved Firecracker runtime provider id. Not implemented for desktop nixling workloads.
+pub const FIRECRACKER_RUNTIME_PROVIDER_ID: &str = "firecracker";
+/// QEMU media remains a sidecar/media runtime, not the full VM runtime.
+pub const QEMU_MEDIA_RUNTIME_PROVIDER_ID: &str = "qemu-media";
+
+/// Feature requirements for selecting a runtime profile. This is local policy
+/// input, not a serialized provider DTO.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeWorkloadRequirements {
+    pub desktop: bool,
+    pub graphics: bool,
+    pub audio: bool,
+    pub usb: bool,
+    pub virtiofs: bool,
+    pub store_sync: bool,
+    pub guest_control: bool,
+}
+
+impl RuntimeWorkloadRequirements {
+    fn firecracker_incompatible(self) -> Option<Capability> {
+        if self.guest_control {
+            Some(Capability::Vsock)
+        } else if self.virtiofs || self.store_sync {
+            Some(Capability::Virtiofs)
+        } else if self.graphics || self.desktop {
+            Some(Capability::GpuAccel)
+        } else if self.audio {
+            Some(Capability::AudioPlayback)
+        } else if self.usb {
+            Some(Capability::Usb)
+        } else {
+            None
+        }
+    }
+}
+
+/// Validate that `profile` can satisfy `requirements` without falling back.
+pub fn validate_runtime_profile(
+    provider_id: &ProviderId,
+    requirements: RuntimeWorkloadRequirements,
+) -> ProviderResult<()> {
+    match provider_id.as_str() {
+        CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID => Ok(()),
+        FIRECRACKER_RUNTIME_PROVIDER_ID => {
+            if let Some(capability) = requirements.firecracker_incompatible() {
+                Err(ProviderError::unsupported(format!(
+                    "runtime provider '{FIRECRACKER_RUNTIME_PROVIDER_ID}' does not support required capability '{}'; drop the incompatible feature or use {CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}",
+                    capability.code()
+                )))
+            } else {
+                Err(ProviderError::unsupported(format!(
+                    "runtime provider '{FIRECRACKER_RUNTIME_PROVIDER_ID}' is not implemented; use {CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}"
+                )))
+            }
+        }
+        QEMU_MEDIA_RUNTIME_PROVIDER_ID => Err(ProviderError::unsupported(format!(
+            "runtime provider '{QEMU_MEDIA_RUNTIME_PROVIDER_ID}' is a media sidecar, not a full VM runtime; use {CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}"
+        ))),
+        CROSVM_RUNTIME_PROVIDER_ID | QEMU_RUNTIME_PROVIDER_ID => {
+            Err(ProviderError::unsupported(format!(
+                "runtime provider '{}' is not implemented; use {CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}",
+                provider_id
+            )))
+        }
+        other => Err(ProviderError::unsupported(format!(
+            "runtime provider '{other}' is not supported; use {CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}"
+        ))),
+    }
+}
+
+/// Daemon/broker runtime authority used by [`CloudHypervisorRuntimeProvider`].
+/// Implementations own runner spawning, pidfds, and inspection. The provider
+/// passes typed host-local input to this seam; none of it is serialized into
+/// [`RuntimePlan`].
+#[async_trait]
+pub trait CloudHypervisorRuntimeControl: Send + Sync {
+    async fn start(&self, plan: RuntimePlan, input: &ChArgvInput) -> ProviderResult<RuntimeHandle>;
+    async fn stop(&self, handle: RuntimeHandle) -> ProviderResult<()>;
+    async fn inspect(&self, handle: RuntimeHandle) -> ProviderResult<RuntimeStatus>;
+}
+
+/// Runtime provider for the existing Cloud Hypervisor microVM path.
+#[derive(Clone)]
+pub struct CloudHypervisorRuntimeProvider {
+    provider_id: ProviderId,
+    ch_input: ChArgvInput,
+    control: Option<Arc<dyn CloudHypervisorRuntimeControl>>,
+}
+
+impl std::fmt::Debug for CloudHypervisorRuntimeProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudHypervisorRuntimeProvider")
+            .field("provider_id", &self.provider_id)
+            .field("control_attached", &self.control.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl CloudHypervisorRuntimeProvider {
+    /// Construct with the canonical Cloud Hypervisor provider id.
+    pub fn new(ch_input: ChArgvInput) -> Self {
+        Self::with_provider_id(
+            static_provider_id(CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID),
+            ch_input,
+        )
+    }
+
+    /// Construct with an explicit provider id.
+    pub fn with_provider_id(provider_id: ProviderId, ch_input: ChArgvInput) -> Self {
+        Self {
+            provider_id,
+            ch_input,
+            control: None,
+        }
+    }
+
+    /// Attach the daemon/broker runtime control seam.
+    pub fn with_control(mut self, control: Arc<dyn CloudHypervisorRuntimeControl>) -> Self {
+        self.control = Some(control);
+        self
+    }
+
+    /// Borrow the Cloud Hypervisor argv input.
+    pub fn ch_input(&self) -> &ChArgvInput {
+        &self.ch_input
+    }
+
+    /// Render Cloud Hypervisor argv through the existing generator. This is
+    /// exposed for conformance tests and daemon-side execution only; the
+    /// provider DTOs never carry the rendered argv.
+    pub fn cloud_hypervisor_argv(&self) -> ProviderResult<Vec<String>> {
+        generate_ch_argv(&self.ch_input).map_err(ch_argv_error)
+    }
+
+    fn ensure_workload_matches(&self, spec: &WorkloadSpec) -> ProviderResult<()> {
+        if spec.alias.as_str() == self.ch_input.vm_name.as_str() {
+            Ok(())
+        } else {
+            Err(ProviderError::new(
+                ErrorKind::InvalidTarget,
+                "workload alias does not match the Cloud Hypervisor runtime input",
+            ))
+        }
+    }
+}
+
+#[async_trait]
+impl RuntimeProvider for CloudHypervisorRuntimeProvider {
+    fn provider_id(&self) -> ProviderId {
+        self.provider_id.clone()
+    }
+
+    fn capabilities(&self) -> RuntimeCapabilitySet {
+        let mut caps = CapabilitySet::empty()
+            .with(Capability::Vsock)
+            .with(Capability::Virtiofs);
+        if self.control.is_some() {
+            caps = caps.with(Capability::Lifecycle);
+        }
+        RuntimeCapabilitySet { caps }
+    }
+
+    async fn plan_workload(&self, spec: WorkloadSpec) -> ProviderResult<RuntimePlan> {
+        self.ensure_workload_matches(&spec)?;
+        self.cloud_hypervisor_argv()?;
+        Ok(RuntimePlan {
+            provider: self.provider_id(),
+            workload: spec.alias,
+        })
+    }
+
+    async fn start(&self, plan: RuntimePlan) -> ProviderResult<RuntimeHandle> {
+        if plan.provider != self.provider_id {
+            return Err(ProviderError::new(
+                ErrorKind::InvalidTarget,
+                "runtime plan provider does not match Cloud Hypervisor provider",
+            ));
+        }
+        let control = self.control.as_ref().ok_or_else(|| {
+            ProviderError::unsupported(format!(
+                "runtime provider '{CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}' start requires daemon runtime control"
+            ))
+        })?;
+        control.start(plan, &self.ch_input).await
+    }
+
+    async fn stop(&self, handle: RuntimeHandle) -> ProviderResult<()> {
+        let control = self.control.as_ref().ok_or_else(|| {
+            ProviderError::unsupported(format!(
+                "runtime provider '{CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}' stop requires daemon runtime control"
+            ))
+        })?;
+        control.stop(handle).await
+    }
+
+    async fn inspect(&self, handle: RuntimeHandle) -> ProviderResult<RuntimeStatus> {
+        let control = self.control.as_ref().ok_or_else(|| {
+            ProviderError::unsupported(format!(
+                "runtime provider '{CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID}' inspect requires daemon runtime control"
+            ))
+        })?;
+        control.inspect(handle).await
+    }
+}
+
+fn static_provider_id(id: &'static str) -> ProviderId {
+    ProviderId::parse(id).expect("static runtime provider id must use the provider-id label shape")
+}
+
+fn ch_argv_error(err: ChArgvError) -> ProviderError {
+    let message = match err {
+        ChArgvError::EmptyVmName => "invalid Cloud Hypervisor runtime input: empty VM name",
+        ChArgvError::InvalidChBinaryPath { .. } => {
+            "invalid Cloud Hypervisor runtime input: invalid binary path"
+        }
+        ChArgvError::ZeroCpus => "invalid Cloud Hypervisor runtime input: zero CPUs",
+        ChArgvError::EmptyKernelPath => "invalid Cloud Hypervisor runtime input: empty kernel path",
+        ChArgvError::TapFdMissing { .. } => {
+            "invalid Cloud Hypervisor runtime input: missing TAP file descriptor"
+        }
+        ChArgvError::TapIfnameMissing { .. } => {
+            "invalid Cloud Hypervisor runtime input: missing TAP interface name"
+        }
+    };
+    ProviderError::new(ErrorKind::ProviderAllocationFailed, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ch_argv::{ChFsShare, ChNetHandoff, ChNetIface, ChVsock};
+    use nixling_constellation_core::WorkloadId;
+    use std::sync::{Arc, Mutex};
+
+    fn workload_id(raw: &str) -> WorkloadId {
+        WorkloadId::parse(raw).expect("test workload id")
+    }
+
+    fn provider_id(raw: &str) -> ProviderId {
+        ProviderId::parse(raw).expect("test provider id")
+    }
+
+    fn representative_input() -> ChArgvInput {
+        ChArgvInput {
+            vm_name: "corp-vm".to_owned(),
+            ch_binary_path: "/runtime-test/cloud-hypervisor".to_owned(),
+            cpus: 1,
+            watchdog: true,
+            kernel_path: "/runtime-test/vmlinux".to_owned(),
+            initramfs_path: Some("/runtime-test/initrd".to_owned()),
+            cmdline: "console=ttyS0 init=/runtime-test/init".to_owned(),
+            seccomp: "true".to_owned(),
+            memory: "shared=on,size=512M".to_owned(),
+            platform_oem_strings: vec!["notify=vsock-stream:2:8888".to_owned()],
+            console: "null".to_owned(),
+            serial: "tty".to_owned(),
+            primary_vsock: Some(ChVsock {
+                cid: 10_914_385,
+                socket: "notify.vsock".to_owned(),
+            }),
+            extra_vsock: Vec::new(),
+            fs_shares: vec![ChFsShare {
+                socket: "runtime-test-virtiofs.sock".to_owned(),
+                tag: "ro-store".to_owned(),
+            }],
+            api_socket_path: "runtime-test-api.sock".to_owned(),
+            net_ifaces: vec![ChNetIface {
+                mac: "02:76:53:AE:57:0A".to_owned(),
+                tap_ifname: "work-l10".to_owned(),
+                tap_fd: None,
+            }],
+            net_handoff: ChNetHandoff::PersistentTap,
+            extra_args: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn cloud_hypervisor_debug_redacts_runtime_inputs() {
+        let mut input = representative_input();
+        input.ch_binary_path = "/runtime-debug/cloud-hypervisor".to_owned();
+        input.kernel_path = "/runtime-debug/vmlinux".to_owned();
+        input.api_socket_path = "runtime-debug-api.sock".to_owned();
+        input.extra_args.push("/runtime-debug/extra".to_owned());
+        let rendered = format!("{:?}", CloudHypervisorRuntimeProvider::new(input));
+        assert!(rendered.contains("CloudHypervisorRuntimeProvider"));
+        assert!(rendered.contains(CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID));
+        for forbidden in ["runtime-debug", "vmlinux", "api.sock", "extra"] {
+            assert!(
+                !rendered.contains(forbidden),
+                "runtime provider Debug leaked {forbidden}: {rendered}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cloud_hypervisor_default_plans_opaque_runtime_plan() {
+        let provider = CloudHypervisorRuntimeProvider::new(representative_input());
+        let plan = provider
+            .plan_workload(WorkloadSpec {
+                alias: workload_id("corp-vm"),
+            })
+            .await
+            .unwrap();
+        assert_eq!(plan.provider.as_str(), CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID);
+        assert_eq!(plan.workload.as_str(), "corp-vm");
+        let encoded = serde_json::to_string(&plan).unwrap();
+        for forbidden in [
+            "runtime-test",
+            "vmlinux",
+            "initrd",
+            "console=ttyS0",
+            "notify.vsock",
+            "work-l10",
+            "02:76",
+        ] {
+            assert!(
+                !encoded.contains(forbidden),
+                "RuntimePlan leaked runtime input {forbidden}: {encoded}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cloud_hypervisor_planning_reuses_argv_validation() {
+        let mut input = representative_input();
+        input.cpus = 0;
+        let err = CloudHypervisorRuntimeProvider::new(input)
+            .plan_workload(WorkloadSpec {
+                alias: workload_id("corp-vm"),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ProviderAllocationFailed);
+        assert!(!err.to_string().contains("runtime-test"));
+    }
+
+    #[tokio::test]
+    async fn cloud_hypervisor_plan_rejects_mismatched_workload_alias() {
+        let err = CloudHypervisorRuntimeProvider::new(representative_input())
+            .plan_workload(WorkloadSpec {
+                alias: workload_id("other-vm"),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidTarget);
+    }
+
+    #[test]
+    fn unsupported_profiles_fail_without_fallback() {
+        for id in [
+            CROSVM_RUNTIME_PROVIDER_ID,
+            QEMU_RUNTIME_PROVIDER_ID,
+            QEMU_MEDIA_RUNTIME_PROVIDER_ID,
+        ] {
+            let err =
+                validate_runtime_profile(&provider_id(id), RuntimeWorkloadRequirements::default())
+                    .unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::UnsupportedFeature);
+            assert!(
+                err.to_string()
+                    .contains(CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID)
+            );
+        }
+
+        let err = validate_runtime_profile(
+            &provider_id("unknown-runtime"),
+            RuntimeWorkloadRequirements::default(),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnsupportedFeature);
+        assert!(
+            err.to_string()
+                .contains(CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID)
+        );
+    }
+
+    #[test]
+    fn firecracker_denies_desktop_dependencies() {
+        for requirements in [
+            RuntimeWorkloadRequirements {
+                guest_control: true,
+                ..Default::default()
+            },
+            RuntimeWorkloadRequirements {
+                virtiofs: true,
+                ..Default::default()
+            },
+            RuntimeWorkloadRequirements {
+                store_sync: true,
+                ..Default::default()
+            },
+            RuntimeWorkloadRequirements {
+                desktop: true,
+                ..Default::default()
+            },
+            RuntimeWorkloadRequirements {
+                graphics: true,
+                ..Default::default()
+            },
+            RuntimeWorkloadRequirements {
+                audio: true,
+                ..Default::default()
+            },
+            RuntimeWorkloadRequirements {
+                usb: true,
+                ..Default::default()
+            },
+        ] {
+            let err = validate_runtime_profile(
+                &provider_id(FIRECRACKER_RUNTIME_PROVIDER_ID),
+                requirements,
+            )
+            .unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::UnsupportedFeature);
+            assert!(
+                err.to_string()
+                    .contains(CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID)
+            );
+        }
+    }
+
+    #[test]
+    fn firecracker_default_is_still_unsupported() {
+        let err = validate_runtime_profile(
+            &provider_id(FIRECRACKER_RUNTIME_PROVIDER_ID),
+            RuntimeWorkloadRequirements::default(),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnsupportedFeature);
+        assert!(err.to_string().contains("not implemented"));
+        assert!(
+            err.to_string()
+                .contains(CLOUD_HYPERVISOR_RUNTIME_PROVIDER_ID)
+        );
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingControl {
+        started: Mutex<Vec<String>>,
+        stopped: Mutex<Vec<String>>,
+        inspected: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl CloudHypervisorRuntimeControl for RecordingControl {
+        async fn start(
+            &self,
+            plan: RuntimePlan,
+            input: &ChArgvInput,
+        ) -> ProviderResult<RuntimeHandle> {
+            self.started
+                .lock()
+                .expect("recording control lock")
+                .push(input.vm_name.clone());
+            Ok(RuntimeHandle {
+                workload: plan.workload,
+            })
+        }
+
+        async fn stop(&self, handle: RuntimeHandle) -> ProviderResult<()> {
+            self.stopped
+                .lock()
+                .expect("recording control lock")
+                .push(handle.workload.as_str().to_owned());
+            Ok(())
+        }
+
+        async fn inspect(&self, handle: RuntimeHandle) -> ProviderResult<RuntimeStatus> {
+            self.inspected
+                .lock()
+                .expect("recording control lock")
+                .push(handle.workload.as_str().to_owned());
+            Ok(RuntimeStatus {
+                workload: handle.workload,
+                running: true,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn cloud_hypervisor_start_delegates_to_control() {
+        let control = Arc::new(RecordingControl::default());
+        let provider = CloudHypervisorRuntimeProvider::new(representative_input())
+            .with_control(control.clone());
+        assert!(provider.capabilities().has(Capability::Lifecycle));
+        let plan = provider
+            .plan_workload(WorkloadSpec {
+                alias: workload_id("corp-vm"),
+            })
+            .await
+            .unwrap();
+        let handle = provider.start(plan).await.unwrap();
+        assert_eq!(handle.workload.as_str(), "corp-vm");
+        assert_eq!(
+            control
+                .started
+                .lock()
+                .expect("recording control lock")
+                .as_slice(),
+            &["corp-vm".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_hypervisor_rejects_plan_for_other_provider() {
+        let control = Arc::new(RecordingControl::default());
+        let provider =
+            CloudHypervisorRuntimeProvider::new(representative_input()).with_control(control);
+        let err = provider
+            .start(RuntimePlan {
+                provider: provider_id("other-provider"),
+                workload: workload_id("corp-vm"),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidTarget);
+    }
+
+    #[tokio::test]
+    async fn cloud_hypervisor_lifecycle_requires_control_seam() {
+        let provider = CloudHypervisorRuntimeProvider::new(representative_input());
+        let plan = RuntimePlan {
+            provider: provider.provider_id(),
+            workload: workload_id("corp-vm"),
+        };
+        assert_eq!(
+            provider.start(plan).await.unwrap_err().kind(),
+            ErrorKind::UnsupportedFeature
+        );
+        let handle = RuntimeHandle {
+            workload: workload_id("corp-vm"),
+        };
+        assert_eq!(
+            provider.stop(handle.clone()).await.unwrap_err().kind(),
+            ErrorKind::UnsupportedFeature
+        );
+        assert_eq!(
+            provider.inspect(handle).await.unwrap_err().kind(),
+            ErrorKind::UnsupportedFeature
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_hypervisor_stop_and_inspect_delegate_to_control() {
+        let control = Arc::new(RecordingControl::default());
+        let provider = CloudHypervisorRuntimeProvider::new(representative_input())
+            .with_control(control.clone());
+        let handle = RuntimeHandle {
+            workload: workload_id("corp-vm"),
+        };
+        provider.stop(handle.clone()).await.unwrap();
+        let status = provider.inspect(handle).await.unwrap();
+        assert!(status.running);
+        assert_eq!(
+            control
+                .stopped
+                .lock()
+                .expect("recording control lock")
+                .as_slice(),
+            &["corp-vm".to_owned()]
+        );
+        assert_eq!(
+            control
+                .inspected
+                .lock()
+                .expect("recording control lock")
+                .as_slice(),
+            &["corp-vm".to_owned()]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a host-side Cloud Hypervisor runtime provider adapter around the existing CH argv generator
- add explicit fail-closed runtime-provider selection policy for crosvm, QEMU, Firecracker, and qemu-media
- document runtime provider selection and cross-link component/runtime references

## Validation
- cargo test -p nixling-host --quiet
- cargo clippy -p nixling-host --all-targets -- -D warnings
- cargo test -p nixling-host-providers --quiet
- cargo clippy -p nixling-host-providers --all-targets -- -D warnings
- cargo test -p nixling-constellation-provider --quiet
- cargo clippy -p nixling-constellation-provider --all-targets -- -D warnings
- make test-drift
- git diff --check && git diff --cached --check
- full Gemini 3.1 Pro W16 R2 implementation panel: unanimous signoff