### PR TITLE
daemon: bound status provider probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ deprecations ship one minor release before removal.
   attach helper instead of returning disabled shell I/O.
 - `nixling list --json` now preserves daemon-reported failed lifecycle state as
   `status = "failed"` instead of collapsing it to `unknown`.
+- `nixling list` and `nixling status` now use a short provider-status probe
+  timeout instead of the graceful shutdown operation timeout, keeping status
+  queries responsive when a VM's provider API socket is slow.
 
 ### Internal
 

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -217,6 +217,7 @@ const VM_RUNNER_ROLE_ID: &str = "ch-runner";
 const VM_STOP_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS: u64 = 90;
 const PROVIDER_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const PUBLIC_STATUS_PROVIDER_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 const EMPTY_VMM_CLEANUP_GRACE: Duration = Duration::from_secs(5);
 const CGROUP_EMPTY_POST_KILL_WAIT: Duration = Duration::from_secs(5);
 const GATEWAY_DISPLAY_SESSION_TTL: Duration = Duration::from_secs(3600);
@@ -13083,11 +13084,15 @@ fn provider_guest_stopped_for_status(
             let Some(socket) = target.api_socket.as_deref() else {
                 return false;
             };
-            ch_api::blocking_get_json(socket, "/api/v1/vm.info", ch_api::DEFAULT_TIMEOUT)
-                .ok()
-                .and_then(|body| ch_api::parse_vm_info(&body).ok())
-                .and_then(|info| info.state)
-                .is_some_and(|state| matches!(state.as_str(), "Created" | "Shutdown"))
+            ch_api::blocking_get_json(
+                socket,
+                "/api/v1/vm.info",
+                PUBLIC_STATUS_PROVIDER_PROBE_TIMEOUT,
+            )
+            .ok()
+            .and_then(|body| ch_api::parse_vm_info(&body).ok())
+            .and_then(|info| info.state)
+            .is_some_and(|state| matches!(state.as_str(), "Created" | "Shutdown"))
         }
         provider_shutdown::ProviderKind::QemuMedia => {
             let request = json!({
@@ -13104,7 +13109,7 @@ fn provider_guest_stopped_for_status(
                 BrokerCallerRole::RootUid {
                     uid: state.daemon_uid,
                 },
-                ch_api::DEFAULT_TIMEOUT,
+                PUBLIC_STATUS_PROVIDER_PROBE_TIMEOUT,
             )
             .ok()
             .and_then(|value| {
@@ -14543,6 +14548,46 @@ mod public_status_tests {
                 .get("detail")
                 .and_then(Value::as_str),
             Some("running")
+        );
+    }
+
+    #[test]
+    fn public_lifecycle_status_probe_does_not_use_shutdown_timeout() {
+        let (state, _dir) = test_state();
+        state
+            .pidfd_table
+            .register(
+                "vm-a".to_owned(),
+                VM_RUNNER_ROLE_ID.to_owned(),
+                current_process_entry(),
+            )
+            .expect("register ch runner");
+        let socket_dir = tempfile::tempdir().expect("socket dir");
+        let socket_path = socket_dir.path().join("ch-api.sock");
+        let listener =
+            std::os::unix::net::UnixListener::bind(&socket_path).expect("bind hanging ch socket");
+        let _server = std::thread::spawn(move || {
+            if let Ok((_stream, _addr)) = listener.accept() {
+                std::thread::sleep(Duration::from_secs(2));
+            }
+        });
+        let manifest_entry = json!({
+            "stateDir": "/nonexistent/nixling-public-status-test",
+            "apiSocket": socket_path,
+            "runtime": {
+                "provider": {
+                    "driver": "cloud-hypervisor"
+                }
+            }
+        });
+
+        let started = Instant::now();
+        let lifecycle = public_vm_lifecycle(&state, "vm-a", &manifest_entry, None);
+
+        assert_eq!(lifecycle_state(&lifecycle), "Running");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "status/list provider probes must not inherit the graceful shutdown API timeout"
         );
     }
 


### PR DESCRIPTION
## Summary
- Keep daemon list/status responsive by giving provider guest-state enrichment a short status-only probe timeout.
- Preserve the full graceful-shutdown timeout for actual stop/restart operations.
- Add a hanging Cloud Hypervisor API socket regression test so status/list cannot inherit the shutdown timeout again.

## Validation
- `cargo fmt --manifest-path packages/Cargo.toml --all`
- `cargo test --manifest-path packages/Cargo.toml -p nixlingd public_lifecycle_status_probe_does_not_use_shutdown_timeout`
