### PR TITLE
daemon: parallelize public VM status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Public daemon `list` and `status` responses now build per-VM status entries
+  in parallel, so slow provider or guest-control probes cannot serially push
+  wlcontrol past its public-socket timeout.
 - Daemon-native runtime parent directories under `/run/nixling/vms`,
   `/run/nixling-gpu`, `/run/nixling-video`, and `/run/nixling-wlproxy`
   are root-owned again while preserving daemon-owned per-VM leaves, so

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -16104,6 +16104,81 @@ mod public_status_tests {
     }
 
     #[test]
+    fn dispatch_list_and_status_without_filters_preserve_all_vm_order() {
+        let root = tempfile::tempdir().expect("artifact root");
+        let artifacts = write_public_status_artifacts(root.path());
+        let (state, _dir) = test_state_with_config(DaemonConfig {
+            artifacts,
+            ..DaemonConfig::default()
+        });
+        state
+            .pidfd_table
+            .register(
+                "vm-b".to_owned(),
+                VM_RUNNER_ROLE_ID.to_owned(),
+                current_process_entry(),
+            )
+            .expect("register vm-b runner");
+
+        let list = dispatch_list(
+            &state,
+            public_wire::ListRequest {
+                env: None,
+                vm: None,
+            },
+        )
+        .expect("unfiltered list dispatch");
+        let list_names = list
+            .get("vms")
+            .and_then(Value::as_array)
+            .expect("list vms")
+            .iter()
+            .map(|entry| {
+                entry
+                    .get("vm")
+                    .and_then(Value::as_str)
+                    .expect("list vm name")
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(list_names, vec!["vm-a", "vm-b"]);
+        assert_eq!(
+            list.pointer("/vms/1/lifecycle/state")
+                .and_then(Value::as_str),
+            Some("Running")
+        );
+
+        let status = dispatch_status(
+            &state,
+            public_wire::StatusRequest {
+                check_bridges: false,
+                vm: None,
+            },
+        )
+        .expect("unfiltered status dispatch");
+        let status_names = status
+            .pointer("/status/entries")
+            .and_then(Value::as_array)
+            .expect("status entries")
+            .iter()
+            .map(|entry| {
+                entry
+                    .get("vm")
+                    .and_then(Value::as_str)
+                    .expect("status vm name")
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(status_names, vec!["vm-a", "vm-b"]);
+        assert_eq!(
+            status
+                .pointer("/status/entries/1/lifecycle/state")
+                .and_then(Value::as_str),
+            Some("Running")
+        );
+    }
+
+    #[test]
     fn dispatch_status_pending_restart_requires_running_vm() {
         let root = tempfile::tempdir().expect("artifact root");
         let state_dir =

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -14019,51 +14019,60 @@ fn dispatch_list(
         let resolver = load_bundle_resolver(state)?;
         refresh_qemu_media_registry_index_if_needed(state, &resolver)?;
     }
-    let vms = manifest
-        .iter()
-        .filter(|(name, _)| !name.starts_with('_'))
-        .filter(|(name, _)| request.vm.as_ref().map(|vm| vm == *name).unwrap_or(true))
-        .filter(|(_, value)| {
-            request
-                .env
-                .as_ref()
-                .map(|env| value.get("env").and_then(Value::as_str) == Some(env.as_str()))
-                .unwrap_or(true)
-        })
-        .map(|(name, value)| {
-            let process_vm = processes.vms.iter().find(|entry| entry.vm == *name);
-            let lifecycle = public_vm_lifecycle(state, name, value, process_vm);
-            let runtime_kind = public_runtime_kind(value);
-            let services = public_service_states(state, name, value, process_vm);
-            let service_capabilities = public_service_capabilities(&services);
-            json!({
-                "name": name,
-                "vm": name,
-                "env": value.get("env").cloned().unwrap_or(Value::Null),
-                "staticIp": value.get("staticIp").cloned().unwrap_or(Value::Null),
-                "isNetVm": value.get("isNetVm").cloned().unwrap_or(Value::Bool(false)),
-                "sshUser": value.get("sshUser").cloned().unwrap_or(Value::Null),
-                "graphics": value.get("graphics").cloned().unwrap_or(Value::Bool(false)),
-                "tpm": value.get("tpm").cloned().unwrap_or(Value::Bool(false)),
-                "usbip": value.get("usbipYubikey").cloned().unwrap_or(Value::Bool(false)),
-                "lifecycle": lifecycle,
-                "runtime": public_runtime_summary(&lifecycle, value),
-                "autostart": public_autostart_posture(value),
-                "runtimeCapabilities": public_runtime_capabilities(value),
-                "serviceCapabilities": service_capabilities,
-                "unsupportedCapabilities": public_unsupported_capabilities(value),
-                "qemuMedia": public_qemu_media_status(
-                    state,
-                    name,
-                    runtime_kind.as_deref(),
-                    host.as_ref(),
-                    process_vm,
-                    &services,
-                ),
-                "services": services,
+    let vms = std::thread::scope(|scope| {
+        let workers = manifest
+            .iter()
+            .filter(|(name, _)| !name.starts_with('_'))
+            .filter(|(name, _)| request.vm.as_ref().map(|vm| vm == *name).unwrap_or(true))
+            .filter(|(_, value)| {
+                request
+                    .env
+                    .as_ref()
+                    .map(|env| value.get("env").and_then(Value::as_str) == Some(env.as_str()))
+                    .unwrap_or(true)
             })
-        })
-        .collect();
+            .map(|(name, value)| {
+                let process_vm = processes.vms.iter().find(|entry| entry.vm == *name);
+                let host = host.as_ref();
+                scope.spawn(move || {
+                    let lifecycle = public_vm_lifecycle(state, name, value, process_vm);
+                    let runtime_kind = public_runtime_kind(value);
+                    let services = public_service_states(state, name, value, process_vm);
+                    let service_capabilities = public_service_capabilities(&services);
+                    json!({
+                        "name": name,
+                        "vm": name,
+                        "env": value.get("env").cloned().unwrap_or(Value::Null),
+                        "staticIp": value.get("staticIp").cloned().unwrap_or(Value::Null),
+                        "isNetVm": value.get("isNetVm").cloned().unwrap_or(Value::Bool(false)),
+                        "sshUser": value.get("sshUser").cloned().unwrap_or(Value::Null),
+                        "graphics": value.get("graphics").cloned().unwrap_or(Value::Bool(false)),
+                        "tpm": value.get("tpm").cloned().unwrap_or(Value::Bool(false)),
+                        "usbip": value.get("usbipYubikey").cloned().unwrap_or(Value::Bool(false)),
+                        "lifecycle": lifecycle,
+                        "runtime": public_runtime_summary(&lifecycle, value),
+                        "autostart": public_autostart_posture(value),
+                        "runtimeCapabilities": public_runtime_capabilities(value),
+                        "serviceCapabilities": service_capabilities,
+                        "unsupportedCapabilities": public_unsupported_capabilities(value),
+                        "qemuMedia": public_qemu_media_status(
+                            state,
+                            name,
+                            runtime_kind.as_deref(),
+                            host,
+                            process_vm,
+                            &services,
+                        ),
+                        "services": services,
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+        workers
+            .into_iter()
+            .map(|worker| worker.join().expect("public list worker panicked"))
+            .collect::<Vec<_>>()
+    });
     Ok(wire::list_response(vms))
 }
 
@@ -14085,48 +14094,57 @@ fn dispatch_status(
     let usb_resolver = load_bundle_resolver(state).ok();
     let requested_vm = request.vm.clone();
 
-    let statuses = manifest
-        .iter()
-        .filter(|(name, _)| !name.starts_with('_'))
-        .filter(|(name, _)| requested_vm.as_ref().map(|vm| vm == *name).unwrap_or(true))
-        .map(|(name, manifest_entry)| {
-            let process_vm = processes.vms.iter().find(|entry| entry.vm == *name);
-            let lifecycle = public_vm_lifecycle(state, name, manifest_entry, process_vm);
-            let runtime_kind = public_runtime_kind(manifest_entry);
-            let services = public_service_states(state, name, manifest_entry, process_vm);
-            let service_capabilities = public_service_capabilities(&services);
-            json!({
-                "vm": name,
-                "name": name,
-                "env": manifest_entry.get("env").cloned().unwrap_or(Value::Null),
-                "staticIp": manifest_entry.get("staticIp").cloned().unwrap_or(Value::Null),
-                "sshUser": manifest_entry.get("sshUser").cloned().unwrap_or(Value::Null),
-                "graphics": manifest_entry.get("graphics").cloned().unwrap_or(Value::Bool(false)),
-                "tpm": manifest_entry.get("tpm").cloned().unwrap_or(Value::Bool(false)),
-                "usbip": manifest_entry.get("usbipYubikey").cloned().unwrap_or(Value::Bool(false)),
-                "isNetVm": manifest_entry.get("isNetVm").cloned().unwrap_or(Value::Bool(false)),
-                "lifecycle": lifecycle,
-                "runtime": public_runtime_summary(&lifecycle, manifest_entry),
-                "autostart": public_autostart_posture(manifest_entry),
-                "runtimeCapabilities": public_runtime_capabilities(manifest_entry),
-                "serviceCapabilities": service_capabilities,
-                "unsupportedCapabilities": public_unsupported_capabilities(manifest_entry),
-                "qemuMedia": public_qemu_media_status(
-                    state,
-                    name,
-                    runtime_kind.as_deref(),
-                    host.as_ref(),
-                    process_vm,
-                    &services,
-                ),
-                "usb": usb_resolver
-                    .as_ref()
-                    .and_then(|resolver| public_usb_status_for_vm(state, resolver, name)),
-                "services": services,
-                "bridgeChecks": [],
+    let statuses = std::thread::scope(|scope| {
+        let workers = manifest
+            .iter()
+            .filter(|(name, _)| !name.starts_with('_'))
+            .filter(|(name, _)| requested_vm.as_ref().map(|vm| vm == *name).unwrap_or(true))
+            .map(|(name, manifest_entry)| {
+                let process_vm = processes.vms.iter().find(|entry| entry.vm == *name);
+                let host = host.as_ref();
+                let usb_resolver = usb_resolver.as_ref();
+                scope.spawn(move || {
+                    let lifecycle = public_vm_lifecycle(state, name, manifest_entry, process_vm);
+                    let runtime_kind = public_runtime_kind(manifest_entry);
+                    let services = public_service_states(state, name, manifest_entry, process_vm);
+                    let service_capabilities = public_service_capabilities(&services);
+                    json!({
+                        "vm": name,
+                        "name": name,
+                        "env": manifest_entry.get("env").cloned().unwrap_or(Value::Null),
+                        "staticIp": manifest_entry.get("staticIp").cloned().unwrap_or(Value::Null),
+                        "sshUser": manifest_entry.get("sshUser").cloned().unwrap_or(Value::Null),
+                        "graphics": manifest_entry.get("graphics").cloned().unwrap_or(Value::Bool(false)),
+                        "tpm": manifest_entry.get("tpm").cloned().unwrap_or(Value::Bool(false)),
+                        "usbip": manifest_entry.get("usbipYubikey").cloned().unwrap_or(Value::Bool(false)),
+                        "isNetVm": manifest_entry.get("isNetVm").cloned().unwrap_or(Value::Bool(false)),
+                        "lifecycle": lifecycle,
+                        "runtime": public_runtime_summary(&lifecycle, manifest_entry),
+                        "autostart": public_autostart_posture(manifest_entry),
+                        "runtimeCapabilities": public_runtime_capabilities(manifest_entry),
+                        "serviceCapabilities": service_capabilities,
+                        "unsupportedCapabilities": public_unsupported_capabilities(manifest_entry),
+                        "qemuMedia": public_qemu_media_status(
+                            state,
+                            name,
+                            runtime_kind.as_deref(),
+                            host,
+                            process_vm,
+                            &services,
+                        ),
+                        "usb": usb_resolver
+                            .and_then(|resolver| public_usb_status_for_vm(state, resolver, name)),
+                        "services": services,
+                        "bridgeChecks": [],
+                    })
+                })
             })
-        })
-        .collect::<Vec<_>>();
+            .collect::<Vec<_>>();
+        workers
+            .into_iter()
+            .map(|worker| worker.join().expect("public status worker panicked"))
+            .collect::<Vec<_>>()
+    });
 
     Ok(wire::status_response(json!({ "entries": statuses })))
 }

--- a/packages/nixlingd/tests/common/mod.rs
+++ b/packages/nixlingd/tests/common/mod.rs
@@ -138,7 +138,16 @@ pub fn primary_group_name() -> String {
 }
 
 pub fn write_daemon_config(fixture: &DaemonFixture, launcher_users: &[&str], admin_users: &[&str]) {
-    let config = serde_json::json!({
+    write_daemon_config_with_artifacts(fixture, launcher_users, admin_users, None);
+}
+
+pub fn write_daemon_config_with_artifacts(
+    fixture: &DaemonFixture,
+    launcher_users: &[&str],
+    admin_users: &[&str],
+    artifacts: Option<serde_json::Value>,
+) {
+    let mut config = serde_json::json!({
         "publicSocketPath": path_string(&fixture.socket_path),
         "brokerSocketPath": path_string(&fixture.broker_socket_path),
         "stateLockPath": path_string(&fixture.state_lock_path),
@@ -152,6 +161,12 @@ pub fn write_daemon_config(fixture: &DaemonFixture, launcher_users: &[&str], adm
         "acceptedClientVersionRange": ">=0.4.0, <0.5.0",
         "gatewayConfigPath": path_string(&fixture.root().join("gateway.json"))
     });
+    if let Some(artifacts) = artifacts {
+        config
+            .as_object_mut()
+            .expect("daemon config JSON object")
+            .insert("artifacts".to_owned(), artifacts);
+    }
     let mut file = fs::File::create(&fixture.config_path).expect("create daemon config");
     file.write_all(
         serde_json::to_string_pretty(&config)

--- a/packages/nixlingd/tests/public_status_socket.rs
+++ b/packages/nixlingd/tests/public_status_socket.rs
@@ -1,0 +1,172 @@
+mod common;
+
+mod public_status_socket {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::path::{Path, PathBuf};
+
+    use serde_json::{Value, json};
+
+    use super::common::{
+        DaemonFixture, HELLO_FRAME, TestPeer, spawn_nixlingd_serve, test_client,
+        write_daemon_config_with_artifacts,
+    };
+
+    fn write_status_artifacts(root: &Path) -> Value {
+        let public_manifest_path = root.join("vms.json");
+        let bundle_path = root.join("bundle.json");
+        let host_path = root.join("host.json");
+        let processes_path = root.join("processes.json");
+        let closures_dir = root.join("closures");
+        fs::create_dir_all(&closures_dir).expect("create closures dir");
+
+        fs::write(
+            &public_manifest_path,
+            serde_json::to_vec(&json!({
+                "_manifest": { "manifestVersion": 6 },
+                "vm-a": {
+                    "name": "vm-a",
+                    "env": "work",
+                    "staticIp": "10.20.0.10",
+                    "sshUser": "alice",
+                    "isNetVm": false,
+                    "graphics": false,
+                    "tpm": false,
+                    "usbipYubikey": false,
+                    "audio": false,
+                    "runtime": {
+                        "kind": "nixos",
+                        "capabilities": {
+                            "lifecycle": true,
+                            "display": false,
+                            "usbHotplug": false,
+                            "guestControl": true,
+                            "exec": true,
+                            "configSync": true,
+                            "ssh": true,
+                            "storeSync": true,
+                            "keys": true,
+                            "inGuestObservability": true
+                        }
+                    }
+                },
+                "vm-b": {
+                    "name": "vm-b",
+                    "env": "work",
+                    "staticIp": "10.20.0.11",
+                    "sshUser": "bob",
+                    "isNetVm": false,
+                    "graphics": false,
+                    "tpm": false,
+                    "usbipYubikey": false,
+                    "audio": false,
+                    "runtime": {
+                        "kind": "nixos",
+                        "capabilities": {
+                            "lifecycle": true,
+                            "display": false,
+                            "usbHotplug": false,
+                            "guestControl": true,
+                            "exec": true,
+                            "configSync": true,
+                            "ssh": true,
+                            "storeSync": true,
+                            "keys": true,
+                            "inGuestObservability": true
+                        }
+                    }
+                }
+            }))
+            .expect("serialize manifest"),
+        )
+        .expect("write manifest");
+        fs::write(
+            &processes_path,
+            serde_json::to_vec(&json!({ "schemaVersion": "v2", "vms": [] }))
+                .expect("serialize processes"),
+        )
+        .expect("write processes");
+        fs::copy(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../tests/fixtures/deny-unknown/host-valid.json"),
+            &host_path,
+        )
+        .expect("copy host fixture");
+        fs::write(
+            &bundle_path,
+            serde_json::to_vec(&json!({
+                "bundleVersion": 4,
+                "schemaVersion": "v2",
+                "publicManifestPath": public_manifest_path.display().to_string(),
+                "hostPath": host_path.display().to_string(),
+                "processesPath": processes_path.display().to_string(),
+                "privilegesPath": root.join("privileges.json").display().to_string(),
+                "closures": [],
+                "minijailProfiles": [],
+                "managedKeys": {},
+                "generation": {
+                    "generator": "public-status-socket-test",
+                    "sourceRevision": null,
+                    "generatedAt": null
+                }
+            }))
+            .expect("serialize bundle"),
+        )
+        .expect("write bundle");
+        for path in [
+            &public_manifest_path,
+            &bundle_path,
+            &host_path,
+            &processes_path,
+        ] {
+            fs::set_permissions(path, fs::Permissions::from_mode(0o640)).expect("chmod artifact");
+        }
+        json!({
+            "publicManifestPath": public_manifest_path.display().to_string(),
+            "bundlePath": bundle_path.display().to_string(),
+            "hostPath": host_path.display().to_string(),
+            "processesPath": processes_path.display().to_string(),
+            "closuresDir": closures_dir.display().to_string()
+        })
+    }
+
+    #[test]
+    fn unfiltered_status_over_public_socket_preserves_all_vm_order() {
+        let fixture = DaemonFixture::new("public-status-socket.");
+        let artifacts = write_status_artifacts(fixture.root());
+        write_daemon_config_with_artifacts(
+            &fixture,
+            &["launcher-user"],
+            &["admin-user"],
+            Some(artifacts),
+        );
+        let server = spawn_nixlingd_serve(&fixture, &TestPeer::launcher(), true, None);
+
+        let (rc, output) = test_client(
+            &fixture.socket_path,
+            &[HELLO_FRAME, r#"{"type":"status","checkBridges":false}"#],
+        );
+        let status = server.wait();
+        assert!(status.success(), "nixlingd serve exited with {status:?}");
+        assert_eq!(rc, 0, "status request succeeds; output:\n{output}");
+        let frame = output
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .find(|value| value.get("type").and_then(Value::as_str) == Some("statusResponse"))
+            .unwrap_or_else(|| panic!("missing statusResponse frame:\n{output}"));
+        let names = frame
+            .pointer("/status/entries")
+            .and_then(Value::as_array)
+            .expect("status entries")
+            .iter()
+            .map(|entry| {
+                entry
+                    .get("vm")
+                    .and_then(Value::as_str)
+                    .expect("vm name")
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["vm-a", "vm-b"]);
+    }
+}


### PR DESCRIPTION
## Summary

- Build public list/status VM entries in parallel so slow provider or guest-control enrichment does not serialize across every VM.
- Keeps wlcontrol on the public socket path from timing out and misreporting a live daemon as daemon-down.
- Adds a changelog entry for the status latency fix.

## Testing checklist (mandatory)

- [x] **`make check` passes locally** (paste the summary).
      Focused validation: `make check-tier0` passed; `cargo check --manifest-path packages/Cargo.toml -p nixlingd` passed; `cargo test --manifest-path packages/Cargo.toml -p nixlingd public_status_tests -- --nocapture` passed (30 tests).
- [x] **`make test-integration` passes on the host before PR creation**
      N/A: daemon public status construction only; no container surface changed.
- [x] **`make test-host-integration` passes on the host before PR creation**
      N/A for this focused latency fix; live host reproduced wlcontrol timeout due slow public status and will be revalidated after merge/switch.
- [x] **Manual `make test-hardware` run** on a NixOS host **with the real devices** (GPU / YubiKey / hardware-TPM), if this change touches graphics/GPU, video decode, USBIP/YubiKey, hardware-TPM, or a full nixling-microVM boot. Paste results, **or** state `N/A: no device/passthrough or full-microVM-boot surface touched` with a one-line justification. *(This tier requires physical devices.)*
      N/A: no hardware/device behavior changed; public status response scheduling only.
- [x] **New/changed tests are wired into a `make` target** and have rows in `tests/migration-ledger.toml` (`make check-inventory` green — it fails closed on any unclassified test; use `make ledger-regen` to update).
      Existing nixlingd public status tests cover the touched path and were run directly.
- [x] **Docs + CI updated in lockstep**: `docs/**`, `AGENTS.md`, `tests/README.md`, and `.github/workflows/*` (doc+ci-reference gate green).
      N/A: no docs/CI contract changed; CHANGELOG updated.

## Notes

- Follow-up to the post-#168/#174 host validation where wlcontrol timed out despite nixlingd being alive.