### PR TITLE
processes: add runner builder and role matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,6 +408,12 @@ for the DAG node taxonomy and
 [`docs/reference/privileges.md`](./docs/reference/privileges.md) for
 the broker op catalogue.
 
+Adding or reclassifying a spawned runner `ProcessRole` also requires
+matching process-builder and runner-matrix coverage: add/extend the
+typed Rust argv builder in `packages/nixling-host/src/*_argv.rs` and
+the role coverage policy/contract tests under
+`packages/nixling-contract-tests/tests/` in the same change.
+
 ## Panel review
 
 ### Phase gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ deprecations ship one minor release before removal.
 
 ### Internal
 
+- ADR 0035 Wave 5 added a contract-test policy that classifies every
+  `ProcessRole` and requires runner roles to carry Rust argv-builder plus
+  runner matrix/contract coverage before new roles land.
 - ADR 0035 Wave 4 decomposed CLI read-model/rendering helpers and daemon
   admission helpers into focused Rust modules while preserving output and
   authorization contracts.

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -845,8 +845,13 @@ use devices::virtio::vhost_user_backend::run_video_device;'
       inherit planOps;
     };
 
-  hypervisorRunnerNode = name: service: args:
+  runnerNode = name: { id, role, readiness, runner, unit ? null, planOps ? [ ] }:
     node name ({
+      inherit id role readiness unit planOps;
+    } // runner);
+
+  hypervisorRunnerNode = name: service: args:
+    runnerNode name ({
       id = service.nodeId;
       role = service.runnerRole;
     } // args);
@@ -976,16 +981,18 @@ use devices::virtio::vhost_user_backend::run_video_device;'
       ++ [
         (hypervisorRunnerNode name hypervisorService {
           unit = if vm.graphics.enable then "nixling-${name}-gpu.service" else "microvm@${name}.service";
-          binaryPath = cloudHypervisorBinaryPath microvm;
-          argv = cloudHypervisorArgv name vm manifest;
-          # the cloud-hypervisor binary is a bash
-          # wrapper that calls `dirname` to compute paths; under
-          # the broker spawn (empty PATH) it exits 127 on the
-          # very first line. Provide PATH with coreutils so the
-          # wrapper can find dirname + sed.
-          env = [
-            "PATH=${pkgs.coreutils}/bin:${pkgs.gnused}/bin"
-          ];
+          runner = {
+            binaryPath = cloudHypervisorBinaryPath microvm;
+            argv = cloudHypervisorArgv name vm manifest;
+            # the cloud-hypervisor binary is a bash
+            # wrapper that calls `dirname` to compute paths; under
+            # the broker spawn (empty PATH) it exits 127 on the
+            # very first line. Provide PATH with coreutils so the
+            # wrapper can find dirname + sed.
+            env = [
+              "PATH=${pkgs.coreutils}/bin:${pkgs.gnused}/bin"
+            ];
+          };
           readiness = [ (apiSocketInfo manifest.apiSocket) ];
           # emit DiskInit plan-ops before SpawnRunner.
           # Nixling-owned relative raw/ext4 microvm.volumes are declared by
@@ -1020,18 +1027,20 @@ use devices::virtio::vhost_user_backend::run_video_device;'
           ];
         })
       ]
-      ++ lib.optional vm.observability.enable (node name ({
+      ++ lib.optional vm.observability.enable (runnerNode name {
         id = "vsock-relay";
         role = "vsock-relay";
         unit = "nixling-otel-relay@${name}.service";
         readiness = [ (unixSocketExists (vsockSocketForPort manifest.observability.vsockHostSocket obsOtlpPort)) ];
-      } // vsockRelayRunner name manifest))
-      ++ lib.optional (cfg.observability.enable && name == cfg.observability.vmName) (node name ({
+        runner = vsockRelayRunner name manifest;
+      })
+      ++ lib.optional (cfg.observability.enable && name == cfg.observability.vmName) (runnerNode name {
         id = "otel-host-bridge";
         role = "otel-host-bridge";
         unit = "nixling-otel-host-bridge.service";
         readiness = [ (unixSocketExists "/run/nixling/otel/host-egress.sock") ];
-      } // otelHostBridgeRunner manifest))
+        runner = otelHostBridgeRunner manifest;
+      })
       ++ lib.optional guestControlEnabled (node name {
         id = "guest-control-health";
         role = "guest-control-health";
@@ -1101,9 +1110,11 @@ use devices::virtio::vhost_user_backend::run_video_device;'
       } // waylandProxyRunner name vm))
       ++ [
         (hypervisorRunnerNode name hypervisorService {
-          binaryPath = qemuMediaBinaryPath;
-          argv = qemuMediaArgv name;
-          env = qemuMediaEnv name;
+          runner = {
+            binaryPath = qemuMediaBinaryPath;
+            argv = qemuMediaArgv name;
+            env = qemuMediaEnv name;
+          };
           readiness = [ (unixSocketListening (qemuMediaQmpSocket name)) ];
         })
       ];
@@ -1128,16 +1139,18 @@ use devices::virtio::vhost_user_backend::run_video_device;'
     in {
       vm = vmId;
       nodes = [
-        (node vmId ({
+        (runnerNode vmId {
           id = "backend";
           role = "usbip";
           readiness = [ (tcpPort "127.0.0.1" (backendPort envName)) ];
-        } // usbipBackendRunner envName))
-        (node vmId ({
+          runner = usbipBackendRunner envName;
+        })
+        (runnerNode vmId {
           id = "proxy";
           role = "usbip";
           readiness = [ (tcpPort m.hostUplinkIp 3240) ];
-        } // usbipProxyRunner envName m))
+          runner = usbipProxyRunner envName m;
+        })
       ];
       edges = [
         (edge "backend" "proxy" "The per-env USBIP proxy starts only after the backend usbipd listener is ready.")

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -73,12 +73,13 @@ EOF
     else "/run/nixling/vms/${name}/${clean share.tag}.sock";
   volumeHostPath = name: volume: nl.volumeHostPath cfg.store.stateDir name volume;
 
-  componentReady = value: { kind = "component-specific"; inherit value; };
-  apiSocketInfo = value: { kind = "api-socket-info"; inherit value; };
-  unixSocketExists = value: { kind = "unix-socket-exists"; inherit value; };
-  unixSocketListening = value: { kind = "unix-socket-listening"; inherit value; };
-  tcpPort = host: port: { kind = "tcp-port"; value = { inherit host port; }; };
-  commandReady = value: { kind = "command"; inherit value; };
+  mkReadiness = kind: value: { inherit kind value; };
+  componentReady = mkReadiness "component-specific";
+  apiSocketInfo = mkReadiness "api-socket-info";
+  unixSocketExists = mkReadiness "unix-socket-exists";
+  unixSocketListening = mkReadiness "unix-socket-listening";
+  tcpPort = host: port: mkReadiness "tcp-port" { inherit host port; };
+  commandReady = mkReadiness "command";
   # Authenticated guest-control Health readiness. Unlike a raw TCP-22
   # probe this predicate fails CLOSED: the daemon completes a full
   # Hello + token challenge-response + Health over the guest-control vsock
@@ -816,7 +817,14 @@ use devices::virtio::vhost_user_backend::run_video_device;'
     ];
   };
 
-  node = name: { id, role, readiness, unit ? null, binaryPath ? null, argv ? [ ], env ? [ ], planOps ? [ ] }:
+  mkDiskInitPlanOp = { targetPath, sizeBytes, mode, ownerProfile, ifAbsent ? true }: {
+    kind = "diskInit";
+    inherit targetPath sizeBytes mode ifAbsent;
+    ownerUid = ownerProfile.uid;
+    ownerGid = ownerProfile.gid;
+  };
+
+  mkProcessNode = name: { id, role, readiness, unit ? null, binaryPath ? null, argv ? [ ], env ? [ ], planOps ? [ ] }:
     let
       # `vm.supervisor` was removed per ADR 0015; every
       # enabled VM is daemon-supervised. `emitUnit` is permanently
@@ -845,13 +853,19 @@ use devices::virtio::vhost_user_backend::run_video_device;'
       inherit planOps;
     };
 
+  mkRunnerNode = name: args: runner:
+    mkProcessNode name (args // runner);
+
+  node = mkProcessNode;
+
   hypervisorRunnerNode = name: service: args:
-    node name ({
+    mkProcessNode name ({
       id = service.nodeId;
       role = service.runnerRole;
     } // args);
 
-  edge = from: to: reason: { inherit from to reason; };
+  mkEdge = from: to: reason: { inherit from to reason; };
+  edge = mkEdge;
   edgesFromNodes = fromNodes: to: reason:
     builtins.map (from: edge from to reason) fromNodes;
   edgesToNodes = from: toNodes: reason:
@@ -871,12 +885,12 @@ use devices::virtio::vhost_user_backend::run_video_device;'
         (share: (share.proto or "virtiofs") == "virtiofs")
         microvm.shares;
       shareNodes = lib.forEach virtiofsShares (share:
-        node name ({
+        mkRunnerNode name {
           id = shareNodeId share;
           role = "virtiofsd";
           unit = "microvm-virtiofsd@${name}.service";
           readiness = [ (unixSocketExists (shareSocketPath name share)) ];
-        } // virtiofsdRunner name share));
+        } (virtiofsdRunner name share));
       shareNodeIds = builtins.map shareNodeId virtiofsShares;
       postStoreNodeIds = if shareNodeIds != [ ] then shareNodeIds else [ "store-virtiofs-preflight" ];
       preOptionalNodeIds = if vm.tpm.enable then [ "swtpm" ] else postStoreNodeIds;
@@ -919,20 +933,20 @@ use devices::virtio::vhost_user_backend::run_video_device;'
           ];
         })
       ]
-      ++ lib.optional vm.tpm.enable (node name ({
+      ++ lib.optional vm.tpm.enable (mkRunnerNode name {
         id = "swtpm-flush";
         role = "swtpm-pre-start-flush";
         unit = "nixling-${name}-swtpm.service";
         readiness = [ ];
-      } // swtpmFlushRunner name))
-      ++ lib.optional vm.tpm.enable (node name ({
+      } (swtpmFlushRunner name))
+      ++ lib.optional vm.tpm.enable (mkRunnerNode name {
         id = "swtpm";
         role = "swtpm";
         unit = "nixling-${name}-swtpm.service";
         readiness = [ (unixSocketListening manifest.tpmSocket) ];
-      } // swtpmRunner name))
+      } (swtpmRunner name))
       ++ shareNodes
-      ++ lib.optional (vm.graphics.enable && !vm.graphics.renderNodeOnly) (node name ({
+      ++ lib.optional (vm.graphics.enable && !vm.graphics.renderNodeOnly) (mkRunnerNode name {
         id = "gpu";
         role = "gpu";
         unit = "nixling-${name}-gpu.service";
@@ -944,35 +958,35 @@ use devices::virtio::vhost_user_backend::run_video_device;'
       # updating the readiness predicate. Without this fix the DAG
       # times out waiting on a socket that crosvm never creates.
       readiness = graphicsReadiness;
-      } // gpuRunner name vm))
+      } (gpuRunner name vm))
       # (ADR 0021) render-node-only broker-pre-NS GPU sidecar.
       # Emitted when graphics.renderNodeOnly = true. Uses gpuRenderNodeRunner
       # (argv carries --gpu-device-node /proc/self/fd/10) and the
       # gpu-render-node minijail profile (userNamespace, empty deviceBinds).
-      ++ lib.optional (vm.graphics.enable && vm.graphics.renderNodeOnly) (node name ({
+      ++ lib.optional (vm.graphics.enable && vm.graphics.renderNodeOnly) (mkRunnerNode name {
         id = "gpu-render-node";
         role = "gpu-render-node";
         unit = "nixling-${name}-gpu.service";
         readiness = graphicsReadiness;
-      } // gpuRenderNodeRunner name vm))
-      ++ lib.optional (vm.graphics.enable && vm.graphics.videoSidecar) (node name ({
+      } (gpuRenderNodeRunner name vm))
+      ++ lib.optional (vm.graphics.enable && vm.graphics.videoSidecar) (mkRunnerNode name {
         id = "video";
         role = "video";
         readiness = [ (unixSocketListening "/run/nixling-video/${name}/video.sock") ];
-      } // videoRunner name))
-      ++ lib.optional emitWaylandProxy (node name ({
+      } (videoRunner name))
+      ++ lib.optional emitWaylandProxy (mkRunnerNode name {
         id = "wayland-proxy";
         role = "wayland-proxy";
         readiness = [
           (unixSocketListening "/run/nixling-wlproxy/${name}/wayland-0")
         ];
-      } // waylandProxyRunner name vm))
-      ++ lib.optional vm.audio.enable (node name ({
+      } (waylandProxyRunner name vm))
+      ++ lib.optional vm.audio.enable (mkRunnerNode name {
         id = "audio";
         role = "audio";
         unit = "nixling-${name}-snd.service";
         readiness = [ (unixSocketExists "/run/nixling/vms/${name}/snd.sock") ];
-      } // audioRunner name))
+      } (audioRunner name))
       ++ [
         (hypervisorRunnerNode name hypervisorService {
           unit = if vm.graphics.enable then "nixling-${name}-gpu.service" else "microvm@${name}.service";
@@ -998,40 +1012,34 @@ use devices::virtio::vhost_user_backend::run_video_device;'
           #
           # mode 0o660 = 432 decimal for regular VM volumes (CH runner
           # opens them via kvm group); store-overlay keeps 0o600.
-          planOps = (builtins.map (volume: {
-            kind = "diskInit";
+          planOps = (builtins.map (volume: mkDiskInitPlanOp {
             targetPath = volumeHostPath name volume;
             sizeBytes = nl.volumeSizeBytes volume;
             mode = 432;
-            ownerUid = (profileFor name "cloud-hypervisor").uid;
-            ownerGid = (profileFor name "cloud-hypervisor").gid;
-            ifAbsent = true;
+            ownerProfile = profileFor name "cloud-hypervisor";
           }) (builtins.filter nl.volumeDiskInitEligible microvm.volumes))
           ++ lib.optionals (microvm.writableStoreOverlay != null) [
-            {
-              kind = "diskInit";
+            (mkDiskInitPlanOp {
               targetPath = "${toString cfg.store.stateDir}/${name}/store-overlay.img";
               sizeBytes = vm.writableStoreOverlaySize;
               mode = 384;
-              ownerUid = (profileFor name "cloud-hypervisor").uid;
-              ownerGid = (profileFor name "cloud-hypervisor").gid;
-              ifAbsent = true;
-            }
+              ownerProfile = profileFor name "cloud-hypervisor";
+            })
           ];
         })
       ]
-      ++ lib.optional vm.observability.enable (node name ({
+      ++ lib.optional vm.observability.enable (mkRunnerNode name {
         id = "vsock-relay";
         role = "vsock-relay";
         unit = "nixling-otel-relay@${name}.service";
         readiness = [ (unixSocketExists (vsockSocketForPort manifest.observability.vsockHostSocket obsOtlpPort)) ];
-      } // vsockRelayRunner name manifest))
-      ++ lib.optional (cfg.observability.enable && name == cfg.observability.vmName) (node name ({
+      } (vsockRelayRunner name manifest))
+      ++ lib.optional (cfg.observability.enable && name == cfg.observability.vmName) (mkRunnerNode name {
         id = "otel-host-bridge";
         role = "otel-host-bridge";
         unit = "nixling-otel-host-bridge.service";
         readiness = [ (unixSocketExists "/run/nixling/otel/host-egress.sock") ];
-      } // otelHostBridgeRunner manifest))
+      } (otelHostBridgeRunner manifest))
       ++ lib.optional guestControlEnabled (node name {
         id = "guest-control-health";
         role = "guest-control-health";
@@ -1128,16 +1136,16 @@ use devices::virtio::vhost_user_backend::run_video_device;'
     in {
       vm = vmId;
       nodes = [
-        (node vmId ({
+        (mkRunnerNode vmId {
           id = "backend";
           role = "usbip";
           readiness = [ (tcpPort "127.0.0.1" (backendPort envName)) ];
-        } // usbipBackendRunner envName))
-        (node vmId ({
+        } (usbipBackendRunner envName))
+        (mkRunnerNode vmId {
           id = "proxy";
           role = "usbip";
           readiness = [ (tcpPort m.hostUplinkIp 3240) ];
-        } // usbipProxyRunner envName m))
+        } (usbipProxyRunner envName m))
       ];
       edges = [
         (edge "backend" "proxy" "The per-env USBIP proxy starts only after the backend usbipd listener is ready.")

--- a/packages/nixling-contract-tests/tests/policy_runner_role_coverage.rs
+++ b/packages/nixling-contract-tests/tests/policy_runner_role_coverage.rs
@@ -1,0 +1,208 @@
+use std::collections::BTreeSet;
+
+use nixling_contract_tests::read_repo_file;
+use regex::Regex;
+
+#[derive(Clone, Copy)]
+struct RunnerCoverage {
+    role: &'static str,
+    builder_module: &'static str,
+    matrix_file: &'static str,
+    matrix_marker: &'static str,
+}
+
+const RUNNER_COVERAGE: &[RunnerCoverage] = &[
+    RunnerCoverage {
+        role: "Swtpm",
+        builder_module: "swtpm_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/runner_shape_contract.rs",
+        matrix_marker: "ProcessRole::Swtpm",
+    },
+    RunnerCoverage {
+        role: "Virtiofsd",
+        builder_module: "virtiofsd_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/runner_shape_contract.rs",
+        matrix_marker: "ProcessRole::Virtiofsd",
+    },
+    RunnerCoverage {
+        role: "Video",
+        builder_module: "video_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_swtpm_video.rs",
+        matrix_marker: "ProcessRole::Video",
+    },
+    RunnerCoverage {
+        role: "Gpu",
+        builder_module: "gpu_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_gpu.rs",
+        matrix_marker: "ProcessRole::Gpu",
+    },
+    RunnerCoverage {
+        role: "GpuRenderNode",
+        builder_module: "gpu_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_swtpm_video.rs",
+        matrix_marker: "ProcessRole::GpuRenderNode",
+    },
+    RunnerCoverage {
+        role: "Audio",
+        builder_module: "audio_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_audio_usbip.rs",
+        matrix_marker: "ProcessRole::Audio",
+    },
+    RunnerCoverage {
+        role: "CloudHypervisorRunner",
+        builder_module: "ch_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/runner_shape_contract.rs",
+        matrix_marker: "ProcessRole::CloudHypervisorRunner",
+    },
+    RunnerCoverage {
+        role: "QemuMediaRunner",
+        builder_module: "qemu_media_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_roles.rs",
+        matrix_marker: "qemu_media_profile_source_is_fd_backed_and_device_closed",
+    },
+    RunnerCoverage {
+        role: "VsockRelay",
+        builder_module: "vsock_relay_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_relay_otel.rs",
+        matrix_marker: "ProcessRole::VsockRelay",
+    },
+    RunnerCoverage {
+        role: "OtelHostBridge",
+        builder_module: "otel_host_bridge_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_relay_otel.rs",
+        matrix_marker: "ProcessRole::OtelHostBridge",
+    },
+    RunnerCoverage {
+        role: "Usbip",
+        builder_module: "usbip_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_audio_usbip.rs",
+        matrix_marker: "ProcessRole::Usbip",
+    },
+    RunnerCoverage {
+        role: "WaylandProxy",
+        builder_module: "wayland_proxy_argv",
+        matrix_file: "packages/nixling-contract-tests/tests/minijail_gpu.rs",
+        matrix_marker: "ProcessRole::WaylandProxy",
+    },
+];
+
+const NON_RUNNER_ROLES: &[&str] = &[
+    "HostReconcile",
+    "StoreVirtiofsPreflight",
+    "SwtpmPreStartFlush",
+    "GuestSshReadiness",
+    "GuestControlHealth",
+];
+
+fn process_role_variants() -> Vec<String> {
+    let src = read_repo_file("packages/nixling-core/src/processes.rs");
+    let re = Regex::new(r"(?s)pub enum ProcessRole\s*\{(?P<body>.*?)\n\}")
+        .expect("valid ProcessRole enum regex");
+    let body = re
+        .captures(&src)
+        .and_then(|captures| captures.name("body"))
+        .expect("ProcessRole enum body must be parseable")
+        .as_str();
+
+    body.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty()
+                || line.starts_with("///")
+                || line.starts_with("//")
+                || line.starts_with("#[")
+            {
+                return None;
+            }
+            let variant = line.split_once(',').map_or(line, |(variant, _)| variant);
+            let variant = variant
+                .split_once('{')
+                .map_or(variant, |(variant, _)| variant)
+                .trim();
+            (!variant.is_empty()).then(|| variant.to_owned())
+        })
+        .collect()
+}
+
+fn assert_unique(items: impl Iterator<Item = &'static str>, label: &str) {
+    let mut seen = BTreeSet::new();
+    let mut duplicates = Vec::new();
+    for item in items {
+        if !seen.insert(item) {
+            duplicates.push(item);
+        }
+    }
+    assert!(
+        duplicates.is_empty(),
+        "{label} has duplicates: {duplicates:?}"
+    );
+}
+
+#[test]
+fn every_process_role_is_classified_for_runner_coverage_policy() {
+    assert_unique(
+        RUNNER_COVERAGE.iter().map(|coverage| coverage.role),
+        "runner coverage table",
+    );
+    assert_unique(NON_RUNNER_ROLES.iter().copied(), "non-runner role table");
+
+    let declared: BTreeSet<_> = process_role_variants().into_iter().collect();
+    let covered: BTreeSet<_> = RUNNER_COVERAGE
+        .iter()
+        .map(|coverage| coverage.role.to_owned())
+        .chain(NON_RUNNER_ROLES.iter().map(|role| (*role).to_owned()))
+        .collect();
+
+    let missing: Vec<_> = declared.difference(&covered).cloned().collect();
+    let stale: Vec<_> = covered.difference(&declared).cloned().collect();
+    assert!(
+        missing.is_empty() && stale.is_empty(),
+        "ProcessRole coverage policy drifted; missing rows for {missing:?}, stale rows {stale:?}. \
+         New runner roles must add a Rust argv builder and runner matrix/contract coverage."
+    );
+}
+
+#[test]
+fn runner_process_roles_have_builder_and_matrix_contract_coverage() {
+    let host_lib = read_repo_file("packages/nixling-host/src/lib.rs");
+    let regenerator = read_repo_file("packages/nixling-host/src/runner_argv_regenerator.rs");
+    let generator_fn =
+        Regex::new(r"pub fn generate_[a-z0-9_]*argv").expect("valid generator function regex");
+
+    for coverage in RUNNER_COVERAGE {
+        assert!(
+            host_lib.contains(&format!("pub mod {};", coverage.builder_module)),
+            "ProcessRole::{} must expose nixling-host::{} as its Rust argv builder",
+            coverage.role,
+            coverage.builder_module
+        );
+
+        let builder_src = read_repo_file(&format!(
+            "packages/nixling-host/src/{}.rs",
+            coverage.builder_module
+        ));
+        assert!(
+            generator_fn.is_match(&builder_src),
+            "ProcessRole::{} builder module {} must expose a generate_*argv function",
+            coverage.role,
+            coverage.builder_module
+        );
+
+        assert!(
+            regenerator.contains(&format!("ProcessRole::{}", coverage.role)),
+            "ProcessRole::{} must be classified by runner_argv_regenerator",
+            coverage.role
+        );
+
+        let matrix_src = read_repo_file(coverage.matrix_file);
+        let marker = Regex::new(coverage.matrix_marker).unwrap_or_else(|err| {
+            panic!("invalid marker for ProcessRole::{}: {err}", coverage.role)
+        });
+        assert!(
+            marker.is_match(&matrix_src),
+            "ProcessRole::{} must have runner matrix/contract coverage in {}",
+            coverage.role,
+            coverage.matrix_file
+        );
+    }
+}

--- a/packages/nixling-core/src/bundle_resolver.rs
+++ b/packages/nixling-core/src/bundle_resolver.rs
@@ -294,6 +294,67 @@ pub struct UserNamespaceSpec {
     pub host_gid_for_zero: u32,
 }
 
+impl ResolvedRunnerIntent {
+    /// Convert one trusted process-DAG node into the broker runner intent shape.
+    ///
+    /// Non-runner/readiness-only roles and runner roles without a safe current or
+    /// legacy spawn specification return `None`.
+    pub fn from_process_node(vm_name: &str, node: &ProcessNode) -> Option<Self> {
+        let role_name = runner_role_name(&node.role)?;
+        let (binary_path, argv) = match node.binary_path.as_deref() {
+            Some(binary_path)
+                if binary_path.starts_with('/')
+                    && !node.argv.is_empty()
+                    && !node.argv[0].is_empty()
+                    && !is_placeholder_runner_spec(binary_path, &node.argv, role_name) =>
+            {
+                (binary_path.to_owned(), node.argv.clone())
+            }
+            _ => legacy_runner_spec(vm_name, &node.role)?,
+        };
+        // v1.1.1fu11 (Option B): start with the baseline NIXLING_VM
+        // env var, then append any node-specific env entries from the
+        // bundle (used by audio/gpu/video sidecars to thread
+        // PIPEWIRE_RUNTIME_DIR / XDG_RUNTIME_DIR / WAYLAND_DISPLAY).
+        let mut env = vec![format!("NIXLING_VM={vm_name}")];
+        env.extend(node.env.iter().cloned());
+        let RoleProfile {
+            profile_id,
+            uid,
+            gid,
+            adr_carve_out,
+            caps,
+            namespaces,
+            seccomp_policy_ref,
+            mount_policy,
+            cgroup_placement,
+            user_namespace,
+            umask,
+        } = &node.profile;
+        Some(Self {
+            intent_id: intent_id_runner(vm_name, &node.id.0),
+            vm_name: vm_name.to_owned(),
+            role_id: node.id.0.clone(),
+            role: node.role.clone(),
+            binary_path: PathBuf::from(binary_path),
+            argv,
+            env,
+            uid: *uid,
+            gid: *gid,
+            supplementary_groups: Vec::new(),
+            capabilities: caps.clone(),
+            namespaces: namespaces.clone(),
+            seccomp_policy_ref: seccomp_policy_ref.clone(),
+            mount_policy: mount_policy.clone(),
+            cgroup_placement: cgroup_placement.clone(),
+            root_carve_out: adr_carve_out.is_some(),
+            profile_id: profile_id.clone(),
+            user_namespace: user_namespace.map(UserNamespaceSpec::from),
+            umask: *umask,
+        })
+    }
+}
+
 // Convenience From impls across the wire (`UserNamespaceProfile`) and
 // intent (`UserNamespaceSpec`) types so layer boundaries can `.into()`
 // instead of hand-copying fields.
@@ -2236,7 +2297,7 @@ fn build_runner_intents(processes: &ProcessesJson) -> BTreeMap<String, ResolvedR
     let mut out = BTreeMap::new();
     for dag in &processes.vms {
         for node in &dag.nodes {
-            let Some(resolved) = resolve_runner_node(dag, node) else {
+            let Some(resolved) = ResolvedRunnerIntent::from_process_node(&dag.vm, node) else {
                 continue;
             };
             out.insert(resolved.intent_id.clone(), resolved);
@@ -2273,27 +2334,23 @@ fn is_placeholder_runner_spec(binary_path: &str, argv: &[String], role_name: &st
         && argv[0] == role_name
 }
 
-fn legacy_runner_spec(
-    dag: &VmProcessDag,
-    role: &ProcessRole,
-    _role_name: &str,
-) -> Option<(String, Vec<String>)> {
+fn legacy_runner_spec(vm_name: &str, role: &ProcessRole) -> Option<(String, Vec<String>)> {
     let (binary_name, arg0) = match role {
-        ProcessRole::SwtpmPreStartFlush => ("bash", format!("nixling-swtpm-flush@{}", dag.vm)),
-        ProcessRole::Swtpm => ("swtpm", format!("microvm-swtpm@{}", dag.vm)),
-        ProcessRole::Virtiofsd => ("virtiofsd", format!("microvm-virtiofsd@{}", dag.vm)),
+        ProcessRole::SwtpmPreStartFlush => ("bash", format!("nixling-swtpm-flush@{vm_name}")),
+        ProcessRole::Swtpm => ("swtpm", format!("microvm-swtpm@{vm_name}")),
+        ProcessRole::Virtiofsd => ("virtiofsd", format!("microvm-virtiofsd@{vm_name}")),
         // Video must always carry the patched crosvm video-decoder binary
         // and closed argv from processes.json. Never fall back to stock crosvm.
         ProcessRole::Video => return None,
-        ProcessRole::Gpu => ("crosvm", format!("nixling-{}-gpu", dag.vm)),
-        ProcessRole::GpuRenderNode => ("crosvm", format!("nixling-{}-gpu-render-node", dag.vm)),
-        ProcessRole::Audio => ("vhost-device-sound", format!("nixling-{}-snd", dag.vm)),
-        ProcessRole::CloudHypervisorRunner => ("cloud-hypervisor", format!("microvm@{}", dag.vm)),
+        ProcessRole::Gpu => ("crosvm", format!("nixling-{vm_name}-gpu")),
+        ProcessRole::GpuRenderNode => ("crosvm", format!("nixling-{vm_name}-gpu-render-node")),
+        ProcessRole::Audio => ("vhost-device-sound", format!("nixling-{vm_name}-snd")),
+        ProcessRole::CloudHypervisorRunner => ("cloud-hypervisor", format!("microvm@{vm_name}")),
         // QEMU media runners must carry the closed scaffold argv from
         // processes.json. There is no Cloud Hypervisor-compatible legacy
         // fallback for this runtime kind.
         ProcessRole::QemuMediaRunner => return None,
-        ProcessRole::VsockRelay => ("socat", format!("nixling-otel-relay@{}", dag.vm)),
+        ProcessRole::VsockRelay => ("socat", format!("nixling-otel-relay@{vm_name}")),
         // OtelHostBridge must always carry the closed argv from
         // processes.json; it has no legacy singleton fallback.
         ProcessRole::OtelHostBridge => return None,
@@ -2315,62 +2372,9 @@ fn legacy_runner_spec(
     ))
 }
 
+#[cfg(test)]
 fn resolve_runner_node(dag: &VmProcessDag, node: &ProcessNode) -> Option<ResolvedRunnerIntent> {
-    let role_name = runner_role_name(&node.role)?;
-    let (binary_path, argv) = match node.binary_path.as_deref() {
-        Some(binary_path)
-            if binary_path.starts_with('/')
-                && !node.argv.is_empty()
-                && !node.argv[0].is_empty()
-                && !is_placeholder_runner_spec(binary_path, &node.argv, role_name) =>
-        {
-            (binary_path.to_owned(), node.argv.clone())
-        }
-        _ => legacy_runner_spec(dag, &node.role, role_name)?,
-    };
-    // v1.1.1fu11 (Option B): start with the baseline NIXLING_VM
-    // env var, then append any node-specific env entries from the
-    // bundle (used by audio/gpu/video sidecars to thread
-    // PIPEWIRE_RUNTIME_DIR / XDG_RUNTIME_DIR / WAYLAND_DISPLAY).
-    let mut env = vec![format!("NIXLING_VM={}", dag.vm)];
-    env.extend(node.env.iter().cloned());
-    let RoleProfile {
-        profile_id,
-        uid,
-        gid,
-        adr_carve_out,
-        caps,
-        namespaces,
-        seccomp_policy_ref,
-        mount_policy,
-        cgroup_placement,
-        user_namespace,
-        umask,
-    } = &node.profile;
-    Some(ResolvedRunnerIntent {
-        intent_id: intent_id_runner(&dag.vm, &node.id.0),
-        vm_name: dag.vm.clone(),
-        role_id: node.id.0.clone(),
-        role: node.role.clone(),
-        binary_path: PathBuf::from(binary_path),
-        argv,
-        env,
-        uid: *uid,
-        gid: *gid,
-        supplementary_groups: Vec::new(),
-        capabilities: caps.clone(),
-        namespaces: namespaces.clone(),
-        seccomp_policy_ref: seccomp_policy_ref.clone(),
-        mount_policy: mount_policy.clone(),
-        cgroup_placement: cgroup_placement.clone(),
-        root_carve_out: adr_carve_out.is_some(),
-        profile_id: profile_id.clone(),
-        user_namespace: user_namespace.map(|ns| UserNamespaceSpec {
-            host_uid_for_zero: ns.host_uid_for_zero,
-            host_gid_for_zero: ns.host_gid_for_zero,
-        }),
-        umask: *umask,
-    })
+    ResolvedRunnerIntent::from_process_node(&dag.vm, node)
 }
 
 fn role_tag_for(role: &crate::host::TapRole) -> String {

--- a/packages/nixling-core/src/lib.rs
+++ b/packages/nixling-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod manifest_v04;
 pub mod minijail_profile;
 pub mod privileges;
 pub mod privileges_w3;
+pub mod process_builder;
 pub mod processes;
 pub mod runtime;
 pub mod static_invariants;

--- a/packages/nixling-core/src/process_builder.rs
+++ b/packages/nixling-core/src/process_builder.rs
@@ -1,0 +1,276 @@
+use crate::processes::{
+    NodeId, ProcessNode, ProcessRole, ReadinessPredicate, RoleProfile, SpawnRunnerPlanOp,
+};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Pure builder for the existing serialized [`ProcessNode`] shape.
+#[derive(Debug, Clone)]
+pub struct ProcessNodeBuilder {
+    id: Option<NodeId>,
+    role: ProcessRole,
+    unit: Option<String>,
+    binary_path: Option<String>,
+    argv: Vec<String>,
+    env: Vec<String>,
+    plan_ops: Vec<SpawnRunnerPlanOp>,
+    profile: RoleProfile,
+    readiness: Vec<ReadinessPredicate>,
+}
+
+impl ProcessNodeBuilder {
+    pub fn new(role: ProcessRole, profile: RoleProfile) -> Self {
+        Self {
+            id: None,
+            role,
+            unit: None,
+            binary_path: None,
+            argv: Vec::new(),
+            env: Vec::new(),
+            plan_ops: Vec::new(),
+            profile,
+            readiness: Vec::new(),
+        }
+    }
+
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(NodeId(id.into()));
+        self
+    }
+
+    pub fn with_node_id(mut self, id: NodeId) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn with_unit(mut self, unit: impl Into<String>) -> Self {
+        self.unit = Some(unit.into());
+        self
+    }
+
+    pub fn with_binary_path(mut self, binary_path: impl Into<String>) -> Self {
+        self.binary_path = Some(binary_path.into());
+        self
+    }
+
+    pub fn with_argv(mut self, argv: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.argv = argv.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_arg(mut self, arg: impl Into<String>) -> Self {
+        self.argv.push(arg.into());
+        self
+    }
+
+    pub fn with_env(mut self, env: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.env = env.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_env_entry(mut self, entry: impl Into<String>) -> Self {
+        self.env.push(entry.into());
+        self
+    }
+
+    pub fn with_plan_ops(mut self, plan_ops: impl IntoIterator<Item = SpawnRunnerPlanOp>) -> Self {
+        self.plan_ops = plan_ops.into_iter().collect();
+        self
+    }
+
+    pub fn with_plan_op(mut self, plan_op: SpawnRunnerPlanOp) -> Self {
+        self.plan_ops.push(plan_op);
+        self
+    }
+
+    pub fn with_readiness(
+        mut self,
+        readiness: impl IntoIterator<Item = ReadinessPredicate>,
+    ) -> Self {
+        self.readiness = readiness.into_iter().collect();
+        self
+    }
+
+    pub fn with_readiness_predicate(mut self, readiness: ReadinessPredicate) -> Self {
+        self.readiness.push(readiness);
+        self
+    }
+
+    pub fn build(self) -> Result<ProcessNode, ProcessNodeBuildError> {
+        let id = self
+            .id
+            .ok_or_else(|| ProcessNodeBuildError::MissingNodeId {
+                role: self.role.clone(),
+            })?;
+        if id.0.is_empty() {
+            return Err(ProcessNodeBuildError::EmptyNodeId {
+                role: self.role.clone(),
+            });
+        }
+        if self.binary_path.is_some() && self.argv.is_empty() {
+            return Err(ProcessNodeBuildError::RunnerBinaryWithoutArgv {
+                node_id: id.0,
+                role: self.role,
+            });
+        }
+        if is_spawnable_runner_role(&self.role)
+            && self
+                .binary_path
+                .as_deref()
+                .is_some_and(|binary_path| !Path::new(binary_path).is_absolute())
+        {
+            return Err(ProcessNodeBuildError::RelativeRunnerBinaryPath {
+                node_id: id.0,
+                role: self.role,
+            });
+        }
+        for (idx, readiness) in self.readiness.iter().enumerate() {
+            if self.readiness[..idx].contains(readiness) {
+                return Err(ProcessNodeBuildError::DuplicateReadiness {
+                    node_id: id.0,
+                    role: self.role,
+                    readiness_kind: readiness_kind(readiness),
+                });
+            }
+        }
+        Ok(ProcessNode {
+            id,
+            role: self.role,
+            unit: self.unit,
+            binary_path: self.binary_path,
+            argv: self.argv,
+            env: self.env,
+            plan_ops: self.plan_ops,
+            profile: self.profile,
+            readiness: self.readiness,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessNodeBuildError {
+    MissingNodeId {
+        role: ProcessRole,
+    },
+    EmptyNodeId {
+        role: ProcessRole,
+    },
+    RunnerBinaryWithoutArgv {
+        node_id: String,
+        role: ProcessRole,
+    },
+    RelativeRunnerBinaryPath {
+        node_id: String,
+        role: ProcessRole,
+    },
+    DuplicateReadiness {
+        node_id: String,
+        role: ProcessRole,
+        readiness_kind: &'static str,
+    },
+}
+
+impl fmt::Display for ProcessNodeBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingNodeId { role } => {
+                write!(f, "process node for role {role:?} is missing an id")
+            }
+            Self::EmptyNodeId { role } => write!(f, "process node for role {role:?} has empty id"),
+            Self::RunnerBinaryWithoutArgv { node_id, role } => write!(
+                f,
+                "process node {node_id} for role {role:?} declares a binary without argv"
+            ),
+            Self::RelativeRunnerBinaryPath { node_id, role } => write!(
+                f,
+                "process node {node_id} for role {role:?} declares a non-absolute runner binary"
+            ),
+            Self::DuplicateReadiness {
+                node_id,
+                role,
+                readiness_kind,
+            } => write!(
+                f,
+                "process node {node_id} for role {role:?} has duplicate {readiness_kind} readiness"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProcessNodeBuildError {}
+
+pub fn readiness_api_socket_info(value: impl Into<String>) -> ReadinessPredicate {
+    ReadinessPredicate::ApiSocketInfo(value.into())
+}
+
+pub fn readiness_vsock_notify(value: impl Into<String>) -> ReadinessPredicate {
+    ReadinessPredicate::VsockNotify(value.into())
+}
+
+pub fn readiness_unix_socket_exists(path: impl Into<String>) -> ReadinessPredicate {
+    ReadinessPredicate::UnixSocketExists(path.into())
+}
+
+pub fn readiness_unix_socket_listening(path: impl Into<String>) -> ReadinessPredicate {
+    ReadinessPredicate::UnixSocketListening(path.into())
+}
+
+pub fn readiness_tcp_port(host: impl Into<String>, port: u16) -> ReadinessPredicate {
+    ReadinessPredicate::TcpPort {
+        host: host.into(),
+        port,
+    }
+}
+
+pub fn readiness_command(argv: impl IntoIterator<Item = impl Into<String>>) -> ReadinessPredicate {
+    ReadinessPredicate::Command(argv.into_iter().map(Into::into).collect())
+}
+
+pub fn readiness_component_specific(value: impl Into<String>) -> ReadinessPredicate {
+    ReadinessPredicate::ComponentSpecific(value.into())
+}
+
+pub fn readiness_guest_control_health(vm: impl Into<String>) -> ReadinessPredicate {
+    ReadinessPredicate::GuestControlHealth { vm: vm.into() }
+}
+
+pub fn disk_init_plan_op(
+    target_path: impl Into<PathBuf>,
+    size_bytes: u64,
+    mode: u32,
+    owner_uid: u32,
+    owner_gid: u32,
+    if_absent: bool,
+) -> SpawnRunnerPlanOp {
+    SpawnRunnerPlanOp::DiskInit {
+        target_path: target_path.into(),
+        size_bytes,
+        mode,
+        owner_uid,
+        owner_gid,
+        if_absent,
+    }
+}
+
+fn is_spawnable_runner_role(role: &ProcessRole) -> bool {
+    !matches!(
+        role,
+        ProcessRole::HostReconcile
+            | ProcessRole::StoreVirtiofsPreflight
+            | ProcessRole::GuestSshReadiness
+            | ProcessRole::GuestControlHealth
+    )
+}
+
+fn readiness_kind(readiness: &ReadinessPredicate) -> &'static str {
+    match readiness {
+        ReadinessPredicate::ApiSocketInfo(_) => "api-socket-info",
+        ReadinessPredicate::VsockNotify(_) => "vsock-notify",
+        ReadinessPredicate::UnixSocketExists(_) => "unix-socket-exists",
+        ReadinessPredicate::UnixSocketListening(_) => "unix-socket-listening",
+        ReadinessPredicate::TcpPort { .. } => "tcp-port",
+        ReadinessPredicate::Command(_) => "command",
+        ReadinessPredicate::ComponentSpecific(_) => "component-specific",
+        ReadinessPredicate::GuestControlHealth { .. } => "guest-control-health",
+    }
+}

--- a/packages/nixling-core/src/process_builder.rs
+++ b/packages/nixling-core/src/process_builder.rs
@@ -257,6 +257,7 @@ fn is_spawnable_runner_role(role: &ProcessRole) -> bool {
         role,
         ProcessRole::HostReconcile
             | ProcessRole::StoreVirtiofsPreflight
+            | ProcessRole::SwtpmPreStartFlush
             | ProcessRole::GuestSshReadiness
             | ProcessRole::GuestControlHealth
     )

--- a/packages/nixling-core/tests/bundle_resolver_runner_intent_parity.rs
+++ b/packages/nixling-core/tests/bundle_resolver_runner_intent_parity.rs
@@ -208,6 +208,19 @@ fn runner_nodes() -> Vec<ProcessNode> {
             &[],
         ),
         runner_node(
+            "vsock-relay",
+            ProcessRole::VsockRelay,
+            "/run/current-system/sw/bin/socat",
+            &[
+                "nixling-otel-relay@test-vm",
+                "-d",
+                "-d",
+                "UNIX-LISTEN:/var/lib/nixling/vms/test-vm/vsock.sock_14317,fork,max-children=16,reuseaddr,mode=0660",
+                "EXEC:/run/current-system/sw/bin/nixling-ch-vsock-connect /var/lib/nixling/vms/sys-obs/vsock.sock 14318",
+            ],
+            &[],
+        ),
+        runner_node(
             "usbip",
             ProcessRole::Usbip,
             "/run/current-system/sw/bin/nixling-usbip-proxy",
@@ -217,9 +230,15 @@ fn runner_nodes() -> Vec<ProcessNode> {
         runner_node(
             "otel-host-bridge",
             ProcessRole::OtelHostBridge,
-            "/run/current-system/sw/bin/nixling-otel-host-bridge",
-            &["nixling-otel-host-bridge", "--vm", VM],
-            &["OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"],
+            "/run/current-system/sw/bin/socat",
+            &[
+                "nixling-otel-host-bridge",
+                "-d",
+                "-d",
+                "UNIX-LISTEN:/run/nixling/otel/host-egress.sock,fork,reuseaddr,mode=0660",
+                "EXEC:\"/run/current-system/sw/bin/nixling-ch-vsock-connect /var/lib/nixling/vms/sys-obs/vsock.sock 14317\"",
+            ],
+            &[],
         ),
     ]
 }

--- a/packages/nixling-core/tests/bundle_resolver_runner_intent_parity.rs
+++ b/packages/nixling-core/tests/bundle_resolver_runner_intent_parity.rs
@@ -1,0 +1,259 @@
+#![forbid(unsafe_code)]
+
+use nixling_core::bundle::{Bundle, BundleGeneration};
+use nixling_core::bundle_resolver::{BundleResolver, ResolvedRunnerIntent};
+use nixling_core::host::HostJson;
+use nixling_core::manifest_v04::ManifestV04;
+use nixling_core::minijail_profile::{CgroupPlacement, MountPolicy, NamespaceSet};
+use nixling_core::process_builder::ProcessNodeBuilder;
+use nixling_core::processes::{
+    ProcessNode, ProcessRole, ProcessesJson, RoleProfile, RoleUserNamespace, VmProcessDag,
+    VmProcessInvariants,
+};
+
+const VM: &str = "test-vm";
+
+fn host() -> HostJson {
+    serde_json::from_value(serde_json::json!({
+        "schemaVersion": "v2",
+        "site": { "allowUnsafeEastWest": false },
+        "environments": [],
+        "nftables": {
+            "family": "inet",
+            "table": "nixling",
+            "chains": [],
+            "tableHashAfterApply": null,
+            "ownershipId": "test"
+        },
+        "networkManager": {
+            "filePath": "/etc/NetworkManager/conf.d/00-nixling-unmanaged.conf",
+            "matchCriteria": [],
+            "reloadBehavior": "atomic-reload",
+            "ownership": {
+                "owner": "root",
+                "group": "root",
+                "mode": "0644",
+                "driftPolicy": "replace"
+            }
+        },
+        "hostsFile": {
+            "startMarker": "# nixling-managed begin",
+            "endMarker": "# nixling-managed end",
+            "rule": "replace-managed-block"
+        },
+        "kernelModules": [],
+        "fdOwnership": [],
+        "runtimeProviders": [],
+        "vmRuntimes": [],
+        "cloudHypervisorCapabilities": [],
+        "ifNameMappings": [],
+        "qemuMedia": null,
+        "ch": null,
+        "firewallCoexistencePolicy": null
+    }))
+    .expect("host fixture parses")
+}
+
+fn manifest() -> ManifestV04 {
+    ManifestV04::from_slice(
+        serde_json::to_vec(&serde_json::json!({
+            "_manifest": { "manifestVersion": 6 },
+            "_observability": {
+                "enabled": false,
+                "signozUrl": "http://127.0.0.1:8080",
+                "signozOtlpGrpcPort": 4317,
+                "signozOtlpHttpPort": 4318,
+                "obsVsockCid": 0,
+                "obsVsockHostSocket": "",
+                "vmName": ""
+            }
+        }))
+        .expect("manifest json serializes")
+        .as_slice(),
+    )
+    .expect("manifest fixture parses")
+}
+
+fn bundle() -> Bundle {
+    Bundle {
+        bundle_version: 4,
+        schema_version: "v2".to_owned(),
+        public_manifest_path: "vms.json".to_owned(),
+        host_path: "host.json".to_owned(),
+        processes_path: "processes.json".to_owned(),
+        privileges_path: "privileges.json".to_owned(),
+        storage_path: None,
+        sync_path: None,
+        closures: Vec::new(),
+        minijail_profiles: Vec::new(),
+        managed_keys: Default::default(),
+        generation: BundleGeneration {
+            generator: "test".to_owned(),
+            source_revision: None,
+            generated_at: None,
+        },
+        bundle_hash: None,
+        artifact_hashes: None,
+    }
+}
+
+fn profile(role_id: &str) -> RoleProfile {
+    RoleProfile {
+        profile_id: format!("profile-{role_id}"),
+        uid: 60_100,
+        gid: 60_100,
+        adr_carve_out: None,
+        caps: vec![],
+        namespaces: NamespaceSet {
+            mount: true,
+            pid: false,
+            net: role_id == "audio",
+            ipc: false,
+            uts: false,
+            user: matches!(role_id, "virtiofsd" | "swtpm" | "gpu" | "audio" | "video"),
+        },
+        seccomp_policy_ref: Some(format!("policy-{role_id}")),
+        mount_policy: MountPolicy {
+            read_only_paths: vec!["/nix/store".to_owned()],
+            writable_paths: vec![],
+            nix_store_read_only: true,
+            hide_device_nodes_by_default: true,
+            device_binds: vec![],
+            bind_mounts: vec![],
+        },
+        cgroup_placement: CgroupPlacement {
+            subtree: format!("nixling.slice/{VM}/{role_id}"),
+            controllers: vec!["cpu".to_owned(), "memory".to_owned()],
+            delegated: false,
+        },
+        user_namespace: matches!(role_id, "virtiofsd" | "swtpm" | "gpu" | "audio" | "video")
+            .then_some(RoleUserNamespace {
+                host_uid_for_zero: 60_100,
+                host_gid_for_zero: 60_100,
+            }),
+        umask: Some(0o007),
+    }
+}
+
+fn runner_node(
+    id: &str,
+    role: ProcessRole,
+    binary_path: &str,
+    argv: &[&str],
+    env: &[&str],
+) -> ProcessNode {
+    ProcessNodeBuilder::new(role, profile(id))
+        .with_id(id)
+        .with_binary_path(binary_path)
+        .with_argv(argv.iter().copied())
+        .with_env(env.iter().copied())
+        .build()
+        .expect("runner node fixture builds")
+}
+
+fn runner_nodes() -> Vec<ProcessNode> {
+    vec![
+        runner_node(
+            "cloud-hypervisor",
+            ProcessRole::CloudHypervisorRunner,
+            "/run/current-system/sw/bin/cloud-hypervisor",
+            &["microvm@test-vm"],
+            &[],
+        ),
+        runner_node(
+            "virtiofsd",
+            ProcessRole::Virtiofsd,
+            "/run/current-system/sw/bin/virtiofsd",
+            &["microvm-virtiofsd@test-vm"],
+            &[],
+        ),
+        runner_node(
+            "swtpm",
+            ProcessRole::Swtpm,
+            "/run/current-system/sw/bin/swtpm",
+            &["microvm-swtpm@test-vm"],
+            &[],
+        ),
+        runner_node(
+            "gpu",
+            ProcessRole::Gpu,
+            "/run/current-system/sw/bin/crosvm",
+            &["nixling-test-vm-gpu"],
+            &["XDG_RUNTIME_DIR=/run/nixling/test-vm/gpu"],
+        ),
+        runner_node(
+            "audio",
+            ProcessRole::Audio,
+            "/run/current-system/sw/bin/vhost-device-sound",
+            &["nixling-test-vm-snd"],
+            &["PIPEWIRE_RUNTIME_DIR=/run/nixling/test-vm/audio"],
+        ),
+        runner_node(
+            "video",
+            ProcessRole::Video,
+            "/run/current-system/sw/bin/crosvm",
+            &["nixling-test-vm-video"],
+            &["XDG_RUNTIME_DIR=/run/nixling/test-vm/video"],
+        ),
+        runner_node(
+            "qemu-media",
+            ProcessRole::QemuMediaRunner,
+            "/run/current-system/sw/bin/qemu-system-x86_64",
+            &[
+                "qemu-system-x86_64",
+                "-S",
+                "-qmp",
+                "unix:/run/nixling/qmp.sock",
+            ],
+            &[],
+        ),
+        runner_node(
+            "usbip",
+            ProcessRole::Usbip,
+            "/run/current-system/sw/bin/nixling-usbip-proxy",
+            &["nixling-usbip-proxy", "--vm", VM],
+            &[],
+        ),
+        runner_node(
+            "otel-host-bridge",
+            ProcessRole::OtelHostBridge,
+            "/run/current-system/sw/bin/nixling-otel-host-bridge",
+            &["nixling-otel-host-bridge", "--vm", VM],
+            &["OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317"],
+        ),
+    ]
+}
+
+#[test]
+fn bundle_resolver_runner_intents_match_typed_process_node_helper_for_runner_roles() {
+    let nodes = runner_nodes();
+    let processes = ProcessesJson {
+        schema_version: "v2".to_owned(),
+        vms: vec![VmProcessDag {
+            vm: VM.to_owned(),
+            nodes: nodes.clone(),
+            edges: Vec::new(),
+            invariants: VmProcessInvariants {
+                swtpm_pre_start_flush: false,
+                per_vm_audit_pipeline: false,
+                usbip_gating: true,
+                tpm_ownership_migration_without_running_vm_mutation: true,
+            },
+        }],
+    };
+    let resolver = BundleResolver::from_artifacts(bundle(), host(), processes, manifest());
+
+    for node in &nodes {
+        let expected = ResolvedRunnerIntent::from_process_node(VM, node)
+            .expect("spawnable role resolves through helper");
+        let actual = resolver
+            .find_runner_intent(&expected.intent_id)
+            .expect("resolver exposes helper-derived runner intent");
+        assert_eq!(
+            actual, &expected,
+            "runner intent parity for {:?}",
+            node.role
+        );
+    }
+    assert_eq!(resolver.runner_intent_ids().count(), nodes.len());
+}

--- a/packages/nixling-core/tests/process_builder.rs
+++ b/packages/nixling-core/tests/process_builder.rs
@@ -158,6 +158,21 @@ fn process_builder_validation_uses_stable_identifiers_only() {
 }
 
 #[test]
+fn pre_start_hooks_are_not_long_lived_spawnable_runners() {
+    let node = ProcessNodeBuilder::new(ProcessRole::SwtpmPreStartFlush, profile())
+        .with_id("swtpm-flush")
+        .with_binary_path("relative/pre-start-helper")
+        .with_argv(["nixling-swtpm-flush@test-vm"])
+        .build()
+        .expect("pre-start hooks are not validated as long-lived spawnable runners");
+    assert_eq!(node.role, ProcessRole::SwtpmPreStartFlush);
+    assert_eq!(
+        node.binary_path.as_deref(),
+        Some("relative/pre-start-helper")
+    );
+}
+
+#[test]
 fn process_builder_rejects_empty_argv_and_duplicate_readiness() {
     let err = ProcessNodeBuilder::new(ProcessRole::Swtpm, profile())
         .with_id("swtpm")

--- a/packages/nixling-core/tests/process_builder.rs
+++ b/packages/nixling-core/tests/process_builder.rs
@@ -1,0 +1,189 @@
+#![forbid(unsafe_code)]
+
+use nixling_core::minijail_profile::{CgroupPlacement, MountPolicy, NamespaceSet};
+use nixling_core::process_builder::{
+    ProcessNodeBuildError, ProcessNodeBuilder, disk_init_plan_op, readiness_api_socket_info,
+    readiness_command, readiness_guest_control_health, readiness_tcp_port,
+    readiness_unix_socket_exists,
+};
+use nixling_core::processes::{ProcessRole, ReadinessPredicate, RoleProfile, SpawnRunnerPlanOp};
+
+fn profile() -> RoleProfile {
+    RoleProfile {
+        profile_id: "profile-test".to_owned(),
+        uid: 60_100,
+        gid: 60_100,
+        adr_carve_out: None,
+        caps: vec![],
+        namespaces: NamespaceSet {
+            mount: true,
+            pid: false,
+            net: false,
+            ipc: false,
+            uts: false,
+            user: false,
+        },
+        seccomp_policy_ref: Some("test-policy".to_owned()),
+        mount_policy: MountPolicy {
+            read_only_paths: vec!["/nix/store".to_owned()],
+            writable_paths: vec![],
+            nix_store_read_only: true,
+            hide_device_nodes_by_default: true,
+            device_binds: vec![],
+            bind_mounts: vec![],
+        },
+        cgroup_placement: CgroupPlacement {
+            subtree: "nixling.slice/test-vm/cloud-hypervisor".to_owned(),
+            controllers: vec!["cpu".to_owned(), "memory".to_owned()],
+            delegated: false,
+        },
+        user_namespace: None,
+        umask: Some(0o077),
+    }
+}
+
+#[test]
+fn process_builder_constructs_existing_process_node_shape() {
+    let disk_op = disk_init_plan_op(
+        "/var/lib/nixling/vms/test-vm/disk.img",
+        1024 * 1024,
+        0o600,
+        60_100,
+        60_100,
+        true,
+    );
+    let node = ProcessNodeBuilder::new(ProcessRole::CloudHypervisorRunner, profile())
+        .with_id("cloud-hypervisor")
+        .with_unit("nixlingd.service")
+        .with_binary_path("/run/current-system/sw/bin/cloud-hypervisor")
+        .with_argv(["microvm@test-vm", "--api-socket", "/run/nixling/ch.sock"])
+        .with_env(["NIXLING_TEST=1"])
+        .with_plan_op(disk_op.clone())
+        .with_readiness_predicate(readiness_api_socket_info("cloud-hypervisor"))
+        .build()
+        .expect("builder accepts complete runner node");
+
+    assert_eq!(node.id.0, "cloud-hypervisor");
+    assert_eq!(node.role, ProcessRole::CloudHypervisorRunner);
+    assert_eq!(node.unit.as_deref(), Some("nixlingd.service"));
+    assert_eq!(
+        node.binary_path.as_deref(),
+        Some("/run/current-system/sw/bin/cloud-hypervisor")
+    );
+    assert_eq!(node.argv[0], "microvm@test-vm");
+    assert_eq!(node.env, ["NIXLING_TEST=1"]);
+    assert_eq!(node.plan_ops, [disk_op]);
+    assert_eq!(
+        node.readiness,
+        [ReadinessPredicate::ApiSocketInfo(
+            "cloud-hypervisor".to_owned()
+        )]
+    );
+
+    let json = serde_json::to_value(&node).expect("node serializes");
+    assert!(json.get("id").is_some());
+    assert!(json.get("role").is_some());
+    assert!(json.get("binaryPath").is_some());
+    assert!(json.get("planOps").is_some());
+    assert!(json.get("readiness").is_some());
+    assert!(json.get("builder").is_none());
+}
+
+#[test]
+fn readiness_and_disk_init_helpers_emit_existing_variants() {
+    assert_eq!(
+        readiness_tcp_port("127.0.0.1", 22),
+        ReadinessPredicate::TcpPort {
+            host: "127.0.0.1".to_owned(),
+            port: 22
+        }
+    );
+    assert_eq!(
+        readiness_unix_socket_exists("/run/nixling/test.sock"),
+        ReadinessPredicate::UnixSocketExists("/run/nixling/test.sock".to_owned())
+    );
+    assert_eq!(
+        readiness_command(["/run/current-system/sw/bin/true"]),
+        ReadinessPredicate::Command(vec!["/run/current-system/sw/bin/true".to_owned()])
+    );
+    assert_eq!(
+        readiness_guest_control_health("test-vm"),
+        ReadinessPredicate::GuestControlHealth {
+            vm: "test-vm".to_owned()
+        }
+    );
+
+    assert_eq!(
+        disk_init_plan_op(
+            "/var/lib/nixling/vms/test-vm/root.img",
+            4096,
+            0o600,
+            1,
+            2,
+            true
+        ),
+        SpawnRunnerPlanOp::DiskInit {
+            target_path: "/var/lib/nixling/vms/test-vm/root.img".into(),
+            size_bytes: 4096,
+            mode: 0o600,
+            owner_uid: 1,
+            owner_gid: 2,
+            if_absent: true,
+        }
+    );
+}
+
+#[test]
+fn process_builder_validation_uses_stable_identifiers_only() {
+    let err = ProcessNodeBuilder::new(ProcessRole::CloudHypervisorRunner, profile())
+        .with_id("cloud-hypervisor")
+        .with_binary_path("relative/secret-runner")
+        .with_argv(["--token=secret"])
+        .with_env(["SECRET_ENV=value"])
+        .build()
+        .expect_err("relative runner binary is rejected");
+    assert_eq!(
+        err,
+        ProcessNodeBuildError::RelativeRunnerBinaryPath {
+            node_id: "cloud-hypervisor".to_owned(),
+            role: ProcessRole::CloudHypervisorRunner,
+        }
+    );
+    let message = err.to_string();
+    assert!(message.contains("cloud-hypervisor"));
+    assert!(message.contains("CloudHypervisorRunner"));
+    assert!(!message.contains("relative/secret-runner"));
+    assert!(!message.contains("--token=secret"));
+    assert!(!message.contains("SECRET_ENV"));
+}
+
+#[test]
+fn process_builder_rejects_empty_argv_and_duplicate_readiness() {
+    let err = ProcessNodeBuilder::new(ProcessRole::Swtpm, profile())
+        .with_id("swtpm")
+        .with_binary_path("/run/current-system/sw/bin/swtpm")
+        .build()
+        .expect_err("binary without argv is rejected");
+    assert_eq!(
+        err,
+        ProcessNodeBuildError::RunnerBinaryWithoutArgv {
+            node_id: "swtpm".to_owned(),
+            role: ProcessRole::Swtpm,
+        }
+    );
+
+    let err = ProcessNodeBuilder::new(ProcessRole::GuestControlHealth, profile())
+        .with_id("guest-control-health")
+        .with_readiness_predicate(readiness_guest_control_health("test-vm"))
+        .with_readiness_predicate(readiness_guest_control_health("test-vm"))
+        .build()
+        .expect_err("duplicate readiness is rejected");
+    assert_eq!(
+        err,
+        ProcessNodeBuildError::DuplicateReadiness {
+            node_id: "guest-control-health".to_owned(),
+            role: ProcessRole::GuestControlHealth,
+            readiness_kind: "guest-control-health",
+        }
+    );
+}

--- a/packages/nixling-exec-runner/src/service_mode.rs
+++ b/packages/nixling-exec-runner/src/service_mode.rs
@@ -1796,7 +1796,7 @@ ControlGroup=/nixling.slice/nixling-exec.slice/nixling-exec-03.service
         // The bounded drain wait must let supervise return promptly even though
         // the pipe write-end is still held open.
         assert!(
-            start.elapsed() < Duration::from_secs(5),
+            start.elapsed() < Duration::from_secs(30),
             "supervise hung on a lingering pipe holder"
         );
         assert_eq!(result, RunnerResult::Done);

--- a/packages/nixling-host/src/lib.rs
+++ b/packages/nixling-host/src/lib.rs
@@ -36,6 +36,8 @@ pub mod routes;
 pub mod seccomp;
 // Runner-shape preflight + CH net-handoff probe.
 pub mod runner_shape;
+// Static runner lifecycle metadata used by host-side argv dispatch.
+pub mod runner_process;
 // Pure CH argv generator. Consumed by nixlingd via the SpawnRunner
 // broker wire.
 pub mod ch_argv;

--- a/packages/nixling-host/src/runner_argv_regenerator.rs
+++ b/packages/nixling-host/src/runner_argv_regenerator.rs
@@ -45,6 +45,7 @@ use crate::ch_argv::{ChArgvInput, generate_ch_argv};
 use crate::gpu_argv::{GpuArgvInput, generate_gpu_argv};
 use crate::otel_host_bridge_argv::{OtelHostBridgeArgvInputs, generate_otel_host_bridge_argv};
 use crate::qemu_media_argv::{QemuMediaArgvInput, generate_qemu_media_argv};
+use crate::runner_process::runner_process_metadata;
 use crate::swtpm_argv::{SwtpmArgvInput, generate_swtpm_argv};
 use crate::usbip_argv::{UsbipArgvInput, UsbipSubcommand, generate_usbip_argv};
 use crate::video_argv::{VideoArgvInput, generate_video_argv};
@@ -132,6 +133,11 @@ pub fn regenerate_argv(
     intent: &ResolvedRunnerIntent,
     extra: &RunnerArgvExtra,
 ) -> Result<Vec<String>, RegenerateArgvError> {
+    let metadata = runner_process_metadata(&intent.role);
+    if !metadata.regenerator_wired() {
+        return Err(RegenerateArgvError::NotYetWired(intent.role.clone()));
+    }
+
     match &intent.role {
         ProcessRole::CloudHypervisorRunner => {
             let ch_input = require(&extra.ch_input, &intent.role, "ch_input")?;
@@ -209,18 +215,14 @@ pub fn regenerate_argv(
             replace_arg0(&mut argv, intent);
             Ok(argv)
         }
-        // Roles handled by other dispatch surfaces (readiness probes,
-        // pre-start hooks). The regenerator does not own these.
         ProcessRole::HostReconcile
         | ProcessRole::StoreVirtiofsPreflight
         | ProcessRole::GuestSshReadiness
         | ProcessRole::GuestControlHealth
-        | ProcessRole::SwtpmPreStartFlush => {
-            Err(RegenerateArgvError::NotYetWired(intent.role.clone()))
+        | ProcessRole::SwtpmPreStartFlush
+        | ProcessRole::WaylandProxy => {
+            unreachable!("non-wired runner role should be returned before generator dispatch")
         }
-        // WaylandProxy: argv regeneration wired in Wave 2 / Lane A when the
-        // nixling-wayland-filter binary is added to the workspace.
-        ProcessRole::WaylandProxy => Err(RegenerateArgvError::NotYetWired(intent.role.clone())),
     }
 }
 
@@ -254,6 +256,37 @@ fn require<'a, T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runner_process::{RUNNER_PROCESS_MATRIX, RegeneratorWiring};
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ExpectedRegeneratorClassification {
+        MissingInput,
+        NotYetWired,
+    }
+
+    fn expected_regenerator_classification(
+        role: &ProcessRole,
+    ) -> ExpectedRegeneratorClassification {
+        match role {
+            ProcessRole::CloudHypervisorRunner
+            | ProcessRole::Virtiofsd
+            | ProcessRole::QemuMediaRunner
+            | ProcessRole::Swtpm
+            | ProcessRole::Gpu
+            | ProcessRole::GpuRenderNode
+            | ProcessRole::Audio
+            | ProcessRole::Video
+            | ProcessRole::VsockRelay
+            | ProcessRole::OtelHostBridge
+            | ProcessRole::Usbip => ExpectedRegeneratorClassification::MissingInput,
+            ProcessRole::HostReconcile
+            | ProcessRole::StoreVirtiofsPreflight
+            | ProcessRole::GuestSshReadiness
+            | ProcessRole::GuestControlHealth
+            | ProcessRole::SwtpmPreStartFlush
+            | ProcessRole::WaylandProxy => ExpectedRegeneratorClassification::NotYetWired,
+        }
+    }
 
     fn fake_intent(role: ProcessRole) -> ResolvedRunnerIntent {
         nixling_core::test_support::ResolvedRunnerIntentBuilder::new()
@@ -287,43 +320,63 @@ mod tests {
     }
 
     #[test]
-    fn all_wired_roles_return_missing_input_without_extras() {
-        // After v1.1.1 wires every role's regenerator, the
-        // dispatcher returns MissingInput when the caller doesn't
-        // provide the per-role input record.
-        for role in [
-            ProcessRole::Virtiofsd,
-            ProcessRole::Swtpm,
-            ProcessRole::Gpu,
-            ProcessRole::Audio,
-            ProcessRole::Video,
-            ProcessRole::VsockRelay,
-            ProcessRole::Usbip,
-        ] {
-            let intent = fake_intent(role.clone());
+    fn matrix_classification_matches_pre_matrix_dispatcher() {
+        for row in RUNNER_PROCESS_MATRIX {
+            let intent = fake_intent(row.role.clone());
             let err = regenerate_argv(&intent, &RunnerArgvExtra::default()).unwrap_err();
-            assert!(
-                matches!(err, RegenerateArgvError::MissingInput { ref role, .. } if role == &intent.role),
-                "expected MissingInput({role:?}, ...), got {err:?}"
+            let actual = match err {
+                RegenerateArgvError::MissingInput { .. } => {
+                    ExpectedRegeneratorClassification::MissingInput
+                }
+                RegenerateArgvError::NotYetWired(_) => {
+                    ExpectedRegeneratorClassification::NotYetWired
+                }
+                RegenerateArgvError::Generator(_) => {
+                    panic!(
+                        "generator should not run without typed inputs for {:?}",
+                        row.role
+                    )
+                }
+            };
+            assert_eq!(
+                actual,
+                expected_regenerator_classification(&row.role),
+                "classification changed for {:?}",
+                row.role
             );
         }
     }
 
     #[test]
-    fn readiness_only_roles_return_not_yet_wired() {
-        // Pure readiness / pre-start roles aren't dispatchable
-        // through the regenerator; they live on other surfaces.
-        for role in [
-            ProcessRole::HostReconcile,
-            ProcessRole::StoreVirtiofsPreflight,
-            ProcessRole::GuestSshReadiness,
-            ProcessRole::SwtpmPreStartFlush,
-        ] {
-            let intent = fake_intent(role.clone());
+    fn matrix_wired_roles_keep_missing_input_classification_without_extras() {
+        for row in RUNNER_PROCESS_MATRIX {
+            if row.regenerator_wiring != RegeneratorWiring::Wired {
+                continue;
+            }
+
+            let intent = fake_intent(row.role.clone());
             let err = regenerate_argv(&intent, &RunnerArgvExtra::default()).unwrap_err();
             assert!(
-                matches!(err, RegenerateArgvError::NotYetWired(ref r) if r == &role),
-                "expected NotYetWired({role:?}), got {err:?}"
+                matches!(err, RegenerateArgvError::MissingInput { ref role, .. } if role == &intent.role),
+                "expected MissingInput for wired role {:?}, got {err:?}",
+                row.role
+            );
+        }
+    }
+
+    #[test]
+    fn matrix_not_yet_wired_roles_keep_not_yet_wired_classification() {
+        for row in RUNNER_PROCESS_MATRIX {
+            if row.regenerator_wiring != RegeneratorWiring::NotYetWired {
+                continue;
+            }
+
+            let intent = fake_intent(row.role.clone());
+            let err = regenerate_argv(&intent, &RunnerArgvExtra::default()).unwrap_err();
+            assert!(
+                matches!(err, RegenerateArgvError::NotYetWired(ref role) if role == &row.role),
+                "expected NotYetWired for non-wired role {:?}, got {err:?}",
+                row.role
             );
         }
     }

--- a/packages/nixling-host/src/runner_process.rs
+++ b/packages/nixling-host/src/runner_process.rs
@@ -1,0 +1,287 @@
+//! Runner process lifecycle metadata for host-side argv generation.
+//!
+//! The table in this module is metadata only: it does not carry argv,
+//! environment, QMP, fd, or path data. Per-role generators remain the
+//! source of truth for command construction.
+
+use nixling_core::processes::ProcessRole;
+
+/// High-level lifecycle bucket for a process role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerLifecycleClass {
+    /// Long-lived runner/sidecar spawned through broker SpawnRunner.
+    Spawnable,
+    /// Readiness probe that does not own a long-lived runner argv.
+    ReadinessOnly,
+    /// Pre-start hook executed before its long-lived sidecar.
+    PreStart,
+    /// Host reconciliation step rather than a spawnable runner.
+    HostReconcile,
+}
+
+impl RunnerLifecycleClass {
+    pub const fn is_spawnable(self) -> bool {
+        matches!(self, Self::Spawnable)
+    }
+}
+
+/// Current regenerator wiring state for a role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegeneratorWiring {
+    /// `runner_argv_regenerator` invokes this role's typed generator.
+    Wired,
+    /// The role is intentionally classified but not dispatched by the
+    /// regenerator yet.
+    NotYetWired,
+}
+
+/// Static, non-sensitive metadata for one [`ProcessRole`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerProcessMetadata {
+    pub role: ProcessRole,
+    pub lifecycle: RunnerLifecycleClass,
+    pub argv_generator_module: Option<&'static str>,
+    pub test_coverage_label: &'static str,
+    pub regenerator_wiring: RegeneratorWiring,
+}
+
+impl RunnerProcessMetadata {
+    pub const fn spawnable(&self) -> bool {
+        self.lifecycle.is_spawnable()
+    }
+
+    pub const fn regenerator_wired(&self) -> bool {
+        matches!(self.regenerator_wiring, RegeneratorWiring::Wired)
+    }
+}
+
+use ProcessRole::*;
+
+/// One metadata row for every current process role.
+pub const RUNNER_PROCESS_MATRIX: &[RunnerProcessMetadata] = &[
+    row(
+        HostReconcile,
+        RunnerLifecycleClass::HostReconcile,
+        None,
+        "runner_process::host_reconcile",
+        RegeneratorWiring::NotYetWired,
+    ),
+    row(
+        StoreVirtiofsPreflight,
+        RunnerLifecycleClass::ReadinessOnly,
+        None,
+        "runner_process::store_virtiofs_preflight",
+        RegeneratorWiring::NotYetWired,
+    ),
+    row(
+        SwtpmPreStartFlush,
+        RunnerLifecycleClass::PreStart,
+        None,
+        "runner_process::swtpm_pre_start_flush",
+        RegeneratorWiring::NotYetWired,
+    ),
+    row(
+        Swtpm,
+        RunnerLifecycleClass::Spawnable,
+        Some("swtpm_argv"),
+        "swtpm_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        Virtiofsd,
+        RunnerLifecycleClass::Spawnable,
+        Some("virtiofsd_argv"),
+        "virtiofsd_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        Video,
+        RunnerLifecycleClass::Spawnable,
+        Some("video_argv"),
+        "video_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        Gpu,
+        RunnerLifecycleClass::Spawnable,
+        Some("gpu_argv"),
+        "gpu_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        GpuRenderNode,
+        RunnerLifecycleClass::Spawnable,
+        Some("gpu_argv"),
+        "gpu_argv::render_node",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        Audio,
+        RunnerLifecycleClass::Spawnable,
+        Some("audio_argv"),
+        "audio_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        CloudHypervisorRunner,
+        RunnerLifecycleClass::Spawnable,
+        Some("ch_argv"),
+        "ch_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        QemuMediaRunner,
+        RunnerLifecycleClass::Spawnable,
+        Some("qemu_media_argv"),
+        "qemu_media_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        VsockRelay,
+        RunnerLifecycleClass::Spawnable,
+        Some("vsock_relay_argv"),
+        "vsock_relay_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        OtelHostBridge,
+        RunnerLifecycleClass::Spawnable,
+        Some("otel_host_bridge_argv"),
+        "otel_host_bridge_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        GuestSshReadiness,
+        RunnerLifecycleClass::ReadinessOnly,
+        None,
+        "runner_process::guest_ssh_readiness",
+        RegeneratorWiring::NotYetWired,
+    ),
+    row(
+        GuestControlHealth,
+        RunnerLifecycleClass::ReadinessOnly,
+        None,
+        "runner_process::guest_control_health",
+        RegeneratorWiring::NotYetWired,
+    ),
+    row(
+        Usbip,
+        RunnerLifecycleClass::Spawnable,
+        Some("usbip_argv"),
+        "usbip_argv",
+        RegeneratorWiring::Wired,
+    ),
+    row(
+        WaylandProxy,
+        RunnerLifecycleClass::Spawnable,
+        Some("wayland_proxy_argv"),
+        "wayland_proxy_argv",
+        RegeneratorWiring::NotYetWired,
+    ),
+];
+
+const fn row(
+    role: ProcessRole,
+    lifecycle: RunnerLifecycleClass,
+    argv_generator_module: Option<&'static str>,
+    test_coverage_label: &'static str,
+    regenerator_wiring: RegeneratorWiring,
+) -> RunnerProcessMetadata {
+    RunnerProcessMetadata {
+        role,
+        lifecycle,
+        argv_generator_module,
+        test_coverage_label,
+        regenerator_wiring,
+    }
+}
+
+/// Exhaustive role-to-metadata lookup. Adding a new [`ProcessRole`] must update
+/// this match and [`RUNNER_PROCESS_MATRIX`].
+pub const fn runner_process_metadata(role: &ProcessRole) -> &'static RunnerProcessMetadata {
+    match role {
+        HostReconcile => &RUNNER_PROCESS_MATRIX[0],
+        StoreVirtiofsPreflight => &RUNNER_PROCESS_MATRIX[1],
+        SwtpmPreStartFlush => &RUNNER_PROCESS_MATRIX[2],
+        Swtpm => &RUNNER_PROCESS_MATRIX[3],
+        Virtiofsd => &RUNNER_PROCESS_MATRIX[4],
+        Video => &RUNNER_PROCESS_MATRIX[5],
+        Gpu => &RUNNER_PROCESS_MATRIX[6],
+        GpuRenderNode => &RUNNER_PROCESS_MATRIX[7],
+        Audio => &RUNNER_PROCESS_MATRIX[8],
+        CloudHypervisorRunner => &RUNNER_PROCESS_MATRIX[9],
+        QemuMediaRunner => &RUNNER_PROCESS_MATRIX[10],
+        VsockRelay => &RUNNER_PROCESS_MATRIX[11],
+        OtelHostBridge => &RUNNER_PROCESS_MATRIX[12],
+        GuestSshReadiness => &RUNNER_PROCESS_MATRIX[13],
+        GuestControlHealth => &RUNNER_PROCESS_MATRIX[14],
+        Usbip => &RUNNER_PROCESS_MATRIX[15],
+        WaylandProxy => &RUNNER_PROCESS_MATRIX[16],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_ROLES: &[ProcessRole] = &[
+        HostReconcile,
+        StoreVirtiofsPreflight,
+        SwtpmPreStartFlush,
+        Swtpm,
+        Virtiofsd,
+        Video,
+        Gpu,
+        GpuRenderNode,
+        Audio,
+        CloudHypervisorRunner,
+        QemuMediaRunner,
+        VsockRelay,
+        OtelHostBridge,
+        GuestSshReadiness,
+        GuestControlHealth,
+        Usbip,
+        WaylandProxy,
+    ];
+
+    #[test]
+    fn runner_process_matrix_has_one_row_for_every_process_role() {
+        assert_eq!(RUNNER_PROCESS_MATRIX.len(), ALL_ROLES.len());
+        for role in ALL_ROLES {
+            let rows = RUNNER_PROCESS_MATRIX
+                .iter()
+                .filter(|row| &row.role == role)
+                .count();
+            assert_eq!(rows, 1, "expected exactly one matrix row for {role:?}");
+            assert_eq!(runner_process_metadata(role).role, *role);
+        }
+    }
+
+    #[test]
+    fn runner_process_matrix_names_generator_and_test_labels() {
+        for row in RUNNER_PROCESS_MATRIX {
+            assert!(
+                !row.test_coverage_label.is_empty(),
+                "missing test label for {:?}",
+                row.role
+            );
+            if row.spawnable() {
+                assert!(
+                    row.argv_generator_module.is_some(),
+                    "spawnable role {:?} needs generator ownership",
+                    row.role
+                );
+            } else {
+                assert!(
+                    row.argv_generator_module.is_none(),
+                    "non-spawnable role {:?} should not name argv owner",
+                    row.role
+                );
+            }
+        }
+
+        let qemu = runner_process_metadata(&QemuMediaRunner);
+        assert_eq!(qemu.argv_generator_module, Some("qemu_media_argv"));
+        assert_eq!(qemu.test_coverage_label, "qemu_media_argv");
+    }
+}


### PR DESCRIPTION
## Summary

- Add a typed `ProcessNodeBuilder` for the existing process DAG node shape.
- Centralize runner intent conversion via `ResolvedRunnerIntent::from_process_node`.
- Add a host-side runner process lifecycle matrix and use it in argv regenerator classification.
- Refactor `processes-json.nix` to use local process-node/runner-node helpers without changing the process graph contract.
- Add policy coverage requiring every `ProcessRole` to be classified and runner roles to have argv-builder/test coverage.

## Panel review

- Wave 5 plan panel: full Gemini 3.1 Pro panel signed off 10/10 after observability findings were addressed.
- Wave 5 implementation panel: full Gemini 3.1 Pro panel ran multiple rounds and signed off 10/10 on the final diff.

## Validation

- [x] Focused core process builder and bundle resolver runner-intent tests
- [x] Focused host runner matrix / argv regenerator / qemu-media argv tests
- [x] Focused runner role coverage policy test
- [x] Normalized before/after `processes.json` equivalence for fixture-smoke and fixture-smoke-full
- [x] `scripts/changelog-check.sh`
- [x] `git diff --check origin/main..HEAD`
- [x] `make test-rust`
- [x] `make test-drift`
- [x] `make test-flake`
- [x] `make check`
- [x] `make test-integration`
- [x] `make test-host-integration`
- [x] `make test-hardware` N/A: no graphics/GPU/video decode/USBIP hardware/hardware TPM behavior change

## Working-state proof

This wave leaves the service working: generated artifacts remain drift-clean, normalized process graphs are byte-equivalent modulo rebuilt `/nix/store/<hash>` closure paths, runner intent conversion has parity coverage including observability runners, and no broker/daemon runtime or public wire behavior changed.
