### PR TITLE
activation: grant role UIDs vms runtime traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Activation now grants every numeric per-role runtime UID traversal on both
+  `/run/nixling` and `/run/nixling/vms`, so broker-spawned runners can reach
+  their per-VM runtime socket directories after a host switch.
 - Public daemon `status` keeps guest USBIP import state, but now uses a short
   status-specific guest-control budget so stale or slow guest USB probes cannot
   push wlcontrol past its public-socket timeout.

--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -581,13 +581,10 @@ in
             for uid in $(${pkgs.jq}/bin/jq -r '.vms[] | select(.vm == "${name}") | .nodes[] | .profile.uid' "$bundle_json" | ${pkgs.coreutils}/bin/sort -u); do
               [ "$uid" = "0" ] && continue
               ${pkgs.acl}/bin/setfacl -m "u:$uid:x" /var/lib/nixling 2>/dev/null || true
-              # Option B: also grant traversal on
-              # /run/nixling (mode 0750 nixlingd:nixling)
-              # so ephemeral role UIDs (audio, video, etc.) can
-              # reach the per-VM socket dir. virtiofsd skips this
-              # via its own pivot_root + CAP_SYS_ADMIN; other
-              # sidecars need explicit ACL.
+              # Grant traversal on both shared runtime parents so numeric
+              # per-role UIDs can reach /run/nixling/vms/<vm> sockets.
               ${pkgs.acl}/bin/setfacl -m "u:$uid:x" /run/nixling 2>/dev/null || true
+              ${pkgs.acl}/bin/setfacl -m "u:$uid:x" /run/nixling/vms 2>/dev/null || true
               if echo "$guest_control_virtiofsd_uids" | ${pkgs.gnugrep}/bin/grep -qx "$uid"; then
                 ${activationHelper} clear-acl-on-path --path "/var/lib/nixling/guest-control-${name}" --require-kind directory --setfacl-bin "${pkgs.acl}/bin/setfacl" 2>/dev/null || true
                 ${activationHelper} clear-acl-on-path --path "/var/lib/nixling/guest-control-${name}/token" --require-kind regular --setfacl-bin "${pkgs.acl}/bin/setfacl" 2>/dev/null || true

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -285,6 +285,13 @@ in
     expected = true;
   };
 
+  "activation-runtime-tmpfiles/role-acl-script-grants-run-vms-parent-traversal" = {
+    expr =
+      lib.hasInfix ''setfacl -m "u:$uid:x" /run/nixling 2>/dev/null || true'' roleAclText
+      && lib.hasInfix ''setfacl -m "u:$uid:x" /run/nixling/vms 2>/dev/null || true'' roleAclText;
+    expected = true;
+  };
+
   "activation-runtime-tmpfiles/state-dir-acl-script-no-static-sidecar-loop" = {
     expr =
       !(lib.hasInfix "for suffix in gpu swtpm audio video wlproxy qemu-media" stateDirAclText)


### PR DESCRIPTION
## Summary

- grant every numeric per-role runtime UID traversal on `/run/nixling/vms` in addition to `/run/nixling`
- add nix-unit coverage for the activation fallback ACL script
- document the runtime traversal fix in the changelog

## Validation

- `make test-nix-unit`
- live sys-obs recovery: DB images recreated, VM DAG running, SigNoz services active after rerun, and a host `logger` marker appeared in `signoz_logs.distributed_logs_v2`
