### PR TITLE
provider: guard host realm boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Changed
 
+- Provider/realm policy coverage now explicitly guards host daemon, broker, and
+  bundle artifacts from storing realm credentials, remote registries, or realm
+  audit state while keeping capability-denied remote dispatch fail-closed.
 - Renamed the internal contract/DTO crate to `nixling-contracts` and added
   workspace taxonomy checks for contract and standalone workspace coverage.
 - CI workflow make-target policy coverage moved from a shell meta gate to a Rust

--- a/packages/nixling-contract-tests/tests/policy_host_realm_relay.rs
+++ b/packages/nixling-contract-tests/tests/policy_host_realm_relay.rs
@@ -1,11 +1,37 @@
 //! Host-side source boundary checks for realm relay credentials.
 
+use std::collections::BTreeSet;
+use std::process::Command;
+
 use nixling_contract_tests::repo_root;
 
 fn read(rel: &str) -> String {
     std::fs::read_to_string(repo_root().join(rel)).unwrap_or_else(|err| {
         panic!("failed to read {rel}: {err}");
     })
+}
+
+fn git_listed_files(roots: &[&str]) -> Vec<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root())
+        .args(["ls-files", "-z", "--"])
+        .args(roots)
+        .output()
+        .expect("run git ls-files");
+    assert!(
+        output.status.success(),
+        "git ls-files failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| String::from_utf8(entry.to_vec()).expect("tracked paths are UTF-8"))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 fn forbidden_needles() -> Vec<String> {
@@ -68,6 +94,109 @@ fn host_cli_and_host_sources_do_not_construct_realm_relay() {
         violations.is_empty(),
         "host-side realm relay source boundary violations:\n{}",
         violations.join("\n")
+    );
+}
+
+#[test]
+fn host_daemon_broker_and_activation_do_not_store_realm_credentials() {
+    let checked = git_listed_files(&[
+        "packages/nixlingd/src",
+        "packages/nixling-priv-broker/src",
+        "nixos-modules",
+    ]);
+    let allowlisted = BTreeSet::from([
+        "packages/nixlingd/src/constellation_stubs.rs",
+        "packages/nixlingd/src/lib.rs",
+        "nixos-modules/assertions.nix",
+        "nixos-modules/gateway-vm.nix",
+        "nixos-modules/options-gateway.nix",
+    ]);
+    let forbidden = [
+        ["Remote", "Daemon", "Access", "Credential"].concat(),
+        ["Relay", "Daemon", "Access", "Credential"].concat(),
+        ["Browser", "Daemon", "Access", "Credential"].concat(),
+        ["Redacted", "Daemon", "Access", "Credential"].concat(),
+        ["Relay", "Credential"].concat(),
+        ["Gateway", "Credential"].concat(),
+        ["Provider", "Credential"].concat(),
+        ["realm", "_audit"].concat(),
+        ["realm", "Audit"].concat(),
+        ["remote", "_node", "_registry"].concat(),
+        ["Remote", "Node", "Registry"].concat(),
+    ];
+    let mut violations = Vec::new();
+    for rel in checked {
+        if allowlisted.contains(rel.as_str()) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(repo_root().join(&rel)) else {
+            continue;
+        };
+        for needle in &forbidden {
+            if content.contains(needle) {
+                violations.push(format!(
+                    "{rel}: forbidden host realm credential/registry token"
+                ));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "host daemon/broker/module realm-boundary violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn host_bundle_artifacts_do_not_materialize_realm_credentials_or_registries() {
+    let checked = git_listed_files(&["nixos-modules"]);
+    let mut violations = Vec::new();
+    let forbidden = [
+        ["relay", "Credential"].concat(),
+        ["provider", "Credential"].concat(),
+        ["realm", "Audit"].concat(),
+        ["remote", "Node", "Registry"].concat(),
+        ["remote", "Registry"].concat(),
+    ];
+    for rel in checked {
+        if !(rel.ends_with("-json.nix")
+            || rel.ends_with("manifest.nix")
+            || rel.ends_with("bundle-artifacts.nix")
+            || rel.ends_with("bundle.nix"))
+        {
+            continue;
+        }
+        let content = read(&rel);
+        for needle in &forbidden {
+            if content.contains(needle) {
+                violations.push(format!("{rel}: forbidden host bundle realm artifact token"));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "host-readable bundle artifact realm-boundary violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn host_relay_credentials_are_explicitly_refused_not_materialized() {
+    let daemon = read("packages/nixlingd/src/lib.rs");
+    assert!(
+        daemon.contains("allow_host_relay_credentials")
+            && daemon.contains(
+                "host-held gateway credentials and relay send-bearer minting are retired"
+            ),
+        "nixlingd must retain the host-relay credential transition guard"
+    );
+
+    let host_daemon = read("nixos-modules/host-daemon.nix");
+    assert!(
+        host_daemon.contains(r#"forbiddenHostEnvPrefixes = [ "NIXLING_RELAY_" ]"#)
+            && host_daemon
+                .contains(r#"omitted = [ "payload" "headers" "token" "endpoint" "credential" ]"#),
+        "host daemon module must emit only a deny/redaction policy for host relay credentials"
     );
 }
 

--- a/packages/nixlingd/src/constellation_stubs.rs
+++ b/packages/nixlingd/src/constellation_stubs.rs
@@ -388,8 +388,10 @@ mod tests {
         }
     }
 
-    fn remote_registration(principal: &PrincipalId) -> RemoteNodeRegistration {
-        let caps = CapabilitySet::empty().with(Capability::Lifecycle);
+    fn remote_registration_with_caps(
+        principal: &PrincipalId,
+        caps: CapabilitySet,
+    ) -> RemoteNodeRegistration {
         RemoteNodeRegistration {
             summary: NodeSummary {
                 id: NodeId::parse("remote-host").unwrap(),
@@ -402,6 +404,13 @@ mod tests {
             substrate_adapter: ProviderId::parse("nixos-host-substrate").unwrap(),
             generation: ProtocolToken::parse("gen-1").unwrap(),
         }
+    }
+
+    fn remote_registration(principal: &PrincipalId) -> RemoteNodeRegistration {
+        remote_registration_with_caps(
+            principal,
+            CapabilitySet::empty().with(Capability::Lifecycle),
+        )
     }
 
     #[derive(Default)]
@@ -559,6 +568,38 @@ mod tests {
             .unwrap();
         assert!(matches!(outcome, RemoteDispatchOutcome::Sent { .. }));
         assert_eq!(peer.sends, 1);
+    }
+
+    #[test]
+    fn peer_daemon_denies_missing_capability_before_peer_send() {
+        let principal = PrincipalId::parse("gateway-principal").unwrap();
+        let mut daemon = PeerDaemon::with_gateway_principal(
+            principal.clone(),
+            CapabilitySet::empty().with(Capability::Lifecycle),
+        );
+        daemon
+            .remote_nodes_mut()
+            .register(
+                remote_registration_with_caps(&principal, CapabilitySet::empty()),
+                std::time::Instant::now(),
+            )
+            .unwrap();
+
+        let mut peer = FakePeerClient::default();
+        let request = remote_start_req(&principal, "op-remote-denied", "idem-remote-denied");
+        let err = daemon
+            .dispatch_remote(&request, &ProtocolToken::parse("gen-1").unwrap(), &mut peer)
+            .expect_err("missing remote lifecycle capability fails before peer send");
+
+        assert_eq!(
+            err.kind,
+            nixling_constellation_router::RemoteNodeErrorKind::CapabilityDenied
+        );
+        assert_eq!(err.missing_capability, Some(Capability::Lifecycle));
+        assert_eq!(
+            peer.sends, 0,
+            "capability denial must happen before remote peer side effects"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add host-boundary policy coverage preventing host daemon, broker, and bundle artifacts from materializing realm credentials, remote registries, or realm audit state.
- Preserve explicit gateway/host relay refusal and redaction guards.
- Add a daemon seam test proving remote capability denial happens before peer send side effects.

## Validation
- Full Wave 9 plan panel: 10/10 Gemini 3.1 Pro signoff.
- `make check`
- `make test-rust`
- `make test-drift`
- `make test-policy`
- `make test-flake`
- focused provider/realm policy and daemon constellation seam tests

## Integration
- `make test-integration` and `make test-host-integration` will be run before merge.
- Hardware testing: N/A; no hardware behavior change.