### PR TITLE
adr0035: land Wave 0 inventory and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ deprecations ship one minor release before removal.
 
 ### Internal
 
+- ADR 0035 Wave 0 internal cleanup removed the unused `ssh_router` test
+  helper compatibility alias after confirming `ssh_net_vm` has no in-tree
+  callers through the retired name.
 - Persistent shell CLI routing now sends gateway-backed `list`, `detach`, and
   `kill` management forms through the configured realm gateway over the typed
   guest-control exec path, while interactive gateway attach fails closed until

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@ deprecations ship one minor release before removal.
 
 ### Internal
 
-- ADR 0035 Wave 0 internal cleanup removed the unused `ssh_router` test
-  helper compatibility alias after confirming `ssh_net_vm` has no in-tree
-  callers through the retired name.
+- ADR 0035 Wave 0 internal cleanup added deterministic inventory tooling and
+  `compat-ADR` bridge-key policy coverage, removed caller-free test/Make
+  compatibility aliases, and dropped stale retired bash-CLI option comments.
 - Persistent shell CLI routing now sends gateway-backed `list`, `detach`, and
   `kill` management forms through the configured realm gateway over the typed
   guest-control exec path, while interactive gateway attach fails closed until

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
         test-flake-list \
         test-drift test-policy test-integration test-host-integration test-hardware perf \
         layer1-workflow layer1-workflow-check \
-        ledger ledger-regen check-inventory pr-checklist-gate ci-uses-make nix-unit-pin flake-matrix-pin
+        ledger-regen check-inventory pr-checklist-gate ci-uses-make nix-unit-pin flake-matrix-pin
 
 # Current Nix system double, used to address per-system flake.checks attrs.
 # Falls back to x86_64-linux if `nix` is unavailable (e.g. a docs-only host).
@@ -146,9 +146,6 @@ layer1-workflow-check:
 ## check-inventory — fail-closed ledger drift check for CI.
 check-inventory:
 	bash tests/tools/gen-migration-ledger.sh --check
-
-## ledger — compatibility alias for the fail-closed check.
-ledger: check-inventory
 
 ## ledger-regen — regenerate tests/migration-ledger.toml in place for humans.
 ledger-regen:

--- a/nixos-modules/options.nix
+++ b/nixos-modules/options.nix
@@ -36,26 +36,4 @@
     description = "Internal: per-env computed metadata (set by network.nix).";
   };
 
-  # ---------------------------------------------------------------------------
-  # the following internal options were
-  # retired together with the bash CLI consumer surface
-  #
-  #   nixling.cliBin             — set by cli.nix to point at the
-  #                                bash CLI; consumed by
-  #                                host-audit.nix (deleted in the
-  #                                same commit; the audit-check
-  #                                service is on the  denylist).
-  #   nixling.audioStateHelperPath — set by cli.nix to point at
-  #                                nixling-read-audio-state.sh; the
-  #                                only consumer (tests/integration/live/audio.sh)
-  #                                now discovers the helper at the
-  #                                daemon-managed path.
-  #   nixling._desktopWrappers   — set by cli.nix to pin the per-VM
-  #.desktop launcher contract. The
-  #                                daemon-native launcher module
-  #                                will re-introduce this option
-  #                                when it lands; until then no
-  #                                graphics VM gets a .desktop
-  #                                wrapper through the framework.
-  # ---------------------------------------------------------------------------
 }

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4071,6 +4071,7 @@ dependencies = [
  "nixling-ipc",
  "protobuf-codegen",
  "schemars",
+ "serde",
  "serde_json",
  "ttrpc-codegen",
 ]

--- a/packages/nixling-contract-tests/tests/policy_compat_adr.rs
+++ b/packages/nixling-contract-tests/tests/policy_compat_adr.rs
@@ -1,0 +1,181 @@
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+use nixling_contract_tests::repo_root;
+use regex::Regex;
+
+const ADR_0035_EXAMPLE_PATH: &str = "docs/adr/0035-efficiency-and-simplification-roadmap.md";
+const ADR_0035_EXAMPLE_MARKER: &str =
+    concat!("compat-", "ADR0042-added-20260815-wire-v6-handshake");
+const REQUIRED_METADATA_FIELDS: [&str; 5] = ["from", "to", "owner", "removeWhen", "validation"];
+const VALID_SURFACES: [&str; 9] = [
+    "cli", "wire", "bundle", "option", "test", "schema", "daemon", "broker", "provider",
+];
+
+fn git_tracked_files() -> Vec<String> {
+    let root = repo_root();
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(&root)
+        .arg("-c")
+        .arg("core.quotePath=false")
+        .args(["ls-files", "-z", "--"])
+        .output()
+        .expect("run `git ls-files -z`");
+    assert!(
+        output.status.success(),
+        "git ls-files failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut files = BTreeSet::new();
+    for raw in output.stdout.split(|byte| *byte == 0) {
+        if raw.is_empty() {
+            continue;
+        }
+        if let Ok(rel) = String::from_utf8(raw.to_vec()) {
+            files.insert(rel);
+        }
+    }
+    files.into_iter().collect()
+}
+
+fn read_tracked_text_file(rel: &str) -> Option<String> {
+    let content = std::fs::read_to_string(repo_root().join(rel)).ok()?;
+    if content.contains('\0') {
+        return None;
+    }
+    Some(content)
+}
+
+fn is_valid_yyyymmdd(date: &str) -> bool {
+    if date.len() != 8 || !date.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+    let year = match date[0..4].parse::<u32>() {
+        Ok(year) => year,
+        Err(_) => return false,
+    };
+    let month = match date[4..6].parse::<u32>() {
+        Ok(month) => month,
+        Err(_) => return false,
+    };
+    let day = match date[6..8].parse::<u32>() {
+        Ok(day) => day,
+        Err(_) => return false,
+    };
+
+    let max_day = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => return false,
+    };
+    year > 0 && (1..=max_day).contains(&day)
+}
+
+fn is_leap_year(year: u32) -> bool {
+    year.is_multiple_of(4) && !year.is_multiple_of(100) || year.is_multiple_of(400)
+}
+
+fn metadata_window(lines: &[&str], line_index: usize) -> String {
+    let start = line_index.saturating_sub(8);
+    let end = (line_index + 9).min(lines.len());
+    lines[start..end].join("\n")
+}
+
+fn missing_metadata_fields(window: &str) -> Vec<&'static str> {
+    REQUIRED_METADATA_FIELDS
+        .into_iter()
+        .filter(|field| {
+            let field_re = Regex::new(&format!(
+                r"(?m)(^|[^A-Za-z0-9_-]){}\s*[:=]\s*\S",
+                regex::escape(field)
+            ))
+            .expect("valid metadata-field regex");
+            !field_re.is_match(window)
+        })
+        .collect()
+}
+
+#[test]
+fn compat_adr_markers_are_well_formed_and_metadata_backed() {
+    let marker_token = Regex::new(concat!("compat-", r#"ADR[^\s`'"\]\[(){}|,;:.]*"#))
+        .expect("valid marker-token regex");
+    let strict_marker = Regex::new(
+        r"^compat-ADR(?P<adr>\d{4})-added-(?P<date>\d{8})-(?P<surface>[a-z]+)-(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)$",
+    )
+    .expect("valid strict-marker regex");
+
+    let mut violations = Vec::new();
+
+    for rel in git_tracked_files() {
+        let Some(content) = read_tracked_text_file(&rel) else {
+            continue;
+        };
+        let lines: Vec<&str> = content.lines().collect();
+        for (line_index, line) in lines.iter().enumerate() {
+            for token in marker_token.find_iter(line).map(|matched| matched.as_str()) {
+                if token == "compat-ADR" || token.contains(['<', '>']) {
+                    continue;
+                }
+                if rel == ADR_0035_EXAMPLE_PATH && token == ADR_0035_EXAMPLE_MARKER {
+                    continue;
+                }
+
+                let Some(captures) = strict_marker.captures(token) else {
+                    violations.push(format!(
+                        "{}:{}: malformed compat-ADR marker `{}`",
+                        rel,
+                        line_index + 1,
+                        token
+                    ));
+                    continue;
+                };
+
+                let date = captures.name("date").expect("date capture").as_str();
+                if !is_valid_yyyymmdd(date) {
+                    violations.push(format!(
+                        "{}:{}: compat-ADR marker `{}` has invalid added date `{}`",
+                        rel,
+                        line_index + 1,
+                        token,
+                        date
+                    ));
+                }
+
+                let surface = captures.name("surface").expect("surface capture").as_str();
+                if !VALID_SURFACES.contains(&surface) {
+                    violations.push(format!(
+                        "{}:{}: compat-ADR marker `{}` uses unknown surface `{}`",
+                        rel,
+                        line_index + 1,
+                        token,
+                        surface
+                    ));
+                }
+
+                let window = metadata_window(&lines, line_index);
+                let missing = missing_metadata_fields(&window);
+                if !missing.is_empty() {
+                    violations.push(format!(
+                        "{}:{}: compat-ADR marker `{}` is missing nearby metadata fields: {}",
+                        rel,
+                        line_index + 1,
+                        token,
+                        missing.join(", ")
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "compat-ADR policy violations:\n{}",
+        violations.join("\n")
+    );
+}

--- a/packages/xtask/Cargo.toml
+++ b/packages/xtask/Cargo.toml
@@ -17,6 +17,7 @@ nixling-constellation-core = { path = "../nixling-constellation-core", version =
 nixling-core = { path = "../nixling-core", version = "0.0.0-bootstrap" }
 nixling-ipc = { path = "../nixling-ipc", version = "0.0.0-bootstrap" }
 protobuf-codegen = "3.7.2"
+serde.workspace = true
 ttrpc-codegen = "0.6.0"
 schemars.workspace = true
 serde_json.workspace = true

--- a/packages/xtask/src/inventory.rs
+++ b/packages/xtask/src/inventory.rs
@@ -580,12 +580,10 @@ exclude = ["standalone"]
 
     #[test]
     fn compatibility_scan_emits_tokens_not_line_content() {
-        let line = "compat-ADR0035-added-20260622-cli-example legacy fallback secret=value";
+        let marker = ["compat", "ADR0035-added-20260622-cli-example"].join("-");
+        let line = format!("{marker} legacy fallback secret=value");
 
-        assert_eq!(
-            compat_adr_tokens(line),
-            ["compat-ADR0035-added-20260622-cli-example"]
-        );
+        assert_eq!(compat_adr_tokens(&line), vec![marker.clone()]);
         assert_eq!(
             compatibility_terms(&line.to_ascii_lowercase()),
             ["fallback", "legacy"]

--- a/packages/xtask/src/inventory.rs
+++ b/packages/xtask/src/inventory.rs
@@ -419,8 +419,9 @@ fn parse_toml_string_array(toml: &str, key: &str) -> Vec<String> {
 }
 
 fn parse_toml_assignment_string(line: &str, key: &str) -> Option<String> {
-    let assignment = format!("{key} =");
-    line.strip_prefix(&assignment)
+    let (left, right) = line.split_once('=')?;
+    (left.trim() == key)
+        .then_some(right)
         .and_then(|value| extract_quoted_strings(value).into_iter().next())
 }
 
@@ -490,7 +491,7 @@ fn compat_adr_tokens(line: &str) -> Vec<String> {
     tokens
 }
 
-fn marker_terms(line_lowercase: &str) -> Vec<String> {
+fn marker_terms(line_lowercase: &str) -> Vec<&'static str> {
     [
         concat!("back", "-compat"),
         concat!("backward ", "compatibility"),
@@ -504,7 +505,6 @@ fn marker_terms(line_lowercase: &str) -> Vec<String> {
         concat!("tomb", "stone"),
     ]
     .into_iter()
-    .map(str::to_owned)
     .filter(|term| line_lowercase.contains(term))
     .collect()
 }
@@ -594,7 +594,7 @@ exclude = ["standalone"]
         assert_eq!(compat_adr_tokens(&line), vec![marker.clone()]);
         assert_eq!(
             marker_terms(&line.to_ascii_lowercase()),
-            ["fallback".to_owned(), "legacy".to_owned()]
+            ["fallback", "legacy"]
         );
     }
 
@@ -608,6 +608,22 @@ version = "0.0.0"
 "#;
 
         assert_eq!(parse_package_name(toml), Some("real-package".to_owned()));
+    }
+
+    #[test]
+    fn toml_assignment_parser_allows_variable_whitespace() {
+        assert_eq!(
+            parse_toml_assignment_string(r#"name="compact""#, "name"),
+            Some("compact".to_owned())
+        );
+        assert_eq!(
+            parse_toml_assignment_string(r#"name  =   "spaced""#, "name"),
+            Some("spaced".to_owned())
+        );
+        assert_eq!(
+            parse_toml_assignment_string(r#"name_suffix = "ignored""#, "name"),
+            None
+        );
     }
 
     #[test]

--- a/packages/xtask/src/inventory.rs
+++ b/packages/xtask/src/inventory.rs
@@ -1,0 +1,613 @@
+use std::{
+    collections::BTreeSet,
+    env, fs,
+    io::{self, Write},
+    path::{Component, Path, PathBuf},
+    process::Command,
+};
+
+use serde::Serialize;
+
+const INVENTORY_SCHEMA_VERSION: u32 = 1;
+const TOP_FILE_LIMIT: usize = 25;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct Inventory {
+    schema_version: u32,
+    source: &'static str,
+    path_policy: PathPolicy,
+    totals: Totals,
+    largest_rust_source_files: Vec<FileMetric>,
+    largest_nix_modules: Vec<FileMetric>,
+    crates: Vec<CrateInfo>,
+    workspace: WorkspaceInfo,
+    candidate_compatibility_markers: Vec<CompatibilityMarker>,
+    generated_artifact_surfaces: Vec<ClassifiedPath>,
+    test_driver_surfaces: Vec<ClassifiedPath>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct PathPolicy {
+    repository_relative_paths_only: bool,
+    includes_absolute_host_paths: bool,
+    includes_timestamps_or_pids: bool,
+    includes_line_content: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct Totals {
+    tracked_files: usize,
+    rust_source_files: usize,
+    nix_files: usize,
+    crate_manifests: usize,
+    compatibility_marker_locations: usize,
+    generated_artifact_surfaces: usize,
+    test_driver_surfaces: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct FileMetric {
+    path: String,
+    bytes: u64,
+    lines: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct CrateInfo {
+    name: String,
+    manifest_path: String,
+    package_dir: String,
+    workspace_role: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct WorkspaceInfo {
+    root_manifest: String,
+    members: Vec<String>,
+    excludes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct CompatibilityMarker {
+    path: String,
+    line: usize,
+    marker: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct ClassifiedPath {
+    path: String,
+    kind: &'static str,
+}
+
+pub(crate) fn emit_adr0035_inventory(
+    output_path: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let repo_root = super::repo_root()?;
+    let tracked_files = git_tracked_files(repo_root)?;
+    let inventory = build_inventory(repo_root, &tracked_files)?;
+    let mut json = serde_json::to_string_pretty(&inventory)?;
+    json.push('\n');
+
+    if let Some(path) = output_path {
+        validate_output_path(repo_root, path, &tracked_files)?;
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, json)?;
+    } else {
+        io::stdout().write_all(json.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+fn git_tracked_files(repo_root: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("ls-files")
+        .arg("-z")
+        .output()?;
+    if !output.status.success() {
+        return Err(format!("git ls-files failed with status {}", output.status).into());
+    }
+
+    let mut files = Vec::new();
+    for raw in output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|raw| !raw.is_empty())
+    {
+        let path = String::from_utf8(raw.to_vec())?;
+        validate_repo_relative_path(&path)?;
+        files.push(path);
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn build_inventory(
+    repo_root: &Path,
+    tracked_files: &[String],
+) -> Result<Inventory, Box<dyn std::error::Error>> {
+    let mut rust_metrics = Vec::new();
+    let mut nix_metrics = Vec::new();
+    let mut crate_manifest_paths = Vec::new();
+    let mut compatibility_markers = Vec::new();
+    let mut generated_surfaces = Vec::new();
+    let mut test_driver_surfaces = Vec::new();
+
+    for path in tracked_files {
+        if is_rust_source(path) {
+            rust_metrics.push(file_metric(repo_root, path)?);
+        }
+        if is_nix_file(path) {
+            nix_metrics.push(file_metric(repo_root, path)?);
+        }
+        if is_crate_manifest(path) {
+            crate_manifest_paths.push(path.clone());
+        }
+        if let Some(kind) = classify_generated_surface(path) {
+            generated_surfaces.push(ClassifiedPath {
+                path: path.clone(),
+                kind,
+            });
+        }
+        if let Some(kind) = classify_test_driver_surface(path) {
+            test_driver_surfaces.push(ClassifiedPath {
+                path: path.clone(),
+                kind,
+            });
+        }
+        compatibility_markers.extend(scan_compatibility_markers(repo_root, path)?);
+    }
+
+    sort_metrics(&mut rust_metrics);
+    sort_metrics(&mut nix_metrics);
+    generated_surfaces
+        .sort_by(|left, right| left.kind.cmp(right.kind).then(left.path.cmp(&right.path)));
+    test_driver_surfaces
+        .sort_by(|left, right| left.kind.cmp(right.kind).then(left.path.cmp(&right.path)));
+    compatibility_markers.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then(left.line.cmp(&right.line))
+            .then(left.marker.cmp(&right.marker))
+    });
+
+    let workspace = workspace_info(repo_root)?;
+    let crates = crate_info(repo_root, &crate_manifest_paths, &workspace)?;
+
+    let totals = Totals {
+        tracked_files: tracked_files.len(),
+        rust_source_files: rust_metrics.len(),
+        nix_files: nix_metrics.len(),
+        crate_manifests: crate_manifest_paths.len(),
+        compatibility_marker_locations: compatibility_markers.len(),
+        generated_artifact_surfaces: generated_surfaces.len(),
+        test_driver_surfaces: test_driver_surfaces.len(),
+    };
+
+    rust_metrics.truncate(TOP_FILE_LIMIT);
+    nix_metrics.truncate(TOP_FILE_LIMIT);
+
+    Ok(Inventory {
+        schema_version: INVENTORY_SCHEMA_VERSION,
+        source: "git ls-files -z",
+        path_policy: PathPolicy {
+            repository_relative_paths_only: true,
+            includes_absolute_host_paths: false,
+            includes_timestamps_or_pids: false,
+            includes_line_content: false,
+        },
+        totals,
+        largest_rust_source_files: rust_metrics,
+        largest_nix_modules: nix_metrics,
+        crates,
+        workspace,
+        candidate_compatibility_markers: compatibility_markers,
+        generated_artifact_surfaces: generated_surfaces,
+        test_driver_surfaces,
+    })
+}
+
+fn validate_repo_relative_path(path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let candidate = Path::new(path);
+    if candidate.is_absolute()
+        || candidate.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(format!("git reported non-repository-relative path: {path}").into());
+    }
+    Ok(())
+}
+
+fn validate_output_path(
+    repo_root: &Path,
+    output_path: &Path,
+    tracked_files: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(repo_relative) = output_repo_relative_path(repo_root, output_path)? {
+        if repo_relative == "docs" || repo_relative.starts_with("docs/") {
+            return Err("inventory output must not be written under tracked docs/".into());
+        }
+        if tracked_files.binary_search(&repo_relative).is_ok() {
+            return Err(format!(
+                "inventory output must not overwrite tracked file {repo_relative}"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn output_repo_relative_path(
+    repo_root: &Path,
+    output_path: &Path,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let absolute = normalize_path(if output_path.is_absolute() {
+        output_path.to_path_buf()
+    } else {
+        env::current_dir()?.join(output_path)
+    });
+    match absolute.strip_prefix(repo_root) {
+        Ok(relative) => Ok(Some(path_to_repo_string(relative)?)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+            Component::RootDir | Component::Prefix(_) => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn path_to_repo_string(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let value = path
+        .to_str()
+        .ok_or_else(|| "path is not valid UTF-8".to_owned())?
+        .trim_start_matches("./")
+        .to_owned();
+    validate_repo_relative_path(&value)?;
+    Ok(value)
+}
+
+fn is_rust_source(path: &str) -> bool {
+    path.ends_with(".rs")
+}
+
+fn is_nix_file(path: &str) -> bool {
+    path.ends_with(".nix")
+}
+
+fn is_crate_manifest(path: &str) -> bool {
+    path != "packages/Cargo.toml" && path.starts_with("packages/") && path.ends_with("/Cargo.toml")
+}
+
+fn file_metric(repo_root: &Path, path: &str) -> Result<FileMetric, Box<dyn std::error::Error>> {
+    let absolute = repo_root.join(path);
+    let bytes = fs::metadata(&absolute)?.len();
+    let data = fs::read(&absolute)?;
+    let lines = data.iter().filter(|byte| **byte == b'\n').count()
+        + usize::from(data.last().is_some_and(|byte| *byte != b'\n'));
+    Ok(FileMetric {
+        path: path.to_owned(),
+        bytes,
+        lines,
+    })
+}
+
+fn sort_metrics(metrics: &mut [FileMetric]) {
+    metrics.sort_by(|left, right| {
+        right
+            .bytes
+            .cmp(&left.bytes)
+            .then(left.path.cmp(&right.path))
+    });
+}
+
+fn workspace_info(repo_root: &Path) -> Result<WorkspaceInfo, Box<dyn std::error::Error>> {
+    let root_manifest = "packages/Cargo.toml";
+    let root_toml = fs::read_to_string(repo_root.join(root_manifest))?;
+    Ok(WorkspaceInfo {
+        root_manifest: root_manifest.to_owned(),
+        members: parse_toml_string_array(&root_toml, "members"),
+        excludes: parse_toml_string_array(&root_toml, "exclude"),
+    })
+}
+
+fn crate_info(
+    repo_root: &Path,
+    manifest_paths: &[String],
+    workspace: &WorkspaceInfo,
+) -> Result<Vec<CrateInfo>, Box<dyn std::error::Error>> {
+    let member_dirs: BTreeSet<&str> = workspace.members.iter().map(String::as_str).collect();
+    let exclude_dirs: BTreeSet<&str> = workspace.excludes.iter().map(String::as_str).collect();
+    let mut crates = Vec::new();
+    for manifest_path in manifest_paths {
+        let cargo_toml = fs::read_to_string(repo_root.join(manifest_path))?;
+        let name = parse_package_name(&cargo_toml)
+            .ok_or_else(|| format!("missing [package] name in {manifest_path}"))?;
+        let package_dir = manifest_path
+            .strip_prefix("packages/")
+            .and_then(|path| path.strip_suffix("/Cargo.toml"))
+            .ok_or_else(|| format!("unexpected package manifest path {manifest_path}"))?
+            .to_owned();
+        let workspace_role = if member_dirs.contains(package_dir.as_str()) {
+            "workspace-member"
+        } else if exclude_dirs.contains(package_dir.as_str()) {
+            "workspace-excluded"
+        } else {
+            "standalone"
+        }
+        .to_owned();
+        crates.push(CrateInfo {
+            name,
+            manifest_path: manifest_path.clone(),
+            package_dir,
+            workspace_role,
+        });
+    }
+    crates.sort_by(|left, right| left.package_dir.cmp(&right.package_dir));
+    Ok(crates)
+}
+
+fn parse_package_name(toml: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in toml.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[package]" {
+            in_package = true;
+            continue;
+        }
+        if in_package && trimmed.starts_with('[') {
+            return None;
+        }
+        if in_package && trimmed.starts_with("name") {
+            return parse_toml_assignment_string(trimmed, "name");
+        }
+    }
+    None
+}
+
+fn parse_toml_string_array(toml: &str, key: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut capturing = false;
+    let assignment = format!("{key} =");
+
+    for line in toml.lines() {
+        let trimmed = line.trim();
+        if !capturing && !trimmed.starts_with(&assignment) {
+            continue;
+        }
+        capturing = true;
+        values.extend(extract_quoted_strings(trimmed));
+        if trimmed.contains(']') {
+            break;
+        }
+    }
+
+    values.sort();
+    values
+}
+
+fn parse_toml_assignment_string(line: &str, key: &str) -> Option<String> {
+    let assignment = format!("{key} =");
+    line.strip_prefix(&assignment)
+        .and_then(|value| extract_quoted_strings(value).into_iter().next())
+}
+
+fn extract_quoted_strings(input: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut remainder = input;
+    while let Some(start) = remainder.find('"') {
+        let after_start = &remainder[start + 1..];
+        if let Some(end) = after_start.find('"') {
+            values.push(after_start[..end].to_owned());
+            remainder = &after_start[end + 1..];
+        } else {
+            break;
+        }
+    }
+    values
+}
+
+fn scan_compatibility_markers(
+    repo_root: &Path,
+    path: &str,
+) -> Result<Vec<CompatibilityMarker>, Box<dyn std::error::Error>> {
+    let Ok(text) = fs::read_to_string(repo_root.join(path)) else {
+        return Ok(Vec::new());
+    };
+    let mut markers = Vec::new();
+    for (index, line) in text.lines().enumerate() {
+        let line_number = index + 1;
+        for token in compat_adr_tokens(line) {
+            markers.push(CompatibilityMarker {
+                path: path.to_owned(),
+                line: line_number,
+                marker: token,
+            });
+        }
+        let lowered = line.to_ascii_lowercase();
+        for term in compatibility_terms(&lowered) {
+            markers.push(CompatibilityMarker {
+                path: path.to_owned(),
+                line: line_number,
+                marker: term.to_owned(),
+            });
+        }
+    }
+    Ok(markers)
+}
+
+fn compat_adr_tokens(line: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut remainder = line;
+    while let Some(start) = remainder.find("compat-ADR") {
+        let candidate = &remainder[start..];
+        let end = candidate
+            .find(|character: char| !(character.is_ascii_alphanumeric() || character == '-'))
+            .unwrap_or(candidate.len());
+        tokens.push(candidate[..end].to_owned());
+        remainder = &candidate[end..];
+    }
+    tokens
+}
+
+fn compatibility_terms(line_lowercase: &str) -> Vec<&'static str> {
+    const TERMS: &[&str] = &[
+        "back-compat",
+        "backward compatibility",
+        "compatibility",
+        "deprecated",
+        "fallback",
+        "legacy",
+        "retired",
+        "shim",
+        "superseded",
+        "tombstone",
+    ];
+
+    TERMS
+        .iter()
+        .copied()
+        .filter(|term| line_lowercase.contains(term))
+        .collect()
+}
+
+fn classify_generated_surface(path: &str) -> Option<&'static str> {
+    if path == ".github/workflows/pr-l1-static-fast.yml" {
+        Some("generated-ci-workflow")
+    } else if path == "tests/layer1-jobs.json" {
+        Some("ci-workflow-source")
+    } else if path.starts_with("docs/reference/schemas/") && path.ends_with(".json") {
+        Some("contract-schema-json")
+    } else if path.starts_with("docs/reference/cli-output/") && path.ends_with(".json") {
+        Some("cli-output-schema-json")
+    } else if path.starts_with("docs/manpages/") {
+        Some("cli-manpage")
+    } else if path.starts_with("docs/completions/") {
+        Some("cli-completion")
+    } else if path.starts_with("packages/nixling-ipc/proto/") && path.ends_with(".proto") {
+        Some("guest-control-proto-source")
+    } else if path.contains("/src/generated/") {
+        Some("generated-rust-binding")
+    } else if path == "docs/reference/daemon-api.md" || path == "docs/reference/error-codes.md" {
+        Some("generated-reference-doc")
+    } else if path == "packages/xtask/src/main.rs" || path.starts_with("packages/xtask/src/bin/") {
+        Some("generator-source")
+    } else if path.starts_with("nixos-modules/") && path.ends_with("-json.nix") {
+        Some("nix-json-emitter")
+    } else if path == "nixos-modules/manifest.nix" {
+        Some("nix-manifest-emitter")
+    } else {
+        None
+    }
+}
+
+fn classify_test_driver_surface(path: &str) -> Option<&'static str> {
+    if path == "Makefile" {
+        Some("make-targets")
+    } else if path == "tests/layer1-jobs.json" {
+        Some("layer1-job-manifest")
+    } else if path.starts_with(".github/workflows/") && path.ends_with(".yml") {
+        Some("ci-workflow")
+    } else if path.starts_with("tests/test-") && path.ends_with(".sh") {
+        Some("make-target-driver")
+    } else if path == "tests/static.sh"
+        || path == "tests/static-fast-tier0.sh"
+        || path == "tests/runner.sh"
+    {
+        Some("top-level-shell-driver")
+    } else if path.starts_with("tests/tools/") {
+        Some("test-tooling")
+    } else if path.starts_with("tests/unit/gates/") {
+        Some("drift-gate")
+    } else if path.starts_with("tests/unit/meta/") {
+        Some("policy-gate")
+    } else if path == "tests/migration-ledger.toml" || path.starts_with("tests/migration-state.d/")
+    {
+        Some("migration-ledger")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toml_string_arrays_are_sorted_and_extracted() {
+        let toml = r#"
+[workspace]
+members = [
+    "zeta",
+    "alpha",
+]
+exclude = ["standalone"]
+"#;
+
+        assert_eq!(parse_toml_string_array(toml, "members"), ["alpha", "zeta"]);
+        assert_eq!(parse_toml_string_array(toml, "exclude"), ["standalone"]);
+    }
+
+    #[test]
+    fn compatibility_scan_emits_tokens_not_line_content() {
+        let line = "compat-ADR0035-added-20260622-cli-example legacy fallback secret=value";
+
+        assert_eq!(
+            compat_adr_tokens(line),
+            ["compat-ADR0035-added-20260622-cli-example"]
+        );
+        assert_eq!(
+            compatibility_terms(&line.to_ascii_lowercase()),
+            ["fallback", "legacy"]
+        );
+    }
+
+    #[test]
+    fn generated_and_test_surfaces_are_classified() {
+        assert_eq!(
+            classify_generated_surface("docs/reference/schemas/v2/bundle.json"),
+            Some("contract-schema-json")
+        );
+        assert_eq!(
+            classify_test_driver_surface("tests/test-rust.sh"),
+            Some("make-target-driver")
+        );
+    }
+
+    #[test]
+    fn rejects_non_repo_relative_paths() {
+        assert!(validate_repo_relative_path("packages/xtask/src/main.rs").is_ok());
+        assert!(validate_repo_relative_path("/home/example/repo/file").is_err());
+        assert!(validate_repo_relative_path("../file").is_err());
+    }
+}

--- a/packages/xtask/src/inventory.rs
+++ b/packages/xtask/src/inventory.rs
@@ -171,7 +171,9 @@ fn build_inventory(
                 kind,
             });
         }
-        compatibility_markers.extend(scan_compatibility_markers(repo_root, path)?);
+        if should_scan_markers(path) {
+            compatibility_markers.extend(scan_markers(repo_root, path)?);
+        }
     }
 
     sort_metrics(&mut rust_metrics);
@@ -388,8 +390,8 @@ fn parse_package_name(toml: &str) -> Option<String> {
         if in_package && trimmed.starts_with('[') {
             return None;
         }
-        if in_package && trimmed.starts_with("name") {
-            return parse_toml_assignment_string(trimmed, "name");
+        if in_package && let Some(name) = parse_toml_assignment_string(trimmed, "name") {
+            return Some(name);
         }
     }
     None
@@ -437,7 +439,15 @@ fn extract_quoted_strings(input: &str) -> Vec<String> {
     values
 }
 
-fn scan_compatibility_markers(
+fn should_scan_markers(path: &str) -> bool {
+    !matches!(
+        path,
+        "packages/xtask/src/inventory.rs"
+            | "packages/nixling-contract-tests/tests/policy_compat_adr.rs"
+    )
+}
+
+fn scan_markers(
     repo_root: &Path,
     path: &str,
 ) -> Result<Vec<CompatibilityMarker>, Box<dyn std::error::Error>> {
@@ -455,7 +465,7 @@ fn scan_compatibility_markers(
             });
         }
         let lowered = line.to_ascii_lowercase();
-        for term in compatibility_terms(&lowered) {
+        for term in marker_terms(&lowered) {
             markers.push(CompatibilityMarker {
                 path: path.to_owned(),
                 line: line_number,
@@ -469,7 +479,7 @@ fn scan_compatibility_markers(
 fn compat_adr_tokens(line: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut remainder = line;
-    while let Some(start) = remainder.find("compat-ADR") {
+    while let Some(start) = remainder.find(concat!("compat", "-ADR")) {
         let candidate = &remainder[start..];
         let end = candidate
             .find(|character: char| !(character.is_ascii_alphanumeric() || character == '-'))
@@ -480,25 +490,23 @@ fn compat_adr_tokens(line: &str) -> Vec<String> {
     tokens
 }
 
-fn compatibility_terms(line_lowercase: &str) -> Vec<&'static str> {
-    const TERMS: &[&str] = &[
-        "back-compat",
-        "backward compatibility",
-        "compatibility",
-        "deprecated",
-        "fallback",
-        "legacy",
-        "retired",
-        "shim",
-        "superseded",
-        "tombstone",
-    ];
-
-    TERMS
-        .iter()
-        .copied()
-        .filter(|term| line_lowercase.contains(term))
-        .collect()
+fn marker_terms(line_lowercase: &str) -> Vec<String> {
+    [
+        concat!("back", "-compat"),
+        concat!("backward ", "compatibility"),
+        concat!("compat", "ibility"),
+        concat!("deprec", "ated"),
+        concat!("fall", "back"),
+        concat!("leg", "acy"),
+        concat!("ret", "ired"),
+        concat!("sh", "im"),
+        concat!("super", "seded"),
+        concat!("tomb", "stone"),
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .filter(|term| line_lowercase.contains(term))
+    .collect()
 }
 
 fn classify_generated_surface(path: &str) -> Option<&'static str> {
@@ -585,9 +593,30 @@ exclude = ["standalone"]
 
         assert_eq!(compat_adr_tokens(&line), vec![marker.clone()]);
         assert_eq!(
-            compatibility_terms(&line.to_ascii_lowercase()),
-            ["fallback", "legacy"]
+            marker_terms(&line.to_ascii_lowercase()),
+            ["fallback".to_owned(), "legacy".to_owned()]
         );
+    }
+
+    #[test]
+    fn package_name_parser_skips_prefix_keys() {
+        let toml = r#"
+[package]
+name_suffix = "not-the-package"
+name = "real-package"
+version = "0.0.0"
+"#;
+
+        assert_eq!(parse_package_name(toml), Some("real-package".to_owned()));
+    }
+
+    #[test]
+    fn marker_scan_skips_scanner_sources() {
+        assert!(!should_scan_markers("packages/xtask/src/inventory.rs"));
+        assert!(!should_scan_markers(
+            "packages/nixling-contract-tests/tests/policy_compat_adr.rs"
+        ));
+        assert!(should_scan_markers("nixos-modules/options.nix"));
     }
 
     #[test]

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -42,6 +42,8 @@ use nixling_core::{
 use nixling_ipc::{WireProtocolSchema, guest_wire::GuestControlSchema};
 use schemars::schema::RootSchema;
 
+mod inventory;
+
 const SCHEMA_VERSION: &str = "v2";
 const DAEMON_API_DOC: &str = "docs/reference/daemon-api.md";
 
@@ -142,26 +144,42 @@ struct RustItem {
 }
 
 fn main() -> std::process::ExitCode {
-    let mut args = env::args().skip(1);
-    match (args.next().as_deref(), args.next(), args.next()) {
-        (Some("gen-schemas"), None, None) => run_task("gen-schemas", gen_schemas),
-        (Some("gen-cli-schemas"), None, None) => run_task("gen-cli-schemas", gen_cli_schemas),
-        (Some("gen-error-codes"), None, None) => run_task("gen-error-codes", gen_error_codes),
-        (Some("gen-cli-shell-artifacts"), None, None) => {
+    let args: Vec<String> = env::args().skip(1).collect();
+    match args.as_slice() {
+        [command] if command == "gen-schemas" => run_task("gen-schemas", gen_schemas),
+        [command] if command == "gen-cli-schemas" => run_task("gen-cli-schemas", gen_cli_schemas),
+        [command] if command == "gen-error-codes" => run_task("gen-error-codes", gen_error_codes),
+        [command] if command == "gen-cli-shell-artifacts" => {
             run_task("gen-cli-shell-artifacts", gen_cli_shell_artifacts)
         }
-        (Some("gen-guest-proto"), None, None) => run_task("gen-guest-proto", gen_guest_proto),
-        (Some("gen-guest-ttrpc"), None, None) => run_task("gen-guest-ttrpc", gen_guest_ttrpc),
-        (Some("gen-daemon-api"), None, None) => {
+        [command] if command == "gen-guest-proto" => run_task("gen-guest-proto", gen_guest_proto),
+        [command] if command == "gen-guest-ttrpc" => run_task("gen-guest-ttrpc", gen_guest_ttrpc),
+        [command] if command == "gen-daemon-api" => {
             run_task("gen-daemon-api", || gen_daemon_api().map(|p| vec![p]))
         }
-        (Some("release-notes"), Some(version), None) => run_task("release-notes", move || {
-            gen_release_notes(&version).map(|p| vec![p])
+        [command, version] if command == "release-notes" => run_task("release-notes", move || {
+            gen_release_notes(version).map(|p| vec![p])
         }),
+        [command] if command == "adr0035-inventory" => run_inventory(None),
+        [command, flag, output]
+            if command == "adr0035-inventory" && (flag == "--output" || flag == "-o") =>
+        {
+            run_inventory(Some(PathBuf::from(output.as_str())))
+        }
         _ => {
             eprintln!(
-                "usage: cargo xtask <gen-schemas|gen-cli-schemas|gen-error-codes|gen-cli-shell-artifacts|gen-guest-proto|gen-guest-ttrpc|gen-daemon-api|release-notes <version>>"
+                "usage: cargo xtask <gen-schemas|gen-cli-schemas|gen-error-codes|gen-cli-shell-artifacts|gen-guest-proto|gen-guest-ttrpc|gen-daemon-api|release-notes <version>|adr0035-inventory [--output <path>]>"
             );
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_inventory(output_path: Option<PathBuf>) -> std::process::ExitCode {
+    match inventory::emit_adr0035_inventory(output_path.as_deref()) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("adr0035-inventory failed: {err}");
             std::process::ExitCode::FAILURE
         }
     }

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -371,15 +371,6 @@ ssh_net_vm() {
       "root@$ip" "$@"
 }
 
-# DEPRECATED back-compat alias. Older test scripts and ad-hoc tooling
-# call `ssh_router <vm>`; new code should call `ssh_net_vm`. The
-# rename of the per-env auto-VM (\`<env>-router\` → \`sys-<env>-net\`)
-# and of the manifest field (\`isRouter\` → \`isNetVm\`) means the
-# old name is misleading, but a hard rename in this commit would
-# break any caller carried over from the pre- era. Remove after
-# all in-tree call sites have switched.
-ssh_router() { ssh_net_vm "$@"; }
-
 # ---------- cleanup ----------
 
 # Per-process cleanup bookkeeping files MUST live outside $(nl_repo_root)


### PR DESCRIPTION
## Summary

Implements ADR 0035 Wave 0 baseline and low-risk cleanup:

- adds `xtask adr0035-inventory` for deterministic tracked-file JSON inventory of hub sizes, crates, compatibility markers, generated surfaces, and test-driver surfaces;
- adds a Rust `compat-ADR...` bridge-key policy test with metadata/date/surface validation;
- removes caller-free internal compatibility aliases (`ssh_router`, `make ledger`);
- drops stale retired bash-CLI option comments from `nixos-modules/options.nix`;
- records the broader candidate audit for later ADR 0035 waves in the session plan.

Full Gemini 3.1 Pro panel signoff: Wave 0 plan and implementation both reached 10/10 signoff (`software`, `test`, `nixos`, `networking`, `security`, `rust`, `product`, `docs`, `observability`, `kernel`).

## Testing checklist (mandatory)

- [x] **`make check` passes locally**: Layer-1 manifest runner OK (`check-tier0`, `test-lint`, `test-rust`, `test-proofs`, `test-flake`, `test-policy`, `test-drift`).
- [x] **`make test-integration` passes on the host before PR creation**: `test-integration OK`.
- [x] **`make test-host-integration` passes on the host before PR creation**: built and ran `bridge-isolation`, `daemon-smoke`, `guest-shell-service`, `host-realm-isolation`, `privilege-oracle`, and `state-dir-acl` VM checks successfully.
- [x] **Manual `make test-hardware` run**: N/A: no graphics/GPU, video decode, USBIP/YubiKey, hardware-TPM, or full-microVM-boot surface touched.
- [x] **New/changed tests are wired into a `make` target**: new Rust policy test is under `packages/nixling-contract-tests/tests/` and covered by `make test-rust`; no new top-level shell gate or migration-ledger row required.
- [x] **Docs + CI updated in lockstep**: no shipped docs/CI workflow changes required; `CHANGELOG.md` updated and `scripts/changelog-check.sh` passed.

Focused validation also run:

- `cargo fmt --check`
- `cargo test -p xtask --quiet`
- `cargo test -p nixling-contract-tests compat_adr_markers_are_well_formed_and_metadata_backed --quiet`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo clippy -p nixling-contract-tests --tests -- -D warnings`
- `nix-instantiate --parse nixos-modules/options.nix`
- `bash -n tests/lib.sh`
- `make -n check-inventory ledger-regen`
- `git diff --check origin/main..HEAD`
- `cargo xtask adr0035-inventory --output /tmp/adr0035-wave0-rustfix2.json`

## Notes

Wave 0 intentionally preserves migration machinery and public compatibility surfaces. Larger candidate buckets are inventoried for later waves rather than removed here.
