### PR TITLE
realm: expose realm policy inspection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1041,9 +1041,9 @@ contract:
   **no** realm relay/provider credentials, remote node registries,
   or realm audit (those live inside a per-realm gateway guest); and
   **relay identity is not local auth** — relay credentials
-  authenticate relay/transport access only, are never mapped to
-  `nixling-launcher`/`nixling-admin`, and `SO_PEERCRED` + `nixling`
-  group membership remains the sole local lifecycle authz surface.
+  authenticate relay/transport access only, are never mapped to a local
+  lifecycle role, and `SO_PEERCRED` + `nixling` group membership remains
+  the sole local lifecycle authz surface.
 - [docs/adr/0034-storage-lifecycle-restart-and-synchronization.md](./docs/adr/0034-storage-lifecycle-restart-and-synchronization.md)
   — selected design for generated storage, restart/adoption, and
   synchronization contracts. **Load-bearing invariant:** normal daemon
@@ -1069,6 +1069,13 @@ contract:
 - [docs/reference/cli-contract.md](./docs/reference/cli-contract.md) —
   CLI lifecycle FSM, signal semantics, exit codes, JSON vs human
   output.
+- [docs/reference/realm-policy.md](./docs/reference/realm-policy.md) —
+  host-resident vs gateway-backed realm policy, default-deny
+  cross-realm behavior, and `nixling realm list` / `inspect`
+  inspection surfaces.
+- [docs/how-to/configure-work-gateway.md](./docs/how-to/configure-work-gateway.md)
+  — configure a dedicated work/provider realm gateway and verify the
+  default-deny boundary.
 - [docs/how-to/migrate-nixling-v0-to-v1.md](./docs/how-to/migrate-nixling-v0-to-v1.md)
   — consumer migration guide for v0.x → v1.0.
 - [docs/how-to/migrate-nixling-v1-0-to-v1-1.md](./docs/how-to/migrate-nixling-v1-0-to-v1-1.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Realm policy: added `nixling realm list` and `nixling realm inspect` to make
+  host-resident vs gateway-backed realms discoverable, documented the
+  default-deny cross-realm policy, and added migration guidance for explicit
+  realm gateways.
+
 - Display and virtual I/O: added explicit display capability helpers and a
   `nixling vm display list|close` gateway display-session surface that returns
   only bounded non-secret session metadata, including the authorizing

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,7 +135,9 @@ Task-oriented recipes. Prescriptive, copy-and-adapt.
   the `nixpkgs` follow policy and eval-only test pattern.
 - [`how-to/configure-work-gateway.md`](./how-to/configure-work-gateway.md) —
   declare a work/provider realm gateway and verify default-deny isolation.
-- [`how-to/migrate-to-realm-gateways.md`](./how-to/migrate-to-realm-gateways.md) —
+- [`how-to/realm-gateway.md`](./how-to/realm-gateway.md) —
+  configure, enter, and recover realm gateway guests.
+- [`how-to/migrate-nixling-v1-2-to-v2.md`](./how-to/migrate-nixling-v1-2-to-v2.md) —
   migrate from local-only or implicit realm metadata to explicit gateway-backed
   realm policy.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,9 @@ The contracts. Stable interfaces a consumer can depend on.
 - [`reference/display-io-capabilities.md`](./reference/display-io-capabilities.md) —
   display, clipboard, audio, USB/HID, GPU, video, and provider display
   lifecycle capability boundaries.
+- [`reference/realm-policy.md`](./reference/realm-policy.md) —
+  host-resident vs gateway-backed realm policy, default-deny cross-realm
+  behavior, authorization, audit, and network isolation boundaries.
 - [`reference/remote-full-host-nodes.md`](./reference/remote-full-host-nodes.md) —
   gateway-managed remote nixling hosts: registration, capability gating,
   operation routing, idempotency, and the non-tunneling boundary.
@@ -130,6 +133,11 @@ Task-oriented recipes. Prescriptive, copy-and-adapt.
 - [`how-to/write-a-nixling-addon.md`](./how-to/write-a-nixling-addon.md) —
   write a sibling flake that composes with `nixling` per VM, including
   the `nixpkgs` follow policy and eval-only test pattern.
+- [`how-to/configure-work-gateway.md`](./how-to/configure-work-gateway.md) —
+  declare a work/provider realm gateway and verify default-deny isolation.
+- [`how-to/migrate-to-realm-gateways.md`](./how-to/migrate-to-realm-gateways.md) —
+  migrate from local-only or implicit realm metadata to explicit gateway-backed
+  realm policy.
 
 ## Explanation
 

--- a/docs/completions/nixling.bash
+++ b/docs/completions/nixling.bash
@@ -322,6 +322,12 @@ _nixling() {
             nixling__subcmd__help__subcmd__realm,enter)
                 cmd="nixling__subcmd__help__subcmd__realm__subcmd__enter"
                 ;;
+            nixling__subcmd__help__subcmd__realm,inspect)
+                cmd="nixling__subcmd__help__subcmd__realm__subcmd__inspect"
+                ;;
+            nixling__subcmd__help__subcmd__realm,list)
+                cmd="nixling__subcmd__help__subcmd__realm__subcmd__list"
+                ;;
             nixling__subcmd__help__subcmd__realm,run)
                 cmd="nixling__subcmd__help__subcmd__realm__subcmd__run"
                 ;;
@@ -448,6 +454,12 @@ _nixling() {
             nixling__subcmd__realm,help)
                 cmd="nixling__subcmd__realm__subcmd__help"
                 ;;
+            nixling__subcmd__realm,inspect)
+                cmd="nixling__subcmd__realm__subcmd__inspect"
+                ;;
+            nixling__subcmd__realm,list)
+                cmd="nixling__subcmd__realm__subcmd__list"
+                ;;
             nixling__subcmd__realm,run)
                 cmd="nixling__subcmd__realm__subcmd__run"
                 ;;
@@ -456,6 +468,12 @@ _nixling() {
                 ;;
             nixling__subcmd__realm__subcmd__help,help)
                 cmd="nixling__subcmd__realm__subcmd__help__subcmd__help"
+                ;;
+            nixling__subcmd__realm__subcmd__help,inspect)
+                cmd="nixling__subcmd__realm__subcmd__help__subcmd__inspect"
+                ;;
+            nixling__subcmd__realm__subcmd__help,list)
+                cmd="nixling__subcmd__realm__subcmd__help__subcmd__list"
                 ;;
             nixling__subcmd__realm__subcmd__help,run)
                 cmd="nixling__subcmd__realm__subcmd__help__subcmd__run"
@@ -1643,7 +1661,7 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__help__subcmd__realm)
-            opts="enter run"
+            opts="list inspect enter run"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1657,6 +1675,34 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__help__subcmd__realm__subcmd__enter)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        nixling__subcmd__help__subcmd__realm__subcmd__inspect)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        nixling__subcmd__help__subcmd__realm__subcmd__list)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -2461,7 +2507,7 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__realm)
-            opts="-h --help enter run help"
+            opts="-h --help list inspect enter run help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2489,7 +2535,7 @@ _nixling() {
             return 0
             ;;
         nixling__subcmd__realm__subcmd__help)
-            opts="enter run help"
+            opts="list inspect enter run help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2530,9 +2576,65 @@ _nixling() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        nixling__subcmd__realm__subcmd__help__subcmd__inspect)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        nixling__subcmd__realm__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         nixling__subcmd__realm__subcmd__help__subcmd__run)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        nixling__subcmd__realm__subcmd__inspect)
+            opts="-h --json --human --help <REALM>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        nixling__subcmd__realm__subcmd__list)
+            opts="-h --json --human --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/docs/completions/nixling.fish
+++ b/docs/completions/nixling.fish
@@ -180,14 +180,24 @@ complete -c nixling -n "__fish_nixling_using_subcommand auth; and __fish_seen_su
 complete -c nixling -n "__fish_nixling_using_subcommand auth; and __fish_seen_subcommand_from status" -s h -l help -d 'Print help'
 complete -c nixling -n "__fish_nixling_using_subcommand auth; and __fish_seen_subcommand_from help" -f -a "status"
 complete -c nixling -n "__fish_nixling_using_subcommand auth; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from enter run help" -s h -l help -d 'Print help'
-complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from enter run help" -f -a "enter" -d 'Open an interactive shell inside the realm gateway VM'
-complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from enter run help" -f -a "run" -d 'Run a one-shot command inside the realm gateway VM'
-complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from enter run help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from list inspect enter run help" -s h -l help -d 'Print help'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from list inspect enter run help" -f -a "list" -d 'List local realm policy entrypoints'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from list inspect enter run help" -f -a "inspect" -d 'Inspect one local realm policy entrypoint'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from list inspect enter run help" -f -a "enter" -d 'Open an interactive shell inside the realm gateway VM'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from list inspect enter run help" -f -a "run" -d 'Run a one-shot command inside the realm gateway VM'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and not __fish_seen_subcommand_from list inspect enter run help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from list" -l json
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from list" -l human
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from inspect" -l json
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from inspect" -l human
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from inspect" -s h -l help -d 'Print help'
 complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from enter" -s h -l help -d 'Print help'
 complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from run" -l json -d 'Emit the outer `vm exec` result as JSON'
 complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from run" -l human -d 'Force human output'
 complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from run" -s h -l help -d 'Print help'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from help" -f -a "list" -d 'List local realm policy entrypoints'
+complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from help" -f -a "inspect" -d 'Inspect one local realm policy entrypoint'
 complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from help" -f -a "enter" -d 'Open an interactive shell inside the realm gateway VM'
 complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from help" -f -a "run" -d 'Run a one-shot command inside the realm gateway VM'
 complete -c nixling -n "__fish_nixling_using_subcommand realm; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
@@ -413,6 +423,8 @@ complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_su
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "reconcile" -d 'Recover host network state after the daemon engaged operator-only mode'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from host" -f -a "validate" -d 'Run the host-side validator suite and write evidence records'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from auth" -f -a "status"
+complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from realm" -f -a "list" -d 'List local realm policy entrypoints'
+complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from realm" -f -a "inspect" -d 'Inspect one local realm policy entrypoint'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from realm" -f -a "enter" -d 'Open an interactive shell inside the realm gateway VM'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from realm" -f -a "run" -d 'Run a one-shot command inside the realm gateway VM'
 complete -c nixling -n "__fish_nixling_using_subcommand help; and __fish_seen_subcommand_from vm" -f -a "start" -d 'Start the per-VM DAG (virtiofsd → CH → readiness probes)'

--- a/docs/completions/nixling.zsh
+++ b/docs/completions/nixling.zsh
@@ -453,7 +453,24 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:nixling-realm-command-$line[1]:"
         case $line[1] in
-            (enter)
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'(--human)--json[]' \
+'(--json)--human[]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(inspect)
+_arguments "${_arguments_options[@]}" : \
+'(--human)--json[]' \
+'(--json)--human[]' \
+'-h[Print help]' \
+'--help[Print help]' \
+':realm -- Realm path, e.g. `work` or `payments.work`:_default' \
+&& ret=0
+;;
+(enter)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -482,7 +499,15 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:nixling-realm-help-command-$line[1]:"
         case $line[1] in
-            (enter)
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(inspect)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(enter)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1266,7 +1291,15 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:nixling-help-realm-command-$line[1]:"
         case $line[1] in
-            (enter)
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(inspect)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(enter)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1978,6 +2011,8 @@ _nixling__subcmd__help__subcmd__migrate_commands() {
 (( $+functions[_nixling__subcmd__help__subcmd__realm_commands] )) ||
 _nixling__subcmd__help__subcmd__realm_commands() {
     local commands; commands=(
+'list:List local realm policy entrypoints' \
+'inspect:Inspect one local realm policy entrypoint' \
 'enter:Open an interactive shell inside the realm gateway VM' \
 'run:Run a one-shot command inside the realm gateway VM' \
     )
@@ -1987,6 +2022,16 @@ _nixling__subcmd__help__subcmd__realm_commands() {
 _nixling__subcmd__help__subcmd__realm__subcmd__enter_commands() {
     local commands; commands=()
     _describe -t commands 'nixling help realm enter commands' commands "$@"
+}
+(( $+functions[_nixling__subcmd__help__subcmd__realm__subcmd__inspect_commands] )) ||
+_nixling__subcmd__help__subcmd__realm__subcmd__inspect_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling help realm inspect commands' commands "$@"
+}
+(( $+functions[_nixling__subcmd__help__subcmd__realm__subcmd__list_commands] )) ||
+_nixling__subcmd__help__subcmd__realm__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling help realm list commands' commands "$@"
 }
 (( $+functions[_nixling__subcmd__help__subcmd__realm__subcmd__run_commands] )) ||
 _nixling__subcmd__help__subcmd__realm__subcmd__run_commands() {
@@ -2313,6 +2358,8 @@ _nixling__subcmd__migrate_commands() {
 (( $+functions[_nixling__subcmd__realm_commands] )) ||
 _nixling__subcmd__realm_commands() {
     local commands; commands=(
+'list:List local realm policy entrypoints' \
+'inspect:Inspect one local realm policy entrypoint' \
 'enter:Open an interactive shell inside the realm gateway VM' \
 'run:Run a one-shot command inside the realm gateway VM' \
 'help:Print this message or the help of the given subcommand(s)' \
@@ -2327,6 +2374,8 @@ _nixling__subcmd__realm__subcmd__enter_commands() {
 (( $+functions[_nixling__subcmd__realm__subcmd__help_commands] )) ||
 _nixling__subcmd__realm__subcmd__help_commands() {
     local commands; commands=(
+'list:List local realm policy entrypoints' \
+'inspect:Inspect one local realm policy entrypoint' \
 'enter:Open an interactive shell inside the realm gateway VM' \
 'run:Run a one-shot command inside the realm gateway VM' \
 'help:Print this message or the help of the given subcommand(s)' \
@@ -2343,10 +2392,30 @@ _nixling__subcmd__realm__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'nixling realm help help commands' commands "$@"
 }
+(( $+functions[_nixling__subcmd__realm__subcmd__help__subcmd__inspect_commands] )) ||
+_nixling__subcmd__realm__subcmd__help__subcmd__inspect_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling realm help inspect commands' commands "$@"
+}
+(( $+functions[_nixling__subcmd__realm__subcmd__help__subcmd__list_commands] )) ||
+_nixling__subcmd__realm__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling realm help list commands' commands "$@"
+}
 (( $+functions[_nixling__subcmd__realm__subcmd__help__subcmd__run_commands] )) ||
 _nixling__subcmd__realm__subcmd__help__subcmd__run_commands() {
     local commands; commands=()
     _describe -t commands 'nixling realm help run commands' commands "$@"
+}
+(( $+functions[_nixling__subcmd__realm__subcmd__inspect_commands] )) ||
+_nixling__subcmd__realm__subcmd__inspect_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling realm inspect commands' commands "$@"
+}
+(( $+functions[_nixling__subcmd__realm__subcmd__list_commands] )) ||
+_nixling__subcmd__realm__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'nixling realm list commands' commands "$@"
 }
 (( $+functions[_nixling__subcmd__realm__subcmd__run_commands] )) ||
 _nixling__subcmd__realm__subcmd__run_commands() {

--- a/docs/explanation/host-realm-isolation.md
+++ b/docs/explanation/host-realm-isolation.md
@@ -16,3 +16,7 @@ personal realms separated by topology instead of by host-side conditionals.
 Remote-management transports follow the same trust boundary: they run from a
 gateway guest or a separately reviewed guest-owned design, never as a
 host-side realm relay exception.
+
+The host is not a global realm-policy singleton. Gateway guests own
+remote/provider realm policy evaluation, while local host authorization remains
+`SO_PEERCRED` plus the canonical `nixling` lifecycle group.

--- a/docs/how-to/configure-work-gateway.md
+++ b/docs/how-to/configure-work-gateway.md
@@ -47,10 +47,10 @@ stores credential material.
 
 ```bash
 nixling realm enter work
-sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=/var/lib/nixling/gateways/work \
+sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=<gateway-state-dir> \
   nixling-gateway-enroll enroll \
-  /var/lib/nixling/gateways/work/credential.sealed.json \
-  /var/lib/nixling/gateways/work/seal.key < enrollment.json
+  <gateway-state-dir>/credential.sealed.json \
+  <gateway-state-dir>/seal.key < enrollment.json
 ```
 
 Use placeholder or test credentials only in examples and fixtures. Do not

--- a/docs/how-to/configure-work-gateway.md
+++ b/docs/how-to/configure-work-gateway.md
@@ -1,0 +1,57 @@
+# Configure a work realm gateway
+
+**Diataxis category:** how-to.
+
+Use a dedicated gateway guest for each work or provider realm. Do not share a
+gateway guest, nixling env, or L2 bridge with personal realms.
+
+## Declare the realm and gateway
+
+```nix
+nixling.envs.work = {
+  lanSubnet = "10.44.0.0/24";
+  uplinkSubnet = "192.0.2.0/30";
+};
+
+nixling.gateways.work = {
+  realm = "work";
+  env = "work";
+  index = 20;
+  relay.namespace = "relns-example.servicebus.windows.net";
+  relay.entity = "hc-nixling-work";
+};
+```
+
+Then start the gateway like any other VM:
+
+```bash
+nixling vm start sys-work-gateway --apply
+```
+
+## Inspect the policy
+
+```bash
+nixling realm list
+nixling realm inspect work
+```
+
+The output reports whether a realm is host-resident or gateway-backed, the
+gateway VM when present, its local lifecycle state, and the default-deny
+cross-realm posture.
+
+## Enroll credentials inside the gateway
+
+Realm relay/provider credentials are enrolled from inside the gateway guest.
+The host declaration contains only non-secret coordinates and never parses or
+stores credential material.
+
+```bash
+nixling realm enter work
+sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=/var/lib/nixling/gateways/work \
+  nixling-gateway-enroll enroll \
+  /var/lib/nixling/gateways/work/credential.sealed.json \
+  /var/lib/nixling/gateways/work/seal.key < enrollment.json
+```
+
+Use placeholder or test credentials only in examples and fixtures. Do not
+commit live provider ids, tokens, keys, host paths, or user identifiers.

--- a/docs/how-to/migrate-nixling-v1-2-to-v2.md
+++ b/docs/how-to/migrate-nixling-v1-2-to-v2.md
@@ -2,9 +2,8 @@
 
 **Diataxis category:** how-to.
 
-This guide is version-neutral until the release boundary for the realm rollout
-is finalized. If the release introduces a versioned migration guide, this file
-should be renamed to the repository's version-bound migration convention.
+This guide covers the realm-gateway policy transition planned for the v2
+control-plane rollout.
 
 ## What changes
 

--- a/docs/how-to/migrate-to-realm-gateways.md
+++ b/docs/how-to/migrate-to-realm-gateways.md
@@ -1,0 +1,37 @@
+# Migrate to explicit realm gateways
+
+**Diataxis category:** how-to.
+
+This guide is version-neutral until the release boundary for the realm rollout
+is finalized. If the release introduces a versioned migration guide, this file
+should be renamed to the repository's version-bound migration convention.
+
+## What changes
+
+- Bare VM names stay local.
+- The reserved `local` realm stays host-resident.
+- Work, provider, and cross-host realms use explicit gateway-backed
+  entrypoints.
+- Cross-realm operations and streams are denied by default.
+- Relay/provider credentials are enrolled inside the gateway guest, not stored
+  or minted by the host.
+
+## Migration steps
+
+1. Declare a dedicated `nixling.envs.<realm>` for each trust-boundary realm.
+2. Declare one `nixling.gateways.<name>` per gateway-backed realm.
+3. Rebuild the host and inspect the rendered policy with
+   `nixling realm list` and `nixling realm inspect <realm>`.
+4. Start each gateway VM and enroll credentials from inside the gateway guest.
+5. Update scripts to use fully-qualified realm targets only where remote or
+   provider routing is intended.
+
+If an existing deployment only uses local VMs and no gateway credentials, no
+state migration is required: local VM names and the `local` realm continue to
+use the host fast path.
+
+## Verify isolation
+
+Confirm that work and personal/provider realms do not share gateway guests,
+envs, or L2 bridges. Stopped gateways must fail closed with remediation rather
+than falling back to host credentials, SSH, or host routing.

--- a/docs/how-to/realm-gateway.md
+++ b/docs/how-to/realm-gateway.md
@@ -70,6 +70,10 @@ If the gateway is missing, stopped, or not reported by the daemon, the
 CLI fails closed with a typed remediation instead of falling back to host
 credentials or SSH.
 
+Use `nixling realm list` and `nixling realm inspect <realm>` to inspect the
+rendered host-resident vs gateway-backed policy and the gateway's local
+lifecycle state.
+
 ## Credential boundary
 
 The host declaration carries non-secret coordinates and state paths only.

--- a/docs/how-to/realm-gateway.md
+++ b/docs/how-to/realm-gateway.md
@@ -91,10 +91,10 @@ keys never appear in argv:
 
 ```bash
 nixling realm enter work
-sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=/var/lib/nixling/gateways/work \
+sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=<gateway-state-dir> \
   nixling-gateway-enroll enroll \
-  /var/lib/nixling/gateways/work/credential.sealed.json \
-  /var/lib/nixling/gateways/work/seal.key <<'JSON'
+  <gateway-state-dir>/credential.sealed.json \
+  <gateway-state-dir>/seal.key <<'JSON'
 {
   "relayListen": { "keyName": "gateway-listen", "key": "<listen-rule-key>" },
   "relaySend": { "keyName": "gateway-send", "key": "<send-rule-key>" }
@@ -113,10 +113,10 @@ Rotate by passing the replacement JSON through the same in-guest helper:
 
 ```bash
 nixling realm enter work
-sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=/var/lib/nixling/gateways/work \
+sudo -u nixlingd NIXLING_GATEWAY_STATE_DIR=<gateway-state-dir> \
   nixling-gateway-enroll rotate \
-  /var/lib/nixling/gateways/work/credential.sealed.json \
-  /var/lib/nixling/gateways/work/seal.key <<'JSON'
+  <gateway-state-dir>/credential.sealed.json \
+  <gateway-state-dir>/seal.key <<'JSON'
 {
   "relayListen": { "keyName": "gateway-listen", "key": "<new-listen-rule-key>" },
   "relaySend": { "keyName": "gateway-send", "key": "<new-send-rule-key>" }

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -132,6 +132,22 @@ the realm through the generated realm entrypoint table and verifies the
 gateway VM is declared and running before attempting the exec. Realm
 relay/provider credentials remain inside the gateway guest.
 
+### `realm list`
+
+**Synopsis:** `nixling realm list [--human | --json]`
+
+Lists rendered local realm entrypoints. The output reports each realm's mode
+(`host-resident` or `gateway-backed`), gateway VM when present, local gateway
+lifecycle state, credential boundary, and default-deny cross-realm policy.
+
+### `realm inspect`
+
+**Synopsis:** `nixling realm inspect <realm> [--human | --json]`
+
+Inspects one realm entrypoint using the same bounded fields as `realm list`.
+Unknown realms fail closed with the same actionable missing-entrypoint envelope
+used by routed VM targets.
+
 ### `realm run`
 
 **Synopsis:** `nixling realm run <realm> -- <argv...> [--human | --json]`

--- a/docs/reference/cli-output/realm-inspect.schema.json
+++ b/docs/reference/cli-output/realm-inspect.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RealmInspectOutputV1",
+  "type": "object",
+  "required": [
+    "command",
+    "credentialBoundary",
+    "crossRealmPolicy",
+    "gatewayState",
+    "mode",
+    "realm"
+  ],
+  "properties": {
+    "command": {
+      "type": "string"
+    },
+    "credentialBoundary": {
+      "type": "string"
+    },
+    "crossRealmPolicy": {
+      "type": "string"
+    },
+    "gatewayState": {
+      "type": "string"
+    },
+    "gatewayTarget": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "gatewayVm": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "mode": {
+      "type": "string"
+    },
+    "realm": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/reference/cli-output/realm-inspect.schema.json
+++ b/docs/reference/cli-output/realm-inspect.schema.json
@@ -41,6 +41,5 @@
     "realm": {
       "type": "string"
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/docs/reference/cli-output/realm-list.schema.json
+++ b/docs/reference/cli-output/realm-list.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RealmListOutputV1",
+  "type": "object",
+  "required": [
+    "command",
+    "realms"
+  ],
+  "properties": {
+    "command": {
+      "type": "string"
+    },
+    "realms": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RealmPolicyOutputV1"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "RealmPolicyOutputV1": {
+      "type": "object",
+      "required": [
+        "credentialBoundary",
+        "crossRealmPolicy",
+        "gatewayState",
+        "mode",
+        "realm"
+      ],
+      "properties": {
+        "credentialBoundary": {
+          "type": "string"
+        },
+        "crossRealmPolicy": {
+          "type": "string"
+        },
+        "gatewayState": {
+          "type": "string"
+        },
+        "gatewayTarget": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gatewayVm": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "type": "string"
+        },
+        "realm": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/reference/realm-policy.md
+++ b/docs/reference/realm-policy.md
@@ -24,8 +24,9 @@ policy storage and evaluation live in the owning gateway guest.
 - Work, personal, and provider realms never share a gateway guest or L2 bridge.
 - Gateway-backed realms do not get wildcard routes such as `0.0.0.0/0` or
   `::/0`.
-- Host L3 forwarding between realm bridges must be blocked by explicit
-  firewall/nftables drops or equivalent namespace/routing isolation.
+- Deployments must validate that host L3 forwarding cannot transit between
+  realm bridges. Use explicit firewall/nftables drops or equivalent
+  namespace/routing isolation before treating realms as isolated at L3.
 - Cross-realm operations and streams are denied unless a future reviewed typed
   policy explicitly allows a named operation or stream. There are no enabled
   default allow rules.

--- a/docs/reference/realm-policy.md
+++ b/docs/reference/realm-policy.md
@@ -22,11 +22,14 @@ policy storage and evaluation live in the owning gateway guest.
 
 - `local` is always host-resident and cannot be declared as gateway-backed.
 - Work, personal, and provider realms never share a gateway guest or L2 bridge.
-- Gateway-backed realms do not get wildcard routes such as `0.0.0.0/0` or
+- Gateway-backed realms do not get default routes such as `0.0.0.0/0` or
   `::/0`.
 - Deployments must validate that host L3 forwarding cannot transit between
   realm bridges. Use explicit firewall/nftables drops or equivalent
-  namespace/routing isolation before treating realms as isolated at L3.
+  namespace/routing isolation before treating realms as isolated at L3. This
+  reference page describes the policy contract; it does not claim code-level L3
+  enforcement for hosts that have not installed those drops or isolation
+  controls.
 - Cross-realm operations and streams are denied unless a future reviewed typed
   policy explicitly allows a named operation or stream. There are no enabled
   default allow rules.

--- a/docs/reference/realm-policy.md
+++ b/docs/reference/realm-policy.md
@@ -1,0 +1,44 @@
+# Realm policy
+
+**Diataxis category:** reference.
+
+Realm policy is fail-closed and local by default. The host keeps the local
+fast path for bare VM names and the reserved `local` realm. Gateway-backed
+realms are fronted by a dedicated gateway guest in a separate nixling env/L2
+segment.
+
+## Policy modes
+
+| Mode | Authority | Credential boundary | Cross-realm default |
+| --- | --- | --- | --- |
+| `host-resident` | Local host daemon for local workloads only. | No realm relay/provider credentials. | Deny. |
+| `gateway-backed` | The owning gateway guest for that realm. | Credentials are enrolled direct-to-guest or by opaque passthrough; the host never parses or stores them. | Deny. |
+
+The host is not a global realm-policy singleton. It publishes local gateway
+entrypoints and routes operators to the right gateway VM, but remote/provider
+policy storage and evaluation live in the owning gateway guest.
+
+## Isolation rules
+
+- `local` is always host-resident and cannot be declared as gateway-backed.
+- Work, personal, and provider realms never share a gateway guest or L2 bridge.
+- Gateway-backed realms do not get wildcard routes such as `0.0.0.0/0` or
+  `::/0`.
+- Host L3 forwarding between realm bridges must be blocked by explicit
+  firewall/nftables drops or equivalent namespace/routing isolation.
+- Cross-realm operations and streams are denied unless a future reviewed typed
+  policy explicitly allows a named operation or stream. There are no enabled
+  default allow rules.
+- SSH fallback and generic tunnels are not policy escape hatches.
+
+## Authorization and audit
+
+Local host authorization remains `SO_PEERCRED` plus the canonical `nixling`
+lifecycle group. Relay, gateway, and cross-realm identities never map to local
+lifecycle roles.
+
+Default-deny decisions are operator-visible through typed errors and bounded
+audit events. Audit and error surfaces carry only low-cardinality realm,
+operation or stream kind, decision, and reason labels. They must not contain
+payload bytes, argv, stdout/stderr, credentials, tokens, provider headers, full
+endpoints, host paths, or PII.

--- a/docs/reference/realm-policy.md
+++ b/docs/reference/realm-policy.md
@@ -22,8 +22,9 @@ policy storage and evaluation live in the owning gateway guest.
 
 - `local` is always host-resident and cannot be declared as gateway-backed.
 - Work, personal, and provider realms never share a gateway guest or L2 bridge.
-- Gateway-backed realms do not get default routes such as `0.0.0.0/0` or
-  `::/0`.
+- Default routes inside a gateway guest are not an isolation boundary by
+  themselves; operators must rely on the dedicated gateway/env topology and L3
+  isolation controls below.
 - Deployments must validate that host L3 forwarding cannot transit between
   realm bridges. Use explicit firewall/nftables drops or equivalent
   namespace/routing isolation before treating realms as isolated at L3. This

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -4321,11 +4321,36 @@ struct RealmEntrypointDocument {
     entries: BTreeMap<String, RealmEntrypointConfig>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RealmEntrypointConfig {
     mode: String,
     gateway: Option<String>,
+}
+
+fn local_realm_entrypoint_config() -> RealmEntrypointConfig {
+    RealmEntrypointConfig {
+        mode: "host-resident".to_owned(),
+        gateway: None,
+    }
+}
+
+fn normalize_realm_entrypoint_entries(
+    mut entries: BTreeMap<String, RealmEntrypointConfig>,
+) -> Result<BTreeMap<String, RealmEntrypointConfig>, CliFailure> {
+    match entries.get("local") {
+        Some(entry) if entry.mode == "host-resident" && entry.gateway.is_none() => {}
+        Some(_) => {
+            return Err(CliFailure::new(
+                1,
+                "realm entrypoint `local` must remain host-resident and credential-free",
+            ));
+        }
+        None => {
+            entries.insert("local".to_owned(), local_realm_entrypoint_config());
+        }
+    }
+    Ok(entries)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -4375,7 +4400,7 @@ fn load_realm_entrypoint_table_from_path(
         return Ok(None);
     };
     let mut table = nixling_constellation_router::RealmEntrypointTable::new();
-    for (realm_raw, entry) in doc.entries {
+    for (realm_raw, entry) in normalize_realm_entrypoint_entries(doc.entries)? {
         let realm = target_routing::parse_realm_arg(&realm_raw).map_err(|err| {
             CliFailure::new(
                 1,
@@ -4418,7 +4443,7 @@ fn configured_realm_gateways(json: bool) -> Result<Vec<ResolvedRealmGateway>, Cl
         return Ok(Vec::new());
     };
     let mut gateways = Vec::new();
-    for (realm_raw, entry) in doc.entries {
+    for (realm_raw, entry) in normalize_realm_entrypoint_entries(doc.entries)? {
         if entry.mode != "gateway-backed" {
             continue;
         }
@@ -4786,16 +4811,10 @@ fn realm_policy_rows(
             doc.entries
         } else {
             let mut entries = std::collections::BTreeMap::new();
-            entries.insert(
-                "local".to_owned(),
-                RealmEntrypointConfig {
-                    mode: "host-resident".to_owned(),
-                    gateway: None,
-                },
-            );
+            entries.insert("local".to_owned(), local_realm_entrypoint_config());
             entries
         };
-    realm_policy_rows_from_entries(context, entries, json)
+    realm_policy_rows_from_entries(context, normalize_realm_entrypoint_entries(entries)?, json)
 }
 
 fn realm_policy_rows_from_entries(
@@ -10627,6 +10646,49 @@ mod host_install_dispatch_tests {
             );
         }
         let _ = std::fs::remove_file(&manifest_path);
+    }
+
+    #[test]
+    fn realm_policy_rows_inject_local_host_resident_entrypoint() {
+        let manifest_path = test_socket_path("realm-policy-local-inject", ".manifest.json");
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).expect("manifest parent");
+        }
+        write_test_manifest(&manifest_path, "sys-work-gateway");
+        let context = test_context(manifest_path.clone());
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            "work".to_owned(),
+            super::RealmEntrypointConfig {
+                mode: "gateway-backed".to_owned(),
+                gateway: Some("sys-work-gateway.nixling".to_owned()),
+            },
+        );
+        let rows = super::realm_policy_rows_from_entries(
+            &context,
+            super::normalize_realm_entrypoint_entries(entries).unwrap(),
+            true,
+        )
+        .expect("realm rows render");
+        assert_eq!(rows[0].realm, "local");
+        assert_eq!(rows[0].mode, "host-resident");
+        let _ = std::fs::remove_file(&manifest_path);
+    }
+
+    #[test]
+    fn realm_policy_rows_reject_local_gateway_backed_entrypoint() {
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            "local".to_owned(),
+            super::RealmEntrypointConfig {
+                mode: "gateway-backed".to_owned(),
+                gateway: Some("sys-local-gateway.nixling".to_owned()),
+            },
+        );
+        let err = super::normalize_realm_entrypoint_entries(entries)
+            .expect_err("local gateway-backed entrypoint must fail closed");
+        assert!(err.message.contains("local"));
+        assert!(err.message.contains("host-resident"));
     }
 
     fn write_qemu_media_manifest(path: &PathBuf, vm: &str) {

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -240,7 +240,7 @@ pub struct RealmListOutputV1 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct RealmInspectOutputV1 {
     pub command: String,
     #[serde(flatten)]
@@ -4328,6 +4328,24 @@ struct RealmEntrypointConfig {
     gateway: Option<String>,
 }
 
+fn safe_error_snippet(raw: &str) -> String {
+    const MAX: usize = 64;
+    let secret_shaped = raw.contains("SharedAccessKey")
+        || raw.contains("Bearer ")
+        || raw.contains("Endpoint=sb://")
+        || raw.contains("AccountKey=")
+        || raw.contains("PRIVATE KEY")
+        || raw.contains("/home/");
+    if secret_shaped {
+        return "<redacted>".to_owned();
+    }
+    let mut snippet = raw.chars().take(MAX).collect::<String>();
+    if raw.chars().count() > MAX {
+        snippet.push_str("...");
+    }
+    snippet
+}
+
 fn local_realm_entrypoint_config() -> RealmEntrypointConfig {
     RealmEntrypointConfig {
         mode: "host-resident".to_owned(),
@@ -4404,7 +4422,10 @@ fn load_realm_entrypoint_table_from_path(
         let realm = target_routing::parse_realm_arg(&realm_raw).map_err(|err| {
             CliFailure::new(
                 1,
-                format!("realm entrypoint `{realm_raw}` is invalid: {err}"),
+                format!(
+                    "realm entrypoint `{}` is invalid: {err}",
+                    safe_error_snippet(&realm_raw)
+                ),
             )
         })?;
         match entry.mode.as_str() {
@@ -4413,7 +4434,10 @@ fn load_realm_entrypoint_table_from_path(
                 let gateway = entry.gateway.ok_or_else(|| {
                     CliFailure::new(
                         1,
-                        format!("gateway-backed realm `{realm_raw}` has no gateway target"),
+                        format!(
+                            "gateway-backed realm `{}` has no gateway target",
+                            safe_error_snippet(&realm_raw)
+                        ),
                     )
                 })?;
                 let gateway_target = nixling_constellation_core::TargetName::parse(&gateway)
@@ -4421,7 +4445,9 @@ fn load_realm_entrypoint_table_from_path(
                         CliFailure::new(
                             1,
                             format!(
-                                "realm `{realm_raw}` gateway target `{gateway}` is invalid: {err}"
+                                "realm `{}` gateway target `{}` is invalid: {err}",
+                                safe_error_snippet(&realm_raw),
+                                safe_error_snippet(&gateway)
                             ),
                         )
                     })?;
@@ -4430,7 +4456,11 @@ fn load_realm_entrypoint_table_from_path(
             other => {
                 return Err(CliFailure::new(
                     1,
-                    format!("realm `{realm_raw}` has unknown entrypoint mode `{other}`"),
+                    format!(
+                        "realm `{}` has unknown entrypoint mode `{}`",
+                        safe_error_snippet(&realm_raw),
+                        safe_error_snippet(other)
+                    ),
                 ));
             }
         }
@@ -4450,13 +4480,19 @@ fn configured_realm_gateways(json: bool) -> Result<Vec<ResolvedRealmGateway>, Cl
         let realm = target_routing::parse_realm_arg(&realm_raw).map_err(|err| {
             CliFailure::new(
                 1,
-                format!("realm entrypoint `{realm_raw}` is invalid: {err}"),
+                format!(
+                    "realm entrypoint `{}` is invalid: {err}",
+                    safe_error_snippet(&realm_raw)
+                ),
             )
         })?;
         let gateway_target = entry.gateway.ok_or_else(|| {
             CliFailure::new(
                 1,
-                format!("gateway-backed realm `{realm_raw}` has no gateway target"),
+                format!(
+                    "gateway-backed realm `{}` has no gateway target",
+                    safe_error_snippet(&realm_raw)
+                ),
             )
         })?;
         gateways.push(ResolvedRealmGateway {
@@ -4478,7 +4514,7 @@ fn gateway_vm_from_target_text(
         .map(|target| target.workload.as_str().to_owned())
         .map_err(|err| target_routing::RouteError::InvalidGatewayTarget {
             realm: realm.to_owned(),
-            gateway: target.to_owned(),
+            gateway: safe_error_snippet(target),
             reason: err.to_string(),
         })
 }
@@ -4654,7 +4690,7 @@ fn resolve_realm_gateway(
 ) -> Result<ResolvedRealmGateway, CliFailure> {
     let realm = target_routing::parse_realm_arg(realm_raw).map_err(|err| {
         emit_realm_usage_error(
-            &format!("invalid realm `{realm_raw}`: {err}"),
+            &format!("invalid realm `{}`: {err}", safe_error_snippet(realm_raw)),
             "realm argument did not parse as a bounded lowercase realm path",
             "Use a DNS-shaped realm path such as `work` or `payments.work`.",
             json,
@@ -4828,7 +4864,10 @@ fn realm_policy_rows_from_entries(
         let realm = target_routing::parse_realm_arg(&realm_raw).map_err(|err| {
             CliFailure::new(
                 1,
-                format!("realm entrypoint `{realm_raw}` is invalid: {err}"),
+                format!(
+                    "realm entrypoint `{}` is invalid: {err}",
+                    safe_error_snippet(&realm_raw)
+                ),
             )
         })?;
         let realm_target = realm.target_form();
@@ -4847,7 +4886,10 @@ fn realm_policy_rows_from_entries(
                 let gateway_target = entry.gateway.ok_or_else(|| {
                     CliFailure::new(
                         1,
-                        format!("gateway-backed realm `{realm_raw}` has no gateway target"),
+                        format!(
+                            "gateway-backed realm `{}` has no gateway target",
+                            safe_error_snippet(&realm_raw)
+                        ),
                     )
                 })?;
                 let gateway_vm = gateway_vm_from_target_text(&realm_target, &gateway_target)
@@ -4870,7 +4912,11 @@ fn realm_policy_rows_from_entries(
             other => {
                 return Err(CliFailure::new(
                     1,
-                    format!("realm `{realm_raw}` has unknown entrypoint mode `{other}`"),
+                    format!(
+                        "realm `{}` has unknown entrypoint mode `{}`",
+                        safe_error_snippet(&realm_raw),
+                        safe_error_snippet(other)
+                    ),
                 ));
             }
         }
@@ -4914,35 +4960,43 @@ fn cmd_realm_list(context: &Context, args: &RealmListArgs) -> Result<i32, CliFai
 }
 
 fn cmd_realm_inspect(context: &Context, args: &RealmInspectArgs) -> Result<i32, CliFailure> {
-    let realm = target_routing::parse_realm_arg(&args.realm).map_err(|err| {
-        emit_realm_usage_error(
-            &format!("invalid realm `{}`: {err}", args.realm),
-            "realm argument did not parse as a bounded lowercase realm path",
-            "Use a DNS-shaped realm path such as `work` or `payments.work`.",
-            args.json,
-        )
-        .unwrap_or_else(|failure| failure)
-    })?;
-    let realm_key = realm.target_form();
     let rows = realm_policy_rows(context, args.json)?;
-    let Some(row) = rows.into_iter().find(|row| row.realm == realm_key) else {
-        return Err(emit_missing_realm_entrypoint(
-            &realm_key,
-            &target_routing::gateway_vm_name(&realm),
-            None,
-            args.json,
-        )?);
-    };
-    let output = RealmInspectOutputV1 {
-        command: "realm inspect".to_owned(),
-        realm: row,
-    };
+    let output = realm_inspect_output(&args.realm, args.json, rows)?;
     if args.json {
         print_json(&output)?;
     } else {
         print_realm_rows_human(std::slice::from_ref(&output.realm));
     }
     Ok(0)
+}
+
+fn realm_inspect_output(
+    raw_realm: &str,
+    json: bool,
+    rows: Vec<RealmPolicyOutputV1>,
+) -> Result<RealmInspectOutputV1, CliFailure> {
+    let realm = target_routing::parse_realm_arg(raw_realm).map_err(|err| {
+        emit_realm_usage_error(
+            &format!("invalid realm `{}`: {err}", safe_error_snippet(raw_realm)),
+            "realm argument did not parse as a bounded lowercase realm path",
+            "Use a DNS-shaped realm path such as `work` or `payments.work`.",
+            json,
+        )
+        .unwrap_or_else(|failure| failure)
+    })?;
+    let realm_key = realm.target_form();
+    let Some(row) = rows.into_iter().find(|row| row.realm == realm_key) else {
+        return Err(emit_missing_realm_entrypoint(
+            &realm_key,
+            &target_routing::gateway_vm_name(&realm),
+            None,
+            json,
+        )?);
+    };
+    Ok(RealmInspectOutputV1 {
+        command: "realm inspect".to_owned(),
+        realm: row,
+    })
 }
 
 fn cmd_realm_enter(context: &Context, args: &RealmEnterArgs) -> Result<i32, CliFailure> {
@@ -10689,6 +10743,77 @@ mod host_install_dispatch_tests {
             .expect_err("local gateway-backed entrypoint must fail closed");
         assert!(err.message.contains("local"));
         assert!(err.message.contains("host-resident"));
+    }
+
+    #[test]
+    fn realm_policy_rows_reject_unknown_mode_and_missing_gateway() {
+        let manifest_path = test_socket_path("realm-policy-bad-entries", ".manifest.json");
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).expect("manifest parent");
+        }
+        write_test_manifest(&manifest_path, "sys-work-gateway");
+        let context = test_context(manifest_path.clone());
+
+        let mut unknown_mode = std::collections::BTreeMap::new();
+        unknown_mode.insert(
+            "work".to_owned(),
+            super::RealmEntrypointConfig {
+                mode: "surprise".to_owned(),
+                gateway: None,
+            },
+        );
+        let err = super::realm_policy_rows_from_entries(&context, unknown_mode, true)
+            .expect_err("unknown mode fails closed");
+        assert!(err.message.contains("unknown entrypoint mode"));
+
+        let mut missing_gateway = std::collections::BTreeMap::new();
+        missing_gateway.insert(
+            "work".to_owned(),
+            super::RealmEntrypointConfig {
+                mode: "gateway-backed".to_owned(),
+                gateway: None,
+            },
+        );
+        let err = super::realm_policy_rows_from_entries(&context, missing_gateway, true)
+            .expect_err("missing gateway fails closed");
+        assert!(err.message.contains("no gateway target"));
+        let _ = std::fs::remove_file(&manifest_path);
+    }
+
+    #[test]
+    fn realm_inspect_invalid_and_unknown_realms_fail_closed() {
+        let rows = vec![super::RealmPolicyOutputV1 {
+            realm: "local".to_owned(),
+            mode: "host-resident".to_owned(),
+            gateway_vm: None,
+            gateway_target: None,
+            gateway_state: "local-only".to_owned(),
+            cross_realm_policy: "default-deny".to_owned(),
+            credential_boundary: "host-resident-local-only".to_owned(),
+        }];
+
+        let (invalid, invalid_stdout) = super::with_test_stdout_capture(|| {
+            super::realm_inspect_output("Bad Realm", true, rows.clone())
+        });
+        let err = invalid.expect_err("invalid realm fails");
+        assert_eq!(err.exit_code, 2);
+        let envelope: Value =
+            serde_json::from_slice(&invalid_stdout).expect("invalid realm json envelope");
+        assert_eq!(
+            envelope.get("code").and_then(Value::as_str),
+            Some("realm-target-usage")
+        );
+
+        let (unknown, unknown_stdout) =
+            super::with_test_stdout_capture(|| super::realm_inspect_output("work", true, rows));
+        let err = unknown.expect_err("unknown realm fails");
+        assert_eq!(err.exit_code, 2);
+        let envelope: Value =
+            serde_json::from_slice(&unknown_stdout).expect("unknown realm json envelope");
+        assert_eq!(
+            envelope.get("code").and_then(Value::as_str),
+            Some("missing-realm-entrypoint")
+        );
     }
 
     fn write_qemu_media_manifest(path: &PathBuf, vm: &str) {

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::OsString,
     fmt::Write as _,
     fs,
-    io::{self, IsTerminal as _, Write as _},
+    io::{self, IsTerminal as _, Read as _, Write as _},
     os::fd::{AsRawFd as _, OwnedFd},
     path::{Path, PathBuf},
     process::{Command, Stdio},
@@ -71,6 +71,7 @@ const DEFAULT_DAEMON_STATE_DIR: &str = "/var/lib/nixling/daemon-state";
 /// Canonical Prometheus scrape URL the doctor probes for reachability.
 /// See `docs/reference/daemon-metrics.md`.
 const DEFAULT_METRICS_URL: &str = "http://127.0.0.1:9101/metrics";
+const MAX_REALM_ENTRYPOINTS_BYTES: u64 = 1024 * 1024;
 /// Exit code for api-ready timeout in strict mode.
 pub const EXIT_API_TIMEOUT: i32 = 33;
 /// Default in-guest path of the editable guest config working copy. Only the
@@ -4396,8 +4397,8 @@ fn load_realm_entrypoint_table()
 fn load_realm_entrypoint_document_from_path(
     path: &Path,
 ) -> Result<Option<RealmEntrypointDocument>, CliFailure> {
-    let raw = match fs::read_to_string(path) {
-        Ok(raw) => raw,
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(err) => {
             return Err(CliFailure::new(
@@ -4406,6 +4407,20 @@ fn load_realm_entrypoint_document_from_path(
             ));
         }
     };
+    let mut raw = String::new();
+    let read = io::Read::by_ref(&mut file)
+        .take(MAX_REALM_ENTRYPOINTS_BYTES + 1)
+        .read_to_string(&mut raw)
+        .map_err(|err| CliFailure::new(1, format!("failed to read {}: {err}", path.display())))?;
+    if read as u64 > MAX_REALM_ENTRYPOINTS_BYTES {
+        return Err(CliFailure::new(
+            1,
+            format!(
+                "realm entrypoints file {} exceeds the 1 MiB limit",
+                path.display()
+            ),
+        ));
+    }
     let doc: RealmEntrypointDocument = serde_json::from_str(&raw)
         .map_err(|err| CliFailure::new(1, format!("failed to parse {}: {err}", path.display())))?;
     Ok(Some(doc))
@@ -4943,6 +4958,25 @@ fn print_realm_rows_human(rows: &[RealmPolicyOutputV1]) {
     }
 }
 
+fn print_realm_inspect_human(row: &RealmPolicyOutputV1) {
+    print_stdout(&format!("realm: {}\n", row.realm));
+    print_stdout(&format!("mode: {}\n", row.mode));
+    print_stdout(&format!(
+        "gatewayVm: {}\n",
+        row.gateway_vm.as_deref().unwrap_or("-")
+    ));
+    print_stdout(&format!(
+        "gatewayTarget: {}\n",
+        row.gateway_target.as_deref().unwrap_or("-")
+    ));
+    print_stdout(&format!("gatewayState: {}\n", row.gateway_state));
+    print_stdout(&format!(
+        "credentialBoundary: {}\n",
+        row.credential_boundary
+    ));
+    print_stdout(&format!("crossRealmPolicy: {}\n", row.cross_realm_policy));
+}
+
 fn cmd_realm_list(context: &Context, args: &RealmListArgs) -> Result<i32, CliFailure> {
     let rows = realm_policy_rows(context, args.json)?;
     let output = RealmListOutputV1 {
@@ -4965,7 +4999,7 @@ fn cmd_realm_inspect(context: &Context, args: &RealmInspectArgs) -> Result<i32, 
     if args.json {
         print_json(&output)?;
     } else {
-        print_realm_rows_human(std::slice::from_ref(&output.realm));
+        print_realm_inspect_human(&output.realm);
     }
     Ok(0)
 }

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -233,6 +233,35 @@ pub struct VmDisplayCloseOutputV1 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmListOutputV1 {
+    pub command: String,
+    pub realms: Vec<RealmPolicyOutputV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmInspectOutputV1 {
+    pub command: String,
+    #[serde(flatten)]
+    pub realm: RealmPolicyOutputV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmPolicyOutputV1 {
+    pub realm: String,
+    pub mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_vm: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_target: Option<String>,
+    pub gateway_state: String,
+    pub cross_realm_policy: String,
+    pub credential_boundary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum StatusOutputV2 {
     Vm(Box<StatusVmOutputV2>),
@@ -903,10 +932,32 @@ struct RealmArgs {
 
 #[derive(Debug, Subcommand)]
 enum RealmCommand {
+    /// List local realm policy entrypoints.
+    List(RealmListArgs),
+    /// Inspect one local realm policy entrypoint.
+    Inspect(RealmInspectArgs),
     /// Open an interactive shell inside the realm gateway VM.
     Enter(RealmEnterArgs),
     /// Run a one-shot command inside the realm gateway VM.
     Run(RealmRunArgs),
+}
+
+#[derive(Debug, Args)]
+struct RealmListArgs {
+    #[arg(long, conflicts_with = "human")]
+    json: bool,
+    #[arg(long, conflicts_with = "json")]
+    human: bool,
+}
+
+#[derive(Debug, Args)]
+struct RealmInspectArgs {
+    /// Realm path, e.g. `work` or `payments.work`.
+    realm: String,
+    #[arg(long, conflicts_with = "human")]
+    json: bool,
+    #[arg(long, conflicts_with = "json")]
+    human: bool,
 }
 
 #[derive(Debug, Args)]
@@ -2027,6 +2078,8 @@ fn dispatch(
             AuthCommand::Status(args) => cmd_auth_status(context, args),
         },
         NativeCommand::Realm(args) => match &args.command {
+            RealmCommand::List(args) => cmd_realm_list(context, args),
+            RealmCommand::Inspect(args) => cmd_realm_inspect(context, args),
             RealmCommand::Enter(args) => cmd_realm_enter(context, args),
             RealmCommand::Run(args) => cmd_realm_run(context, args),
         },
@@ -4707,6 +4760,150 @@ fn realm_gateway_exec_args(
         management: Vec::new(),
         command: argv,
     }
+}
+
+fn realm_policy_rows(
+    context: &Context,
+    json: bool,
+) -> Result<Vec<RealmPolicyOutputV1>, CliFailure> {
+    let entries =
+        if let Some(doc) = load_realm_entrypoint_document_from_path(&realm_entrypoints_path())? {
+            doc.entries
+        } else {
+            let mut entries = std::collections::BTreeMap::new();
+            entries.insert(
+                "local".to_owned(),
+                RealmEntrypointConfig {
+                    mode: "host-resident".to_owned(),
+                    gateway: None,
+                },
+            );
+            entries
+        };
+    realm_policy_rows_from_entries(context, entries, json)
+}
+
+fn realm_policy_rows_from_entries(
+    context: &Context,
+    entries: BTreeMap<String, RealmEntrypointConfig>,
+    json: bool,
+) -> Result<Vec<RealmPolicyOutputV1>, CliFailure> {
+    let mut rows = Vec::new();
+    for (realm_raw, entry) in entries {
+        let realm = target_routing::parse_realm_arg(&realm_raw).map_err(|err| {
+            CliFailure::new(
+                1,
+                format!("realm entrypoint `{realm_raw}` is invalid: {err}"),
+            )
+        })?;
+        match entry.mode.as_str() {
+            "host-resident" => rows.push(RealmPolicyOutputV1 {
+                realm: realm.target_form(),
+                mode: "host-resident".to_owned(),
+                gateway_vm: None,
+                gateway_target: None,
+                gateway_state: "local-only".to_owned(),
+                cross_realm_policy: "default-deny".to_owned(),
+                credential_boundary: "host-resident-local-only".to_owned(),
+            }),
+            "gateway-backed" => {
+                let gateway_target = entry.gateway.ok_or_else(|| {
+                    CliFailure::new(
+                        1,
+                        format!("gateway-backed realm `{realm_raw}` has no gateway target"),
+                    )
+                })?;
+                let gateway_vm = gateway_vm_from_target_text(&realm.target_form(), &gateway_target)
+                    .map_err(|err| emit_route_error(err, json).unwrap_or_else(|failure| failure))?;
+                let gateway_state = gateway_lifecycle_state(context, &gateway_vm)?
+                    .map(gateway_state_label)
+                    .unwrap_or("not reported by nixlingd")
+                    .to_owned();
+                rows.push(RealmPolicyOutputV1 {
+                    realm: realm.target_form(),
+                    mode: "gateway-backed".to_owned(),
+                    gateway_vm: Some(gateway_vm),
+                    gateway_target: Some(gateway_target),
+                    gateway_state,
+                    cross_realm_policy: "default-deny".to_owned(),
+                    credential_boundary: "gateway-owned".to_owned(),
+                });
+            }
+            other => {
+                return Err(CliFailure::new(
+                    1,
+                    format!("realm `{realm_raw}` has unknown entrypoint mode `{other}`"),
+                ));
+            }
+        }
+    }
+    rows.sort_by(|a, b| a.realm.cmp(&b.realm));
+    Ok(rows)
+}
+
+fn print_realm_rows_human(rows: &[RealmPolicyOutputV1]) {
+    print_stdout(&format!(
+        "{:<24} {:<16} {:<24} {:<22} {}\n",
+        "REALM", "MODE", "GATEWAY", "STATE", "CROSS_REALM"
+    ));
+    for row in rows {
+        print_stdout(&format!(
+            "{:<24} {:<16} {:<24} {:<22} {}\n",
+            row.realm,
+            row.mode,
+            row.gateway_vm.as_deref().unwrap_or("-"),
+            row.gateway_state,
+            row.cross_realm_policy
+        ));
+    }
+}
+
+fn cmd_realm_list(context: &Context, args: &RealmListArgs) -> Result<i32, CliFailure> {
+    let rows = realm_policy_rows(context, args.json)?;
+    let output = RealmListOutputV1 {
+        command: "realm list".to_owned(),
+        realms: rows,
+    };
+    if args.json {
+        print_json(&output)?;
+    } else if output.realms.is_empty() {
+        print_stdout("No realm entrypoints configured\n");
+    } else {
+        print_realm_rows_human(&output.realms);
+    }
+    Ok(0)
+}
+
+fn cmd_realm_inspect(context: &Context, args: &RealmInspectArgs) -> Result<i32, CliFailure> {
+    let realm = target_routing::parse_realm_arg(&args.realm).map_err(|err| {
+        emit_realm_usage_error(
+            &format!("invalid realm `{}`: {err}", args.realm),
+            "realm argument did not parse as a bounded lowercase realm path",
+            "Use a DNS-shaped realm path such as `work` or `payments.work`.",
+            args.json,
+        )
+        .unwrap_or_else(|failure| failure)
+    })?;
+    let realm_key = realm.target_form();
+    let rows = realm_policy_rows(context, args.json)?;
+    let Some(row) = rows.into_iter().find(|row| row.realm == realm_key) else {
+        return Err(emit_missing_realm_entrypoint(
+            &realm_key,
+            &target_routing::gateway_vm_name(&realm),
+            None,
+            args.json,
+        )?);
+    };
+    let output = RealmInspectOutputV1 {
+        command: "realm inspect".to_owned(),
+        realm: row,
+    };
+    if args.json {
+        print_json(&output)?;
+    } else {
+        print_realm_rows_human(std::slice::from_ref(&output.realm));
+    }
+    Ok(0)
 }
 
 fn cmd_realm_enter(context: &Context, args: &RealmEnterArgs) -> Result<i32, CliFailure> {
@@ -10349,6 +10546,67 @@ mod host_install_dispatch_tests {
             serde_json::to_vec(&manifest).expect("serialize manifest"),
         )
         .expect("write manifest");
+    }
+
+    fn test_context(manifest_path: PathBuf) -> Context {
+        Context {
+            manifest_path: manifest_path.clone(),
+            bundle_path: manifest_path.with_extension("bundle.json"),
+            public_socket: manifest_path.with_extension("sock"),
+            broker_socket: manifest_path.with_extension("broker.sock"),
+            state_root: None,
+            host_runtime_path: manifest_path.with_extension("host-runtime.json"),
+            system_state_fixture: None,
+            auth_status_fixture: None,
+            daemon_state_dir: manifest_path.with_extension("daemon-state"),
+            metrics_url: "http://127.0.0.1:9101/metrics".to_owned(),
+        }
+    }
+
+    #[test]
+    fn realm_policy_rows_surface_default_deny_boundaries() {
+        let manifest_path = test_socket_path("realm-policy-rows", ".manifest.json");
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).expect("manifest parent");
+        }
+        write_test_manifest(&manifest_path, "sys-work-gateway");
+        let context = test_context(manifest_path.clone());
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            "local".to_owned(),
+            super::RealmEntrypointConfig {
+                mode: "host-resident".to_owned(),
+                gateway: None,
+            },
+        );
+        entries.insert(
+            "work".to_owned(),
+            super::RealmEntrypointConfig {
+                mode: "gateway-backed".to_owned(),
+                gateway: Some("sys-work-gateway.nixling".to_owned()),
+            },
+        );
+
+        let rows = super::realm_policy_rows_from_entries(&context, entries, true)
+            .expect("realm rows render");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].realm, "local");
+        assert_eq!(rows[0].mode, "host-resident");
+        assert_eq!(rows[0].cross_realm_policy, "default-deny");
+        assert_eq!(rows[0].credential_boundary, "host-resident-local-only");
+        assert_eq!(rows[1].realm, "work");
+        assert_eq!(rows[1].mode, "gateway-backed");
+        assert_eq!(rows[1].gateway_vm.as_deref(), Some("sys-work-gateway"));
+        assert_eq!(rows[1].cross_realm_policy, "default-deny");
+        assert_eq!(rows[1].credential_boundary, "gateway-owned");
+        let rendered = serde_json::to_string(&rows).expect("rows serialize");
+        for forbidden in ["SharedAccessKey", "Bearer ", "/home/", "stdout", "stderr"] {
+            assert!(
+                !rendered.contains(forbidden),
+                "realm policy output leaked {forbidden}: {rendered}"
+            );
+        }
+        let _ = std::fs::remove_file(&manifest_path);
     }
 
     fn write_qemu_media_manifest(path: &PathBuf, vm: &str) {

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -4687,6 +4687,21 @@ fn gateway_lifecycle_state(
     }
 }
 
+fn gateway_lifecycle_states(context: &Context) -> Result<BTreeMap<String, String>, CliFailure> {
+    match try_list_via_socket(context)? {
+        ListSocketOutcome::Entries(entries) => {
+            let mut states = BTreeMap::new();
+            for entry in entries {
+                let label = gateway_state_label(entry.lifecycle.state).to_owned();
+                states.insert(entry.vm, label.clone());
+                states.insert(entry.name, label);
+            }
+            Ok(states)
+        }
+        ListSocketOutcome::Unavailable => Ok(BTreeMap::new()),
+    }
+}
+
 fn gateway_state_allows_exec(state: IpcVmLifecycleState) -> bool {
     matches!(
         state,
@@ -4788,6 +4803,7 @@ fn realm_policy_rows_from_entries(
     entries: BTreeMap<String, RealmEntrypointConfig>,
     json: bool,
 ) -> Result<Vec<RealmPolicyOutputV1>, CliFailure> {
+    let gateway_states = gateway_lifecycle_states(context)?;
     let mut rows = Vec::new();
     for (realm_raw, entry) in entries {
         let realm = target_routing::parse_realm_arg(&realm_raw).map_err(|err| {
@@ -4796,10 +4812,12 @@ fn realm_policy_rows_from_entries(
                 format!("realm entrypoint `{realm_raw}` is invalid: {err}"),
             )
         })?;
-        match entry.mode.as_str() {
+        let realm_target = realm.target_form();
+        let mode = entry.mode;
+        match mode.as_str() {
             "host-resident" => rows.push(RealmPolicyOutputV1 {
-                realm: realm.target_form(),
-                mode: "host-resident".to_owned(),
+                realm: realm_target,
+                mode,
                 gateway_vm: None,
                 gateway_target: None,
                 gateway_state: "local-only".to_owned(),
@@ -4813,15 +4831,16 @@ fn realm_policy_rows_from_entries(
                         format!("gateway-backed realm `{realm_raw}` has no gateway target"),
                     )
                 })?;
-                let gateway_vm = gateway_vm_from_target_text(&realm.target_form(), &gateway_target)
+                let gateway_vm = gateway_vm_from_target_text(&realm_target, &gateway_target)
                     .map_err(|err| emit_route_error(err, json).unwrap_or_else(|failure| failure))?;
-                let gateway_state = gateway_lifecycle_state(context, &gateway_vm)?
-                    .map(gateway_state_label)
+                let gateway_state = gateway_states
+                    .get(&gateway_vm)
+                    .map(String::as_str)
                     .unwrap_or("not reported by nixlingd")
                     .to_owned();
                 rows.push(RealmPolicyOutputV1 {
-                    realm: realm.target_form(),
-                    mode: "gateway-backed".to_owned(),
+                    realm: realm_target,
+                    mode,
                     gateway_vm: Some(gateway_vm),
                     gateway_target: Some(gateway_target),
                     gateway_state,
@@ -4843,16 +4862,17 @@ fn realm_policy_rows_from_entries(
 
 fn print_realm_rows_human(rows: &[RealmPolicyOutputV1]) {
     print_stdout(&format!(
-        "{:<24} {:<16} {:<24} {:<22} {}\n",
-        "REALM", "MODE", "GATEWAY", "STATE", "CROSS_REALM"
+        "{:<24} {:<16} {:<24} {:<22} {:<26} {}\n",
+        "REALM", "MODE", "GATEWAY", "STATE", "CREDENTIAL_BOUNDARY", "CROSS_REALM"
     ));
     for row in rows {
         print_stdout(&format!(
-            "{:<24} {:<16} {:<24} {:<22} {}\n",
+            "{:<24} {:<16} {:<24} {:<22} {:<26} {}\n",
             row.realm,
             row.mode,
             row.gateway_vm.as_deref().unwrap_or("-"),
             row.gateway_state,
+            row.credential_boundary,
             row.cross_realm_policy
         ));
     }

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -10,9 +10,10 @@ use clap_complete::{
 };
 use clap_mangen::Man;
 use nixling::{
-    AuditOutputV2, AuthStatusOutputV2, HostCheckOutputV2, ListOutputV2, StatusOutputV2,
-    StoreVerifyOutputV2, VmDisplayCloseOutputV1, VmDisplayListOutputV1, VmExecCreateOutputV1,
-    VmExecKillOutputV1, VmExecListOutputV1, VmExecLogsOutputV1, VmExecStatusOutputV1,
+    AuditOutputV2, AuthStatusOutputV2, HostCheckOutputV2, ListOutputV2, RealmInspectOutputV1,
+    RealmListOutputV1, StatusOutputV2, StoreVerifyOutputV2, VmDisplayCloseOutputV1,
+    VmDisplayListOutputV1, VmExecCreateOutputV1, VmExecKillOutputV1, VmExecListOutputV1,
+    VmExecLogsOutputV1, VmExecStatusOutputV1,
 };
 use nixling_constellation_core::{
     AdmissionAuditRecord, AuditEnvelope, Capability, CapabilityNegotiation, CapabilitySet,
@@ -324,9 +325,17 @@ fn gen_cli_schemas() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
     let out_dir = repo_root.join("docs/reference/cli-output");
     fs::create_dir_all(&out_dir)?;
 
-    let schemas: [(&str, RootSchema); 13] = [
+    let schemas: [(&str, RootSchema); 15] = [
         ("list.schema.json", schemars::schema_for!(ListOutputV2)),
         ("status.schema.json", schemars::schema_for!(StatusOutputV2)),
+        (
+            "realm-list.schema.json",
+            schemars::schema_for!(RealmListOutputV1),
+        ),
+        (
+            "realm-inspect.schema.json",
+            schemars::schema_for!(RealmInspectOutputV1),
+        ),
         (
             "vm-display-list.schema.json",
             schemars::schema_for!(VmDisplayListOutputV1),


### PR DESCRIPTION
## Summary
- add `nixling realm list` and `nixling realm inspect` with generated JSON schemas/completions
- document realm policy, work gateway setup, and v1.2-to-v2 migration guidance
- harden realm entrypoint handling so `local` remains host-resident and reflected errors are bounded/redacted

## Validation
- `cargo fmt --all`
- `cargo test -p nixling realm --quiet`
- `cargo test -p nixling --quiet`
- `cargo test -p xtask --quiet`
- `cargo clippy -p nixling --all-targets -- -D warnings`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `make test-drift`
- `git diff --check && git diff --cached --check`
- added-line process-marker and sensitive-shape scans

## Panel
- Full Gemini 3.1 Pro implementation panel: R6 14/14 signoff
