### PR TITLE
cli: tolerate shell close transport loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ deprecations ship one minor release before removal.
 - Persistent shell detach now treats a successful daemon best-effort close as a
   clean owner close even if the first close-attach RPC reports a transient
   guest-control transport error.
+- Persistent shell detach now treats the known close-attach transport-unavailable
+  response as a successful local detach, matching the daemon's owner-disconnect
+  cleanup semantics.
 - `nixling list --json` now preserves daemon-reported failed lifecycle state as
   `status = "failed"` instead of collapsing it to `unknown`.
 

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -2471,10 +2471,20 @@ where
             Error = CliFailure,
         >,
 {
-    let _ = transport.round_trip(&ShellOp::CloseAttach(public_wire::ShellCloseAttachArgs {
+    match transport.round_trip(&ShellOp::CloseAttach(public_wire::ShellCloseAttachArgs {
         session: session.to_owned(),
-    }))?;
-    Ok(())
+    })) {
+        Ok(_) => Ok(()),
+        Err(err) if is_close_attach_transport_unavailable(&err) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+fn is_close_attach_transport_unavailable(err: &CliFailure) -> bool {
+    err.exit_code == 69
+        && err
+            .message
+            .contains("guest-control-shell-transport-unavailable")
 }
 
 fn run_shell_fsm<T, H, S>(
@@ -11548,6 +11558,7 @@ mod host_install_dispatch_tests {
         ops: Vec<public_wire::ShellOp>,
         write_accepts: VecDeque<u64>,
         read_chunks: VecDeque<nixling_ipc::terminal_wire::TerminalReadOutputChunk>,
+        close_transport_unavailable: bool,
     }
 
     impl super::terminal_client::TerminalTransport for FakeShellTransport {
@@ -11578,6 +11589,12 @@ mod host_install_dispatch_tests {
                 public_wire::ShellOp::ReadOutput(_) => {
                     Ok(public_wire::ShellOpResponse::ReadOutput(
                         self.read_chunks.pop_front().expect("read chunk queued"),
+                    ))
+                }
+                public_wire::ShellOp::CloseAttach(close) if self.close_transport_unavailable => {
+                    Err(super::CliFailure::new(
+                        69,
+                        "guest-control-shell-transport-unavailable: guest-control shell transport to the VM is unavailable",
                     ))
                 }
                 public_wire::ShellOp::CloseAttach(close) => Ok(
@@ -11638,6 +11655,7 @@ mod host_install_dispatch_tests {
         let mut transport = FakeShellTransport {
             ops: Vec::new(),
             write_accepts: VecDeque::new(),
+            close_transport_unavailable: false,
             read_chunks: VecDeque::from([nixling_ipc::terminal_wire::TerminalReadOutputChunk {
                 data_base64: nixling_core::base64_codec::encode(b"hello\n"),
                 next_offset: 6,
@@ -11699,6 +11717,7 @@ mod host_install_dispatch_tests {
         let mut transport = FakeShellTransport {
             ops: Vec::new(),
             write_accepts: VecDeque::new(),
+            close_transport_unavailable: false,
             read_chunks: VecDeque::new(),
         };
         let mut host = FakeShellHost {
@@ -11722,10 +11741,38 @@ mod host_install_dispatch_tests {
     }
 
     #[test]
+    fn shell_attach_fsm_treats_close_transport_unavailable_as_detached() {
+        let mut transport = FakeShellTransport {
+            ops: Vec::new(),
+            write_accepts: VecDeque::new(),
+            close_transport_unavailable: true,
+            read_chunks: VecDeque::new(),
+        };
+        let mut host = FakeShellHost {
+            stdin: Some(vec![0x00, 0x11]),
+            stdout: Vec::new(),
+        };
+        let mut signals = FakeShellSignals {
+            pending: VecDeque::new(),
+        };
+
+        super::run_shell_fsm(&mut transport, &mut host, &mut signals, "shell-session")
+            .expect("transient close transport error should still detach locally");
+
+        assert!(matches!(
+            transport.ops.as_slice(),
+            [public_wire::ShellOp::CloseAttach(public_wire::ShellCloseAttachArgs {
+                session
+            })] if session == "shell-session"
+        ));
+    }
+
+    #[test]
     fn shell_attach_fsm_closes_on_fatal_signal() {
         let mut transport = FakeShellTransport {
             ops: Vec::new(),
             write_accepts: VecDeque::new(),
+            close_transport_unavailable: false,
             read_chunks: VecDeque::new(),
         };
         let mut host = FakeShellHost {
@@ -11752,6 +11799,7 @@ mod host_install_dispatch_tests {
         let mut transport = FakeShellTransport {
             ops: Vec::new(),
             write_accepts: VecDeque::from([3, 4]),
+            close_transport_unavailable: false,
             read_chunks: VecDeque::from([nixling_ipc::terminal_wire::TerminalReadOutputChunk {
                 data_base64: String::new(),
                 next_offset: 0,


### PR DESCRIPTION
## Summary
- treat the known `guest-control-shell-transport-unavailable` response during explicit `CloseAttach` as a successful local detach
- add FSM regression coverage for Ctrl-Space/Ctrl-q when the close transport reports unavailable

Completes the live-validation fix for #154.

## Validation
- `cargo fmt --all --check`
- `cargo test -p nixling shell`
- `cargo clippy -p nixling --all-targets -- -D warnings`
- `make check-tier0`
- `make test-drift`
