### PR TITLE
daemon: bound public USB guest status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Public daemon `status` keeps guest USBIP import state, but now uses a short
+  status-specific guest-control budget so stale or slow guest USB probes cannot
+  push wlcontrol past its public-socket timeout.
 - Public daemon `list` and `status` responses now build per-VM status entries
   in parallel, so slow provider or guest-control probes cannot serially push
   wlcontrol past its public-socket timeout.

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -232,6 +232,7 @@ const VM_STOP_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS: u64 = 90;
 const PROVIDER_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const PUBLIC_STATUS_PROVIDER_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
+const PUBLIC_STATUS_GUEST_USBIP_TIMEOUT: Duration = Duration::from_millis(250);
 const EMPTY_VMM_CLEANUP_GRACE: Duration = Duration::from_secs(5);
 const CGROUP_EMPTY_POST_KILL_WAIT: Duration = Duration::from_secs(5);
 const GATEWAY_DISPLAY_SESSION_TTL: Duration = Duration::from_secs(3600);
@@ -3746,6 +3747,7 @@ fn run_guest_usbip_status(
     resolver: &BundleResolver,
     vm: &str,
     bus_id: &str,
+    timeout: Duration,
 ) -> Result<guest_control_health::GuestUsbipStatusResult, String> {
     let Some(entry) = resolver.manifest.vms.get(vm) else {
         return Err(format!("VM '{vm}' is not present in the trusted manifest"));
@@ -3771,7 +3773,7 @@ fn run_guest_usbip_status(
         broker_socket_path(state),
         Some(host.to_owned()),
         Some(bus_id.to_owned()),
-        guest_control_bridge::GUEST_CONTROL_USBIP_IMPORT_TIMEOUT,
+        timeout,
     )
     .map_err(|error| guest_usbip_import_error_summary(vm, error))
 }
@@ -3932,13 +3934,19 @@ impl usbip_reconcile_state::UsbipVmStartReconcileExecutor
         usbip_reconcile_state::UsbipGuestImportState,
         usbip_reconcile_state::UsbipLifecycleStepError,
     > {
-        let status = run_guest_usbip_status(self.state, self.resolver, &claim.vm, &claim.bus_id)
-            .map_err(|summary| {
-                usbip_reconcile_state::UsbipLifecycleStepError::new(
-                    usbip_reconcile_state::UsbipLifecycleFailureKind::GuestFailed,
-                    summary,
-                )
-            })?;
+        let status = run_guest_usbip_status(
+            self.state,
+            self.resolver,
+            &claim.vm,
+            &claim.bus_id,
+            guest_control_bridge::GUEST_CONTROL_USBIP_IMPORT_TIMEOUT,
+        )
+        .map_err(|summary| {
+            usbip_reconcile_state::UsbipLifecycleStepError::new(
+                usbip_reconcile_state::UsbipLifecycleFailureKind::GuestFailed,
+                summary,
+            )
+        })?;
         let imported = status
             .imports
             .iter()
@@ -4617,7 +4625,14 @@ fn dispatch_broker_usbip_probe(state: &ServerState) -> Result<Value, TypedError>
         .iter()
         .map(String::as_str)
         .filter_map(|intent_id| resolver.find_usbip_bind_intent(intent_id))
-        .map(|intent| usbip_probe_entry_from_intent(state, &resolver, intent))
+        .map(|intent| {
+            usbip_probe_entry_from_intent(
+                state,
+                &resolver,
+                intent,
+                Some(guest_control_bridge::GUEST_CONTROL_USBIP_IMPORT_TIMEOUT),
+            )
+        })
         .collect();
     entries.extend(qemu_media_probe_entries(&resolver));
     Ok(wire::usbip_probe_response(
@@ -4629,6 +4644,7 @@ fn usbip_probe_entry_from_intent(
     state: &ServerState,
     resolver: &BundleResolver,
     intent: &nixling_core::bundle_resolver::ResolvedUsbipBindIntent,
+    guest_status_timeout: Option<Duration>,
 ) -> public_wire::UsbipProbeEntry {
     let owner_vm = fs::read_to_string(&intent.lock_path)
         .ok()
@@ -4673,22 +4689,46 @@ fn usbip_probe_entry_from_intent(
                 )),
             ));
         }
-        match run_guest_usbip_status(state, resolver, &intent.vm_name, &intent.bus_id) {
-            Ok(status) => {
-                let imported = status
-                    .imports
-                    .iter()
-                    .any(|entry| entry.bus_id == intent.bus_id);
-                guest_import = if imported {
-                    public_wire::UsbipGuestImportState::Imported
-                } else {
-                    public_wire::UsbipGuestImportState::Detached
-                };
-                if !imported {
+        if let Some(guest_status_timeout) = guest_status_timeout {
+            match run_guest_usbip_status(
+                state,
+                resolver,
+                &intent.vm_name,
+                &intent.bus_id,
+                guest_status_timeout,
+            ) {
+                Ok(status) => {
+                    let imported = status
+                        .imports
+                        .iter()
+                        .any(|entry| entry.bus_id == intent.bus_id);
+                    guest_import = if imported {
+                        public_wire::UsbipGuestImportState::Imported
+                    } else {
+                        public_wire::UsbipGuestImportState::Detached
+                    };
+                    if !imported {
+                        degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
+                            usbip_reconcile_state::UsbipDegradedReason::GuestImportUnavailable,
+                            Some(format!(
+                                "Run `nixling usb attach {vm} {bus} --apply` after the VM is running.",
+                                vm = intent.vm_name,
+                                bus = intent.bus_id
+                            )),
+                        ));
+                        remediation_commands.push(format!(
+                            "nixling usb attach {vm} {bus} --apply",
+                            vm = intent.vm_name,
+                            bus = intent.bus_id
+                        ));
+                    }
+                }
+                Err(_) => {
+                    guest_import = public_wire::UsbipGuestImportState::Unavailable;
                     degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
                         usbip_reconcile_state::UsbipDegradedReason::GuestImportUnavailable,
                         Some(format!(
-                            "Run `nixling usb attach {vm} {bus} --apply` after the VM is running.",
+                            "Start the VM with `nixling vm start {vm} --apply`, then run `nixling usb attach {vm} {bus} --apply`.",
                             vm = intent.vm_name,
                             bus = intent.bus_id
                         )),
@@ -4699,22 +4739,6 @@ fn usbip_probe_entry_from_intent(
                         bus = intent.bus_id
                     ));
                 }
-            }
-            Err(_) => {
-                guest_import = public_wire::UsbipGuestImportState::Unavailable;
-                degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
-                    usbip_reconcile_state::UsbipDegradedReason::GuestImportUnavailable,
-                    Some(format!(
-                        "Start the VM with `nixling vm start {vm} --apply`, then run `nixling usb attach {vm} {bus} --apply`.",
-                        vm = intent.vm_name,
-                        bus = intent.bus_id
-                    )),
-                ));
-                remediation_commands.push(format!(
-                    "nixling usb attach {vm} {bus} --apply",
-                    vm = intent.vm_name,
-                    bus = intent.bus_id
-                ));
             }
         }
         degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
@@ -4966,7 +4990,14 @@ fn public_usb_status_for_vm(
         .usbip_bind_intent_ids()
         .filter_map(|intent_id| resolver.find_usbip_bind_intent(intent_id))
         .filter(|intent| intent.vm_name == vm)
-        .map(|intent| usbip_probe_entry_from_intent(state, resolver, intent))
+        .map(|intent| {
+            usbip_probe_entry_from_intent(
+                state,
+                resolver,
+                intent,
+                Some(PUBLIC_STATUS_GUEST_USBIP_TIMEOUT),
+            )
+        })
         .collect();
     if entries.is_empty() {
         return None;

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -3748,14 +3748,16 @@ fn run_guest_usbip_status(
     vm: &str,
     bus_id: &str,
     timeout: Duration,
-) -> Result<guest_control_health::GuestUsbipStatusResult, String> {
+) -> Result<guest_control_health::GuestUsbipStatusResult, GuestUsbipStatusError> {
     let Some(entry) = resolver.manifest.vms.get(vm) else {
-        return Err(format!("VM '{vm}' is not present in the trusted manifest"));
+        return Err(GuestUsbipStatusError::Failed(format!(
+            "VM '{vm}' is not present in the trusted manifest"
+        )));
     };
     let Some(host) = entry.usbipd_host_ip.as_deref() else {
-        return Err(format!(
+        return Err(GuestUsbipStatusError::Failed(format!(
             "VM '{vm}' has no per-env USBIP host IP in the trusted manifest"
-        ));
+        )));
     };
     let params = resolve_guest_control_probe_params(state, resolver, vm).map_err(|detail| {
         tracing::warn!(
@@ -3764,9 +3766,9 @@ fn run_guest_usbip_status(
             error_kind = "transport-io",
             "guest-control USBIP status: probe params unresolved: {detail}"
         );
-        format!(
+        GuestUsbipStatusError::Failed(format!(
             "guest-control USBIP status for vm '{vm}' could not resolve guest-control transport"
-        )
+        ))
     })?;
     guest_control_bridge::run_usbip_status_on_dedicated_thread(
         params,
@@ -3775,7 +3777,7 @@ fn run_guest_usbip_status(
         Some(bus_id.to_owned()),
         timeout,
     )
-    .map_err(|error| guest_usbip_import_error_summary(vm, error))
+    .map_err(|error| classify_guest_usbip_status_error(vm, error))
 }
 
 fn persisted_same_vm_usbip_claims(
@@ -3941,10 +3943,10 @@ impl usbip_reconcile_state::UsbipVmStartReconcileExecutor
             &claim.bus_id,
             guest_control_bridge::GUEST_CONTROL_USBIP_IMPORT_TIMEOUT,
         )
-        .map_err(|summary| {
+        .map_err(|error| {
             usbip_reconcile_state::UsbipLifecycleStepError::new(
                 usbip_reconcile_state::UsbipLifecycleFailureKind::GuestFailed,
-                summary,
+                error.summary().to_owned(),
             )
         })?;
         let imported = status
@@ -4250,6 +4252,38 @@ fn guest_usbip_import_error_summary(
         E::InvalidOutput => "guest usbip command output was invalid",
     };
     format!("guest-control USBIP import failed for vm '{vm}': {detail}")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GuestUsbipStatusError {
+    Timeout(String),
+    Failed(String),
+}
+
+impl GuestUsbipStatusError {
+    fn summary(&self) -> &str {
+        match self {
+            Self::Timeout(summary) | Self::Failed(summary) => summary,
+        }
+    }
+}
+
+fn classify_guest_usbip_status_error(
+    vm: &str,
+    error: guest_control_health::GuestUsbipImportError,
+) -> GuestUsbipStatusError {
+    let is_timeout = matches!(
+        error,
+        guest_control_health::GuestUsbipImportError::Probe(
+            guest_control_health::GuestControlHealthError::Timeout
+        ) | guest_control_health::GuestUsbipImportError::CommandTimeout
+    );
+    let summary = guest_usbip_import_error_summary(vm, error);
+    if is_timeout {
+        GuestUsbipStatusError::Timeout(summary)
+    } else {
+        GuestUsbipStatusError::Failed(summary)
+    }
 }
 
 fn compensate_usbip_bind_failure(
@@ -4723,22 +4757,14 @@ fn usbip_probe_entry_from_intent(
                         ));
                     }
                 }
-                Err(_) => {
-                    guest_import = public_wire::UsbipGuestImportState::Unavailable;
-                    degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
-                        usbip_reconcile_state::UsbipDegradedReason::GuestImportUnavailable,
-                        Some(format!(
-                            "Start the VM with `nixling vm start {vm} --apply`, then run `nixling usb attach {vm} {bus} --apply`.",
-                            vm = intent.vm_name,
-                            bus = intent.bus_id
-                        )),
-                    ));
-                    remediation_commands.push(format!(
-                        "nixling usb attach {vm} {bus} --apply",
-                        vm = intent.vm_name,
-                        bus = intent.bus_id
-                    ));
-                }
+                Err(error) => push_guest_usbip_status_error(
+                    error,
+                    &intent.vm_name,
+                    &intent.bus_id,
+                    &mut guest_import,
+                    &mut degraded_reasons,
+                    &mut remediation_commands,
+                ),
             }
         }
         degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
@@ -4816,6 +4842,35 @@ fn usbip_probe_entry_from_intent(
         topology_policy,
         degraded_reasons,
         remediation_commands,
+    }
+}
+
+fn push_guest_usbip_status_error(
+    error: GuestUsbipStatusError,
+    vm: &str,
+    bus_id: &str,
+    guest_import: &mut public_wire::UsbipGuestImportState,
+    degraded_reasons: &mut Vec<public_wire::UsbipProbeDegradedReason>,
+    remediation_commands: &mut Vec<String>,
+) {
+    if matches!(error, GuestUsbipStatusError::Timeout(_)) {
+        *guest_import = public_wire::UsbipGuestImportState::Unknown;
+        degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
+            usbip_reconcile_state::UsbipDegradedReason::GuestImportUnavailable,
+            Some(format!(
+                "{}; retry `nixling usb probe` for a full diagnostic budget.",
+                error.summary()
+            )),
+        ));
+    } else {
+        *guest_import = public_wire::UsbipGuestImportState::Unavailable;
+        degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
+            usbip_reconcile_state::UsbipDegradedReason::GuestImportUnavailable,
+            Some(format!(
+                "Start the VM with `nixling vm start {vm} --apply`, then run `nixling usb attach {vm} {bus_id} --apply`."
+            )),
+        ));
+        remediation_commands.push(format!("nixling usb attach {vm} {bus_id} --apply"));
     }
 }
 
@@ -15998,6 +16053,43 @@ mod public_status_tests {
         assert_eq!(
             services.get("virtiofsd").and_then(Value::as_str),
             Some("running")
+        );
+    }
+
+    #[test]
+    fn guest_usbip_status_timeout_is_unknown_without_start_remediation() {
+        let mut guest_import = public_wire::UsbipGuestImportState::Unavailable;
+        let mut degraded_reasons = Vec::new();
+        let mut remediation_commands = vec!["nixling usb attach stale 1-2 --apply".to_owned()];
+
+        push_guest_usbip_status_error(
+            GuestUsbipStatusError::Timeout(
+                "guest-control USBIP import failed for vm 'corp-vm': guest-control USBIP import timed out"
+                    .to_owned(),
+            ),
+            "corp-vm",
+            "1-2",
+            &mut guest_import,
+            &mut degraded_reasons,
+            &mut remediation_commands,
+        );
+
+        assert_eq!(guest_import, public_wire::UsbipGuestImportState::Unknown);
+        assert!(
+            degraded_reasons
+                .iter()
+                .any(|reason| reason.remediation.contains("full diagnostic budget"))
+        );
+        assert!(
+            !degraded_reasons
+                .iter()
+                .any(|reason| reason.remediation.contains("vm start corp-vm")),
+            "status timeout must not tell operators to start an already-running VM"
+        );
+        assert_eq!(
+            remediation_commands,
+            vec!["nixling usb attach stale 1-2 --apply"],
+            "timeouts do not add attach/start remediation commands"
         );
     }
 


### PR DESCRIPTION
## Summary

- Keep public status USB data enriched from the guest, but use a short status-specific guest-control budget instead of the full USB import budget.
- Preserve the full USBIP import/status budget for lifecycle reconciliation and USB probe diagnostics.
- Prevent one slow or stale guest USB status probe from making wlcontrol report a live daemon as daemon-down.

## Testing checklist (mandatory)

- [x] make check passes locally: focused validation passed with check-tier0, cargo check for nixlingd, public_status_tests, and public_status_socket.
- [x] make test-integration: N/A, daemon public status timeout budget only.
- [x] make test-host-integration: N/A for this focused latency fix; live host validation will run after merge/switch.
- [x] make test-hardware: N/A, no hardware/device behavior changed.
- [x] New or changed tests are wired into an existing make target: existing nixlingd public status tests and public status socket test cover the touched path.
- [x] Docs and CI updated in lockstep: N/A; CHANGELOG updated.

## Notes

Follow-up to PR #175: keep guest USB status in public status, but make it fast enough for wlcontrol.