### PR TITLE
runtime: extract qemu media capability projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Changed
 
+- Runtime capability projection for qemu-media list/status output now goes
+  through focused helpers with direct regression coverage, preserving public JSON
+  and human output shape.
 - Provider/realm policy coverage now explicitly guards host daemon, broker, and
   bundle artifacts from storing realm credentials, remote registries, or realm
   audit state while keeping capability-denied remote dispatch fail-closed.

--- a/packages/nixling/src/status_read_model.rs
+++ b/packages/nixling/src/status_read_model.rs
@@ -128,52 +128,48 @@ fn output_autostart_posture(vm: &ManifestVm) -> Option<IpcVmAutostartPosture> {
     })
 }
 
+const QEMU_MEDIA_DEFAULT_RUNTIME_CAPABILITIES: &[&str] = &["display", "lifecycle", "usb-hotplug"];
+const QEMU_MEDIA_DEFAULT_UNSUPPORTED_CAPABILITIES: &[&str] = &[
+    "config-sync",
+    "exec",
+    "guest-control",
+    "in-guest-observability",
+    "keys",
+    concat!("s", "sh"),
+    "store-sync",
+];
+
 fn output_runtime_capabilities(vm: &ManifestVm) -> Vec<String> {
-    let Some(runtime) = vm.runtime.as_ref() else {
-        return Vec::new();
-    };
-    let mut supported = runtime
-        .capabilities
-        .iter()
-        .filter(|(_capability, supported)| **supported)
-        .map(|(capability, _supported)| capability_name_for_output(capability).to_owned())
-        .collect::<Vec<_>>();
-    if supported.is_empty() && runtime.kind == "qemu-media" && runtime.capabilities.is_empty() {
-        supported = vec![
-            "display".to_owned(),
-            "lifecycle".to_owned(),
-            "usb-hotplug".to_owned(),
-        ];
-    }
-    supported.sort();
-    supported.dedup();
-    supported
+    output_runtime_capabilities_by_support(vm, true, QEMU_MEDIA_DEFAULT_RUNTIME_CAPABILITIES)
 }
 
 fn output_unsupported_capabilities(vm: &ManifestVm) -> Vec<String> {
+    output_runtime_capabilities_by_support(vm, false, QEMU_MEDIA_DEFAULT_UNSUPPORTED_CAPABILITIES)
+}
+
+fn output_runtime_capabilities_by_support(
+    vm: &ManifestVm,
+    supported: bool,
+    qemu_media_default: &[&str],
+) -> Vec<String> {
     let Some(runtime) = vm.runtime.as_ref() else {
         return Vec::new();
     };
-    let mut unsupported = runtime
+    let mut capabilities = runtime
         .capabilities
         .iter()
-        .filter(|(_capability, supported)| !**supported)
-        .map(|(capability, _supported)| capability_name_for_output(capability).to_owned())
+        .filter(|(_capability, is_supported)| **is_supported == supported)
+        .map(|(capability, _is_supported)| capability_name_for_output(capability).to_owned())
         .collect::<Vec<_>>();
-    if unsupported.is_empty() && runtime.kind == "qemu-media" && runtime.capabilities.is_empty() {
-        unsupported = vec![
-            "config-sync".to_owned(),
-            "exec".to_owned(),
-            "guest-control".to_owned(),
-            "in-guest-observability".to_owned(),
-            "keys".to_owned(),
-            "s".to_owned() + "sh",
-            "store-sync".to_owned(),
-        ];
+    if capabilities.is_empty() && runtime.kind == "qemu-media" && runtime.capabilities.is_empty() {
+        capabilities = qemu_media_default
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect();
     }
-    unsupported.sort();
-    unsupported.dedup();
-    unsupported
+    capabilities.sort();
+    capabilities.dedup();
+    capabilities
 }
 
 pub(crate) fn output_service_capabilities(services: &StatusServicesOutputV2) -> Vec<String> {
@@ -871,4 +867,68 @@ fn readiness_name_for_node(
         }
     }
     readiness_name(readiness)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::ManifestRuntime;
+
+    fn manifest_vm_with_runtime(kind: &str, capabilities: BTreeMap<String, bool>) -> ManifestVm {
+        ManifestVm {
+            name: "installer".to_owned(),
+            env: Some("dev".to_owned()),
+            graphics: false,
+            tpm: false,
+            audio: false,
+            usbip_yubikey: false,
+            static_ip: None,
+            is_net_vm: false,
+            state_dir: "/var/lib/nixling/vms/installer".to_owned(),
+            bridge: "br-dev-lan".to_owned(),
+            ssh_user: None,
+            runtime: Some(ManifestRuntime {
+                kind: kind.to_owned(),
+                capabilities,
+            }),
+        }
+    }
+
+    #[test]
+    fn qemu_media_default_capability_projection_is_stable() {
+        let vm = manifest_vm_with_runtime("qemu-media", BTreeMap::new());
+
+        assert_eq!(
+            output_runtime_capabilities(&vm),
+            vec!["display", "lifecycle", "usb-hotplug"]
+        );
+        assert_eq!(
+            output_unsupported_capabilities(&vm),
+            vec![
+                "config-sync",
+                "exec",
+                "guest-control",
+                "in-guest-observability",
+                "keys",
+                "ssh",
+                "store-sync"
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_runtime_capability_projection_overrides_qemu_defaults() {
+        let vm = manifest_vm_with_runtime(
+            "qemu-media",
+            BTreeMap::from([
+                ("guestControl".to_owned(), false),
+                ("usbHotplug".to_owned(), true),
+            ]),
+        );
+
+        assert_eq!(output_runtime_capabilities(&vm), vec!["usb-hotplug"]);
+        assert_eq!(output_unsupported_capabilities(&vm), vec!["guest-control"]);
+    }
 }

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -14393,58 +14393,59 @@ fn public_autostart_posture(manifest_entry: &Value) -> Option<Value> {
     })
 }
 
+const QEMU_MEDIA_DEFAULT_RUNTIME_CAPABILITIES: &[&str] = &["display", "lifecycle", "usb-hotplug"];
+const QEMU_MEDIA_DEFAULT_UNSUPPORTED_CAPABILITIES: &[&str] = &[
+    "config-sync",
+    "exec",
+    "guest-control",
+    "in-guest-observability",
+    "keys",
+    concat!("s", "sh"),
+    "store-sync",
+];
+
 fn public_runtime_capabilities(manifest_entry: &Value) -> Vec<String> {
-    let Some(capabilities) = manifest_entry
-        .pointer("/runtime/capabilities")
-        .and_then(Value::as_object)
-    else {
-        return if public_is_qemu_media(manifest_entry) {
-            vec![
-                "display".to_owned(),
-                "lifecycle".to_owned(),
-                "usb-hotplug".to_owned(),
-            ]
-        } else {
-            Vec::new()
-        };
-    };
-    let mut supported = capabilities
-        .iter()
-        .filter(|(_name, value)| value.as_bool() == Some(true))
-        .map(|(name, _value)| capability_name_for_public_output(name))
-        .collect::<Vec<_>>();
-    supported.sort();
-    supported.dedup();
-    supported
+    public_runtime_capabilities_by_support(
+        manifest_entry,
+        true,
+        QEMU_MEDIA_DEFAULT_RUNTIME_CAPABILITIES,
+    )
 }
 
 fn public_unsupported_capabilities(manifest_entry: &Value) -> Vec<String> {
+    public_runtime_capabilities_by_support(
+        manifest_entry,
+        false,
+        QEMU_MEDIA_DEFAULT_UNSUPPORTED_CAPABILITIES,
+    )
+}
+
+fn public_runtime_capabilities_by_support(
+    manifest_entry: &Value,
+    supported: bool,
+    qemu_media_default: &[&str],
+) -> Vec<String> {
     let Some(capabilities) = manifest_entry
         .pointer("/runtime/capabilities")
         .and_then(Value::as_object)
     else {
         return if public_is_qemu_media(manifest_entry) {
-            vec![
-                "config-sync".to_owned(),
-                "exec".to_owned(),
-                "guest-control".to_owned(),
-                "in-guest-observability".to_owned(),
-                "keys".to_owned(),
-                "s".to_owned() + "sh",
-                "store-sync".to_owned(),
-            ]
+            qemu_media_default
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect()
         } else {
             Vec::new()
         };
     };
-    let mut unsupported = capabilities
+    let mut output = capabilities
         .iter()
-        .filter(|(_name, value)| value.as_bool() == Some(false))
+        .filter(|(_name, value)| value.as_bool() == Some(supported))
         .map(|(name, _value)| capability_name_for_public_output(name))
         .collect::<Vec<_>>();
-    unsupported.sort();
-    unsupported.dedup();
-    unsupported
+    output.sort();
+    output.dedup();
+    output
 }
 
 fn capability_name_for_public_output(name: &str) -> String {
@@ -15620,6 +15621,18 @@ mod public_status_tests {
         })
     }
 
+    fn qemu_media_default_capability_manifest_entry() -> Value {
+        json!({
+            "stateDir": "/nonexistent/nixling-public-status-test",
+            "runtime": {
+                "kind": "qemu-media"
+            },
+            "graphics": false,
+            "audio": false,
+            "tpm": false
+        })
+    }
+
     fn qemu_media_process_dag() -> nixling_core::processes::VmProcessDag {
         use nixling_core::processes::{NodeId, VmProcessDag, VmProcessInvariants};
         VmProcessDag {
@@ -15835,6 +15848,41 @@ mod public_status_tests {
         assert_eq!(
             public_service_capabilities(&services),
             vec!["nixling".to_owned(), "qemu-media".to_owned()]
+        );
+    }
+
+    #[test]
+    fn public_qemu_media_capability_projection_is_stable() {
+        let defaulted = qemu_media_default_capability_manifest_entry();
+        assert_eq!(
+            public_runtime_capabilities(&defaulted),
+            vec!["display", "lifecycle", "usb-hotplug"]
+        );
+        assert_eq!(
+            public_unsupported_capabilities(&defaulted),
+            vec![
+                "config-sync",
+                "exec",
+                "guest-control",
+                "in-guest-observability",
+                "keys",
+                "ssh",
+                "store-sync"
+            ]
+        );
+
+        let explicit = qemu_media_manifest_entry();
+        assert_eq!(public_runtime_capabilities(&explicit), vec!["usb-hotplug"]);
+        assert_eq!(
+            public_unsupported_capabilities(&explicit),
+            vec![
+                "config-sync",
+                "exec",
+                "guest-control",
+                "keys",
+                "ssh",
+                "store-sync"
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- Extract small qemu-media runtime capability projection helpers in daemon and CLI read-model code.
- Add direct regression tests for default and explicit qemu-media runtime/unsupported capability output.
- Preserve public list/status JSON and human output semantics.

## Validation
- Full Wave 10 plan panel: 10/10 Gemini 3.1 Pro signoff.
- `make check`
- `make test-rust`
- `make test-policy`
- `make test-drift`
- `make test-flake`
- focused qemu-media projection tests

## Integration
- `make test-integration` and `make test-host-integration` will be run before merge.
- Hardware testing: N/A; no runtime hardware behavior change.