### PR TITLE
daemon: add persistent shell control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ deprecations ship one minor release before removal.
 
 ### Internal
 
+- Persistent shell daemon: started nixlingd-side shell control-plane routing with
+  admin-gated management operations, guest-control capability checks, shell
+  response framing, and attached-owner terminal proxying scaffolding.
 - Persistent shell runtime: started guestd-side shell session runtime scaffolding
   with staged Nix/PAM/service wiring, in-memory admission/idempotency tests, and
   fail-closed guest-control shell capability handling.

--- a/packages/nixling-contract-tests/tests/policy_metrics.rs
+++ b/packages/nixling-contract-tests/tests/policy_metrics.rs
@@ -95,6 +95,13 @@ const EXPECTED_METRICS: &[ExpectedMetric] = &[
         buckets_expr: "&[]",
         bucket_values: None,
     },
+    ExpectedMetric {
+        name: "nixling_daemon_guest_control_shell_total",
+        kind: "Counter",
+        labels: &["subsystem", "outcome", "error_kind"],
+        buckets_expr: "&[]",
+        bucket_values: None,
+    },
 ];
 
 // The retired bash gate's doc-parity table predated the guest-control exec

--- a/packages/nixling-priv-broker/src/ops/disk_init.rs
+++ b/packages/nixling-priv-broker/src/ops/disk_init.rs
@@ -329,20 +329,47 @@ fn fd_target_path(file: &File) -> std::path::PathBuf {
 
 fn run_mkfs_ext4_on_fd_with(file: &File, display_path: &Path, tool: &MkfsTool) -> io::Result<()> {
     let target = fd_target_path(file);
-    let mkfs_output = std::process::Command::new(&tool.path)
-        .arg("-q")
-        .arg("-F")
-        .arg("-E")
-        .arg("lazy_itable_init=1,lazy_journal_init=1")
-        .arg(&target)
-        .output()
-        .map_err(|e| {
-            DiskInitError::formatter(format!(
-                "mkfs.ext4 ({}) spawn on {} failed: {e}",
+    let mut last_spawn_error = None;
+    let mut mkfs_output = None;
+    for attempt in 0..5 {
+        match std::process::Command::new(&tool.path)
+            .arg("-q")
+            .arg("-F")
+            .arg("-E")
+            .arg("lazy_itable_init=1,lazy_journal_init=1")
+            .arg(&target)
+            .output()
+        {
+            Ok(output) => {
+                mkfs_output = Some(output);
+                break;
+            }
+            Err(error) if error.raw_os_error() == Some(nix::libc::ETXTBSY) && attempt < 4 => {
+                last_spawn_error = Some(error);
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(error) => {
+                return Err(DiskInitError::formatter(format!(
+                    "mkfs.ext4 ({}) spawn on {} failed: {error}",
+                    tool.raw,
+                    display_path.display()
+                ))
+                .into());
+            }
+        }
+    };
+    let mkfs_output = match mkfs_output {
+        Some(output) => output,
+        None => {
+            let error = last_spawn_error.expect("ETXTBSY error recorded");
+            return Err(DiskInitError::formatter(format!(
+                "mkfs.ext4 ({}) spawn on {} failed: {error}",
                 tool.raw,
                 display_path.display()
             ))
-        })?;
+            .into());
+        }
+    };
     if !mkfs_output.status.success() {
         let stderr = bounded_lossy(&mkfs_output.stderr, MKFS_STDERR_LIMIT);
         let detail = if stderr.is_empty() {

--- a/packages/nixlingd/src/daemon_audit.rs
+++ b/packages/nixlingd/src/daemon_audit.rs
@@ -150,6 +150,9 @@ pub enum DaemonEvent {
         action: ShellAuditAction,
         /// Closed shell result.
         result: ShellAuditResult,
+        /// Fixed-length non-raw correlation digest for the targeted shell. This
+        /// is safe to record; raw shell names/session ids are never written.
+        shell_ref_digest: String,
         /// Whether the caller requested force takeover.
         force: bool,
     },
@@ -166,6 +169,9 @@ pub enum DaemonEvent {
         action: ShellAuditAction,
         /// Closed teardown result.
         result: ShellAuditResult,
+        /// Fixed-length non-raw correlation digest for the targeted shell. This
+        /// is safe to record; raw shell names/session ids are never written.
+        shell_ref_digest: String,
     },
     /// Emitted when a detached `vm exec -d` create succeeds.
     ///
@@ -1518,6 +1524,7 @@ mod tests {
             peer_uid: 1000,
             action: ShellAuditAction::Attach,
             result: ShellAuditResult::Attached,
+            shell_ref_digest: "0123456789abcdef".to_owned(),
             force: true,
         })
         .expect("write shell attached event");
@@ -1526,6 +1533,7 @@ mod tests {
             peer_uid: 1000,
             action: ShellAuditAction::Detach,
             result: ShellAuditResult::Closed,
+            shell_ref_digest: "0123456789abcdef".to_owned(),
         })
         .expect("write shell detached event");
 
@@ -1550,7 +1558,13 @@ mod tests {
                 assert!(
                     matches!(
                         key.as_str(),
-                        "kind" | "vm" | "peer_uid" | "action" | "result" | "force"
+                        "kind"
+                            | "vm"
+                            | "peer_uid"
+                            | "action"
+                            | "result"
+                            | "shell_ref_digest"
+                            | "force"
                     ),
                     "shell lifecycle audit exposed unexpected key {key:?}: {line}"
                 );

--- a/packages/nixlingd/src/daemon_audit.rs
+++ b/packages/nixlingd/src/daemon_audit.rs
@@ -114,6 +114,32 @@ pub enum DaemonEvent {
         /// Admin peer uid (from `SO_PEERCRED`) that owned the session.
         peer_uid: u32,
     },
+    /// Emitted when an authenticated persistent shell owner attachment is
+    /// established.
+    ///
+    /// Leak-safe: carries ONLY the VM name, admin peer uid, and whether a force
+    /// takeover was requested. Shell names, session handles, and terminal bytes
+    /// are never recorded.
+    GuestControlShellAttached {
+        /// VM name the shell attachment targets.
+        vm: String,
+        /// Admin peer uid (from `SO_PEERCRED`) that opened the attachment.
+        peer_uid: u32,
+        /// Whether the caller requested force takeover.
+        force: bool,
+    },
+    /// Emitted when a persistent shell owner attachment ends.
+    ///
+    /// Leak-safe: carries ONLY the VM name, admin peer uid, and a closed result
+    /// enum. No shell name, session handle, or terminal bytes.
+    GuestControlShellDetached {
+        /// VM name the shell attachment targeted.
+        vm: String,
+        /// Admin peer uid (from `SO_PEERCRED`) that owned the attachment.
+        peer_uid: u32,
+        /// Closed teardown result: `"closed"`, `"close-timeout"`, or `"error"`.
+        result: String,
+    },
     /// Emitted when a detached `vm exec -d` create succeeds.
     ///
     /// Leak-safe: carries ONLY the VM name, admin peer uid, closed

--- a/packages/nixlingd/src/daemon_audit.rs
+++ b/packages/nixlingd/src/daemon_audit.rs
@@ -48,6 +48,27 @@ pub enum DetachedExecAuditResult {
     Error,
 }
 
+/// Closed persistent-shell owner action.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ShellAuditAction {
+    Attach,
+    Detach,
+    Kill,
+}
+
+/// Closed persistent-shell owner/management result.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ShellAuditResult {
+    Attached,
+    Detached,
+    Killed,
+    Closed,
+    Timeout,
+    Error,
+}
+
 /// Closed reason a vm-start runner node fast-failed before readiness.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -125,6 +146,10 @@ pub enum DaemonEvent {
         vm: String,
         /// Admin peer uid (from `SO_PEERCRED`) that opened the attachment.
         peer_uid: u32,
+        /// Closed shell action.
+        action: ShellAuditAction,
+        /// Closed shell result.
+        result: ShellAuditResult,
         /// Whether the caller requested force takeover.
         force: bool,
     },
@@ -137,8 +162,10 @@ pub enum DaemonEvent {
         vm: String,
         /// Admin peer uid (from `SO_PEERCRED`) that owned the attachment.
         peer_uid: u32,
-        /// Closed teardown result: `"closed"`, `"close-timeout"`, or `"error"`.
-        result: String,
+        /// Closed shell action.
+        action: ShellAuditAction,
+        /// Closed teardown result.
+        result: ShellAuditResult,
     },
     /// Emitted when a detached `vm exec -d` create succeeds.
     ///
@@ -1479,6 +1506,66 @@ mod tests {
         );
         // The terminate event has no tty field (only vm + peer_uid).
         assert!(terminated["event"].get("tty").is_none());
+    }
+
+    #[test]
+    fn shell_lifecycle_events_are_leak_safe() {
+        const SENTINEL: &str = "SECRET-shell-name-session-terminal-/nix/store/path-like-token";
+        let log = DaemonAuditLog::no_op();
+
+        log.write_event(&DaemonEvent::GuestControlShellAttached {
+            vm: "corp-vm".to_owned(),
+            peer_uid: 1000,
+            action: ShellAuditAction::Attach,
+            result: ShellAuditResult::Attached,
+            force: true,
+        })
+        .expect("write shell attached event");
+        log.write_event(&DaemonEvent::GuestControlShellDetached {
+            vm: "corp-vm".to_owned(),
+            peer_uid: 1000,
+            action: ShellAuditAction::Detach,
+            result: ShellAuditResult::Closed,
+        })
+        .expect("write shell detached event");
+
+        let records = log.captured.lock().expect("lock captured");
+        assert_eq!(records.len(), 2, "expected two captured shell records");
+        for line in records.iter() {
+            assert!(
+                !line.contains(SENTINEL),
+                "shell lifecycle audit leaked sentinel: {line}"
+            );
+            for forbidden in ["SECRET", "/nix/store", "session", "handle", "terminal"] {
+                assert!(
+                    !line.contains(forbidden),
+                    "shell lifecycle audit leaked forbidden canary {forbidden:?}: {line}",
+                );
+            }
+            let record: serde_json::Value =
+                serde_json::from_str(line).expect("parse captured shell record");
+            let event = record.get("event").expect("event object");
+            let obj = event.as_object().expect("event is object");
+            for key in obj.keys() {
+                assert!(
+                    matches!(
+                        key.as_str(),
+                        "kind" | "vm" | "peer_uid" | "action" | "result" | "force"
+                    ),
+                    "shell lifecycle audit exposed unexpected key {key:?}: {line}"
+                );
+            }
+        }
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&records[0]).unwrap()["event"]["result"]
+                .as_str(),
+            Some("attached")
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&records[1]).unwrap()["event"]["result"]
+                .as_str(),
+            Some("closed")
+        );
     }
 
     #[test]

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -15400,10 +15400,11 @@ mod broker_dispatch_tests {
         ChildReapedNotification, DeregisterRunnerPidfdResponse, PollChildReapedResponse,
         RunnerRole, RunnerSignal, SignalRunnerResponse, SpawnRunnerResponse,
     };
+    use nixling_ipc::guest_proto as pb;
     use nixling_ipc::public_wire::{
         ActivationRequest, GcRequest, HostDestroyRequest, HostInstallRequest, HostPrepareRequest,
-        KeysRotateRequest, MigrateRequest, MutationFlags, RotateKnownHostRequest, TrustRequest,
-        VmLifecycleRequest,
+        KeysRotateRequest, MigrateRequest, MutationFlags, RotateKnownHostRequest,
+        ShellSessionState, TrustRequest, VmLifecycleRequest,
     };
     use nixling_ipc::types::{RoleId, VmId};
     use serde::Serialize;
@@ -15426,9 +15427,10 @@ mod broker_dispatch_tests {
         dispatch_broker_run_migrate, dispatch_broker_switch, dispatch_broker_test,
         dispatch_broker_trust, dispatch_broker_vm_restart, dispatch_broker_vm_start,
         dispatch_broker_vm_stop, dispatch_broker_vm_stop_with_timeout, dispatch_request,
-        redact_broker_dispatch_failure_for_launcher, redact_broker_error_for_launcher,
-        resolve_store_view_intent_for_vm, stale_qemu_media_dependency_roles_from_entries,
-        vm_start_node_mode,
+        map_shell_attach_response, map_shell_detach_response, map_shell_kill_response,
+        map_shell_list_response, redact_broker_dispatch_failure_for_launcher,
+        redact_broker_error_for_launcher, resolve_store_view_intent_for_vm,
+        stale_qemu_media_dependency_roles_from_entries, vm_start_node_mode,
     };
 
     static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
@@ -19250,6 +19252,52 @@ mod broker_dispatch_tests {
         // workload-user terminal, so the daemon must deny launchers before any
         // session lookup, guest-control probe, or owner reservation.
         assert!(verb_requires_admin("shell"));
+    }
+
+    #[test]
+    fn shell_guest_responses_map_to_public_dtos() {
+        let mut attach = pb::ShellAttachResponse::new();
+        attach.session_id = Some("shell-1".to_owned());
+        attach.resolved_name = "default".to_owned();
+        attach.state = protobuf::EnumOrUnknown::new(pb::ShellState::SHELL_STATE_ATTACHED);
+        attach.force_evicted = true;
+        let attach = map_shell_attach_response(attach).expect("attach maps");
+        assert_eq!(attach.session, "shell-1");
+        assert_eq!(attach.resolved_name.as_str(), "default");
+        assert_eq!(attach.state, ShellSessionState::Attached);
+        assert!(attach.force_evicted);
+
+        let mut list = pb::ShellListResponse::new();
+        list.default_name = "default".to_owned();
+        let mut entry = pb::ShellListEntry::new();
+        entry.name = "ops_1".to_owned();
+        entry.state = protobuf::EnumOrUnknown::new(pb::ShellState::SHELL_STATE_DETACHED);
+        entry.attached = false;
+        entry.is_default = false;
+        list.sessions.push(entry);
+        let list = map_shell_list_response(list).expect("list maps");
+        assert_eq!(list.default_name.as_str(), "default");
+        assert_eq!(list.sessions[0].name.as_str(), "ops_1");
+        assert_eq!(list.sessions[0].state, ShellSessionState::Detached);
+
+        let mut detach = pb::ShellDetachResponse::new();
+        detach.resolved_name = "default".to_owned();
+        detach.detached = false;
+        detach.cause =
+            protobuf::EnumOrUnknown::new(pb::ShellCloseCause::SHELL_CLOSE_CAUSE_CLIENT_DETACH);
+        let detach = map_shell_detach_response(detach).expect("detach maps");
+        assert_eq!(detach.resolved_name.as_str(), "default");
+        assert!(!detach.detached);
+        assert!(detach.cause.is_some());
+
+        let mut kill = pb::ShellKillResponse::new();
+        kill.name = "default".to_owned();
+        kill.killed = false;
+        kill.state = protobuf::EnumOrUnknown::new(pb::ShellState::SHELL_STATE_KILLED);
+        let kill = map_shell_kill_response(kill).expect("kill maps");
+        assert_eq!(kill.name.as_str(), "default");
+        assert!(!kill.killed);
+        assert_eq!(kill.state, ShellSessionState::Killed);
     }
 
     #[test]

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -4496,6 +4496,7 @@ fn dispatch_read_guest_config(
 }
 
 const SHELL_MANAGEMENT_TIMEOUT: Duration = Duration::from_secs(12);
+const SHELL_OWNER_INFLIGHT_CAP: usize = 64;
 
 fn dispatch_shell_management(
     state: &ServerState,
@@ -4571,9 +4572,10 @@ fn run_shell_owner(
     first_op: public_wire::ShellOp,
     _conn_permit: Option<concurrency::ConnPermit>,
 ) {
+    let stream = Arc::new(stream);
     let public_wire::ShellOp::Attach(attach) = first_op else {
         let _ = write_json_frame(
-            &stream,
+            stream.as_ref(),
             &wire::error_frame_with_id(first_op_id, &TypedError::GuestShellDisabled),
         );
         return;
@@ -4581,7 +4583,10 @@ fn run_shell_owner(
     let (client, guest_boot_id, attach_response) = match establish_shell_owner(&state, &attach) {
         Ok(value) => value,
         Err(error) => {
-            let _ = write_json_frame(&stream, &wire::error_frame_with_id(first_op_id, &error));
+            let _ = write_json_frame(
+                stream.as_ref(),
+                &wire::error_frame_with_id(first_op_id, &error),
+            );
             return;
         }
     };
@@ -4589,7 +4594,7 @@ fn run_shell_owner(
         Some(session) => session,
         None => {
             let _ = write_json_frame(
-                &stream,
+                stream.as_ref(),
                 &wire::error_frame_with_id(first_op_id, &TypedError::GuestShellDisabled),
             );
             return;
@@ -4599,12 +4604,15 @@ fn run_shell_owner(
     let public_attach = match map_shell_attach_response(attach_response) {
         Ok(value) => public_wire::ShellOpResponse::Attach(value),
         Err(error) => {
-            let _ = write_json_frame(&stream, &wire::error_frame_with_id(first_op_id, &error));
+            let _ = write_json_frame(
+                stream.as_ref(),
+                &wire::error_frame_with_id(first_op_id, &error),
+            );
             return;
         }
     };
     if write_json_frame(
-        &stream,
+        stream.as_ref(),
         &wire::shell_response_with_id(first_op_id, &public_attach),
     )
     .is_err()
@@ -4614,36 +4622,100 @@ fn run_shell_owner(
     }
 
     let mut control_seq = initial_control_seq;
-    while let Ok(frame) = read_frame(&stream) {
+    let mut poll_tasks: Vec<std::thread::JoinHandle<()>> = Vec::new();
+    while let Ok(frame) = read_frame(stream.as_ref()) {
+        poll_tasks.retain(|task| !task.is_finished());
         let op_id = wire::shell_op_id(&frame);
-        let response = match wire::parse_shell_op(&frame) {
-            Ok((_, op)) => handle_shell_owner_op(
-                &client,
-                &attach.vm,
-                &session_id,
-                &guest_boot_id,
-                &mut control_seq,
-                op,
-            ),
-            Err(error) => Err(error),
+        let op = match wire::parse_shell_op(&frame) {
+            Ok((_, op)) => op,
+            Err(error) => {
+                if write_json_frame(stream.as_ref(), &wire::error_frame_with_id(op_id, &error))
+                    .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
         };
+        if matches!(op, public_wire::ShellOp::ReadOutput(_)) {
+            if poll_tasks.len() >= SHELL_OWNER_INFLIGHT_CAP {
+                if write_json_frame(
+                    stream.as_ref(),
+                    &wire::error_frame_with_id(op_id, &TypedError::GuestShellDisabled),
+                )
+                .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
+            let client = Arc::clone(&client);
+            let poll_stream = Arc::clone(&stream);
+            let vm = attach.vm.clone();
+            let session_id = session_id.clone();
+            let guest_boot_id = guest_boot_id.clone();
+            let task = std::thread::Builder::new()
+                .name("nixling-shell-poll".to_owned())
+                .spawn(move || {
+                    let mut ignored_control_seq = 0;
+                    let value = match handle_shell_owner_op(
+                        client.as_ref(),
+                        &vm,
+                        &session_id,
+                        &guest_boot_id,
+                        &mut ignored_control_seq,
+                        op,
+                    ) {
+                        Ok(Some(response)) => wire::shell_response_with_id(op_id, &response),
+                        Ok(None) => return,
+                        Err(error) => wire::error_frame_with_id(op_id, &error),
+                    };
+                    let _ = write_json_frame(poll_stream.as_ref(), &value);
+                });
+            match task {
+                Ok(task) => poll_tasks.push(task),
+                Err(_) => {
+                    let _ = write_json_frame(
+                        stream.as_ref(),
+                        &wire::error_frame_with_id(op_id, &TypedError::GuestShellDisabled),
+                    );
+                }
+            }
+            continue;
+        }
+        let response = handle_shell_owner_op(
+            &client,
+            &attach.vm,
+            &session_id,
+            &guest_boot_id,
+            &mut control_seq,
+            op,
+        );
         match response {
             Ok(Some(response)) => {
-                if write_json_frame(&stream, &wire::shell_response_with_id(op_id, &response))
-                    .is_err()
+                if write_json_frame(
+                    stream.as_ref(),
+                    &wire::shell_response_with_id(op_id, &response),
+                )
+                .is_err()
                 {
                     break;
                 }
             }
             Ok(None) => break,
             Err(error) => {
-                if write_json_frame(&stream, &wire::error_frame_with_id(op_id, &error)).is_err() {
+                if write_json_frame(stream.as_ref(), &wire::error_frame_with_id(op_id, &error))
+                    .is_err()
+                {
                     break;
                 }
             }
         }
     }
     shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
+    for task in poll_tasks {
+        let _ = task.join();
+    }
 }
 
 fn establish_shell_owner(

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -4653,7 +4653,6 @@ fn dispatch_shell_management(
         }
         public_wire::ShellOp::Detach(args) => {
             let vm = args.vm.clone();
-            let name_for_audit = args.name.as_ref().map(|name| name.as_str().to_owned());
             let result = run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
                 let mut request = pb::ShellDetachRequest::new();
                 request.metadata = protobuf::MessageField::some(metadata);
@@ -4674,7 +4673,7 @@ fn dispatch_shell_management(
                 &vm,
                 daemon_audit::ShellAuditAction::Detach,
                 daemon_audit::ShellAuditResult::Detached,
-                &shell_ref_digest(&[&vm, name_for_audit.as_deref().unwrap_or("<default>")]),
+                &shell_ref_digest(&[&vm, result.resolved_name.as_str()]),
             );
             shell_metric(state, "management", "none");
             public_wire::ShellOpResponse::Detach(result)
@@ -4775,8 +4774,8 @@ fn run_shell_owner(
             return;
         }
     };
-    let owner_shell_ref_digest = shell_ref_digest(&[&attach.vm, &session_id]);
     let initial_control_seq = attach_response.control_seq;
+    let owner_shell_ref_digest = shell_ref_digest(&[&attach.vm, &attach_response.resolved_name]);
     let public_attach = match map_shell_attach_response(attach_response) {
         Ok(value) => public_wire::ShellOpResponse::Attach(value),
         Err(error) => {
@@ -19608,6 +19607,21 @@ mod broker_dispatch_tests {
         let err = super::ensure_shell_owner_session("stale-session", "owner-session")
             .expect_err("stale session must fail");
         assert_eq!(err.kind(), "guest-control-shell-stale-session");
+    }
+
+    #[test]
+    fn shell_audit_digest_correlates_on_resolved_name_not_session_id() {
+        let vm = "corp-vm";
+        let resolved_name = "default";
+        let owner_digest = super::shell_ref_digest(&[vm, resolved_name]);
+        let management_digest = super::shell_ref_digest(&[vm, resolved_name]);
+        let session_digest = super::shell_ref_digest(&[vm, "shell-0000000000000001"]);
+
+        assert_eq!(owner_digest, management_digest);
+        assert_ne!(
+            owner_digest, session_digest,
+            "audit correlation must not use generated session ids"
+        );
     }
 
     #[test]

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -4567,7 +4567,7 @@ fn dispatch_shell_management(
 fn run_shell_owner(
     stream: Socket,
     state: ServerState,
-    _peer: PeerIdentity,
+    peer: PeerIdentity,
     first_op_id: u64,
     first_op: public_wire::ShellOp,
     _conn_permit: Option<concurrency::ConnPermit>,
@@ -4620,6 +4620,13 @@ fn run_shell_owner(
         shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
         return;
     }
+    let _ = state
+        .daemon_audit
+        .write_event(&daemon_audit::DaemonEvent::GuestControlShellAttached {
+            vm: attach.vm.clone(),
+            peer_uid: peer.uid,
+            force: attach.force,
+        });
 
     let mut control_seq = initial_control_seq;
     let mut poll_tasks: Vec<std::thread::JoinHandle<()>> = Vec::new();
@@ -4712,7 +4719,15 @@ fn run_shell_owner(
             }
         }
     }
-    shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
+    let close_result =
+        shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
+    let _ = state
+        .daemon_audit
+        .write_event(&daemon_audit::DaemonEvent::GuestControlShellDetached {
+            vm: attach.vm.clone(),
+            peer_uid: peer.uid,
+            result: close_result.to_owned(),
+        });
     for task in poll_tasks {
         let _ = task.join();
     }
@@ -4989,8 +5004,11 @@ fn shell_close_attach_best_effort(
     vm: &str,
     session_id: &str,
     guest_boot_id: &str,
-) {
-    let _ = shell_close_attach(client, vm, session_id, guest_boot_id);
+) -> &'static str {
+    match shell_close_attach(client, vm, session_id, guest_boot_id) {
+        Ok(_) => "closed",
+        Err(_) => "error",
+    }
 }
 
 fn run_guest_shell_management<F, Fut, T>(

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -2311,6 +2311,43 @@ fn handle_connection_authorized(
                 }
             }
         }
+        if let wire::Request::Shell(op) = &request {
+            if !matches!(peer.role, PeerRole::Admin) {
+                let error = TypedError::AuthzNotAdmin {
+                    verb: "shell".to_owned(),
+                };
+                let _ = write_json_frame(&stream, &wire::error_frame(&error));
+                continue;
+            }
+            if matches!(op, public_wire::ShellOp::Attach(_)) {
+                let first_op_id = wire::shell_op_id(&frame);
+                let owner_state = state.clone();
+                let owner_peer = peer.clone();
+                let op = op.clone();
+                set_frame_read_deadline(&stream, None);
+                let owner_permit = permit;
+                match std::thread::Builder::new()
+                    .name("nixling-shell-owner".to_owned())
+                    .spawn(move || {
+                        run_shell_owner(
+                            stream,
+                            owner_state,
+                            owner_peer,
+                            first_op_id,
+                            op,
+                            owner_permit,
+                        );
+                    }) {
+                    Ok(_) => return Ok(()),
+                    Err(err) => {
+                        return Err(TypedError::InternalIo {
+                            context: "spawn shell owner handler".to_owned(),
+                            detail: err.to_string(),
+                        });
+                    }
+                }
+            }
+        }
         // Gateway display operations can perform provider/relay orchestration.
         // Hand them off the serial accept loop just like exec owner sessions.
         if let wire::Request::GatewayDisplay(op) = &request {
@@ -4526,6 +4563,364 @@ fn dispatch_shell_management(
     Ok(wire::shell_response(&response))
 }
 
+fn run_shell_owner(
+    stream: Socket,
+    state: ServerState,
+    _peer: PeerIdentity,
+    first_op_id: u64,
+    first_op: public_wire::ShellOp,
+    _conn_permit: Option<concurrency::ConnPermit>,
+) {
+    let public_wire::ShellOp::Attach(attach) = first_op else {
+        let _ = write_json_frame(
+            &stream,
+            &wire::error_frame_with_id(first_op_id, &TypedError::GuestShellDisabled),
+        );
+        return;
+    };
+    let (client, guest_boot_id, attach_response) = match establish_shell_owner(&state, &attach) {
+        Ok(value) => value,
+        Err(error) => {
+            let _ = write_json_frame(&stream, &wire::error_frame_with_id(first_op_id, &error));
+            return;
+        }
+    };
+    let session_id = match attach_response.session_id.clone() {
+        Some(session) => session,
+        None => {
+            let _ = write_json_frame(
+                &stream,
+                &wire::error_frame_with_id(first_op_id, &TypedError::GuestShellDisabled),
+            );
+            return;
+        }
+    };
+    let initial_control_seq = attach_response.control_seq;
+    let public_attach = match map_shell_attach_response(attach_response) {
+        Ok(value) => public_wire::ShellOpResponse::Attach(value),
+        Err(error) => {
+            let _ = write_json_frame(&stream, &wire::error_frame_with_id(first_op_id, &error));
+            return;
+        }
+    };
+    if write_json_frame(
+        &stream,
+        &wire::shell_response_with_id(first_op_id, &public_attach),
+    )
+    .is_err()
+    {
+        shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
+        return;
+    }
+
+    let mut control_seq = initial_control_seq;
+    while let Ok(frame) = read_frame(&stream) {
+        let op_id = wire::shell_op_id(&frame);
+        let response = match wire::parse_shell_op(&frame) {
+            Ok((_, op)) => handle_shell_owner_op(
+                &client,
+                &attach.vm,
+                &session_id,
+                &guest_boot_id,
+                &mut control_seq,
+                op,
+            ),
+            Err(error) => Err(error),
+        };
+        match response {
+            Ok(Some(response)) => {
+                if write_json_frame(&stream, &wire::shell_response_with_id(op_id, &response))
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(error) => {
+                if write_json_frame(&stream, &wire::error_frame_with_id(op_id, &error)).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+    shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
+}
+
+fn establish_shell_owner(
+    state: &ServerState,
+    attach: &public_wire::ShellAttachArgs,
+) -> Result<
+    (
+        Arc<guest_control_health::TtrpcGuestControlClient>,
+        String,
+        pb::ShellAttachResponse,
+    ),
+    TypedError,
+> {
+    ensure_vm_runtime_capability(
+        state,
+        &attach.vm,
+        RuntimeCapabilityGate::GuestControl,
+        "shell",
+    )?;
+    let resolver = load_bundle_resolver(state)?;
+    let params = resolve_guest_control_probe_params(state, &resolver, &attach.vm)
+        .map_err(|_| TypedError::GuestShellDisabled)?;
+    let broker_path = broker_socket_path(state);
+    block_on_future(async move {
+        let budget = guest_control_health::AttemptBudget::from_now(
+            SHELL_MANAGEMENT_TIMEOUT,
+            guest_control_bridge::GUEST_CONTROL_ATTEMPT_CAP,
+        );
+        let signer = guest_control_bridge::BrokerSigner::new(broker_path, budget);
+        let nonce =
+            guest_control_bridge::host_nonce().map_err(|_| TypedError::GuestShellDisabled)?;
+        let client = guest_control_bridge::connect_and_build_client(&params, budget)
+            .map_err(|_| TypedError::GuestShellDisabled)?;
+        let evidence = guest_control_health::probe_guest_control_health(
+            &params.vm_id,
+            Some(guest_control_bridge::VMADDR_CID_HOST),
+            nonce,
+            &client,
+            &signer,
+        )
+        .await
+        .map_err(|_| TypedError::GuestShellDisabled)?;
+        if !guest_advertises_capability(
+            &evidence.health.capabilities,
+            pb::GuestCapability::GUEST_CAPABILITY_SHELL_ATTACHED,
+        ) {
+            return Err(TypedError::GuestShellDisabled);
+        }
+        if attach.force
+            && !guest_advertises_capability(
+                &evidence.health.capabilities,
+                pb::GuestCapability::GUEST_CAPABILITY_SHELL_FORCE_ATTACH,
+            )
+        {
+            return Err(TypedError::GuestShellDisabled);
+        }
+        let mut request = pb::ShellAttachRequest::new();
+        request.metadata = protobuf::MessageField::some(shell_request_metadata(&params.vm_id));
+        request.name = attach.name.as_ref().map(|name| name.as_str().to_owned());
+        request.force = attach.force;
+        let mut size = pb::TerminalSize::new();
+        size.rows = attach.initial_terminal_size.rows;
+        size.cols = attach.initial_terminal_size.cols;
+        request.initial_terminal_size = protobuf::MessageField::some(size);
+        let response: pb::ShellAttachResponse = client
+            .unary_with_timeout("ShellAttach", request, SHELL_MANAGEMENT_TIMEOUT)
+            .await
+            .map_err(|_| TypedError::GuestShellDisabled)?;
+        shell_error_to_typed(response.error.as_ref())?;
+        Ok((Arc::new(client), evidence.guest_boot_id, response))
+    })
+}
+
+fn shell_request_metadata(vm: &str) -> pb::RequestMetadata {
+    let mut metadata = pb::RequestMetadata::new();
+    metadata.vm_id = vm.to_owned();
+    metadata.request_id = "guest-control-shell".to_owned();
+    metadata.protocol_version = nixling_ipc::guest_wire::GUEST_CONTROL_PROTOCOL_VERSION;
+    metadata
+}
+
+fn shell_terminal_metadata(
+    vm: &str,
+    session_id: &str,
+    guest_boot_id: &str,
+) -> pb::TerminalRequestMetadata {
+    let mut metadata = pb::TerminalRequestMetadata::new();
+    metadata.common = protobuf::MessageField::some(shell_request_metadata(vm));
+    metadata.session_id = session_id.to_owned();
+    metadata.guest_boot_id = guest_boot_id.to_owned();
+    metadata.kind = protobuf::EnumOrUnknown::new(pb::TerminalKind::TERMINAL_KIND_SHELL);
+    metadata
+}
+
+fn handle_shell_owner_op(
+    client: &guest_control_health::TtrpcGuestControlClient,
+    vm: &str,
+    session_id: &str,
+    guest_boot_id: &str,
+    control_seq: &mut u64,
+    op: public_wire::ShellOp,
+) -> Result<Option<public_wire::ShellOpResponse>, TypedError> {
+    use nixling_ipc::terminal_wire as tw;
+    match op {
+        public_wire::ShellOp::WriteStdin(args) => {
+            if args.session != session_id {
+                return Err(TypedError::GuestShellDisabled);
+            }
+            let data = nixling_core::base64_codec::decode(&args.chunk_base64)
+                .map_err(|_| TypedError::GuestShellDisabled)?;
+            let mut request = pb::TerminalWriteStdinRequest::new();
+            request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
+                vm,
+                session_id,
+                guest_boot_id,
+            ));
+            request.offset = args.offset;
+            request.data = data;
+            request.close_after = args.eof;
+            let response: pb::WriteStdinResponse = block_on_future(client.unary_with_timeout(
+                "TerminalWriteStdin",
+                request,
+                SHELL_MANAGEMENT_TIMEOUT,
+            ))
+            .map_err(|_| TypedError::GuestShellDisabled)?;
+            shell_error_to_typed(response.error.as_ref())?;
+            Ok(Some(public_wire::ShellOpResponse::WriteStdin(
+                tw::TerminalWriteStdinResult {
+                    accepted_len: response.accepted_len,
+                    next_offset: response.next_offset,
+                    backpressured: response.blocked_ms > 0,
+                    stdin_closed: matches!(
+                        response.stdin_state.enum_value(),
+                        Ok(pb::StdinState::STDIN_STATE_CLOSED
+                            | pb::StdinState::STDIN_STATE_CLOSED_BY_PROCESS
+                            | pb::StdinState::STDIN_STATE_CLOSING)
+                    ),
+                },
+            )))
+        }
+        public_wire::ShellOp::ReadOutput(args) => {
+            if args.session != session_id {
+                return Err(TypedError::GuestShellDisabled);
+            }
+            let mut request = pb::TerminalReadOutputRequest::new();
+            request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
+                vm,
+                session_id,
+                guest_boot_id,
+            ));
+            request.stream = protobuf::EnumOrUnknown::new(match args.stream {
+                tw::TerminalStream::Stdout => pb::OutputStream::OUTPUT_STREAM_STDOUT,
+                tw::TerminalStream::Stderr => pb::OutputStream::OUTPUT_STREAM_STDERR,
+            });
+            request.offset = args.offset;
+            request.max_len = args
+                .max_len
+                .min(nixling_ipc::public_wire::EXEC_MAX_CHUNK_BYTES);
+            request.wait = args.wait;
+            request.timeout_ms = args.timeout_ms;
+            let response: pb::ReadOutputResponse = block_on_future(client.unary_with_timeout(
+                "TerminalReadOutput",
+                request,
+                SHELL_MANAGEMENT_TIMEOUT,
+            ))
+            .map_err(|_| TypedError::GuestShellDisabled)?;
+            shell_error_to_typed(response.error.as_ref())?;
+            Ok(Some(public_wire::ShellOpResponse::ReadOutput(
+                tw::TerminalReadOutputChunk {
+                    data_base64: nixling_core::base64_codec::encode(&response.data),
+                    next_offset: response.next_offset,
+                    eof: response.eof,
+                    dropped_bytes: response.dropped_bytes,
+                    truncated: response.truncated,
+                    timed_out: response.timed_out,
+                },
+            )))
+        }
+        public_wire::ShellOp::Resize(args) => {
+            if args.session != session_id {
+                return Err(TypedError::GuestShellDisabled);
+            }
+            *control_seq = control_seq.saturating_add(1);
+            let mut request = pb::TerminalTtyWinResizeRequest::new();
+            request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
+                vm,
+                session_id,
+                guest_boot_id,
+            ));
+            request.control_seq = *control_seq;
+            request.rows = args.rows;
+            request.cols = args.cols;
+            let response: pb::ControlAck = block_on_future(client.unary_with_timeout(
+                "TerminalTtyWinResize",
+                request,
+                SHELL_MANAGEMENT_TIMEOUT,
+            ))
+            .map_err(|_| TypedError::GuestShellDisabled)?;
+            shell_error_to_typed(response.error.as_ref())?;
+            Ok(Some(public_wire::ShellOpResponse::Resize(
+                tw::TerminalControlResult { delivered: true },
+            )))
+        }
+        public_wire::ShellOp::CloseStdin(args) => {
+            if args.session != session_id {
+                return Err(TypedError::GuestShellDisabled);
+            }
+            let mut request = pb::TerminalCloseStdinRequest::new();
+            request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
+                vm,
+                session_id,
+                guest_boot_id,
+            ));
+            let response: pb::CloseStdinResponse = block_on_future(client.unary_with_timeout(
+                "TerminalCloseStdin",
+                request,
+                SHELL_MANAGEMENT_TIMEOUT,
+            ))
+            .map_err(|_| TypedError::GuestShellDisabled)?;
+            shell_error_to_typed(response.error.as_ref())?;
+            Ok(Some(public_wire::ShellOpResponse::CloseStdin(
+                tw::TerminalCloseResult { stdin_closed: true },
+            )))
+        }
+        public_wire::ShellOp::CloseAttach(args) => {
+            if args.session != session_id {
+                return Err(TypedError::GuestShellDisabled);
+            }
+            let response = shell_close_attach(client, vm, session_id, guest_boot_id)?;
+            Ok(Some(public_wire::ShellOpResponse::CloseAttach(response)))
+        }
+        public_wire::ShellOp::Wait(args) => {
+            if args.session != session_id {
+                return Err(TypedError::GuestShellDisabled);
+            }
+            Ok(Some(public_wire::ShellOpResponse::Wait(
+                tw::TerminalWaitResult {
+                    running: true,
+                    terminal_status: None,
+                },
+            )))
+        }
+        public_wire::ShellOp::Attach(_)
+        | public_wire::ShellOp::List(_)
+        | public_wire::ShellOp::Detach(_)
+        | public_wire::ShellOp::Kill(_) => Err(TypedError::GuestShellDisabled),
+    }
+}
+
+fn shell_close_attach(
+    client: &guest_control_health::TtrpcGuestControlClient,
+    vm: &str,
+    session_id: &str,
+    guest_boot_id: &str,
+) -> Result<public_wire::ShellDetachResult, TypedError> {
+    let mut request = pb::ShellCloseAttachRequest::new();
+    request.metadata =
+        protobuf::MessageField::some(shell_terminal_metadata(vm, session_id, guest_boot_id));
+    let response: pb::ShellDetachResponse = block_on_future(client.unary_with_timeout(
+        "ShellCloseAttach",
+        request,
+        SHELL_MANAGEMENT_TIMEOUT,
+    ))
+    .map_err(|_| TypedError::GuestShellDisabled)?;
+    shell_error_to_typed(response.error.as_ref())?;
+    map_shell_detach_response(response)
+}
+
+fn shell_close_attach_best_effort(
+    client: &guest_control_health::TtrpcGuestControlClient,
+    vm: &str,
+    session_id: &str,
+    guest_boot_id: &str,
+) {
+    let _ = shell_close_attach(client, vm, session_id, guest_boot_id);
+}
+
 fn run_guest_shell_management<F, Fut, T>(
     state: &ServerState,
     vm: &str,
@@ -4672,6 +5067,17 @@ fn map_shell_list_response(
                 })
             })
             .collect::<Result<Vec<_>, TypedError>>()?,
+    })
+}
+
+fn map_shell_attach_response(
+    response: pb::ShellAttachResponse,
+) -> Result<public_wire::ShellAttachResult, TypedError> {
+    Ok(public_wire::ShellAttachResult {
+        session: response.session_id.ok_or(TypedError::GuestShellDisabled)?,
+        resolved_name: shell_name_from_guest(response.resolved_name)?,
+        state: map_shell_state(response.state),
+        force_evicted: response.force_evicted,
     })
 }
 

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -4630,6 +4630,7 @@ fn run_shell_owner(
 
     let mut control_seq = initial_control_seq;
     let mut poll_tasks: Vec<std::thread::JoinHandle<()>> = Vec::new();
+    let mut attachment_closed = false;
     while let Ok(frame) = read_frame(stream.as_ref()) {
         poll_tasks.retain(|task| !task.is_finished());
         let op_id = wire::shell_op_id(&frame);
@@ -4690,6 +4691,7 @@ fn run_shell_owner(
             }
             continue;
         }
+        let closes_owner = matches!(op, public_wire::ShellOp::CloseAttach(_));
         let response = handle_shell_owner_op(
             &client,
             &attach.vm,
@@ -4708,6 +4710,10 @@ fn run_shell_owner(
                 {
                     break;
                 }
+                if closes_owner {
+                    attachment_closed = true;
+                    break;
+                }
             }
             Ok(None) => break,
             Err(error) => {
@@ -4719,8 +4725,11 @@ fn run_shell_owner(
             }
         }
     }
-    let close_result =
-        shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
+    let close_result = if attachment_closed {
+        "closed"
+    } else {
+        shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id)
+    };
     let _ = state
         .daemon_audit
         .write_event(&daemon_audit::DaemonEvent::GuestControlShellDetached {

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -78,6 +78,7 @@ use nixling_ipc::{
         UsbipProxyReconcileRequest as BrokerUsbipProxyReconcileRequest,
         UsbipUnbindRequest as BrokerUsbipUnbindRequest,
     },
+    guest_proto as pb,
     public_wire::{self, AuthRole, AuthStatusResponse, DeniedCommandHint, SocketReachability},
     types::{BundleClosureRef, BundleOpId, MediaRef, RoleId, ScopeId, VmId},
 };
@@ -2460,6 +2461,7 @@ fn verb_requires_admin(verb: &str) -> bool {
             | "hostReconcile"
             | "readGuestConfig"
             | "exec"
+            | "shell"
     )
 }
 
@@ -2557,7 +2559,7 @@ fn dispatch_request_locked(
         // spawned worker off the serial accept loop). Detached management ops
         // are ordinary one-shot requests.
         wire::Request::Exec(op) => dispatch_exec_management(state, peer, op),
-        wire::Request::Shell(_) => Err(TypedError::GuestShellDisabled),
+        wire::Request::Shell(op) => dispatch_shell_management(state, op),
         wire::Request::GatewayDisplay(op) => dispatch_gateway_display(state, peer, op),
     }
 }
@@ -4454,6 +4456,243 @@ fn dispatch_read_guest_config(
             content_base64: encoded,
         },
     ))
+}
+
+const SHELL_MANAGEMENT_TIMEOUT: Duration = Duration::from_secs(12);
+
+fn dispatch_shell_management(
+    state: &ServerState,
+    op: public_wire::ShellOp,
+) -> Result<Value, TypedError> {
+    let response = match op {
+        public_wire::ShellOp::List(args) => {
+            let result =
+                run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
+                    let mut request = pb::ShellListRequest::new();
+                    request.metadata = protobuf::MessageField::some(metadata);
+                    async move {
+                        let response: pb::ShellListResponse = client
+                            .unary_with_timeout("ShellList", request, SHELL_MANAGEMENT_TIMEOUT)
+                            .await
+                            .map_err(|_| TypedError::GuestShellDisabled)?;
+                        shell_error_to_typed(response.error.as_ref())?;
+                        map_shell_list_response(response)
+                    }
+                })?;
+            public_wire::ShellOpResponse::List(result)
+        }
+        public_wire::ShellOp::Detach(args) => {
+            let result =
+                run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
+                    let mut request = pb::ShellDetachRequest::new();
+                    request.metadata = protobuf::MessageField::some(metadata);
+                    request.name = args.name.map(|name| name.as_str().to_owned());
+                    async move {
+                        let response: pb::ShellDetachResponse = client
+                            .unary_with_timeout("ShellDetach", request, SHELL_MANAGEMENT_TIMEOUT)
+                            .await
+                            .map_err(|_| TypedError::GuestShellDisabled)?;
+                        shell_error_to_typed(response.error.as_ref())?;
+                        map_shell_detach_response(response)
+                    }
+                })?;
+            public_wire::ShellOpResponse::Detach(result)
+        }
+        public_wire::ShellOp::Kill(args) => {
+            let result =
+                run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
+                    let mut request = pb::ShellKillRequest::new();
+                    request.metadata = protobuf::MessageField::some(metadata);
+                    request.name = args.name.as_str().to_owned();
+                    async move {
+                        let response: pb::ShellKillResponse = client
+                            .unary_with_timeout("ShellKill", request, SHELL_MANAGEMENT_TIMEOUT)
+                            .await
+                            .map_err(|_| TypedError::GuestShellDisabled)?;
+                        shell_error_to_typed(response.error.as_ref())?;
+                        map_shell_kill_response(response)
+                    }
+                })?;
+            public_wire::ShellOpResponse::Kill(result)
+        }
+        public_wire::ShellOp::Attach(_)
+        | public_wire::ShellOp::WriteStdin(_)
+        | public_wire::ShellOp::ReadOutput(_)
+        | public_wire::ShellOp::Resize(_)
+        | public_wire::ShellOp::Wait(_)
+        | public_wire::ShellOp::CloseStdin(_)
+        | public_wire::ShellOp::CloseAttach(_) => return Err(TypedError::GuestShellDisabled),
+    };
+    Ok(wire::shell_response(&response))
+}
+
+fn run_guest_shell_management<F, Fut, T>(
+    state: &ServerState,
+    vm: &str,
+    f: F,
+) -> Result<T, TypedError>
+where
+    F: FnOnce(Arc<guest_control_health::TtrpcGuestControlClient>, pb::RequestMetadata) -> Fut,
+    Fut: Future<Output = Result<T, TypedError>>,
+{
+    ensure_vm_runtime_capability(state, vm, RuntimeCapabilityGate::GuestControl, "shell")?;
+    let resolver = load_bundle_resolver(state)?;
+    let params = resolve_guest_control_probe_params(state, &resolver, vm).map_err(|detail| {
+        tracing::warn!(
+            kind = "critical",
+            subsystem = "guest-control-shell",
+            error_kind = "transport-io",
+            "guest-control shell: probe params unresolved: {detail}"
+        );
+        TypedError::GuestShellDisabled
+    })?;
+    let broker_path = broker_socket_path(state);
+    block_on_future(async move {
+        let budget = guest_control_health::AttemptBudget::from_now(
+            SHELL_MANAGEMENT_TIMEOUT,
+            guest_control_bridge::GUEST_CONTROL_ATTEMPT_CAP,
+        );
+        let signer = guest_control_bridge::BrokerSigner::new(broker_path, budget);
+        let nonce =
+            guest_control_bridge::host_nonce().map_err(|_| TypedError::GuestShellDisabled)?;
+        let client = guest_control_bridge::connect_and_build_client(&params, budget)
+            .map_err(|_| TypedError::GuestShellDisabled)?;
+        let evidence = guest_control_health::probe_guest_control_health(
+            &params.vm_id,
+            Some(guest_control_bridge::VMADDR_CID_HOST),
+            nonce,
+            &client,
+            &signer,
+        )
+        .await
+        .map_err(|_| TypedError::GuestShellDisabled)?;
+        if !guest_advertises_capability(
+            &evidence.health.capabilities,
+            pb::GuestCapability::GUEST_CAPABILITY_SHELL_MANAGEMENT,
+        ) {
+            return Err(TypedError::GuestShellDisabled);
+        }
+        let mut metadata = pb::RequestMetadata::new();
+        metadata.vm_id = params.vm_id.clone();
+        metadata.request_id = "guest-control-shell".to_owned();
+        metadata.protocol_version = nixling_ipc::guest_wire::GUEST_CONTROL_PROTOCOL_VERSION;
+        f(Arc::new(client), metadata).await
+    })
+}
+
+fn guest_advertises_capability(
+    capabilities: &[protobuf::EnumOrUnknown<pb::GuestCapability>],
+    cap: pb::GuestCapability,
+) -> bool {
+    capabilities
+        .iter()
+        .filter_map(|value| value.enum_value().ok())
+        .any(|value| value == cap)
+}
+
+fn shell_error_to_typed(error: Option<&pb::GuestControlError>) -> Result<(), TypedError> {
+    if let Some(error) = error
+        && !exec_session_real::is_unspecified(error.kind)
+    {
+        return Err(TypedError::GuestShellDisabled);
+    }
+    Ok(())
+}
+
+fn shell_name_from_guest(value: String) -> Result<public_wire::ShellName, TypedError> {
+    public_wire::ShellName::new(value).map_err(|_| TypedError::WireInvalidFrame {
+        detail: "guest shell response carried an invalid shell name".to_owned(),
+    })
+}
+
+fn map_shell_state(
+    state: protobuf::EnumOrUnknown<pb::ShellState>,
+) -> public_wire::ShellSessionState {
+    match state
+        .enum_value()
+        .unwrap_or(pb::ShellState::SHELL_STATE_UNSPECIFIED)
+    {
+        pb::ShellState::SHELL_STATE_ATTACHED => public_wire::ShellSessionState::Attached,
+        pb::ShellState::SHELL_STATE_DETACHED => public_wire::ShellSessionState::Detached,
+        pb::ShellState::SHELL_STATE_KILLED => public_wire::ShellSessionState::Killed,
+        pb::ShellState::SHELL_STATE_POOL_UNAVAILABLE => {
+            public_wire::ShellSessionState::PoolUnavailable
+        }
+        pb::ShellState::SHELL_STATE_FEATURE_DISABLED => {
+            public_wire::ShellSessionState::FeatureDisabled
+        }
+        pb::ShellState::SHELL_STATE_OUTPUT_GAP => public_wire::ShellSessionState::OutputGap,
+        pb::ShellState::SHELL_STATE_UNSPECIFIED => public_wire::ShellSessionState::Detached,
+    }
+}
+
+fn map_shell_close_cause(
+    cause: protobuf::EnumOrUnknown<pb::ShellCloseCause>,
+) -> Option<public_wire::ShellCloseCause> {
+    match cause
+        .enum_value()
+        .unwrap_or(pb::ShellCloseCause::SHELL_CLOSE_CAUSE_UNSPECIFIED)
+    {
+        pb::ShellCloseCause::SHELL_CLOSE_CAUSE_CLIENT_DETACH => {
+            Some(public_wire::ShellCloseCause::ClientDetach)
+        }
+        pb::ShellCloseCause::SHELL_CLOSE_CAUSE_EVICTED_BY_FORCE => {
+            Some(public_wire::ShellCloseCause::EvictedByForce)
+        }
+        pb::ShellCloseCause::SHELL_CLOSE_CAUSE_EVICTED_BY_ADMIN_DETACH => {
+            Some(public_wire::ShellCloseCause::EvictedByAdminDetach)
+        }
+        pb::ShellCloseCause::SHELL_CLOSE_CAUSE_KILLED_BY_ADMIN => {
+            Some(public_wire::ShellCloseCause::KilledByAdmin)
+        }
+        pb::ShellCloseCause::SHELL_CLOSE_CAUSE_POOL_UNAVAILABLE => {
+            Some(public_wire::ShellCloseCause::PoolUnavailable)
+        }
+        pb::ShellCloseCause::SHELL_CLOSE_CAUSE_OUTPUT_GAP => {
+            Some(public_wire::ShellCloseCause::OutputGap)
+        }
+        pb::ShellCloseCause::SHELL_CLOSE_CAUSE_UNSPECIFIED => None,
+    }
+}
+
+fn map_shell_list_response(
+    response: pb::ShellListResponse,
+) -> Result<public_wire::ShellListResult, TypedError> {
+    Ok(public_wire::ShellListResult {
+        default_name: shell_name_from_guest(response.default_name)?,
+        sessions: response
+            .sessions
+            .into_iter()
+            .map(|entry| {
+                Ok(public_wire::ShellListEntry {
+                    name: shell_name_from_guest(entry.name)?,
+                    state: map_shell_state(entry.state),
+                    attached: entry.attached,
+                    is_default: entry.is_default,
+                })
+            })
+            .collect::<Result<Vec<_>, TypedError>>()?,
+    })
+}
+
+fn map_shell_detach_response(
+    response: pb::ShellDetachResponse,
+) -> Result<public_wire::ShellDetachResult, TypedError> {
+    Ok(public_wire::ShellDetachResult {
+        resolved_name: shell_name_from_guest(response.resolved_name)?,
+        detached: response.detached,
+        cause: map_shell_close_cause(response.cause),
+    })
+}
+
+fn map_shell_kill_response(
+    response: pb::ShellKillResponse,
+) -> Result<public_wire::ShellKillResult, TypedError> {
+    Ok(public_wire::ShellKillResult {
+        name: shell_name_from_guest(response.name)?,
+        killed: response.killed,
+        state: map_shell_state(response.state),
+    })
 }
 
 const EXEC_METRIC: &str = "nixling_daemon_guest_control_exec_total";
@@ -18596,6 +18835,15 @@ mod broker_dispatch_tests {
         // a launcher / non-admin peer MUST be denied BEFORE any probe / sign /
         // read runs (the gate is enforced in `dispatch_request`).
         assert!(verb_requires_admin("readGuestConfig"));
+    }
+
+    #[test]
+    fn shell_verb_is_admin_only() {
+        use super::verb_requires_admin;
+        // Shell operations cross into the guest and can attach/detach/kill a
+        // workload-user terminal, so the daemon must deny launchers before any
+        // session lookup, guest-control probe, or owner reservation.
+        assert!(verb_requires_admin("shell"));
     }
 
     #[test]

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -2596,7 +2596,7 @@ fn dispatch_request_locked(
         // spawned worker off the serial accept loop). Detached management ops
         // are ordinary one-shot requests.
         wire::Request::Exec(op) => dispatch_exec_management(state, peer, op),
-        wire::Request::Shell(op) => dispatch_shell_management(state, op),
+        wire::Request::Shell(op) => dispatch_shell_management(state, peer, op),
         wire::Request::GatewayDisplay(op) => dispatch_gateway_display(state, peer, op),
     }
 }
@@ -4496,10 +4496,90 @@ fn dispatch_read_guest_config(
 }
 
 const SHELL_MANAGEMENT_TIMEOUT: Duration = Duration::from_secs(12);
+const SHELL_POLL_CAP: Duration = Duration::from_secs(30);
+const SHELL_POLL_SLACK: Duration = Duration::from_secs(2);
 const SHELL_OWNER_INFLIGHT_CAP: usize = 64;
+const SHELL_METRIC: &str = "nixling_daemon_guest_control_shell_total";
+
+fn shell_failed(kind: crate::typed_error::GuestControlShellErrorKind) -> TypedError {
+    TypedError::GuestControlShellFailed { kind }
+}
+
+fn map_shell_health_error(error: guest_control_health::GuestControlHealthError) -> TypedError {
+    use crate::typed_error::GuestControlShellErrorKind as K;
+    match error {
+        guest_control_health::GuestControlHealthError::TransportIo
+        | guest_control_health::GuestControlHealthError::Ttrpc
+        | guest_control_health::GuestControlHealthError::Signer => shell_failed(K::Transport),
+        guest_control_health::GuestControlHealthError::Timeout => shell_failed(K::Timeout),
+        guest_control_health::GuestControlHealthError::AuthFailed => shell_failed(K::Auth),
+        guest_control_health::GuestControlHealthError::StaleSession => {
+            shell_failed(K::StaleSession)
+        }
+        guest_control_health::GuestControlHealthError::Protocol => shell_failed(K::Protocol),
+    }
+}
+
+fn shell_transport_failed() -> TypedError {
+    shell_failed(crate::typed_error::GuestControlShellErrorKind::Transport)
+}
+
+fn shell_capability_failed() -> TypedError {
+    shell_failed(crate::typed_error::GuestControlShellErrorKind::Capability)
+}
+
+fn shell_protocol_failed() -> TypedError {
+    shell_failed(crate::typed_error::GuestControlShellErrorKind::Protocol)
+}
+
+fn map_shell_guest_error(error: &pb::GuestControlError) -> TypedError {
+    use crate::typed_error::GuestControlShellErrorKind as K;
+    use pb::GuestControlErrorKind as G;
+    let kind = match error.kind.enum_value() {
+        Ok(G::GUEST_CONTROL_ERROR_KIND_AUTH_FAILED) => K::Auth,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_STALE_SESSION) => K::StaleSession,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_TRANSPORT_UNREACHABLE) => K::Transport,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_PROTOCOL_ERROR)
+        | Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_INVALID_NAME) => K::Protocol,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_GUEST_SHELL_DISABLED)
+        | Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_POOL_UNAVAILABLE)
+        | Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_DAEMON_EPOCH_MISMATCH) => K::Capability,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_CAPACITY_EXCEEDED)
+        | Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_ATTACH_CAPACITY_EXCEEDED) => K::Capacity,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_ALREADY_ATTACHED) => K::AlreadyAttached,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_NOT_FOUND) => K::NotFound,
+        Ok(G::GUEST_CONTROL_ERROR_KIND_SHELL_OUTPUT_GAP) => K::OutputGap,
+        _ => K::GuestError,
+    };
+    shell_failed(kind)
+}
+
+fn shell_poll_timeout(args_timeout_ms: u64, wait: bool) -> (u64, Duration) {
+    if !wait {
+        return (0, SHELL_MANAGEMENT_TIMEOUT);
+    }
+    let cap_ms = SHELL_POLL_CAP.as_millis().min(u64::MAX as u128) as u64;
+    let timeout_ms = args_timeout_ms.min(cap_ms);
+    (
+        timeout_ms,
+        Duration::from_millis(timeout_ms) + SHELL_POLL_SLACK,
+    )
+}
+
+fn shell_metric(state: &ServerState, outcome: &'static str, error_kind: &'static str) {
+    state.metrics_registry.counter_inc(
+        SHELL_METRIC,
+        &[
+            ("subsystem", "guest-control-shell"),
+            ("outcome", outcome),
+            ("error_kind", error_kind),
+        ],
+    );
+}
 
 fn dispatch_shell_management(
     state: &ServerState,
+    peer: &PeerIdentity,
     op: public_wire::ShellOp,
 ) -> Result<Value, TypedError> {
     let response = match op {
@@ -4512,14 +4592,16 @@ fn dispatch_shell_management(
                         let response: pb::ShellListResponse = client
                             .unary_with_timeout("ShellList", request, SHELL_MANAGEMENT_TIMEOUT)
                             .await
-                            .map_err(|_| TypedError::GuestShellDisabled)?;
+                            .map_err(map_shell_health_error)?;
                         shell_error_to_typed(response.error.as_ref())?;
                         map_shell_list_response(response)
                     }
                 })?;
+            shell_metric(state, "management", "none");
             public_wire::ShellOpResponse::List(result)
         }
         public_wire::ShellOp::Detach(args) => {
+            let vm = args.vm.clone();
             let result =
                 run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
                     let mut request = pb::ShellDetachRequest::new();
@@ -4529,14 +4611,23 @@ fn dispatch_shell_management(
                         let response: pb::ShellDetachResponse = client
                             .unary_with_timeout("ShellDetach", request, SHELL_MANAGEMENT_TIMEOUT)
                             .await
-                            .map_err(|_| TypedError::GuestShellDisabled)?;
+                            .map_err(map_shell_health_error)?;
                         shell_error_to_typed(response.error.as_ref())?;
                         map_shell_detach_response(response)
                     }
                 })?;
+            emit_shell_management_audit(
+                state,
+                peer.uid,
+                &vm,
+                daemon_audit::ShellAuditAction::Detach,
+                daemon_audit::ShellAuditResult::Detached,
+            );
+            shell_metric(state, "management", "none");
             public_wire::ShellOpResponse::Detach(result)
         }
         public_wire::ShellOp::Kill(args) => {
+            let vm = args.vm.clone();
             let result =
                 run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
                     let mut request = pb::ShellKillRequest::new();
@@ -4546,11 +4637,19 @@ fn dispatch_shell_management(
                         let response: pb::ShellKillResponse = client
                             .unary_with_timeout("ShellKill", request, SHELL_MANAGEMENT_TIMEOUT)
                             .await
-                            .map_err(|_| TypedError::GuestShellDisabled)?;
+                            .map_err(map_shell_health_error)?;
                         shell_error_to_typed(response.error.as_ref())?;
                         map_shell_kill_response(response)
                     }
                 })?;
+            emit_shell_management_audit(
+                state,
+                peer.uid,
+                &vm,
+                daemon_audit::ShellAuditAction::Kill,
+                daemon_audit::ShellAuditResult::Killed,
+            );
+            shell_metric(state, "management", "none");
             public_wire::ShellOpResponse::Kill(result)
         }
         public_wire::ShellOp::Attach(_)
@@ -4559,9 +4658,26 @@ fn dispatch_shell_management(
         | public_wire::ShellOp::Resize(_)
         | public_wire::ShellOp::Wait(_)
         | public_wire::ShellOp::CloseStdin(_)
-        | public_wire::ShellOp::CloseAttach(_) => return Err(TypedError::GuestShellDisabled),
+        | public_wire::ShellOp::CloseAttach(_) => return Err(shell_protocol_failed()),
     };
     Ok(wire::shell_response(&response))
+}
+
+fn emit_shell_management_audit(
+    state: &ServerState,
+    peer_uid: u32,
+    vm: &str,
+    action: daemon_audit::ShellAuditAction,
+    result: daemon_audit::ShellAuditResult,
+) {
+    let _ = state
+        .daemon_audit
+        .write_event(&daemon_audit::DaemonEvent::GuestControlShellDetached {
+            vm: vm.to_owned(),
+            peer_uid,
+            action,
+            result,
+        });
 }
 
 fn run_shell_owner(
@@ -4570,13 +4686,13 @@ fn run_shell_owner(
     peer: PeerIdentity,
     first_op_id: u64,
     first_op: public_wire::ShellOp,
-    _conn_permit: Option<concurrency::ConnPermit>,
+    conn_permit: Option<concurrency::ConnPermit>,
 ) {
     let stream = Arc::new(stream);
     let public_wire::ShellOp::Attach(attach) = first_op else {
         let _ = write_json_frame(
             stream.as_ref(),
-            &wire::error_frame_with_id(first_op_id, &TypedError::GuestShellDisabled),
+            &wire::error_frame_with_id(first_op_id, &shell_protocol_failed()),
         );
         return;
     };
@@ -4595,7 +4711,7 @@ fn run_shell_owner(
         None => {
             let _ = write_json_frame(
                 stream.as_ref(),
-                &wire::error_frame_with_id(first_op_id, &TypedError::GuestShellDisabled),
+                &wire::error_frame_with_id(first_op_id, &shell_protocol_failed()),
             );
             return;
         }
@@ -4618,6 +4734,7 @@ fn run_shell_owner(
     .is_err()
     {
         shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id);
+        shell_metric(&state, "error", "transport");
         return;
     }
     let _ = state
@@ -4625,8 +4742,11 @@ fn run_shell_owner(
         .write_event(&daemon_audit::DaemonEvent::GuestControlShellAttached {
             vm: attach.vm.clone(),
             peer_uid: peer.uid,
+            action: daemon_audit::ShellAuditAction::Attach,
+            result: daemon_audit::ShellAuditResult::Attached,
             force: attach.force,
         });
+    shell_metric(&state, "established", "none");
 
     let mut control_seq = initial_control_seq;
     let mut poll_tasks: Vec<std::thread::JoinHandle<()>> = Vec::new();
@@ -4649,7 +4769,10 @@ fn run_shell_owner(
             if poll_tasks.len() >= SHELL_OWNER_INFLIGHT_CAP {
                 if write_json_frame(
                     stream.as_ref(),
-                    &wire::error_frame_with_id(op_id, &TypedError::GuestShellDisabled),
+                    &wire::error_frame_with_id(
+                        op_id,
+                        &shell_failed(crate::typed_error::GuestControlShellErrorKind::Capacity),
+                    ),
                 )
                 .is_err()
                 {
@@ -4685,7 +4808,7 @@ fn run_shell_owner(
                 Err(_) => {
                     let _ = write_json_frame(
                         stream.as_ref(),
-                        &wire::error_frame_with_id(op_id, &TypedError::GuestShellDisabled),
+                        &wire::error_frame_with_id(op_id, &shell_transport_failed()),
                     );
                 }
             }
@@ -4726,7 +4849,7 @@ fn run_shell_owner(
         }
     }
     let close_result = if attachment_closed {
-        "closed"
+        daemon_audit::ShellAuditResult::Closed
     } else {
         shell_close_attach_best_effort(&client, &attach.vm, &session_id, &guest_boot_id)
     };
@@ -4735,8 +4858,11 @@ fn run_shell_owner(
         .write_event(&daemon_audit::DaemonEvent::GuestControlShellDetached {
             vm: attach.vm.clone(),
             peer_uid: peer.uid,
-            result: close_result.to_owned(),
+            action: daemon_audit::ShellAuditAction::Detach,
+            result: close_result,
         });
+    shell_metric(&state, "closed", "none");
+    drop(conn_permit);
     for task in poll_tasks {
         let _ = task.join();
     }
@@ -4761,7 +4887,7 @@ fn establish_shell_owner(
     )?;
     let resolver = load_bundle_resolver(state)?;
     let params = resolve_guest_control_probe_params(state, &resolver, &attach.vm)
-        .map_err(|_| TypedError::GuestShellDisabled)?;
+        .map_err(|_| shell_transport_failed())?;
     let broker_path = broker_socket_path(state);
     block_on_future(async move {
         let budget = guest_control_health::AttemptBudget::from_now(
@@ -4769,10 +4895,9 @@ fn establish_shell_owner(
             guest_control_bridge::GUEST_CONTROL_ATTEMPT_CAP,
         );
         let signer = guest_control_bridge::BrokerSigner::new(broker_path, budget);
-        let nonce =
-            guest_control_bridge::host_nonce().map_err(|_| TypedError::GuestShellDisabled)?;
+        let nonce = guest_control_bridge::host_nonce().map_err(|_| shell_transport_failed())?;
         let client = guest_control_bridge::connect_and_build_client(&params, budget)
-            .map_err(|_| TypedError::GuestShellDisabled)?;
+            .map_err(map_shell_health_error)?;
         let evidence = guest_control_health::probe_guest_control_health(
             &params.vm_id,
             Some(guest_control_bridge::VMADDR_CID_HOST),
@@ -4781,12 +4906,12 @@ fn establish_shell_owner(
             &signer,
         )
         .await
-        .map_err(|_| TypedError::GuestShellDisabled)?;
+        .map_err(map_shell_health_error)?;
         if !guest_advertises_capability(
             &evidence.health.capabilities,
             pb::GuestCapability::GUEST_CAPABILITY_SHELL_ATTACHED,
         ) {
-            return Err(TypedError::GuestShellDisabled);
+            return Err(shell_capability_failed());
         }
         if attach.force
             && !guest_advertises_capability(
@@ -4794,7 +4919,7 @@ fn establish_shell_owner(
                 pb::GuestCapability::GUEST_CAPABILITY_SHELL_FORCE_ATTACH,
             )
         {
-            return Err(TypedError::GuestShellDisabled);
+            return Err(shell_capability_failed());
         }
         let mut request = pb::ShellAttachRequest::new();
         request.metadata = protobuf::MessageField::some(shell_request_metadata(&params.vm_id));
@@ -4807,7 +4932,7 @@ fn establish_shell_owner(
         let response: pb::ShellAttachResponse = client
             .unary_with_timeout("ShellAttach", request, SHELL_MANAGEMENT_TIMEOUT)
             .await
-            .map_err(|_| TypedError::GuestShellDisabled)?;
+            .map_err(map_shell_health_error)?;
         shell_error_to_typed(response.error.as_ref())?;
         Ok((Arc::new(client), evidence.guest_boot_id, response))
     })
@@ -4846,10 +4971,12 @@ fn handle_shell_owner_op(
     match op {
         public_wire::ShellOp::WriteStdin(args) => {
             if args.session != session_id {
-                return Err(TypedError::GuestShellDisabled);
+                return Err(shell_failed(
+                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
+                ));
             }
             let data = nixling_core::base64_codec::decode(&args.chunk_base64)
-                .map_err(|_| TypedError::GuestShellDisabled)?;
+                .map_err(|_| shell_protocol_failed())?;
             let mut request = pb::TerminalWriteStdinRequest::new();
             request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
                 vm,
@@ -4864,7 +4991,7 @@ fn handle_shell_owner_op(
                 request,
                 SHELL_MANAGEMENT_TIMEOUT,
             ))
-            .map_err(|_| TypedError::GuestShellDisabled)?;
+            .map_err(map_shell_health_error)?;
             shell_error_to_typed(response.error.as_ref())?;
             Ok(Some(public_wire::ShellOpResponse::WriteStdin(
                 tw::TerminalWriteStdinResult {
@@ -4882,7 +5009,9 @@ fn handle_shell_owner_op(
         }
         public_wire::ShellOp::ReadOutput(args) => {
             if args.session != session_id {
-                return Err(TypedError::GuestShellDisabled);
+                return Err(shell_failed(
+                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
+                ));
             }
             let mut request = pb::TerminalReadOutputRequest::new();
             request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
@@ -4899,13 +5028,14 @@ fn handle_shell_owner_op(
                 .max_len
                 .min(nixling_ipc::public_wire::EXEC_MAX_CHUNK_BYTES);
             request.wait = args.wait;
-            request.timeout_ms = args.timeout_ms;
+            let (timeout_ms, op_deadline) = shell_poll_timeout(args.timeout_ms, args.wait);
+            request.timeout_ms = timeout_ms;
             let response: pb::ReadOutputResponse = block_on_future(client.unary_with_timeout(
                 "TerminalReadOutput",
                 request,
-                SHELL_MANAGEMENT_TIMEOUT,
+                op_deadline,
             ))
-            .map_err(|_| TypedError::GuestShellDisabled)?;
+            .map_err(map_shell_health_error)?;
             shell_error_to_typed(response.error.as_ref())?;
             Ok(Some(public_wire::ShellOpResponse::ReadOutput(
                 tw::TerminalReadOutputChunk {
@@ -4920,7 +5050,9 @@ fn handle_shell_owner_op(
         }
         public_wire::ShellOp::Resize(args) => {
             if args.session != session_id {
-                return Err(TypedError::GuestShellDisabled);
+                return Err(shell_failed(
+                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
+                ));
             }
             *control_seq = control_seq.saturating_add(1);
             let mut request = pb::TerminalTtyWinResizeRequest::new();
@@ -4937,7 +5069,7 @@ fn handle_shell_owner_op(
                 request,
                 SHELL_MANAGEMENT_TIMEOUT,
             ))
-            .map_err(|_| TypedError::GuestShellDisabled)?;
+            .map_err(map_shell_health_error)?;
             shell_error_to_typed(response.error.as_ref())?;
             Ok(Some(public_wire::ShellOpResponse::Resize(
                 tw::TerminalControlResult { delivered: true },
@@ -4945,7 +5077,9 @@ fn handle_shell_owner_op(
         }
         public_wire::ShellOp::CloseStdin(args) => {
             if args.session != session_id {
-                return Err(TypedError::GuestShellDisabled);
+                return Err(shell_failed(
+                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
+                ));
             }
             let mut request = pb::TerminalCloseStdinRequest::new();
             request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
@@ -4958,7 +5092,7 @@ fn handle_shell_owner_op(
                 request,
                 SHELL_MANAGEMENT_TIMEOUT,
             ))
-            .map_err(|_| TypedError::GuestShellDisabled)?;
+            .map_err(map_shell_health_error)?;
             shell_error_to_typed(response.error.as_ref())?;
             Ok(Some(public_wire::ShellOpResponse::CloseStdin(
                 tw::TerminalCloseResult { stdin_closed: true },
@@ -4966,26 +5100,27 @@ fn handle_shell_owner_op(
         }
         public_wire::ShellOp::CloseAttach(args) => {
             if args.session != session_id {
-                return Err(TypedError::GuestShellDisabled);
+                return Err(shell_failed(
+                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
+                ));
             }
             let response = shell_close_attach(client, vm, session_id, guest_boot_id)?;
             Ok(Some(public_wire::ShellOpResponse::CloseAttach(response)))
         }
         public_wire::ShellOp::Wait(args) => {
             if args.session != session_id {
-                return Err(TypedError::GuestShellDisabled);
+                return Err(shell_failed(
+                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
+                ));
             }
-            Ok(Some(public_wire::ShellOpResponse::Wait(
-                tw::TerminalWaitResult {
-                    running: true,
-                    terminal_status: None,
-                },
-            )))
+            Err(shell_failed(
+                crate::typed_error::GuestControlShellErrorKind::Capability,
+            ))
         }
         public_wire::ShellOp::Attach(_)
         | public_wire::ShellOp::List(_)
         | public_wire::ShellOp::Detach(_)
-        | public_wire::ShellOp::Kill(_) => Err(TypedError::GuestShellDisabled),
+        | public_wire::ShellOp::Kill(_) => Err(shell_protocol_failed()),
     }
 }
 
@@ -5003,7 +5138,7 @@ fn shell_close_attach(
         request,
         SHELL_MANAGEMENT_TIMEOUT,
     ))
-    .map_err(|_| TypedError::GuestShellDisabled)?;
+    .map_err(map_shell_health_error)?;
     shell_error_to_typed(response.error.as_ref())?;
     map_shell_detach_response(response)
 }
@@ -5013,10 +5148,13 @@ fn shell_close_attach_best_effort(
     vm: &str,
     session_id: &str,
     guest_boot_id: &str,
-) -> &'static str {
+) -> daemon_audit::ShellAuditResult {
     match shell_close_attach(client, vm, session_id, guest_boot_id) {
-        Ok(_) => "closed",
-        Err(_) => "error",
+        Ok(_) => daemon_audit::ShellAuditResult::Closed,
+        Err(TypedError::GuestControlShellFailed {
+            kind: crate::typed_error::GuestControlShellErrorKind::Timeout,
+        }) => daemon_audit::ShellAuditResult::Timeout,
+        Err(_) => daemon_audit::ShellAuditResult::Error,
     }
 }
 
@@ -5038,7 +5176,7 @@ where
             error_kind = "transport-io",
             "guest-control shell: probe params unresolved: {detail}"
         );
-        TypedError::GuestShellDisabled
+        shell_transport_failed()
     })?;
     let broker_path = broker_socket_path(state);
     block_on_future(async move {
@@ -5047,10 +5185,9 @@ where
             guest_control_bridge::GUEST_CONTROL_ATTEMPT_CAP,
         );
         let signer = guest_control_bridge::BrokerSigner::new(broker_path, budget);
-        let nonce =
-            guest_control_bridge::host_nonce().map_err(|_| TypedError::GuestShellDisabled)?;
+        let nonce = guest_control_bridge::host_nonce().map_err(|_| shell_transport_failed())?;
         let client = guest_control_bridge::connect_and_build_client(&params, budget)
-            .map_err(|_| TypedError::GuestShellDisabled)?;
+            .map_err(map_shell_health_error)?;
         let evidence = guest_control_health::probe_guest_control_health(
             &params.vm_id,
             Some(guest_control_bridge::VMADDR_CID_HOST),
@@ -5059,12 +5196,12 @@ where
             &signer,
         )
         .await
-        .map_err(|_| TypedError::GuestShellDisabled)?;
+        .map_err(map_shell_health_error)?;
         if !guest_advertises_capability(
             &evidence.health.capabilities,
             pb::GuestCapability::GUEST_CAPABILITY_SHELL_MANAGEMENT,
         ) {
-            return Err(TypedError::GuestShellDisabled);
+            return Err(shell_capability_failed());
         }
         let mut metadata = pb::RequestMetadata::new();
         metadata.vm_id = params.vm_id.clone();
@@ -5088,15 +5225,13 @@ fn shell_error_to_typed(error: Option<&pb::GuestControlError>) -> Result<(), Typ
     if let Some(error) = error
         && !exec_session_real::is_unspecified(error.kind)
     {
-        return Err(TypedError::GuestShellDisabled);
+        return Err(map_shell_guest_error(error));
     }
     Ok(())
 }
 
 fn shell_name_from_guest(value: String) -> Result<public_wire::ShellName, TypedError> {
-    public_wire::ShellName::new(value).map_err(|_| TypedError::WireInvalidFrame {
-        detail: "guest shell response carried an invalid shell name".to_owned(),
-    })
+    public_wire::ShellName::new(value).map_err(|_| shell_protocol_failed())
 }
 
 fn map_shell_state(
@@ -5173,7 +5308,7 @@ fn map_shell_attach_response(
     response: pb::ShellAttachResponse,
 ) -> Result<public_wire::ShellAttachResult, TypedError> {
     Ok(public_wire::ShellAttachResult {
-        session: response.session_id.ok_or(TypedError::GuestShellDisabled)?,
+        session: response.session_id.ok_or_else(shell_protocol_failed)?,
         resolved_name: shell_name_from_guest(response.resolved_name)?,
         state: map_shell_state(response.state),
         force_evicted: response.force_evicted,

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -5026,6 +5026,23 @@ fn shell_terminal_metadata(
     metadata
 }
 
+fn ensure_shell_owner_session(
+    request_session: &str,
+    owner_session: &str,
+) -> Result<(), TypedError> {
+    if request_session == owner_session {
+        Ok(())
+    } else {
+        Err(shell_failed(
+            crate::typed_error::GuestControlShellErrorKind::StaleSession,
+        ))
+    }
+}
+
+fn unsupported_shell_wait_error() -> TypedError {
+    shell_capability_failed()
+}
+
 fn handle_shell_owner_op(
     client: &guest_control_health::TtrpcGuestControlClient,
     vm: &str,
@@ -5037,11 +5054,7 @@ fn handle_shell_owner_op(
     use nixling_ipc::terminal_wire as tw;
     match op {
         public_wire::ShellOp::WriteStdin(args) => {
-            if args.session != session_id {
-                return Err(shell_failed(
-                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
-                ));
-            }
+            ensure_shell_owner_session(&args.session, session_id)?;
             let data = nixling_core::base64_codec::decode(&args.chunk_base64)
                 .map_err(|_| shell_protocol_failed())?;
             let mut request = pb::TerminalWriteStdinRequest::new();
@@ -5075,11 +5088,7 @@ fn handle_shell_owner_op(
             )))
         }
         public_wire::ShellOp::ReadOutput(args) => {
-            if args.session != session_id {
-                return Err(shell_failed(
-                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
-                ));
-            }
+            ensure_shell_owner_session(&args.session, session_id)?;
             let mut request = pb::TerminalReadOutputRequest::new();
             request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
                 vm,
@@ -5116,11 +5125,7 @@ fn handle_shell_owner_op(
             )))
         }
         public_wire::ShellOp::Resize(args) => {
-            if args.session != session_id {
-                return Err(shell_failed(
-                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
-                ));
-            }
+            ensure_shell_owner_session(&args.session, session_id)?;
             *control_seq = control_seq.saturating_add(1);
             let mut request = pb::TerminalTtyWinResizeRequest::new();
             request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
@@ -5143,11 +5148,7 @@ fn handle_shell_owner_op(
             )))
         }
         public_wire::ShellOp::CloseStdin(args) => {
-            if args.session != session_id {
-                return Err(shell_failed(
-                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
-                ));
-            }
+            ensure_shell_owner_session(&args.session, session_id)?;
             let mut request = pb::TerminalCloseStdinRequest::new();
             request.metadata = protobuf::MessageField::some(shell_terminal_metadata(
                 vm,
@@ -5166,23 +5167,13 @@ fn handle_shell_owner_op(
             )))
         }
         public_wire::ShellOp::CloseAttach(args) => {
-            if args.session != session_id {
-                return Err(shell_failed(
-                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
-                ));
-            }
+            ensure_shell_owner_session(&args.session, session_id)?;
             let response = shell_close_attach(client, vm, session_id, guest_boot_id)?;
             Ok(Some(public_wire::ShellOpResponse::CloseAttach(response)))
         }
         public_wire::ShellOp::Wait(args) => {
-            if args.session != session_id {
-                return Err(shell_failed(
-                    crate::typed_error::GuestControlShellErrorKind::StaleSession,
-                ));
-            }
-            Err(shell_failed(
-                crate::typed_error::GuestControlShellErrorKind::Capability,
-            ))
+            ensure_shell_owner_session(&args.session, session_id)?;
+            Err(unsupported_shell_wait_error())
         }
         public_wire::ShellOp::Attach(_)
         | public_wire::ShellOp::List(_)
@@ -19599,6 +19590,30 @@ mod broker_dispatch_tests {
         assert_eq!(kill.name.as_str(), "default");
         assert!(!kill.killed);
         assert_eq!(kill.state, ShellSessionState::Killed);
+    }
+
+    #[test]
+    fn shell_poll_timeout_clamps_guest_wait_and_extends_transport_deadline() {
+        let (timeout_ms, deadline) = super::shell_poll_timeout(999_000, true);
+        assert_eq!(timeout_ms, super::SHELL_POLL_CAP.as_millis() as u64);
+        assert_eq!(deadline, super::SHELL_POLL_CAP + super::SHELL_POLL_SLACK);
+
+        let (timeout_ms, deadline) = super::shell_poll_timeout(999_000, false);
+        assert_eq!(timeout_ms, 0);
+        assert_eq!(deadline, super::SHELL_MANAGEMENT_TIMEOUT);
+    }
+
+    #[test]
+    fn shell_owner_rejects_stale_session_ids() {
+        let err = super::ensure_shell_owner_session("stale-session", "owner-session")
+            .expect_err("stale session must fail");
+        assert_eq!(err.kind(), "guest-control-shell-stale-session");
+    }
+
+    #[test]
+    fn shell_wait_is_explicitly_unsupported() {
+        let err = super::unsupported_shell_wait_error();
+        assert_eq!(err.kind(), "guest-control-shell-capability-unavailable");
     }
 
     #[test]

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -4500,6 +4500,7 @@ const SHELL_POLL_CAP: Duration = Duration::from_secs(30);
 const SHELL_POLL_SLACK: Duration = Duration::from_secs(2);
 const SHELL_OWNER_INFLIGHT_CAP: usize = 64;
 const SHELL_METRIC: &str = "nixling_daemon_guest_control_shell_total";
+const SHELL_SUBSYSTEM: &str = "guest-control-shell";
 
 fn shell_failed(kind: crate::typed_error::GuestControlShellErrorKind) -> TypedError {
     TypedError::GuestControlShellFailed { kind }
@@ -4567,14 +4568,64 @@ fn shell_poll_timeout(args_timeout_ms: u64, wait: bool) -> (u64, Duration) {
 }
 
 fn shell_metric(state: &ServerState, outcome: &'static str, error_kind: &'static str) {
+    debug_assert!(matches!(
+        outcome,
+        "management" | "established" | "closed" | "error"
+    ));
+    debug_assert!(matches!(
+        error_kind,
+        "none"
+            | "transport"
+            | "auth"
+            | "protocol"
+            | "timeout"
+            | "capability"
+            | "stale-session"
+            | "capacity"
+            | "already-attached"
+            | "not-found"
+            | "output-gap"
+            | "guest"
+            | "internal"
+    ));
     state.metrics_registry.counter_inc(
         SHELL_METRIC,
         &[
-            ("subsystem", "guest-control-shell"),
+            ("subsystem", SHELL_SUBSYSTEM),
             ("outcome", outcome),
             ("error_kind", error_kind),
         ],
     );
+}
+
+fn shell_error_kind_label(error: &TypedError) -> &'static str {
+    use crate::typed_error::GuestControlShellErrorKind as K;
+    match error {
+        TypedError::GuestControlShellFailed { kind } => match kind {
+            K::Transport => "transport",
+            K::Auth => "auth",
+            K::Protocol => "protocol",
+            K::Timeout => "timeout",
+            K::Capability => "capability",
+            K::StaleSession => "stale-session",
+            K::Capacity => "capacity",
+            K::AlreadyAttached => "already-attached",
+            K::NotFound => "not-found",
+            K::OutputGap => "output-gap",
+            K::GuestError => "guest",
+            K::Internal => "internal",
+        },
+        _ => "internal",
+    }
+}
+
+fn shell_ref_digest(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update((part.len() as u64).to_le_bytes());
+        hasher.update(part.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())[..16].to_owned()
 }
 
 fn dispatch_shell_management(
@@ -4584,70 +4635,74 @@ fn dispatch_shell_management(
 ) -> Result<Value, TypedError> {
     let response = match op {
         public_wire::ShellOp::List(args) => {
-            let result =
-                run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
-                    let mut request = pb::ShellListRequest::new();
-                    request.metadata = protobuf::MessageField::some(metadata);
-                    async move {
-                        let response: pb::ShellListResponse = client
-                            .unary_with_timeout("ShellList", request, SHELL_MANAGEMENT_TIMEOUT)
-                            .await
-                            .map_err(map_shell_health_error)?;
-                        shell_error_to_typed(response.error.as_ref())?;
-                        map_shell_list_response(response)
-                    }
-                })?;
+            let result = run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
+                let mut request = pb::ShellListRequest::new();
+                request.metadata = protobuf::MessageField::some(metadata);
+                async move {
+                    let response: pb::ShellListResponse = client
+                        .unary_with_timeout("ShellList", request, SHELL_MANAGEMENT_TIMEOUT)
+                        .await
+                        .map_err(map_shell_health_error)?;
+                    shell_error_to_typed(response.error.as_ref())?;
+                    map_shell_list_response(response)
+                }
+            })
+            .inspect_err(|error| shell_metric(state, "error", shell_error_kind_label(error)))?;
             shell_metric(state, "management", "none");
             public_wire::ShellOpResponse::List(result)
         }
         public_wire::ShellOp::Detach(args) => {
             let vm = args.vm.clone();
-            let result =
-                run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
-                    let mut request = pb::ShellDetachRequest::new();
-                    request.metadata = protobuf::MessageField::some(metadata);
-                    request.name = args.name.map(|name| name.as_str().to_owned());
-                    async move {
-                        let response: pb::ShellDetachResponse = client
-                            .unary_with_timeout("ShellDetach", request, SHELL_MANAGEMENT_TIMEOUT)
-                            .await
-                            .map_err(map_shell_health_error)?;
-                        shell_error_to_typed(response.error.as_ref())?;
-                        map_shell_detach_response(response)
-                    }
-                })?;
+            let name_for_audit = args.name.as_ref().map(|name| name.as_str().to_owned());
+            let result = run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
+                let mut request = pb::ShellDetachRequest::new();
+                request.metadata = protobuf::MessageField::some(metadata);
+                request.name = args.name.map(|name| name.as_str().to_owned());
+                async move {
+                    let response: pb::ShellDetachResponse = client
+                        .unary_with_timeout("ShellDetach", request, SHELL_MANAGEMENT_TIMEOUT)
+                        .await
+                        .map_err(map_shell_health_error)?;
+                    shell_error_to_typed(response.error.as_ref())?;
+                    map_shell_detach_response(response)
+                }
+            })
+            .inspect_err(|error| shell_metric(state, "error", shell_error_kind_label(error)))?;
             emit_shell_management_audit(
                 state,
                 peer.uid,
                 &vm,
                 daemon_audit::ShellAuditAction::Detach,
                 daemon_audit::ShellAuditResult::Detached,
+                &shell_ref_digest(&[&vm, name_for_audit.as_deref().unwrap_or("<default>")]),
             );
             shell_metric(state, "management", "none");
             public_wire::ShellOpResponse::Detach(result)
         }
         public_wire::ShellOp::Kill(args) => {
             let vm = args.vm.clone();
-            let result =
-                run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
-                    let mut request = pb::ShellKillRequest::new();
-                    request.metadata = protobuf::MessageField::some(metadata);
-                    request.name = args.name.as_str().to_owned();
-                    async move {
-                        let response: pb::ShellKillResponse = client
-                            .unary_with_timeout("ShellKill", request, SHELL_MANAGEMENT_TIMEOUT)
-                            .await
-                            .map_err(map_shell_health_error)?;
-                        shell_error_to_typed(response.error.as_ref())?;
-                        map_shell_kill_response(response)
-                    }
-                })?;
+            let digest = shell_ref_digest(&[&vm, args.name.as_str()]);
+            let result = run_guest_shell_management(state, args.vm.as_str(), |client, metadata| {
+                let mut request = pb::ShellKillRequest::new();
+                request.metadata = protobuf::MessageField::some(metadata);
+                request.name = args.name.as_str().to_owned();
+                async move {
+                    let response: pb::ShellKillResponse = client
+                        .unary_with_timeout("ShellKill", request, SHELL_MANAGEMENT_TIMEOUT)
+                        .await
+                        .map_err(map_shell_health_error)?;
+                    shell_error_to_typed(response.error.as_ref())?;
+                    map_shell_kill_response(response)
+                }
+            })
+            .inspect_err(|error| shell_metric(state, "error", shell_error_kind_label(error)))?;
             emit_shell_management_audit(
                 state,
                 peer.uid,
                 &vm,
                 daemon_audit::ShellAuditAction::Kill,
                 daemon_audit::ShellAuditResult::Killed,
+                &digest,
             );
             shell_metric(state, "management", "none");
             public_wire::ShellOpResponse::Kill(result)
@@ -4669,6 +4724,7 @@ fn emit_shell_management_audit(
     vm: &str,
     action: daemon_audit::ShellAuditAction,
     result: daemon_audit::ShellAuditResult,
+    shell_ref_digest: &str,
 ) {
     let _ = state
         .daemon_audit
@@ -4677,6 +4733,7 @@ fn emit_shell_management_audit(
             peer_uid,
             action,
             result,
+            shell_ref_digest: shell_ref_digest.to_owned(),
         });
 }
 
@@ -4703,6 +4760,7 @@ fn run_shell_owner(
                 stream.as_ref(),
                 &wire::error_frame_with_id(first_op_id, &error),
             );
+            shell_metric(&state, "error", shell_error_kind_label(&error));
             return;
         }
     };
@@ -4713,9 +4771,11 @@ fn run_shell_owner(
                 stream.as_ref(),
                 &wire::error_frame_with_id(first_op_id, &shell_protocol_failed()),
             );
+            shell_metric(&state, "error", "protocol");
             return;
         }
     };
+    let owner_shell_ref_digest = shell_ref_digest(&[&attach.vm, &session_id]);
     let initial_control_seq = attach_response.control_seq;
     let public_attach = match map_shell_attach_response(attach_response) {
         Ok(value) => public_wire::ShellOpResponse::Attach(value),
@@ -4724,6 +4784,7 @@ fn run_shell_owner(
                 stream.as_ref(),
                 &wire::error_frame_with_id(first_op_id, &error),
             );
+            shell_metric(&state, "error", shell_error_kind_label(&error));
             return;
         }
     };
@@ -4744,6 +4805,7 @@ fn run_shell_owner(
             peer_uid: peer.uid,
             action: daemon_audit::ShellAuditAction::Attach,
             result: daemon_audit::ShellAuditResult::Attached,
+            shell_ref_digest: owner_shell_ref_digest.clone(),
             force: attach.force,
         });
     shell_metric(&state, "established", "none");
@@ -4860,12 +4922,17 @@ fn run_shell_owner(
             peer_uid: peer.uid,
             action: daemon_audit::ShellAuditAction::Detach,
             result: close_result,
+            shell_ref_digest: owner_shell_ref_digest,
         });
     shell_metric(&state, "closed", "none");
-    drop(conn_permit);
+    let _ = nix::sys::socket::shutdown(
+        stream.as_ref().as_raw_fd(),
+        nix::sys::socket::Shutdown::Both,
+    );
     for task in poll_tasks {
         let _ = task.join();
     }
+    drop(conn_permit);
 }
 
 fn establish_shell_owner(

--- a/packages/nixlingd/src/metrics.rs
+++ b/packages/nixlingd/src/metrics.rs
@@ -127,6 +127,12 @@ pub const METRIC_INVENTORY: &[MetricDescriptor] = &[
         labels: &["subsystem", "outcome", "error_kind"],
         buckets_seconds: &[],
     },
+    MetricDescriptor {
+        name: "nixling_daemon_guest_control_shell_total",
+        kind: MetricKind::Counter,
+        labels: &["subsystem", "outcome", "error_kind"],
+        buckets_seconds: &[],
+    },
 ];
 
 /// Lookup a descriptor by name. `None` for any unknown name —
@@ -362,6 +368,9 @@ fn help_text(name: &str) -> &'static str {
         "nixling_daemon_guest_control_exec_total" => {
             "Cumulative count of guest-control exec session/op outcomes by error_kind."
         }
+        "nixling_daemon_guest_control_shell_total" => {
+            "Cumulative count of guest-control shell session/op outcomes by error_kind."
+        }
         _ => "",
     }
 }
@@ -514,6 +523,7 @@ mod tests {
                 "nixling_daemon_pidfd_table_size",
                 "nixling_daemon_uptime_seconds",
                 "nixling_daemon_guest_control_exec_total",
+                "nixling_daemon_guest_control_shell_total",
             ]
         );
     }

--- a/packages/nixlingd/src/typed_error.rs
+++ b/packages/nixlingd/src/typed_error.rs
@@ -232,6 +232,106 @@ impl GuestControlExecErrorKind {
     }
 }
 
+/// Closed enum of guest-control **shell** failure classes. The daemon never
+/// attaches shell names, session handles, terminal bytes, or guest-supplied
+/// strings to this error; the enum is the only public payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuestControlShellErrorKind {
+    Transport,
+    Auth,
+    Protocol,
+    Timeout,
+    Capability,
+    StaleSession,
+    Capacity,
+    AlreadyAttached,
+    NotFound,
+    OutputGap,
+    GuestError,
+    Internal,
+}
+
+impl GuestControlShellErrorKind {
+    pub fn wire_kind(self) -> &'static str {
+        match self {
+            Self::Transport => "guest-control-shell-transport-unavailable",
+            Self::Auth => "guest-control-shell-auth-failed",
+            Self::Protocol => "guest-control-shell-protocol-error",
+            Self::Timeout => "guest-control-shell-timeout",
+            Self::Capability => "guest-control-shell-capability-unavailable",
+            Self::StaleSession => "guest-control-shell-stale-session",
+            Self::Capacity => "guest-control-shell-capacity",
+            Self::AlreadyAttached => "guest-control-shell-already-attached",
+            Self::NotFound => "guest-control-shell-not-found",
+            Self::OutputGap => "guest-control-shell-output-gap",
+            Self::GuestError => "guest-control-shell-error",
+            Self::Internal => "guest-control-shell-internal",
+        }
+    }
+
+    fn exit_code(self) -> u8 {
+        match self {
+            Self::Transport | Self::Timeout => 69,
+            Self::Capability => 70,
+            Self::Capacity | Self::AlreadyAttached => 75,
+            Self::Protocol | Self::NotFound | Self::OutputGap | Self::GuestError => 76,
+            Self::Auth | Self::StaleSession => 77,
+            Self::Internal => 42,
+        }
+    }
+
+    fn human_message(self) -> &'static str {
+        match self {
+            Self::Transport => "guest-control shell transport to the VM is unavailable",
+            Self::Auth => "guest-control shell authentication to the VM failed",
+            Self::Protocol => "the guest returned a malformed guest-control shell response",
+            Self::Timeout => "the guest-control shell operation timed out",
+            Self::Capability => "the guest does not advertise a required shell capability",
+            Self::StaleSession => "the guest-control shell session is stale",
+            Self::Capacity => "the persistent shell session table is at capacity",
+            Self::AlreadyAttached => "the persistent shell is already attached",
+            Self::NotFound => "the persistent shell session was not found",
+            Self::OutputGap => "the persistent shell output stream has a gap",
+            Self::GuestError => "the guest rejected the shell operation",
+            Self::Internal => "the daemon failed to drive the shell session",
+        }
+    }
+
+    fn remediation(self) -> &'static str {
+        match self {
+            Self::Transport | Self::Timeout => {
+                "confirm the VM is running and guest-control-health is ready (`nixling vm status <vm>`), then retry"
+            }
+            Self::Auth => {
+                "the guest rejected the authenticated handshake; rotate the VM's guest-control material and restart the VM"
+            }
+            Self::Protocol => {
+                "the guest-control protocol versions are skewed; rebuild the guest with a matching nixling generation"
+            }
+            Self::Capability => {
+                "enable persistent guest shell support for the VM and rebuild/restart the guest so it advertises shell capabilities"
+            }
+            Self::StaleSession => {
+                "reattach to the shell after confirming the VM is still running; if the failure persists, restart the VM"
+            }
+            Self::Capacity => "detach or kill an existing persistent shell session, then retry",
+            Self::AlreadyAttached => {
+                "reattach with the force flag or detach the existing owner first"
+            }
+            Self::NotFound => {
+                "list persistent shell sessions for the VM and retry with a listed name"
+            }
+            Self::OutputGap => {
+                "reattach to redraw the persistent shell; terminal output before the gap is no longer available"
+            }
+            Self::GuestError => "inspect guestd shell state and retry the shell operation",
+            Self::Internal => {
+                "retry; if the failure persists inspect the daemon log for the typed shell-session record"
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum TypedError {
     AuthzNotALauncher {
@@ -414,6 +514,11 @@ pub enum TypedError {
     GuestControlExecFailed {
         kind: GuestControlExecErrorKind,
     },
+    /// Authenticated guest-control **shell** failed. Closed-enum kind only; no
+    /// shell name, session handle, terminal bytes, or guest string.
+    GuestControlShellFailed {
+        kind: GuestControlShellErrorKind,
+    },
     /// The daemon refused a new connection because the bounded in-flight
     /// connection-handler pool is saturated. Returned immediately
     /// (non-blocking) from the accept path so a burst of clients cannot
@@ -486,6 +591,7 @@ impl TypedError {
             Self::RuntimeCapabilityUnsupported { .. } => "runtime-capability-unsupported",
             Self::GuestControlReadFailed { kind } => kind.wire_kind(),
             Self::GuestControlExecFailed { kind } => kind.wire_kind(),
+            Self::GuestControlShellFailed { kind } => kind.wire_kind(),
             Self::DaemonBusy => "daemon-busy",
         }
     }
@@ -532,6 +638,7 @@ impl TypedError {
             // distinct `kind` slug carries the sub-class.
             Self::GuestControlReadFailed { .. } => 70,
             Self::GuestControlExecFailed { kind } => kind.exit_code(),
+            Self::GuestControlShellFailed { kind } => kind.exit_code(),
             // Shares the EX_TEMPFAIL-class exit code with the other
             // transient back-pressure refusals (session-capacity,
             // rate-limited): a retry may succeed.
@@ -644,6 +751,7 @@ impl TypedError {
             }
             Self::GuestControlReadFailed { kind } => kind.human_message().to_owned(),
             Self::GuestControlExecFailed { kind } => kind.human_message().to_owned(),
+            Self::GuestControlShellFailed { kind } => kind.human_message().to_owned(),
             Self::DaemonBusy => "the daemon is at its in-flight connection limit".to_owned(),
         }
     }
@@ -752,6 +860,7 @@ impl TypedError {
             }
             Self::GuestControlReadFailed { kind } => kind.remediation().to_owned(),
             Self::GuestControlExecFailed { kind } => kind.remediation().to_owned(),
+            Self::GuestControlShellFailed { kind } => kind.remediation().to_owned(),
             Self::DaemonBusy => {
                 "the daemon is briefly at capacity; retry the command shortly".to_owned()
             }
@@ -880,6 +989,7 @@ impl TypedError {
             | Self::RuntimeCapabilityUnsupported { .. }
             | Self::GuestControlReadFailed { .. }
             | Self::GuestControlExecFailed { .. }
+            | Self::GuestControlShellFailed { .. }
             | Self::DaemonBusy => "internalError",
         }
     }
@@ -1075,6 +1185,47 @@ mod tests {
             // The public envelope must never carry guest-supplied tokens.
             for surface in [err.message(), err.remediation()] {
                 for forbidden in ["argv", "stdout", "stderr", "session=", "handle="] {
+                    assert!(
+                        !surface.contains(forbidden),
+                        "kind={slug} leaks {forbidden:?}: {surface:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn guest_control_shell_failed_kinds_are_leak_free() {
+        let kinds = [
+            GuestControlShellErrorKind::Transport,
+            GuestControlShellErrorKind::Auth,
+            GuestControlShellErrorKind::Protocol,
+            GuestControlShellErrorKind::Timeout,
+            GuestControlShellErrorKind::Capability,
+            GuestControlShellErrorKind::StaleSession,
+            GuestControlShellErrorKind::Capacity,
+            GuestControlShellErrorKind::AlreadyAttached,
+            GuestControlShellErrorKind::NotFound,
+            GuestControlShellErrorKind::OutputGap,
+            GuestControlShellErrorKind::GuestError,
+            GuestControlShellErrorKind::Internal,
+        ];
+        for kind in kinds {
+            let err = TypedError::GuestControlShellFailed { kind };
+            let slug = err.kind();
+            assert!(
+                slug.starts_with("guest-control-shell-"),
+                "slug={slug} does not use guest-control-shell prefix"
+            );
+            assert!(!err.message().is_empty(), "kind={slug} message empty");
+            assert!(
+                !err.remediation().is_empty(),
+                "kind={slug} remediation empty"
+            );
+            assert_no_path_leak(slug, &err.message());
+            assert_no_path_leak(slug, &err.remediation());
+            for surface in [err.message(), err.remediation()] {
+                for forbidden in ["stdout", "stderr", "session=", "handle=", "shell="] {
                     assert!(
                         !surface.contains(forbidden),
                         "kind={slug} leaks {forbidden:?}: {surface:?}"

--- a/packages/nixlingd/src/wire.rs
+++ b/packages/nixlingd/src/wire.rs
@@ -397,6 +397,46 @@ pub fn parse_exec_op(bytes: &[u8]) -> Result<(u64, public_wire::ExecOp), TypedEr
     Ok((op_id, op))
 }
 
+/// Extract the envelope-level `opId` from a shell request frame, defaulting to
+/// `0` when absent. Mirrors exec owner framing without making `opId` part of the
+/// public `ShellOp` JSON body.
+pub fn shell_op_id(bytes: &[u8]) -> u64 {
+    serde_json::from_slice::<Value>(bytes)
+        .ok()
+        .and_then(|value| value.get("opId").and_then(Value::as_u64))
+        .unwrap_or(0)
+}
+
+/// Parse a shell op frame into its correlating `opId` and multiplexed op.
+pub fn parse_shell_op(bytes: &[u8]) -> Result<(u64, public_wire::ShellOp), TypedError> {
+    let mut value: Value =
+        serde_json::from_slice(bytes).map_err(|err| TypedError::WireInvalidFrame {
+            detail: err.to_string(),
+        })?;
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| TypedError::WireInvalidFrame {
+            detail: "request frame must be a JSON object".to_owned(),
+        })?;
+    let request_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TypedError::WireInvalidFrame {
+            detail: "missing request type".to_owned(),
+        })?
+        .to_owned();
+    if request_type != "shell" {
+        return Err(TypedError::WireUnsupportedRequest { request_type });
+    }
+    object.remove("type");
+    let op_id = object
+        .remove("opId")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    let op = serde_json::from_value(Value::Object(object.clone())).map_err(map_parse_error)?;
+    Ok((op_id, op))
+}
+
 pub fn negotiate_version(
     client_range: &str,
     accepted_range: &str,
@@ -575,6 +615,24 @@ pub fn exec_response_with_id(op_id: u64, payload: &public_wire::ExecOpResponse) 
     value
 }
 
+/// Serialize a `ShellOpResponse` as the `shellResponse` daemon wire frame.
+pub fn shell_response(payload: &public_wire::ShellOpResponse) -> Value {
+    let mut value = serde_json::to_value(payload).unwrap_or_else(|_| json!({}));
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("type".to_owned(), Value::String("shellResponse".to_owned()));
+    }
+    value
+}
+
+/// `shellResponse` frame tagged with the correlating envelope `opId`.
+pub fn shell_response_with_id(op_id: u64, payload: &public_wire::ShellOpResponse) -> Value {
+    let mut value = shell_response(payload);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("opId".to_owned(), Value::from(op_id));
+    }
+    value
+}
+
 /// `error` frame tagged with the correlating envelope `opId` so the owner
 /// connection can return an out-of-order op error without the CLI mismatching
 /// it against a different in-flight op.
@@ -614,8 +672,8 @@ fn map_parse_error(error: serde_json::Error) -> TypedError {
 
 #[cfg(test)]
 mod tests {
-    use super::{Request, parse_request};
-    use nixling_ipc::public_wire::ShellOp;
+    use super::{Request, parse_request, shell_response_with_id};
+    use nixling_ipc::public_wire::{ShellListResult, ShellName, ShellOp, ShellOpResponse};
 
     #[test]
     fn shell_request_parses_as_typed_shell_op() {
@@ -632,5 +690,17 @@ mod tests {
         let frame = br#"{"type":"shell","op":"kill","args":{"vm":"corp-vm"}}"#;
         let error = parse_request(frame).expect_err("kill without name rejects");
         assert_eq!(error.kind(), "wire-invalid-frame");
+    }
+
+    #[test]
+    fn shell_response_is_op_id_tagged() {
+        let payload = ShellOpResponse::List(ShellListResult {
+            default_name: ShellName::new("default").unwrap(),
+            sessions: Vec::new(),
+        });
+        let value = shell_response_with_id(42, &payload);
+        assert_eq!(value["type"], "shellResponse");
+        assert_eq!(value["opId"], 42);
+        assert_eq!(value["op"], "list");
     }
 }


### PR DESCRIPTION
## Summary
- route public shell management ops through nixlingd with admin/capability gates
- add attached shell owner proxying over guest-control terminal RPCs
- add bounded shell owner polling, typed shell errors, shell metrics, and leak-safe audit events
- add test coverage for shell DTO mapping, timeout clamping, stale-session rejection, unsupported wait, audit redaction, metrics policy, and disk-init formatter retry

## Validation
- cargo test -p nixlingd shell
- cargo test -p nixlingd metrics
- cargo test -p nixlingd
- cargo test -p nixling-ipc shell
- cargo test ops::disk_init::tests::existing_sparse_unformatted_image_is_repaired (nixling-priv-broker)
- cargo clippy --all-targets -- -D warnings (nixling-priv-broker)
- cargo test -p nixling-contract-tests --test policy_metrics
- make check-tier0
- make test-rust
- make test-drift
- make test-policy

## Review status
Wave 4 implementation panel reached 10/10 signoff after targeted product/test/kernel/rust/observability follow-ups.