### PR TITLE
host: preserve safe runtime parent ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Daemon-native runtime parent directories under `/run/nixling/vms`,
+  `/run/nixling-gpu`, `/run/nixling-video`, and `/run/nixling-wlproxy`
+  are root-owned again while preserving daemon-owned per-VM leaves, so
+  broker path-safety checks no longer reject VM starts after a host switch.
 - `nixlingd.service` now reports systemd readiness only after the daemon has
   rebound its public socket and completed startup adoption, so post-switch
   scripts no longer race `/run/nixling/public.sock`; daemon updates may restart

--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -111,6 +111,13 @@ EOF
   tmpfilesAcl = path: acl: [
     "a+ ${path} - - - - ${acl}"
   ];
+  runtimeAclMask = path: [
+    "a+ ${path} - - - - m::rwx"
+    "a+ ${path} - - - - default:m::rwx"
+  ];
+  runtimeAclUser = path: principal: perms: tmpfilesAcl path "u:${principal}:${perms}";
+  runtimeDefaultAclUser = path: principal: perms: tmpfilesAcl path "default:u:${principal}:${perms}";
+  stablePrincipal = principal: toString (nl.stablePrincipalId principal);
   perVmNamedStateTraversalAcls = lib.concatLists [
     (lib.concatLists (lib.mapAttrsToList (name: _: tmpfilesAcl "/var/lib/nixling" "u:nixling-${name}-gpu:--x")
       (lib.filterAttrs (_: vm: vm.graphics.enable) normalNixosVms)))
@@ -125,21 +132,76 @@ EOF
     (lib.concatLists (lib.mapAttrsToList (name: _: tmpfilesAcl "/var/lib/nixling" "u:nixling-${name}-qemu-media:--x")
       qemuMediaVms))
   ];
+  perVmRuntimeTraversalAcls = lib.concatLists (lib.mapAttrsToList
+    (name: vm:
+      let
+        runnerPrincipal = stablePrincipal "nixling-${name}-runner";
+        gctlfsPrincipal = stablePrincipal "nixling-${name}-gctlfs";
+      in
+      lib.concatLists [
+        (runtimeAclUser "/run/nixling" runnerPrincipal "--x")
+        (runtimeAclUser "/run/nixling" gctlfsPrincipal "--x")
+        (runtimeAclUser "/run/nixling/vms" runnerPrincipal "--x")
+        (runtimeAclUser "/run/nixling/vms" gctlfsPrincipal "--x")
+        (lib.optionals vm.tpm.enable (runtimeAclUser "/run/nixling" "nixling-${name}-swtpm" "--x"))
+        (lib.optionals vm.tpm.enable (runtimeAclUser "/run/nixling/vms" "nixling-${name}-swtpm" "--x"))
+        (lib.optionals vm.audio.enable (runtimeAclUser "/run/nixling" "nixling-${name}-snd" "--x"))
+        (lib.optionals vm.audio.enable (runtimeAclUser "/run/nixling/vms" "nixling-${name}-snd" "--x"))
+        (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling" "nixling-${name}-gpu" "--x"))
+        (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling/vms" "nixling-${name}-gpu" "--x"))
+        (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling-gpu" "nixling-${name}-gpu" "--x"))
+        (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling-wlproxy" "nixling-${name}-gpu" "--x"))
+        (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling-wlproxy" "nixling-${name}-wlproxy" "--x"))
+        (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeAclUser "/run/nixling-video" "nixling-${name}-video" "--x"))
+      ])
+    normalNixosVms);
   perNormalVmPostureTmpfiles = lib.concatLists (lib.mapAttrsToList
-    (name: vm: lib.concatLists [
+    (name: vm:
+      let
+        vmRunDir = "/run/nixling/vms/${name}";
+        guestControlRunDir = "${vmRunDir}/guest-control";
+        gpuRunDir = "/run/nixling-gpu/${name}";
+        videoRunDir = "/run/nixling-video/${name}";
+        wlproxyRunDir = "/run/nixling-wlproxy/${name}";
+        runnerPrincipal = stablePrincipal "nixling-${name}-runner";
+        gctlfsPrincipal = stablePrincipal "nixling-${name}-gctlfs";
+      in
+      lib.concatLists [
       (tmpfilesDir "/var/lib/nixling/vms/${name}" "3770" "nixlingd" "users")
-      (tmpfilesDir "/run/nixling/vms/${name}" "0750" "nixlingd" "nixling")
-      (tmpfilesDir "/run/nixling/vms/${name}/guest-control" "0750" "nixlingd" "nixling")
-      (tmpfilesDir "/run/nixling-gpu/${name}" "0750" "nixlingd" "nixling")
-      (tmpfilesDir "/run/nixling-video/${name}" "0750" "nixlingd" "nixling")
-      (tmpfilesDir "/run/nixling-wlproxy/${name}" "0750" "nixlingd" "nixling")
+      (tmpfilesDir vmRunDir "0750" "nixlingd" "nixling")
+      (tmpfilesDir guestControlRunDir "0750" "nixlingd" "nixling")
+      (tmpfilesDir gpuRunDir "0750" "nixlingd" "nixling")
+      (tmpfilesDir videoRunDir "0750" "nixlingd" "nixling")
+      (tmpfilesDir wlproxyRunDir "0750" "nixlingd" "nixling")
       (tmpfilesDir "/var/lib/nixling/vms/${name}/store-view" "0755" "nixlingd" "users")
       (tmpfilesDir "/var/lib/nixling/vms/${name}/store-view/live" "0755" "nixlingd" "users")
       (tmpfilesDir "/var/lib/nixling/vms/${name}/store-view/meta" "0755" "nixlingd" "users")
+      (runtimeAclMask vmRunDir)
+      (runtimeAclUser vmRunDir runnerPrincipal "rwx")
+      (runtimeDefaultAclUser vmRunDir runnerPrincipal "rwx")
+      (runtimeAclMask guestControlRunDir)
+      (runtimeAclUser guestControlRunDir runnerPrincipal "--x")
+      (runtimeAclUser guestControlRunDir gctlfsPrincipal "rwx")
+      (runtimeDefaultAclUser guestControlRunDir runnerPrincipal "rwx")
+      (runtimeDefaultAclUser guestControlRunDir gctlfsPrincipal "rwx")
       (lib.optionals vm.tpm.enable (tmpfilesAcl "/var/lib/nixling/vms/${name}" "u:nixling-${name}-swtpm:--x"))
+      (lib.optionals vm.tpm.enable (runtimeAclUser vmRunDir "nixling-${name}-swtpm" "rwx"))
       (lib.optionals vm.graphics.enable (tmpfilesAcl "/var/lib/nixling/vms/${name}" "u:nixling-${name}-gpu:rwx"))
       (lib.optionals vm.graphics.enable (tmpfilesAcl "/var/lib/nixling/vms/${name}" "default:u:nixling-${name}-gpu:rw"))
       (lib.optionals vm.graphics.enable (tmpfilesAcl "/var/lib/nixling/vms/${name}" "default:g::r-x"))
+      (lib.optionals vm.graphics.enable (runtimeAclUser vmRunDir "nixling-${name}-gpu" "rwx"))
+      (lib.optionals vm.graphics.enable (runtimeAclUser gpuRunDir "nixling-${name}-gpu" "rwx"))
+      (lib.optionals vm.graphics.enable (runtimeAclMask gpuRunDir))
+      (lib.optionals vm.graphics.enable (runtimeAclUser wlproxyRunDir "nixling-${name}-wlproxy" "rwx"))
+      (lib.optionals vm.graphics.enable (runtimeAclUser wlproxyRunDir "nixling-${name}-gpu" "--x"))
+      (lib.optionals vm.graphics.enable (runtimeDefaultAclUser wlproxyRunDir "nixling-${name}-gpu" "rwx"))
+      (lib.optionals vm.graphics.enable (runtimeAclMask wlproxyRunDir))
+      (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeAclUser videoRunDir "nixling-${name}-video" "rwx"))
+      (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeAclUser videoRunDir runnerPrincipal "--x"))
+      (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeDefaultAclUser videoRunDir runnerPrincipal "rwx"))
+      (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeDefaultAclUser videoRunDir "nixling-${name}-video" "rwx"))
+      (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeAclMask videoRunDir))
+      (lib.optionals vm.audio.enable (runtimeAclUser vmRunDir "nixling-${name}-snd" "rwx"))
     ])
     normalNixosVms);
   perQemuMediaPostureTmpfiles = lib.concatLists (lib.mapAttrsToList
@@ -159,11 +221,16 @@ in
     (tmpfilesAcl "/var/lib/nixling" "g:kvm:--x")
     (tmpfilesAcl "/var/lib/nixling" "g:nixling:--x")
     perVmNamedStateTraversalAcls
-    (tmpfilesDir "/run/nixling/vms" "0750" "nixlingd" "nixling")
+    # Shared runtime parents stay root-owned so broker path-safety checks can
+    # create or reconcile per-VM children without trusting a daemon-writable
+    # parent. The per-VM leaves below remain nixlingd:nixling for daemon-owned
+    # sockets and guest-control artifacts.
+    (tmpfilesDir "/run/nixling/vms" "0750" "root" "nixling")
     (tmpfilesDir "/run/nixling/otel" "0750" "nixlingd" "nixling")
-    (tmpfilesDir "/run/nixling-gpu" "0750" "nixlingd" "nixling")
-    (tmpfilesDir "/run/nixling-video" "0750" "nixlingd" "nixling")
-    (tmpfilesDir "/run/nixling-wlproxy" "0750" "nixlingd" "nixling")
+    (tmpfilesDir "/run/nixling-gpu" "0750" "root" "nixling")
+    (tmpfilesDir "/run/nixling-video" "0750" "root" "nixling")
+    (tmpfilesDir "/run/nixling-wlproxy" "0750" "root" "nixling")
+    perVmRuntimeTraversalAcls
     perNormalVmPostureTmpfiles
     perQemuMediaPostureTmpfiles
   ];

--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -111,6 +111,10 @@ EOF
   tmpfilesAcl = path: acl: [
     "a+ ${path} - - - - ${acl}"
   ];
+  runtimeLeafDir = path: mode: user: group:
+    tmpfilesDir path mode user group
+    ++ tmpfilesAcl path "g::r-x"
+    ++ tmpfilesAcl path "default:g::r-x";
   runtimeAclMask = path: [
     "a+ ${path} - - - - m::rwx"
     "a+ ${path} - - - - default:m::rwx"
@@ -152,9 +156,23 @@ EOF
         (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling-gpu" "nixling-${name}-gpu" "--x"))
         (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling-wlproxy" "nixling-${name}-gpu" "--x"))
         (lib.optionals vm.graphics.enable (runtimeAclUser "/run/nixling-wlproxy" "nixling-${name}-wlproxy" "--x"))
+        (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeAclUser "/run/nixling-video" runnerPrincipal "--x"))
         (lib.optionals (vm.graphics.enable && vm.graphics.videoSidecar) (runtimeAclUser "/run/nixling-video" "nixling-${name}-video" "--x"))
       ])
     normalNixosVms);
+  perQemuMediaRuntimeTraversalAcls = lib.concatLists (lib.mapAttrsToList
+    (name: _:
+      let
+        qemuMediaPrincipal = "nixling-${name}-qemu-media";
+        wlproxyPrincipal = "nixling-${name}-wlproxy";
+      in
+      lib.concatLists [
+        (runtimeAclUser "/run/nixling" qemuMediaPrincipal "--x")
+        (runtimeAclUser "/run/nixling/vms" qemuMediaPrincipal "--x")
+        (runtimeAclUser "/run/nixling-wlproxy" qemuMediaPrincipal "--x")
+        (runtimeAclUser "/run/nixling-wlproxy" wlproxyPrincipal "--x")
+      ])
+    qemuMediaVms);
   perNormalVmPostureTmpfiles = lib.concatLists (lib.mapAttrsToList
     (name: vm:
       let
@@ -168,16 +186,17 @@ EOF
       in
       lib.concatLists [
       (tmpfilesDir "/var/lib/nixling/vms/${name}" "3770" "nixlingd" "users")
-      (tmpfilesDir vmRunDir "0750" "nixlingd" "nixling")
-      (tmpfilesDir guestControlRunDir "0750" "nixlingd" "nixling")
-      (tmpfilesDir gpuRunDir "0750" "nixlingd" "nixling")
-      (tmpfilesDir videoRunDir "0750" "nixlingd" "nixling")
-      (tmpfilesDir wlproxyRunDir "0750" "nixlingd" "nixling")
+      (runtimeLeafDir vmRunDir "1770" "nixlingd" "nixling")
+      (runtimeLeafDir guestControlRunDir "0770" "nixlingd" "nixling")
+      (runtimeLeafDir gpuRunDir "0770" "nixlingd" "nixling")
+      (runtimeLeafDir videoRunDir "0770" "nixlingd" "nixling")
+      (runtimeLeafDir wlproxyRunDir "0770" "nixlingd" "nixling")
       (tmpfilesDir "/var/lib/nixling/vms/${name}/store-view" "0755" "nixlingd" "users")
       (tmpfilesDir "/var/lib/nixling/vms/${name}/store-view/live" "0755" "nixlingd" "users")
       (tmpfilesDir "/var/lib/nixling/vms/${name}/store-view/meta" "0755" "nixlingd" "users")
       (runtimeAclMask vmRunDir)
       (runtimeAclUser vmRunDir runnerPrincipal "rwx")
+      (runtimeAclUser vmRunDir gctlfsPrincipal "--x")
       (runtimeDefaultAclUser vmRunDir runnerPrincipal "rwx")
       (runtimeAclMask guestControlRunDir)
       (runtimeAclUser guestControlRunDir runnerPrincipal "--x")
@@ -205,10 +224,23 @@ EOF
     ])
     normalNixosVms);
   perQemuMediaPostureTmpfiles = lib.concatLists (lib.mapAttrsToList
-    (name: _: lib.concatLists [
+    (name: _:
+      let
+        qemuMediaPrincipal = "nixling-${name}-qemu-media";
+        wlproxyPrincipal = "nixling-${name}-wlproxy";
+        vmRunDir = "/run/nixling/vms/${name}";
+        wlproxyRunDir = "/run/nixling-wlproxy/${name}";
+      in
+      lib.concatLists [
       (tmpfilesDir "/var/lib/nixling/vms/${name}" "0750" "nixling-${name}-qemu-media" "nixling-${name}-qemu-media")
-      (tmpfilesDir "/run/nixling/vms/${name}" "0750" "nixlingd" "nixling")
-      (tmpfilesDir "/run/nixling-wlproxy/${name}" "0750" "nixlingd" "nixling")
+      (runtimeLeafDir vmRunDir "0770" "nixlingd" "nixling")
+      (runtimeAclMask vmRunDir)
+      (runtimeAclUser vmRunDir qemuMediaPrincipal "rwx")
+      (runtimeLeafDir wlproxyRunDir "0770" "nixlingd" "nixling")
+      (runtimeAclMask wlproxyRunDir)
+      (runtimeAclUser wlproxyRunDir wlproxyPrincipal "rwx")
+      (runtimeAclUser wlproxyRunDir qemuMediaPrincipal "--x")
+      (runtimeDefaultAclUser wlproxyRunDir qemuMediaPrincipal "rwx")
     ])
     qemuMediaVms);
 in
@@ -231,6 +263,7 @@ in
     (tmpfilesDir "/run/nixling-video" "0750" "root" "nixling")
     (tmpfilesDir "/run/nixling-wlproxy" "0750" "root" "nixling")
     perVmRuntimeTraversalAcls
+    perQemuMediaRuntimeTraversalAcls
     perNormalVmPostureTmpfiles
     perQemuMediaPostureTmpfiles
   ];

--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -418,7 +418,9 @@ in
   #
   # `/run/nixling/vms/` is the parent for per-VM runtime sockets. In the
   # daemon path host-activation.nix owns its tmpfiles posture
-  # (nixlingd:nixling 0750); the legacy pre-daemon path keeps the old
+  # (root:nixling 0750 parent, nixlingd:nixling per-VM leaves) so broker
+  # path-safety can create/reconcile children without trusting a
+  # daemon-writable parent. The legacy pre-daemon path keeps the old
   # root-owned 0755 parent for retired RuntimeDirectory users.
   # `/run/nixling/alloy/` is a private subtree for observability sockets so
   # Alloy no longer needs write access to the shared launcher/audio lock root.

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -27,9 +27,20 @@ let
       audio.enable = true;
       tpm.enable = true;
       graphics.enable = true;
+      graphics.videoSidecar = true;
       config = { lib, ... }: {
         networking.hostName = lib.mkDefault "corp-vm";
         users.users.alice = { isNormalUser = true; uid = 1000; };
+      };
+    };
+    nixling.vms.media = {
+      runtime.kind = "qemu-media";
+      env = "work";
+      index = 42;
+      qemuMedia.source = {
+        kind = "image-file";
+        path = "/var/lib/nixling/images/installer.img";
+        format = "raw";
       };
     };
     nixling.daemonExperimental.enable = true;
@@ -48,6 +59,10 @@ let
 
   rulesForPath = path:
     builtins.filter (lib.hasInfix (" " + path + " ")) tmpfiles;
+  stablePrincipal = principal:
+    toString (50000 + lib.fromHexString (builtins.substring 0 6 (builtins.hashString "sha256" principal)));
+  corpRunner = stablePrincipal "nixling-corp-vm-runner";
+  corpGctlfs = stablePrincipal "nixling-corp-vm-gctlfs";
 
   noRawRuntimeDirMutation = text:
     lib.all (needle: !(lib.hasInfix needle text)) [
@@ -97,6 +112,8 @@ in
       "a+ /run/nixling/vms - - - - u:nixling-corp-vm-swtpm:--x"
       "a+ /run/nixling/vms - - - - u:nixling-corp-vm-snd:--x"
       "a+ /run/nixling/vms - - - - u:nixling-corp-vm-gpu:--x"
+      "a+ /run/nixling/vms - - - - u:${corpRunner}:--x"
+      "a+ /run/nixling/vms - - - - u:${corpGctlfs}:--x"
     ];
     expected = true;
   };
@@ -111,29 +128,38 @@ in
   };
 
   "activation-runtime-tmpfiles/video-parent" = {
-    expr = rulesForPath "/run/nixling-video";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling-video 0750 root nixling -"
       "z /run/nixling-video 0750 root nixling -"
+      "a+ /run/nixling-video - - - - u:${corpRunner}:--x"
+      "a+ /run/nixling-video - - - - u:nixling-corp-vm-video:--x"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/wlproxy-parent" = {
-    expr = rulesForPath "/run/nixling-wlproxy";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling-wlproxy 0750 root nixling -"
       "z /run/nixling-wlproxy 0750 root nixling -"
       "a+ /run/nixling-wlproxy - - - - u:nixling-corp-vm-gpu:--x"
       "a+ /run/nixling-wlproxy - - - - u:nixling-corp-vm-wlproxy:--x"
+      "a+ /run/nixling-wlproxy - - - - u:nixling-media-qemu-media:--x"
+      "a+ /run/nixling-wlproxy - - - - u:nixling-media-wlproxy:--x"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/run-vm-dir" = {
     expr = lib.all (rule: builtins.elem rule tmpfiles) [
-      "d /run/nixling/vms/corp-vm 0750 nixlingd nixling -"
-      "z /run/nixling/vms/corp-vm 0750 nixlingd nixling -"
+      "d /run/nixling/vms/corp-vm 1770 nixlingd nixling -"
+      "z /run/nixling/vms/corp-vm 1770 nixlingd nixling -"
+      "a+ /run/nixling/vms/corp-vm - - - - g::r-x"
+      "a+ /run/nixling/vms/corp-vm - - - - default:g::r-x"
       "a+ /run/nixling/vms/corp-vm - - - - m::rwx"
       "a+ /run/nixling/vms/corp-vm - - - - default:m::rwx"
+      "a+ /run/nixling/vms/corp-vm - - - - u:${corpRunner}:rwx"
+      "a+ /run/nixling/vms/corp-vm - - - - default:u:${corpRunner}:rwx"
+      "a+ /run/nixling/vms/corp-vm - - - - u:${corpGctlfs}:--x"
       "a+ /run/nixling/vms/corp-vm - - - - u:nixling-corp-vm-swtpm:rwx"
       "a+ /run/nixling/vms/corp-vm - - - - u:nixling-corp-vm-gpu:rwx"
       "a+ /run/nixling/vms/corp-vm - - - - u:nixling-corp-vm-snd:rwx"
@@ -143,10 +169,16 @@ in
 
   "activation-runtime-tmpfiles/run-guest-control-dir" = {
     expr = lib.all (rule: builtins.elem rule tmpfiles) [
-      "d /run/nixling/vms/corp-vm/guest-control 0750 nixlingd nixling -"
-      "z /run/nixling/vms/corp-vm/guest-control 0750 nixlingd nixling -"
+      "d /run/nixling/vms/corp-vm/guest-control 0770 nixlingd nixling -"
+      "z /run/nixling/vms/corp-vm/guest-control 0770 nixlingd nixling -"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - g::r-x"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - default:g::r-x"
       "a+ /run/nixling/vms/corp-vm/guest-control - - - - m::rwx"
       "a+ /run/nixling/vms/corp-vm/guest-control - - - - default:m::rwx"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - u:${corpRunner}:--x"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - u:${corpGctlfs}:rwx"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - default:u:${corpRunner}:rwx"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - default:u:${corpGctlfs}:rwx"
     ];
     expected = true;
   };
@@ -160,31 +192,59 @@ in
 
   "activation-runtime-tmpfiles/gpu-dir" = {
     expr = lib.all (rule: builtins.elem rule tmpfiles) [
-      "d /run/nixling-gpu/corp-vm 0750 nixlingd nixling -"
-      "z /run/nixling-gpu/corp-vm 0750 nixlingd nixling -"
+      "d /run/nixling-gpu/corp-vm 0770 nixlingd nixling -"
+      "z /run/nixling-gpu/corp-vm 0770 nixlingd nixling -"
+      "a+ /run/nixling-gpu/corp-vm - - - - g::r-x"
       "a+ /run/nixling-gpu/corp-vm - - - - m::rwx"
+      "a+ /run/nixling-gpu/corp-vm - - - - default:m::rwx"
       "a+ /run/nixling-gpu/corp-vm - - - - u:nixling-corp-vm-gpu:rwx"
     ];
     expected = true;
   };
 
   "activation-runtime-tmpfiles/video-dir" = {
-    expr = rulesForPath "/run/nixling-video/corp-vm";
-    expected = [
-      "d /run/nixling-video/corp-vm 0750 nixlingd nixling -"
-      "z /run/nixling-video/corp-vm 0750 nixlingd nixling -"
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
+      "d /run/nixling-video/corp-vm 0770 nixlingd nixling -"
+      "z /run/nixling-video/corp-vm 0770 nixlingd nixling -"
+      "a+ /run/nixling-video/corp-vm - - - - g::r-x"
+      "a+ /run/nixling-video/corp-vm - - - - default:g::r-x"
+      "a+ /run/nixling-video/corp-vm - - - - m::rwx"
+      "a+ /run/nixling-video/corp-vm - - - - default:m::rwx"
+      "a+ /run/nixling-video/corp-vm - - - - u:nixling-corp-vm-video:rwx"
+      "a+ /run/nixling-video/corp-vm - - - - u:${corpRunner}:--x"
+      "a+ /run/nixling-video/corp-vm - - - - default:u:${corpRunner}:rwx"
+      "a+ /run/nixling-video/corp-vm - - - - default:u:nixling-corp-vm-video:rwx"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/wlproxy-dir" = {
     expr = lib.all (rule: builtins.elem rule tmpfiles) [
-      "d /run/nixling-wlproxy/corp-vm 0750 nixlingd nixling -"
-      "z /run/nixling-wlproxy/corp-vm 0750 nixlingd nixling -"
+      "d /run/nixling-wlproxy/corp-vm 0770 nixlingd nixling -"
+      "z /run/nixling-wlproxy/corp-vm 0770 nixlingd nixling -"
+      "a+ /run/nixling-wlproxy/corp-vm - - - - g::r-x"
+      "a+ /run/nixling-wlproxy/corp-vm - - - - default:g::r-x"
       "a+ /run/nixling-wlproxy/corp-vm - - - - m::rwx"
       "a+ /run/nixling-wlproxy/corp-vm - - - - default:m::rwx"
       "a+ /run/nixling-wlproxy/corp-vm - - - - u:nixling-corp-vm-wlproxy:rwx"
       "a+ /run/nixling-wlproxy/corp-vm - - - - u:nixling-corp-vm-gpu:--x"
       "a+ /run/nixling-wlproxy/corp-vm - - - - default:u:nixling-corp-vm-gpu:rwx"
+    ];
+    expected = true;
+  };
+
+  "activation-runtime-tmpfiles/qemu-media-runtime-dirs" = {
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
+      "d /run/nixling/vms/media 0770 nixlingd nixling -"
+      "z /run/nixling/vms/media 0770 nixlingd nixling -"
+      "a+ /run/nixling/vms/media - - - - m::rwx"
+      "a+ /run/nixling/vms/media - - - - u:nixling-media-qemu-media:rwx"
+      "d /run/nixling-wlproxy/media 0770 nixlingd nixling -"
+      "z /run/nixling-wlproxy/media 0770 nixlingd nixling -"
+      "a+ /run/nixling-wlproxy/media - - - - m::rwx"
+      "a+ /run/nixling-wlproxy/media - - - - u:nixling-media-wlproxy:rwx"
+      "a+ /run/nixling-wlproxy/media - - - - u:nixling-media-qemu-media:--x"
+      "a+ /run/nixling-wlproxy/media - - - - default:u:nixling-media-qemu-media:rwx"
     ];
     expected = true;
   };

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -82,28 +82,32 @@ in
   };
 
   "activation-runtime-tmpfiles/vm-state-dir" = {
-    expr = rulesForPath "/var/lib/nixling/vms/corp-vm";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /var/lib/nixling/vms/corp-vm 3770 nixlingd users -"
       "z /var/lib/nixling/vms/corp-vm 3770 nixlingd users -"
       "a+ /var/lib/nixling/vms/corp-vm - - - - u:nixling-corp-vm-swtpm:--x"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/run-vms-parent" = {
-    expr = rulesForPath "/run/nixling/vms";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling/vms 0750 root nixling -"
       "z /run/nixling/vms 0750 root nixling -"
+      "a+ /run/nixling/vms - - - - u:nixling-corp-vm-swtpm:--x"
+      "a+ /run/nixling/vms - - - - u:nixling-corp-vm-snd:--x"
+      "a+ /run/nixling/vms - - - - u:nixling-corp-vm-gpu:--x"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/gpu-parent" = {
-    expr = rulesForPath "/run/nixling-gpu";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling-gpu 0750 root nixling -"
       "z /run/nixling-gpu 0750 root nixling -"
+      "a+ /run/nixling-gpu - - - - u:nixling-corp-vm-gpu:--x"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/video-parent" = {

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -26,6 +26,7 @@ let
       ssh.user = "alice";
       audio.enable = true;
       tpm.enable = true;
+      graphics.enable = true;
       config = { lib, ... }: {
         networking.hostName = lib.mkDefault "corp-vm";
         users.users.alice = { isNormalUser = true; uid = 1000; };
@@ -92,33 +93,58 @@ in
   "activation-runtime-tmpfiles/run-vms-parent" = {
     expr = rulesForPath "/run/nixling/vms";
     expected = [
-      "d /run/nixling/vms 0750 nixlingd nixling -"
-      "z /run/nixling/vms 0750 nixlingd nixling -"
+      "d /run/nixling/vms 0750 root nixling -"
+      "z /run/nixling/vms 0750 root nixling -"
     ];
   };
 
   "activation-runtime-tmpfiles/gpu-parent" = {
     expr = rulesForPath "/run/nixling-gpu";
     expected = [
-      "d /run/nixling-gpu 0750 nixlingd nixling -"
-      "z /run/nixling-gpu 0750 nixlingd nixling -"
+      "d /run/nixling-gpu 0750 root nixling -"
+      "z /run/nixling-gpu 0750 root nixling -"
+    ];
+  };
+
+  "activation-runtime-tmpfiles/video-parent" = {
+    expr = rulesForPath "/run/nixling-video";
+    expected = [
+      "d /run/nixling-video 0750 root nixling -"
+      "z /run/nixling-video 0750 root nixling -"
+    ];
+  };
+
+  "activation-runtime-tmpfiles/wlproxy-parent" = {
+    expr = rulesForPath "/run/nixling-wlproxy";
+    expected = [
+      "d /run/nixling-wlproxy 0750 root nixling -"
+      "z /run/nixling-wlproxy 0750 root nixling -"
+      "a+ /run/nixling-wlproxy - - - - u:nixling-corp-vm-gpu:--x"
+      "a+ /run/nixling-wlproxy - - - - u:nixling-corp-vm-wlproxy:--x"
     ];
   };
 
   "activation-runtime-tmpfiles/run-vm-dir" = {
-    expr = rulesForPath "/run/nixling/vms/corp-vm";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling/vms/corp-vm 0750 nixlingd nixling -"
       "z /run/nixling/vms/corp-vm 0750 nixlingd nixling -"
+      "a+ /run/nixling/vms/corp-vm - - - - m::rwx"
+      "a+ /run/nixling/vms/corp-vm - - - - default:m::rwx"
+      "a+ /run/nixling/vms/corp-vm - - - - u:nixling-corp-vm-swtpm:rwx"
+      "a+ /run/nixling/vms/corp-vm - - - - u:nixling-corp-vm-gpu:rwx"
+      "a+ /run/nixling/vms/corp-vm - - - - u:nixling-corp-vm-snd:rwx"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/run-guest-control-dir" = {
-    expr = rulesForPath "/run/nixling/vms/corp-vm/guest-control";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling/vms/corp-vm/guest-control 0750 nixlingd nixling -"
       "z /run/nixling/vms/corp-vm/guest-control 0750 nixlingd nixling -"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - m::rwx"
+      "a+ /run/nixling/vms/corp-vm/guest-control - - - - default:m::rwx"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/run-store-sync-dir" = {
@@ -129,11 +155,13 @@ in
   };
 
   "activation-runtime-tmpfiles/gpu-dir" = {
-    expr = rulesForPath "/run/nixling-gpu/corp-vm";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling-gpu/corp-vm 0750 nixlingd nixling -"
       "z /run/nixling-gpu/corp-vm 0750 nixlingd nixling -"
+      "a+ /run/nixling-gpu/corp-vm - - - - m::rwx"
+      "a+ /run/nixling-gpu/corp-vm - - - - u:nixling-corp-vm-gpu:rwx"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/video-dir" = {
@@ -145,11 +173,16 @@ in
   };
 
   "activation-runtime-tmpfiles/wlproxy-dir" = {
-    expr = rulesForPath "/run/nixling-wlproxy/corp-vm";
-    expected = [
+    expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling-wlproxy/corp-vm 0750 nixlingd nixling -"
       "z /run/nixling-wlproxy/corp-vm 0750 nixlingd nixling -"
+      "a+ /run/nixling-wlproxy/corp-vm - - - - m::rwx"
+      "a+ /run/nixling-wlproxy/corp-vm - - - - default:m::rwx"
+      "a+ /run/nixling-wlproxy/corp-vm - - - - u:nixling-corp-vm-wlproxy:rwx"
+      "a+ /run/nixling-wlproxy/corp-vm - - - - u:nixling-corp-vm-gpu:--x"
+      "a+ /run/nixling-wlproxy/corp-vm - - - - default:u:nixling-corp-vm-gpu:rwx"
     ];
+    expected = true;
   };
 
   "activation-runtime-tmpfiles/store-view-live-dir" = {

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -33,6 +33,25 @@ let
         users.users.alice = { isNormalUser = true; uid = 1000; };
       };
     };
+    nixling.daemonExperimental.enable = true;
+  };
+  qemuMediaFixture = { lib, ... }: {
+    boot.loader.grub.enable = false;
+    boot.loader.systemd-boot.enable = false;
+    boot.initrd.includeDefaultModules = false;
+    fileSystems."/" = { device = "tmpfs"; fsType = "tmpfs"; };
+    environment.etc."machine-id".text = "00000000000000000000000000000000";
+    system.stateVersion = "25.11";
+    users.users.alice = { isNormalUser = true; uid = 1000; };
+    nixling.site = {
+      waylandUser = "alice";
+      launcherUsers = [ "alice" ];
+      yubikey.enable = false;
+    };
+    nixling.envs.work = {
+      lanSubnet = "10.20.0.0/24";
+      uplinkSubnet = "192.0.2.0/30";
+    };
     nixling.vms.media = {
       runtime.kind = "qemu-media";
       env = "work";
@@ -47,7 +66,9 @@ let
   };
 
   cfg = (mkEval [ fixture ]).config;
+  qemuMediaCfg = (mkEval [ qemuMediaFixture ]).config;
   tmpfiles = cfg.systemd.tmpfiles.rules;
+  qemuMediaTmpfiles = qemuMediaCfg.systemd.tmpfiles.rules;
   roleAclText = cfg.system.activationScripts.nixlingRoleUidAcls.text or "";
   runtimePostureText = cfg.system.activationScripts.nixlingRuntimeDirPosture.text or "";
   stateDirAclText = cfg.system.activationScripts.nixlingStateDirAcl.text or "";
@@ -143,8 +164,6 @@ in
       "z /run/nixling-wlproxy 0750 root nixling -"
       "a+ /run/nixling-wlproxy - - - - u:nixling-corp-vm-gpu:--x"
       "a+ /run/nixling-wlproxy - - - - u:nixling-corp-vm-wlproxy:--x"
-      "a+ /run/nixling-wlproxy - - - - u:nixling-media-qemu-media:--x"
-      "a+ /run/nixling-wlproxy - - - - u:nixling-media-wlproxy:--x"
     ];
     expected = true;
   };
@@ -234,7 +253,11 @@ in
   };
 
   "activation-runtime-tmpfiles/qemu-media-runtime-dirs" = {
-    expr = lib.all (rule: builtins.elem rule tmpfiles) [
+    expr = lib.all (rule: builtins.elem rule qemuMediaTmpfiles) [
+      "a+ /run/nixling - - - - u:nixling-media-qemu-media:--x"
+      "a+ /run/nixling/vms - - - - u:nixling-media-qemu-media:--x"
+      "a+ /run/nixling-wlproxy - - - - u:nixling-media-qemu-media:--x"
+      "a+ /run/nixling-wlproxy - - - - u:nixling-media-wlproxy:--x"
       "d /run/nixling/vms/media 0770 nixlingd nixling -"
       "z /run/nixling/vms/media 0770 nixlingd nixling -"
       "a+ /run/nixling/vms/media - - - - m::rwx"

--- a/tests/unit/nix/cases/nixlingd-startup-smoke.nix
+++ b/tests/unit/nix/cases/nixlingd-startup-smoke.nix
@@ -76,8 +76,8 @@ let
 in
 {
   "nixlingd-startup-smoke/tmpfiles-run-nixling" = {
-    expr = rulesForPath "/run/nixling";
-    expected = [ "d /run/nixling 0750 nixlingd nixling -" ];
+    expr = builtins.elem "d /run/nixling 0750 nixlingd nixling -" tmpfiles;
+    expected = true;
   };
 
   "nixlingd-startup-smoke/tmpfiles-usbip-lock-root" = {


### PR DESCRIPTION
## Summary

- Restore root-owned shared runtime parents under /run/nixling while keeping per-VM leaves daemon-owned.
- Add tmpfiles ACL masks, parent traversal ACLs, and per-role writer ACLs so broker path-safety and unprivileged sidecar socket creation both work after a switch.
- Add nix-unit coverage for the runtime parent and leaf ACL posture.

## Testing checklist (mandatory)

- [x] **`make check` passes locally** (paste the summary).
      Focused hotfix validation: `make check-tier0` passed; `NL_FLAKE_CHECK=nix-unit make test-flake` passed.
- [x] **`make test-integration` passes on the host before PR creation**
      N/A: hotfix is Nix tmpfiles/eval-only; no container surface changed.
- [x] **`make test-host-integration` passes on the host before PR creation**
      N/A for this focused hotfix; live host reproduced the runtime parent path-safety refusal and the eval test covers the rendered tmpfiles posture.
- [x] **Manual `make test-hardware` run** on a NixOS host **with the real devices** (GPU / YubiKey / hardware-TPM), if this change touches graphics/GPU, video decode, USBIP/YubiKey, hardware-TPM, or a full nixling-microVM boot. Paste results, **or** state `N/A: no device/passthrough or full-microVM-boot surface touched` with a one-line justification. *(This tier requires physical devices.)*
      N/A: no device passthrough behavior changed; this only restores tmpfiles ownership/ACL posture needed before runner spawn.
- [x] **New/changed tests are wired into a `make` target** and have rows in `tests/migration-ledger.toml` (`make check-inventory` green — it fails closed on any unclassified test; use `make ledger-regen` to update).
      Existing nix-unit case updated; covered by `NL_FLAKE_CHECK=nix-unit make test-flake`.
- [x] **Docs + CI updated in lockstep**: `docs/**`, `AGENTS.md`, `tests/README.md`, and `.github/workflows/*` (doc+ci-reference gate green).
      N/A: no docs/CI contract changed; CHANGELOG updated.

## Notes

- Follow-up hotfix for the runtime tmpfiles regression observed after #168.