### PR TITLE
docs: add persistent shell references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ deprecations ship one minor release before removal.
   images before treating `ifAbsent` as satisfied, safely formats only
   proven-empty images, and fails closed before VM spawn for malformed or
   ambiguous image data.
+- Persistent shell guests now render the shpool daemon unit with a store-backed
+  start script instead of an inline multi-line `ExecStart` command, avoiding
+  systemd quote parsing failures.
 - `nixling list --json` now preserves daemon-reported failed lifecycle state as
   `status = "failed"` instead of collapsing it to `unknown`.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Nixling gives you:
   tools use the same host/env/VM identity colors.
 - **One operator surface:** the Rust `nixling` CLI talks to `nixlingd`
   and the privileged broker for lifecycle, keys, USB, and host prep.
+- **Persistent guest shells:** `nixling shell <vm>` can reconnect to
+  named interactive guest shells when `guest.shell` is enabled.
 
 At a high level:
 
@@ -82,6 +84,8 @@ sudo nixling vm start personal-dev --apply
 Other entry points: see [Where to start](#where-to-start) below for a
 table of the doc-friendly example aliases (`personal-dev`,
 `graphics-workstation`, `multi-env`) plus the manual integration path.
+For reconnectable interactive shells, see
+[Use persistent guest shells](./docs/how-to/use-persistent-shells.md).
 
 ## Who this is for
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,9 @@ The contracts. Stable interfaces a consumer can depend on.
 - [`reference/constellation-observability.md`](./reference/constellation-observability.md) —
   bounded `nixling op inspect`, TraceContext propagation, degraded partial
   results, and telemetry redaction/cardinality constraints.
+- [`reference/guest-control-persistent-shell.md`](./reference/guest-control-persistent-shell.md) —
+  guest-control shell RPCs, terminal-generic streaming, shell states,
+  close causes, and redaction contracts.
 - [`reference/remote-full-host-nodes.md`](./reference/remote-full-host-nodes.md) —
   gateway-managed remote nixling hosts: registration, capability gating,
   operation routing, idempotency, and the non-tunneling boundary.
@@ -97,6 +100,8 @@ The contracts. Stable interfaces a consumer can depend on.
   - [`reference/components-audio.md`](./reference/components-audio.md) —
     `nixling.vms.<vm>.audio.*` (vhost-user-sound + PipeWire) plus
     the `nixling audio` CLI surface.
+  - [`reference/components-shell.md`](./reference/components-shell.md) —
+    `nixling.vms.<vm>.guest.shell.*` (persistent named guest shells).
   - [`reference/components-home-manager.md`](./reference/components-home-manager.md) —
     `nixling.vms.<vm>.homeManager.*` (Home Manager as a NixOS
     module inside the VM).
@@ -140,6 +145,8 @@ Task-oriented recipes. Prescriptive, copy-and-adapt.
   declare a work/provider realm gateway and verify default-deny isolation.
 - [`how-to/realm-gateway.md`](./how-to/realm-gateway.md) —
   configure, enter, and recover realm gateway guests.
+- [`how-to/use-persistent-shells.md`](./how-to/use-persistent-shells.md) —
+  enable, attach, detach, reattach, list, and kill persistent named guest shells.
 - [`how-to/migrate-nixling-v1-2-to-v2.md`](./how-to/migrate-nixling-v1-2-to-v2.md) —
   migrate from local-only or implicit realm metadata to explicit gateway-backed
   realm policy.
@@ -156,6 +163,9 @@ Understanding-oriented prose. The "why" behind the design choices.
 - [`explanation/storage-lifecycle.md`](./explanation/storage-lifecycle.md) —
   why nixling treats host paths, restart adoption, locks, cleanup, and
   degraded-state reporting as explicit control-plane contracts.
+- [`explanation/persistent-shells.md`](./explanation/persistent-shells.md) —
+  persistence boundary, local IPC model, same-UID AF_UNIX trust boundary, and
+  non-goals for persistent named guest shells.
 - [`adr/README.md`](./adr/README.md) — architecture decision
   records for load-bearing design choices that complement the
   explanation narrative.

--- a/docs/explanation/persistent-shells.md
+++ b/docs/explanation/persistent-shells.md
@@ -1,0 +1,60 @@
+# Persistent shell sessions
+
+> Diataxis: explanation. Conceptual model for `nixling shell`.
+
+`nixling shell` attaches an admin's terminal to a named shell session inside a
+running guest. The user-facing surface is:
+
+```text
+nixling shell <vm> [ACTION]
+```
+
+where `ACTION` is `attach`, `list`, `detach`, or `kill`. Omitting `ACTION`
+attaches to the VM's configured default session.
+
+## Persistence boundary
+
+Persistent shell state belongs to the guest-local shell pool, not to the host
+CLI process. A session is expected to survive:
+
+- the local CLI disconnecting;
+- the terminal window closing;
+- guestd restart when guestd can adopt the still-running shell pool.
+
+It is not expected to survive:
+
+- VM reboot;
+- shell-pool daemon restart or loss;
+- explicit `nixling shell <vm> kill --name <name>`;
+- `exit` or `Ctrl-D` inside the shell.
+
+This is intentionally different from `nixling vm exec -it`, whose command is
+connection-owned and exits with the command's status.
+
+## Local dispatch and network surface
+
+The host CLI connects to the local `nixlingd` public socket. It rejects
+gateway-backed realm targets locally; operators manage those guests by running
+the command against the realm gateway's `nixlingd`.
+
+Persistent shells do not add TCP or UDP listeners, network ports, or
+network-bound debug/metrics surfaces. The host-to-guest path reuses the existing
+daemon public socket and authenticated guest-control transport.
+
+## Same-UID AF_UNIX boundary
+
+Inside the guest, shpool exposes an AF_UNIX socket under the workload user's
+runtime directory. Helpers that connect to that socket run as the workload UID.
+The socket is a same-UID IPC boundary, not a cryptographic separation boundary:
+code already running as that workload user can potentially interact with the
+same shell pool.
+
+For that reason, persistent shells are appropriate for a trusted workload-user
+environment. They are not a way to hide admin shell state from other code
+already executing as the same guest user.
+
+## Non-goals
+
+Persistent shells do not provide tmux-style multiplexing, panes, windows, SSH
+fallbacks, or shell templates/start-command customization. One CLI invocation
+attaches to one named session.

--- a/docs/how-to/use-persistent-shells.md
+++ b/docs/how-to/use-persistent-shells.md
@@ -1,0 +1,112 @@
+# Use persistent guest shells
+
+> Diataxis: how-to. Task-oriented operator guide for `nixling shell`.
+
+Persistent shells let you reconnect to a named interactive shell inside a
+running guest. Use them for long-lived interactive work. Use
+`nixling vm exec <vm> -- <cmd>` for one-off commands.
+
+For the persistence model, local IPC boundary, and same-UID trust model,
+see [Persistent shell sessions](../explanation/persistent-shells.md).
+
+## Enable persistent shells for a VM
+
+Enable guest control, exec, and shell for a VM with a non-root workload user:
+
+```nix
+nixling.vms.work = {
+  ssh.user = "alice";
+
+  guest.control.enable = true;
+  guest.exec.enable = true;
+  guest.shell = {
+    enable = true;
+    defaultName = "default";
+    maxSessions = 8;
+    maxAttached = 1;
+  };
+};
+```
+
+Switch the host configuration, then restart the affected VM so guestd sees the
+new shell policy.
+
+## Attach to the default shell
+
+```bash
+nixling shell work
+```
+
+The CLI prints the resolved session name before entering raw terminal mode. To
+detach without ending the shell, press `Ctrl-Space` followed by `Ctrl-q`.
+
+Typing `exit` or pressing `Ctrl-D` at an empty prompt ends the persistent shell
+session.
+
+## Attach to a named shell
+
+```bash
+nixling shell work --name build
+```
+
+Names must be 1-64 ASCII bytes, start with `[A-Za-z0-9_]`, and then contain only
+`[A-Za-z0-9._-]`.
+
+## Reattach
+
+After detaching or closing the local terminal, attach to the same name again:
+
+```bash
+nixling shell work --name build
+```
+
+If another client is already attached to the same session, the attach fails.
+Use `--force` only when you intentionally want to detach that existing client:
+
+```bash
+nixling shell work --name build --force
+```
+
+## List sessions
+
+```bash
+nixling shell work list
+nixling shell work list --json
+```
+
+The human output marks the configured default session. JSON output includes
+`default_name` and a `sessions` array.
+
+## Detach a stale client
+
+Detach defaults to the VM's configured default name when `--name` is omitted:
+
+```bash
+nixling shell work detach
+nixling shell work detach --name build
+```
+
+Detach is non-destructive. It is safe to retry when the session is already
+detached or absent.
+
+## Kill a session
+
+Killing is destructive and always requires an explicit name:
+
+```bash
+nixling shell work kill --name build
+```
+
+Use `list` first if you need to discover the configured default name.
+
+## Gateway-backed targets
+
+`nixling shell` talks to the local host daemon's public socket. The host daemon
+does not dispatch persistent shell requests into gateway-backed realm targets.
+Run the command against the realm gateway's `nixlingd` instead.
+
+## Avoid co-locating untrusted same-UID services
+
+Persistent shells use a workload-user shpool socket inside the guest. Code
+already running as the same workload UID can reach that AF_UNIX socket. Do not
+co-locate untrusted same-UID services with persistent admin shells.

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -2487,6 +2487,113 @@ Pending-staging notes (`nixling status`, `nixling up`/`start`, and the
 mutating verbs) are emitted on **stderr** for human output only, so they
 never perturb a `--json` stdout envelope.
 
+### `shell`
+
+**Synopsis:** `nixling shell <vm> [ACTION] [--name NAME] [--force] [--json|--human]`
+
+`ACTION` is one of:
+
+- omitted or `attach` — attach to the VM's configured default shell session, or
+  to `--name NAME`;
+- `list` — list persistent shell sessions;
+- `detach` — detach a live/stale client without killing the shell;
+- `kill` — terminate a named shell session.
+
+The first positional after `shell` is always the VM name. A VM named `list`,
+`attach`, `detach`, or `kill` attaches by default; use
+`nixling shell <vm> <ACTION>` for management. Command-like trailing words such as
+`nixling shell work htop` are rejected with a hint to use
+`nixling vm exec <vm> -- <cmd>` for one-off commands.
+
+`shell` uses the local daemon public socket and the authenticated guest-control
+terminal transport. The host daemon does not proxy shell operations into
+gateway-backed realm targets; gateway-backed shells must be managed by running
+the command against the realm gateway's `nixlingd`.
+
+**Flags**
+
+| Flag | Applies to | Semantics |
+| --- | --- | --- |
+| `--name NAME` | attach, detach, kill | Persistent shell session name. Omitted attach/detach uses the configured default; kill requires `--name`. |
+| `--force` | attach | Detach an already-attached client for the same named session before attaching. |
+| `--json` | list, detach, kill | Emit one JSON document on stdout. Attach is human/TTY-only and rejects JSON. |
+| `--human` | list, detach, kill | Force human output. Attach is always human/TTY-only. |
+
+**Shell name rule**
+
+Names are 1-64 ASCII bytes, start with `[A-Za-z0-9_]`, and then contain only
+`[A-Za-z0-9._-]`. Names are user-visible operational identifiers, but daemon
+metrics never use names or terminal handles as labels.
+
+**Human examples**
+
+```text
+$ nixling shell work
+attached to shell 'default' on vm 'work'; detach with Ctrl-Space Ctrl-q; exit or Ctrl-D ends the session
+```
+
+```text
+$ nixling shell work list
+NAME    STATE     ATTACHED  DEFAULT
+default detached  false     true
+```
+
+**`--json` examples**
+
+```json
+{
+  "command": "shell list",
+  "vm": "work",
+  "default_name": "default",
+  "sessions": [
+    {
+      "name": "default",
+      "state": "detached",
+      "attached": false,
+      "is_default": true
+    }
+  ]
+}
+```
+
+```json
+{
+  "command": "shell detach",
+  "vm": "work",
+  "name": "default",
+  "result": "already-detached-or-absent",
+  "cause": null
+}
+```
+
+```json
+{
+  "command": "shell kill",
+  "vm": "work",
+  "name": "build",
+  "result": "killed",
+  "state": "killed"
+}
+```
+
+**Exit codes**
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success, including idempotent detach/kill no-op results. |
+| `1` | Unexpected daemon reply or local protocol/serialization failure. |
+| `2` | Usage error, invalid flag combination, missing required `--name` for kill, invalid shell name, non-TTY attach, or gateway-backed target on the host daemon. |
+| `69` | Local daemon public socket unavailable for shell dispatch. |
+| `70` | Daemon generation does not support persistent shell operations. |
+| `75` | Daemon admin authorization failed before guest contact. |
+
+**Redaction**
+
+Shell management JSON may include validated shell names because they are
+operator-facing identifiers. Daemon audit records use a fixed shell correlation
+digest; metrics labels never carry shell names, terminal session handles, attach
+ids, helper diagnostics, paths, argv, env, or terminal bytes.
+
 ### `vm exec`
 
 **Synopsis:** `nixling vm exec [-i] [-t] [-d|--detach] [--env KEY=VALUE]… [--cwd DIR] [--json|--human] <vm> -- <cmd> [args…]`

--- a/docs/reference/cli-output/README.md
+++ b/docs/reference/cli-output/README.md
@@ -28,6 +28,9 @@ JSON envelopes.
 | `vm exec <vm> status` | `vm-exec-status.schema.json` | [cli-contract.md § `vm exec`](../cli-contract.md#vm-exec) |
 | `vm exec <vm> logs` | `vm-exec-logs.schema.json` | [cli-contract.md § `vm exec`](../cli-contract.md#vm-exec) |
 | `vm exec <vm> kill` | `vm-exec-kill.schema.json` | [cli-contract.md § `vm exec`](../cli-contract.md#vm-exec) |
+| `shell <vm> list` | `shell-list.schema.json` | [shell-list.md](./shell-list.md) |
+| `shell <vm> detach` | `shell-detach.schema.json` | [shell-detach.md](./shell-detach.md) |
+| `shell <vm> kill` | `shell-kill.schema.json` | [shell-kill.md](./shell-kill.md) |
 
 The legacy bash compatibility commands keep their existing JSON
 contracts, but only rust-native JSON surfaces get dedicated schema

--- a/docs/reference/cli-output/shell-detach.md
+++ b/docs/reference/cli-output/shell-detach.md
@@ -24,6 +24,6 @@ Schema: [`shell-detach.schema.json`](./shell-detach.schema.json).
 | `vm` | Local VM name after CLI target routing. |
 | `name` | Resolved shell session name. When `--name` is omitted, this is the configured default. |
 | `result` | `detached` when a live client was detached; otherwise `already-detached-or-absent`. |
-| `cause` | Optional close cause reported by the daemon/guest path, such as `client-detach` or `evicted-by-admin-detach`. Omitted when absent. |
+| `cause` | Optional close cause reported by the daemon/guest path, such as `client-detach` or `evicted-by-admin-detach`. Null when absent. |
 
 Detach is non-destructive and retry-safe.

--- a/docs/reference/cli-output/shell-detach.md
+++ b/docs/reference/cli-output/shell-detach.md
@@ -1,0 +1,29 @@
+# `nixling shell <vm> detach --json`
+
+> Diataxis: reference. JSON output contract for persistent shell detach.
+
+Schema: [`shell-detach.schema.json`](./shell-detach.schema.json).
+
+## Shape
+
+```json
+{
+  "command": "shell detach",
+  "vm": "work",
+  "name": "default",
+  "result": "already-detached-or-absent",
+  "cause": null
+}
+```
+
+## Fields
+
+| Field | Meaning |
+| --- | --- |
+| `command` | Stable command discriminator, always `shell detach`. |
+| `vm` | Local VM name after CLI target routing. |
+| `name` | Resolved shell session name. When `--name` is omitted, this is the configured default. |
+| `result` | `detached` when a live client was detached; otherwise `already-detached-or-absent`. |
+| `cause` | Optional close cause reported by the daemon/guest path, such as `client-detach` or `evicted-by-admin-detach`. Omitted when absent. |
+
+Detach is non-destructive and retry-safe.

--- a/docs/reference/cli-output/shell-detach.schema.json
+++ b/docs/reference/cli-output/shell-detach.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ShellDetachOutputV1",
+  "type": "object",
+  "required": [
+    "command",
+    "name",
+    "result",
+    "vm"
+  ],
+  "properties": {
+    "cause": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "command": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "result": {
+      "type": "string"
+    },
+    "vm": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/reference/cli-output/shell-kill.md
+++ b/docs/reference/cli-output/shell-kill.md
@@ -1,0 +1,29 @@
+# `nixling shell <vm> kill --name <name> --json`
+
+> Diataxis: reference. JSON output contract for persistent shell kill.
+
+Schema: [`shell-kill.schema.json`](./shell-kill.schema.json).
+
+## Shape
+
+```json
+{
+  "command": "shell kill",
+  "vm": "work",
+  "name": "build",
+  "result": "killed",
+  "state": "killed"
+}
+```
+
+## Fields
+
+| Field | Meaning |
+| --- | --- |
+| `command` | Stable command discriminator, always `shell kill`. |
+| `vm` | Local VM name after CLI target routing. |
+| `name` | Explicit shell session name supplied with `--name`. Kill never defaults to `default`. |
+| `result` | `killed` when the session was terminated; otherwise `already-absent`. |
+| `state` | Terminal shell state reported by the daemon, normally `killed` for this command. |
+
+Kill is destructive, so `--name` is required.

--- a/docs/reference/cli-output/shell-kill.schema.json
+++ b/docs/reference/cli-output/shell-kill.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ShellKillOutputV1",
+  "type": "object",
+  "required": [
+    "command",
+    "name",
+    "result",
+    "state",
+    "vm"
+  ],
+  "properties": {
+    "command": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "result": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "vm": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/reference/cli-output/shell-list.md
+++ b/docs/reference/cli-output/shell-list.md
@@ -1,0 +1,39 @@
+# `nixling shell <vm> list --json`
+
+> Diataxis: reference. JSON output contract for persistent shell listing.
+
+Schema: [`shell-list.schema.json`](./shell-list.schema.json).
+
+## Shape
+
+```json
+{
+  "command": "shell list",
+  "vm": "work",
+  "default_name": "default",
+  "sessions": [
+    {
+      "name": "default",
+      "state": "detached",
+      "attached": false,
+      "is_default": true
+    }
+  ]
+}
+```
+
+## Fields
+
+| Field | Meaning |
+| --- | --- |
+| `command` | Stable command discriminator, always `shell list`. |
+| `vm` | Local VM name after CLI target routing. Gateway-backed targets are rejected before daemon dispatch. |
+| `default_name` | Configured default shell session name for the VM. Present even when `sessions` is empty. |
+| `sessions[]` | Bounded session rows reported by guestd. |
+| `sessions[].name` | Validated shell session name. |
+| `sessions[].state` | One of `attached`, `detached`, `killed`, `pool-unavailable`, `feature-disabled`, or `output-gap`. |
+| `sessions[].attached` | Whether a client is currently attached. |
+| `sessions[].is_default` | Whether the row is the configured default session. |
+
+Shell names are operational identifiers and may appear in CLI output. They are
+not metric labels or raw daemon audit fields.

--- a/docs/reference/cli-output/shell-list.schema.json
+++ b/docs/reference/cli-output/shell-list.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ShellListOutputV1",
+  "type": "object",
+  "required": [
+    "command",
+    "default_name",
+    "sessions",
+    "vm"
+  ],
+  "properties": {
+    "command": {
+      "type": "string"
+    },
+    "default_name": {
+      "type": "string"
+    },
+    "sessions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ShellListSessionOutputV1"
+      }
+    },
+    "vm": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "ShellListSessionOutputV1": {
+      "type": "object",
+      "required": [
+        "attached",
+        "is_default",
+        "name",
+        "state"
+      ],
+      "properties": {
+        "attached": {
+          "type": "boolean"
+        },
+        "is_default": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/reference/components-shell.md
+++ b/docs/reference/components-shell.md
@@ -1,0 +1,79 @@
+# Persistent shell component
+
+> Diataxis: reference. Option and policy contract for persistent guest shells.
+
+Persistent shells are disabled by default and are configured per VM:
+
+```nix
+nixling.vms.<vm>.guest.shell = {
+  enable = true;
+  defaultName = "default";
+  maxSessions = 8;
+  maxAttached = 1;
+};
+```
+
+## Options
+
+| Option | Type/default | Meaning |
+| --- | --- | --- |
+| `guest.shell.enable` | boolean, default `false` | Enables the persistent shell policy and guest runtime wiring for this VM. |
+| `guest.shell.defaultName` | shell name, default `default` | Session name used when attach/detach omit `--name`. |
+| `guest.shell.maxSessions` | integer 1-256, default `8` | Maximum persistent shell sessions tracked for the VM, attached plus detached. |
+| `guest.shell.maxAttached` | integer 1-64, default `1` | Maximum concurrently attached persistent shell clients. Must be `<= maxSessions`. |
+
+## Requirements
+
+Enabling `guest.shell` requires:
+
+- `guest.control.enable = true`;
+- `guest.exec.enable = true`;
+- a non-root workload user (`ssh.user`);
+- a runtime/provider that supports guest-control shell operation capability.
+
+`qemu-media` and providers without guest-control reject non-default
+`guest.shell.*` settings at eval time.
+
+## Guest wiring
+
+When enabled for a workload user, the guest module:
+
+- passes `--shell-enable`, `--shell-default-name`, `--shell-max-sessions`, and
+  `--shell-max-attached` to guestd;
+- wires the static `nixling-guest-shell-runner` and `systemctl` paths;
+- declares `nixling-shpool-daemon.service` as the workload user with
+  `PAMName=nixling-shpool-daemon`;
+- sets workload-user linger so `/run/user/<uid>` exists while all shell clients
+  are detached.
+
+The shpool daemon remains in the delegated system service cgroup; the PAM service
+uses `startSession = false`, `setEnvironment = true`, and `setLoginUid = true`.
+
+## Manifest metadata
+
+Supported providers emit a per-VM manifest block:
+
+```json
+{
+  "shell": {
+    "enabled": true,
+    "defaultName": "default",
+    "maxSessions": 8,
+    "maxAttached": 1
+  }
+}
+```
+
+Providers without guest-control emit `shell = null`. The manifest never exposes
+runtime helper sockets, terminal handles, shpool state paths, or live session
+names beyond the configured default.
+
+## Trust and redaction
+
+Persistent shells use a same-UID AF_UNIX shpool socket inside the guest. This is
+not a boundary against other processes already running as the workload user.
+
+Daemon metrics and audit surfaces do not use raw shell names, terminal handles,
+terminal bytes, helper diagnostics, argv, env, or paths as labels or log fields.
+The daemon audit stream uses a fixed shell correlation digest where correlation
+is needed.

--- a/docs/reference/daemon-api.md
+++ b/docs/reference/daemon-api.md
@@ -402,6 +402,8 @@ The redaction policy is strict:
 - no host paths unless the path itself is already part of the stable
   public contract;
 - no secrets, stack traces, credential material, or raw command output;
+- no terminal payloads, argv/env/cwd, helper stderr/stdout, raw shell session
+  handles, or raw shell names in daemon metrics or broad debug/audit fields;
 - one human-readable remediation hint per failure;
 - one docs anchor into [`error-codes.md`](./error-codes.md).
 
@@ -501,6 +503,14 @@ bounded event metadata plus `prev_hash` and `record_hash` fields so a
 verifier can detect missing, reordered, or modified lines. The hash-chain
 helper reports tampering explicitly; the write path remains best-effort so
 an audit sink outage does not abort an already-authorized local operation.
+
+Persistent shell daemon events are in this daemon-owned stream, not the broker
+audit log. The shell variants record only the VM name, admin peer uid, closed
+action/result enums, force flag when relevant, and a fixed shell correlation
+digest. Raw shell names, terminal session handles, terminal bytes, helper
+diagnostics, argv, env, and paths are never written. Abrupt owner disconnects,
+close timeouts, and stale/unsupported guest generations are represented by
+closed result or typed-error buckets rather than free-form text.
 
 Daemon audit sink health is exposed as an explicit report rather than a
 silent fallback. The report distinguishes writable, degraded, and

--- a/docs/reference/daemon-metrics.md
+++ b/docs/reference/daemon-metrics.md
@@ -151,6 +151,21 @@ declared schema; see "Cardinality bounds" below.
   `changes(nixling_daemon_uptime_seconds[5m]) > 0` for a restart
   alert.
 
+### `nixling_daemon_guest_control_exec_total`
+
+- **Type:** counter
+- **Labels:** `subsystem`, `outcome`, `error_kind`
+- **Meaning:** Cumulative count of guest-control exec session/op outcomes by
+  subsystem, closed outcome, and bounded error bucket.
+
+### `nixling_daemon_guest_control_shell_total`
+
+- **Type:** counter
+- **Labels:** `subsystem`, `outcome`, `error_kind`
+- **Meaning:** Cumulative count of guest-control persistent-shell management and
+  attached-owner outcomes. Shell names, terminal session handles, attach ids,
+  helper diagnostics, and terminal bytes are never metric labels.
+
 ## Cardinality bounds
 
 | Label | Source | Bound |
@@ -161,9 +176,12 @@ declared schema; see "Cardinality bounds" below.
 | `step` | closed enum (host-prep DAG step IDs) | bounded by [`host-prep-dag.md`](./host-prep-dag.md) |
 | `op` | closed enum (broker wire op names) | bounded by [`daemon-api.md`](./daemon-api.md) |
 | `outcome` (broker) | closed enum | 3 |
+| `subsystem` | closed guest-control subsystem enum | bounded by daemon code |
+| `outcome` (guest-control) | closed enum | bounded by daemon code |
+| `error_kind` | normalized daemon error bucket | bounded by daemon code |
 
 No label carries free-form text (no error messages, no store paths,
-no command output). The
+no command output, no shell session names, no terminal handles). The
 [observability panel's cardinality + PII rules](../../AGENTS.md#default-observability-panel)
 apply.
 

--- a/docs/reference/guest-control-persistent-shell.md
+++ b/docs/reference/guest-control-persistent-shell.md
@@ -1,0 +1,86 @@
+# Guest-control persistent shell protocol
+
+> Diataxis: reference. Guest-control shell RPC and terminal transport contract.
+
+Persistent shell RPCs live on the authenticated guest-control ttRPC service.
+They are available only when guestd advertises the shell capabilities for the
+running generation.
+
+## RPCs
+
+| RPC | Purpose |
+| --- | --- |
+| `ShellAttach` | Create or attach to a named persistent shell session. |
+| `ShellList` | Return the configured default name and known sessions. |
+| `ShellDetach` | Detach a named session's live client without killing the shell. |
+| `ShellKill` | Terminate a named shell session. |
+| `ShellCloseAttach` | Close the current owner attachment. |
+| `TerminalWriteStdin` | Write terminal bytes to an attached shell session. |
+| `TerminalReadOutput` | Read merged PTY output for an attached shell session. |
+| `TerminalCloseStdin` | Close stdin for a terminal session. |
+| `TerminalTtyWinResize` | Forward a terminal resize. |
+
+Shell terminal I/O uses the terminal-generic metadata:
+
+```text
+TerminalRequestMetadata {
+  common,
+  session_id,
+  guest_boot_id,
+  kind = SHELL
+}
+```
+
+The existing exec-named RPCs remain wire-compatible; persistent shells use the
+terminal-generic methods to avoid duplicating the streaming vocabulary.
+
+## Public wire mirror
+
+The public daemon wire exposes `PublicRequest::Shell(ShellOp)` and
+`PublicResponse::Shell(ShellOpResponse)`. Shell ops include:
+
+- `Attach { vm, name?, force, initialTerminalSize }`;
+- terminal ops: `WriteStdin`, `ReadOutput`, `Resize`, `Wait`, `CloseStdin`,
+  `CloseAttach`;
+- management ops: `List`, `Detach`, `Kill`.
+
+`Kill` requires a name. `Attach` and `Detach` may omit the name so the VM's
+configured default can be resolved by the daemon/guest.
+
+## States and close causes
+
+Shell session states are closed enum values:
+
+- `attached`;
+- `detached`;
+- `killed`;
+- `pool-unavailable`;
+- `feature-disabled`;
+- `output-gap`.
+
+Close causes are:
+
+- `client-detach`;
+- `evicted-by-force`;
+- `evicted-by-admin-detach`;
+- `killed-by-admin`;
+- `pool-unavailable`;
+- `output-gap`.
+
+Stale guest boot, guestd instance, or shell-pool epoch mismatches fail closed
+rather than silently binding a client to an unrelated session.
+
+## Stream behavior
+
+Persistent shells are PTY-backed. Output is merged stdout-style terminal output;
+stderr reads are unsupported. Ctrl-C, Ctrl-D, Ctrl-\, and other terminal control
+bytes are sent in-band. Resize is the out-of-band terminal control operation.
+
+## Redaction contract
+
+DTO `Debug` implementations redact shell names where broad debug output does not
+need them, and always redact terminal session handles and terminal byte payloads.
+Metrics labels and daemon audit fields never contain raw terminal bytes, helper
+stderr/stdout, argv, env, paths, or raw terminal handles. The daemon audit stream
+uses a fixed shell correlation digest where it needs to relate attach, detach, or
+kill actions.

--- a/docs/reference/naming-conventions.md
+++ b/docs/reference/naming-conventions.md
@@ -50,6 +50,20 @@ host-side group renames.
 
 These constraints let the CLI, manifest, and host-side units resolve resources mechanically without collisions. When docs and code differ, the passing code is canon; see [AGENTS.md](../../AGENTS.md#existing-code-is-canon).
 
+## Persistent shell session names
+
+Persistent shell names use a separate operational identifier shape:
+
+- 1-64 ASCII bytes.
+- First byte: `[A-Za-z0-9_]`.
+- Remaining bytes: `[A-Za-z0-9._-]`.
+- No whitespace, slash, shell template braces, or leading `-`.
+
+The configured default is `default`. Session names may appear in CLI output and
+operator commands, but daemon metrics never use them as labels. Daemon audit
+records use a fixed-length digest for shell correlation instead of raw shell
+names or terminal session handles.
+
 ## Constellation target and model identifiers
 
 Constellation targets extend the VM/env naming rules without making a

--- a/docs/reference/privileges.md
+++ b/docs/reference/privileges.md
@@ -633,6 +633,33 @@ Notes:
   `OpAuditRecord`; the daemon records the public-operation decision and
   the session-establishment event instead.
 
+## Public `shell` operation (daemon-handled, no broker dispatch)
+
+The `nixling shell` verb is a **public** operation handled by the
+unprivileged daemon and CLI. It dispatches **no** broker request
+(`brokerRequired: false`): the daemon proxies persistent-shell management and
+terminal operations over the authenticated guest-control channel to guestd. It
+is in the machine-readable public-operation matrix
+([`schemas/v2/privileges.json`](schemas/v2/privileges.json),
+`publicOperations[].operation = "shell"`).
+
+| Operation | Subject | Scope | Broker dispatch | Destructive | Secret access | Allowed authz | Audit | Default-for-unknown |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `shell` | VM (persistent guest shell) | per VM | none | yes (`kill` terminates a guest shell session) | no | `nixling-admin` only | yes | deny |
+
+Notes:
+
+- `shell` is **admin-only**: the daemon checks the `SO_PEERCRED` admin role
+  before guest-control contact or owner-session handoff.
+- The daemon records attach, detach, and kill decisions in its daemon-owned JSONL
+  event stream. Records carry only the VM name, peer uid, closed action/result
+  enums, force flag when relevant, and a fixed shell correlation digest.
+- Raw shell names, terminal session handles, terminal bytes, helper diagnostics,
+  argv, env, paths, and guest-control nonces never appear in metric labels,
+  traces, or daemon audit fields.
+- No host mutation flows through the broker for `shell`, so there is no
+  `OpAuditRecord`; the broker remains uninvolved.
+
 ## Cross-references
 
 - ADR 0011 (cgroup + pidfd), ADR 0012 (IPv6/IfName/bridge-port),

--- a/docs/reference/tracing-contract.md
+++ b/docs/reference/tracing-contract.md
@@ -25,7 +25,8 @@ allowlist.
   [broker audit record](./daemon-api.md) (`OpAuditRecord.tracing_span_id`
   links the audit row back to the span). They MUST NOT appear as span
   attrs.
-* **Secrets, argv contents, command output** never enter traces.
+* **Secrets, argv contents, command output, terminal bytes, helper diagnostics,
+  raw shell names, and terminal session handles** never enter traces.
 
 ## Allowed scalar attribute names
 

--- a/nixos-modules/guest-control.nix
+++ b/nixos-modules/guest-control.nix
@@ -282,7 +282,7 @@ in
           PAMName = "nixling-shpool-daemon";
           ExecStart =
             let
-              daemonScript = ''
+              daemonScript = pkgs.writeShellScript "nixling-shpool-daemon-start" ''
                 set -eu
                 uid="$(${pkgs.coreutils}/bin/id -u)"
                 home="$HOME"
@@ -293,7 +293,7 @@ in
                   --home "$home"
               '';
             in
-            "${pkgs.bash}/bin/sh -c ${lib.escapeShellArg daemonScript}";
+            "${daemonScript}";
           WorkingDirectory = "~";
           KillMode = "control-group";
           Delegate = true;

--- a/packages/nixling-contract-tests/tests/policy_metrics.rs
+++ b/packages/nixling-contract-tests/tests/policy_metrics.rs
@@ -104,10 +104,7 @@ const EXPECTED_METRICS: &[ExpectedMetric] = &[
     },
 ];
 
-// The retired bash gate's doc-parity table predated the guest-control exec
-// metric. The source inventory above is code-canonical; this count preserves the
-// exact reference-doc assertions that shell gate actually ran.
-const RETIRED_DOC_METRIC_COUNT: usize = 9;
+const RETIRED_DOC_METRIC_COUNT: usize = EXPECTED_METRICS.len();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedMetric {

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -213,6 +213,47 @@ pub struct VmExecKillOutputV1 {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ShellListOutputV1 {
+    pub command: String,
+    pub vm: String,
+    #[serde(rename = "default_name")]
+    pub default_name: String,
+    pub sessions: Vec<ShellListSessionOutputV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ShellListSessionOutputV1 {
+    pub name: String,
+    pub state: String,
+    pub attached: bool,
+    #[serde(rename = "is_default")]
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ShellDetachOutputV1 {
+    pub command: String,
+    pub vm: String,
+    pub name: String,
+    pub result: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cause: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ShellKillOutputV1 {
+    pub command: String,
+    pub vm: String,
+    pub name: String,
+    pub result: String,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct VmDisplayListOutputV1 {
     pub command: String,
     pub target: Option<String>,
@@ -2196,17 +2237,22 @@ fn cmd_shell(context: &Context, args: &ShellArgs) -> Result<i32, CliFailure> {
                 return Err(CliFailure::new(1, "shell list: unexpected daemon response"));
             };
             if args.json {
-                print_json(&serde_json::json!({
-                    "command": "shell list",
-                    "vm": local_vm,
-                    "default_name": result.default_name.as_str(),
-                    "sessions": result.sessions.iter().map(|entry| serde_json::json!({
-                        "name": entry.name.as_str(),
-                        "state": shell_state_str(entry.state),
-                        "attached": entry.attached,
-                        "is_default": entry.is_default,
-                    })).collect::<Vec<_>>()
-                }))?;
+                let output = ShellListOutputV1 {
+                    command: "shell list".to_owned(),
+                    vm: local_vm,
+                    default_name: result.default_name.as_str().to_owned(),
+                    sessions: result
+                        .sessions
+                        .iter()
+                        .map(|entry| ShellListSessionOutputV1 {
+                            name: entry.name.as_str().to_owned(),
+                            state: shell_state_str(entry.state).to_owned(),
+                            attached: entry.attached,
+                            is_default: entry.is_default,
+                        })
+                        .collect(),
+                };
+                print_json(&output)?;
             } else {
                 print_stdout("NAME\tSTATE\tATTACHED\tDEFAULT\n");
                 for entry in result.sessions {
@@ -2236,13 +2282,19 @@ fn cmd_shell(context: &Context, args: &ShellArgs) -> Result<i32, CliFailure> {
                 ));
             };
             if args.json {
-                print_json(&serde_json::json!({
-                    "command": "shell detach",
-                    "vm": local_vm,
-                    "name": result.resolved_name.as_str(),
-                    "result": if result.detached { "detached" } else { "already-detached-or-absent" },
-                    "cause": result.cause.map(shell_close_cause_str),
-                }))?;
+                let output = ShellDetachOutputV1 {
+                    command: "shell detach".to_owned(),
+                    vm: local_vm,
+                    name: result.resolved_name.as_str().to_owned(),
+                    result: if result.detached {
+                        "detached"
+                    } else {
+                        "already-detached-or-absent"
+                    }
+                    .to_owned(),
+                    cause: result.cause.map(shell_close_cause_str).map(str::to_owned),
+                };
+                print_json(&output)?;
             } else if result.detached {
                 print_stdout(&format!(
                     "detached shell '{}' on vm '{}'\n",
@@ -2270,13 +2322,19 @@ fn cmd_shell(context: &Context, args: &ShellArgs) -> Result<i32, CliFailure> {
                 return Err(CliFailure::new(1, "shell kill: unexpected daemon response"));
             };
             if args.json {
-                print_json(&serde_json::json!({
-                    "command": "shell kill",
-                    "vm": local_vm,
-                    "name": result.name.as_str(),
-                    "result": if result.killed { "killed" } else { "already-absent" },
-                    "state": shell_state_str(result.state),
-                }))?;
+                let output = ShellKillOutputV1 {
+                    command: "shell kill".to_owned(),
+                    vm: local_vm,
+                    name: result.name.as_str().to_owned(),
+                    result: if result.killed {
+                        "killed"
+                    } else {
+                        "already-absent"
+                    }
+                    .to_owned(),
+                    state: shell_state_str(result.state).to_owned(),
+                };
+                print_json(&output)?;
             } else if result.killed {
                 print_stdout(&format!(
                     "killed shell '{}' on vm '{}'\n",

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -238,7 +238,6 @@ pub struct ShellDetachOutputV1 {
     pub vm: String,
     pub name: String,
     pub result: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cause: Option<String>,
 }
 

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -11,9 +11,10 @@ use clap_complete::{
 use clap_mangen::Man;
 use nixling::{
     AuditOutputV2, AuthStatusOutputV2, HostCheckOutputV2, ListOutputV2, OpInspectOutputV1,
-    RealmInspectOutputV1, RealmListOutputV1, StatusOutputV2, StoreVerifyOutputV2,
-    VmDisplayCloseOutputV1, VmDisplayListOutputV1, VmExecCreateOutputV1, VmExecKillOutputV1,
-    VmExecListOutputV1, VmExecLogsOutputV1, VmExecStatusOutputV1,
+    RealmInspectOutputV1, RealmListOutputV1, ShellDetachOutputV1, ShellKillOutputV1,
+    ShellListOutputV1, StatusOutputV2, StoreVerifyOutputV2, VmDisplayCloseOutputV1,
+    VmDisplayListOutputV1, VmExecCreateOutputV1, VmExecKillOutputV1, VmExecListOutputV1,
+    VmExecLogsOutputV1, VmExecStatusOutputV1,
 };
 use nixling_constellation_core::{
     AdmissionAuditRecord, AuditEnvelope, Capability, CapabilityNegotiation, CapabilitySet,
@@ -325,7 +326,7 @@ fn gen_cli_schemas() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
     let out_dir = repo_root.join("docs/reference/cli-output");
     fs::create_dir_all(&out_dir)?;
 
-    let schemas: [(&str, RootSchema); 16] = [
+    let schemas: [(&str, RootSchema); 19] = [
         ("list.schema.json", schemars::schema_for!(ListOutputV2)),
         ("status.schema.json", schemars::schema_for!(StatusOutputV2)),
         (
@@ -369,6 +370,18 @@ fn gen_cli_schemas() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
             schemars::schema_for!(VmExecKillOutputV1),
         ),
         ("audit.schema.json", schemars::schema_for!(AuditOutputV2)),
+        (
+            "shell-list.schema.json",
+            schemars::schema_for!(ShellListOutputV1),
+        ),
+        (
+            "shell-detach.schema.json",
+            schemars::schema_for!(ShellDetachOutputV1),
+        ),
+        (
+            "shell-kill.schema.json",
+            schemars::schema_for!(ShellKillOutputV1),
+        ),
         (
             "host-check.schema.json",
             schemars::schema_for!(HostCheckOutputV2),

--- a/tests/host-integration/guest-shell-service.nix
+++ b/tests/host-integration/guest-shell-service.nix
@@ -1,0 +1,83 @@
+# Type-G runNixOSTest: guest persistent-shell service wiring.
+#
+# Applies the guest-control module directly to a NixOS test node and asserts the
+# real systemd/PAM/linger boundary for the guest-local shell pool. This avoids a
+# nested nixling-managed VM while still exercising NixOS module realization.
+{ pkgs, self }:
+
+pkgs.testers.runNixOSTest {
+  name = "nixling-guest-shell-service";
+
+  nodes.machine = { lib, ... }: {
+    imports = [
+      ../../nixos-modules/guest-control.nix
+      {
+        _module.args = {
+          nixlingInputs = { inherit self; };
+        };
+
+        users.users.alice = {
+          isNormalUser = true;
+          uid = 1000;
+        };
+
+        nixling.guestControl = {
+          enable = lib.mkForce true;
+          exec = {
+            enable = lib.mkForce true;
+            execUser = lib.mkForce "alice";
+            detachedMaxRuntimeSec = lib.mkForce 0;
+            interactiveMaxRuntimeSec = lib.mkForce 0;
+          };
+          guestConfigPath = lib.mkForce null;
+          usbipPath = lib.mkForce null;
+          shell = {
+            enable = lib.mkForce true;
+            defaultName = lib.mkForce "default";
+            maxSessions = lib.mkForce 8;
+            maxAttached = lib.mkForce 1;
+          };
+        };
+
+        system.stateVersion = "25.11";
+      }
+    ];
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    # The shell pool daemon is declared but dormant: guestd owns when it starts
+    # or adopts the pool.
+    machine.succeed("systemctl cat nixling-shpool-daemon.service")
+    machine.succeed(
+        "test \"$(systemctl show -P PAMName nixling-shpool-daemon.service)\" = nixling-shpool-daemon"
+    )
+    machine.succeed(
+        "test \"$(systemctl show -P User nixling-shpool-daemon.service)\" = alice"
+    )
+    machine.succeed(
+        "test \"$(systemctl show -P KillMode nixling-shpool-daemon.service)\" = control-group"
+    )
+    machine.succeed(
+        "test \"$(systemctl show -P Delegate nixling-shpool-daemon.service)\" = yes"
+    )
+    machine.succeed(
+        "! find /etc/systemd/system -path '*wants/nixling-shpool-daemon.service' | grep -q ."
+    )
+    machine.fail("systemctl is-active --quiet nixling-shpool-daemon.service")
+
+    pam_file = "/etc/pam.d/nixling-shpool-daemon"
+    machine.succeed(f"test -f {pam_file}")
+    pam = machine.succeed(f"cat {pam_file}")
+    assert "pam_loginuid.so" in pam, pam
+    assert "pam_systemd.so" not in pam, (
+        "nixling-shpool-daemon must not start a pam_systemd session; "
+        "that would migrate the daemon out of the delegated service cgroup"
+    )
+
+    machine.succeed("test -f /var/lib/systemd/linger/alice")
+    machine.succeed("id -u alice | grep -qx 1000")
+  '';
+}

--- a/tests/unit/nix/eval-cases/guest-shell-policy-eval.nix
+++ b/tests/unit/nix/eval-cases/guest-shell-policy-eval.nix
@@ -172,11 +172,8 @@ let
     assert shpoolService.serviceConfig.User == "alice";
     assert shpoolService.serviceConfig.PAMName == "nixling-shpool-daemon";
     assert shpoolService.serviceConfig.Delegate == true;
-    assert lib.hasInfix "/bin/sh -c" shpoolExecStart;
-    assert lib.hasInfix ''uid="$('' shpoolExecStart;
-    assert lib.hasInfix ''export XDG_RUNTIME_DIR="/run/user/$uid"'' shpoolExecStart;
-    assert lib.hasInfix ''export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"'' shpoolExecStart;
-    assert lib.hasInfix "/bin/nixling-guest-shell-runner daemon" shpoolExecStart;
+    assert lib.hasInfix "/nix/store/" shpoolExecStart;
+    assert lib.hasInfix "nixling-shpool-daemon-start" shpoolExecStart;
     assert !(lib.hasInfix "%U" shpoolExecStart);
     assert !(lib.hasInfix "%h" shpoolExecStart);
     assert (shpoolService.wantedBy or [ ]) == [ ];
@@ -223,8 +220,8 @@ let
     assert lib.hasInfix "--shell-systemctl-path /nix/store/" guestdExecStart;
     assert shpoolService.serviceConfig.User == "alice";
     assert shpoolService.serviceConfig.Delegate == true;
-    assert lib.hasInfix ''export XDG_RUNTIME_DIR="/run/user/$uid"'' shpoolExecStart;
-    assert lib.hasInfix ''export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"'' shpoolExecStart;
+    assert lib.hasInfix "/nix/store/" shpoolExecStart;
+    assert lib.hasInfix "nixling-shpool-daemon-start" shpoolExecStart;
     assert !(lib.hasInfix "%U" shpoolExecStart);
     assert !(lib.hasInfix "%h" shpoolExecStart);
     assert shpoolPam.startSession == false;


### PR DESCRIPTION
## Summary
- add persistent shell how-to, explanation, component, CLI, guest-control, naming, privileges, metrics, audit, tracing, and JSON-output references
- add generated schemas for `nixling shell <vm> list|detach|kill --json`
- fix guest shpool daemon service rendering with a store-backed start script and add runNixOSTest coverage for the guest service/PAM/linger boundary

## Validation
- `cargo fmt --all --check`
- `cargo test -p nixling shell`
- `cargo test -p nixling cli_json`
- `cargo test -p nixling-contract-tests --test policy_metrics`
- `cargo clippy -p nixling -p xtask -p nixling-contract-tests --all-targets -- -D warnings`
- `make check-tier0`
- `make test-drift`
- `make test-policy`
- `make test-rust`
- `make test-flake`
- `make check`
- `make test-integration`
- `make test-host-integration` (KVM unavailable, runNixOSTest used TCG fallback)
- `nix build --no-link --print-build-logs .#vmChecks.x86_64-linux.guest-shell-service`

## Review
- Wave 6 plan panel reached 10/10 Gemini 3.1 Pro signoff.
- Wave 6 implementation panel reached 10/10 Gemini 3.1 Pro signoff after follow-up fixes for docs index coverage and shell detach JSON `cause: null` parity.

## Checklist
- [x] **`make check` passes before PR creation**
- [x] **`make test-integration` passes on the host before PR creation**
- [x] **`make test-host-integration` passes on the host before PR creation**
- [ ] **Hardware/live-host tests run or explicitly marked not required**
- [x] **Make-target/test wiring updated when adding/moving tests**
- [x] **Docs, generated artifacts, schemas, and CI references updated in lockstep**
