### PR TITLE
Fix qemu-media sync lock rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- `qemu-media` TAP synchronization locks now render the TAP identifier as a
+  resource id instead of a non-path `pathTemplate`, so the generated `sync.json`
+  deserializes through the Rust `SyncJson` DTO and `nixlingd` can load the bundle
+  after hosts with qemu-media VMs switch.
 - Daemon startup no longer lets the diagnostic bridge preflight pre-skip
   autostarted net VMs on cold boot; net VMs now get to run their host-prep DAG
   and workloads degrade only if their env net VM actually fails to start.

--- a/nixos-modules/sync-json.nix
+++ b/nixos-modules/sync-json.nix
@@ -44,10 +44,10 @@ let
     cloexecRequired = true;
   };
 
-  kernelLock = { id, scope, path, owner, scopeClass ? "host", root ? "run", normalizedPath ? id, staleKind ? "cutover-only", adoptionPolicy ? "reacquire-after-proof", timeoutKind ? "fail-fast", timeoutMs ? null, degradeScope ? "host" }: {
+  kernelLock = { id, scope, path ? null, resourceId ? null, owner, scopeClass ? "host", root ? "run", normalizedPath ? id, staleKind ? "cutover-only", adoptionPolicy ? "reacquire-after-proof", timeoutKind ? "fail-fast", timeoutMs ? null, degradeScope ? "host" }: {
     inherit id scope;
     pathTemplate = path;
-    resourceId = null;
+    inherit resourceId;
     kind = "kernel-object";
     ownerProcess = owner;
     allowedHolders = [ owner ];
@@ -139,7 +139,7 @@ let
   qemuMediaTapGrant = vm: kernelLock {
     id = "lock:qemu-media-tap:${vm}";
     scope = "vm:${vm}";
-    path = "tap:${cfg.manifest.${vm}.tap}";
+    resourceId = "tap:${cfg.manifest.${vm}.tap}";
     owner = actor "role" "role:${vm}:qemu-media";
     scopeClass = "vm";
     root = "kernel";

--- a/tests/unit/nix/cases/external-vm-kind.nix
+++ b/tests/unit/nix/cases/external-vm-kind.nix
@@ -66,6 +66,8 @@ let
     if positiveQemuProcess == null then null else lib.findFirst (node: node.id == "qemu-media") null positiveQemuProcess.nodes;
   positiveQemuWaylandProxy =
     if positiveQemuProcess == null then null else lib.findFirst (node: node.id == "wayland-proxy") null positiveQemuProcess.nodes;
+  positiveQemuTapLock =
+    lib.findFirst (lock: lock.id == "lock:qemu-media-tap:media") null positiveCfg.nixling._bundle.syncJson.data.locks;
   positiveProfileNames = lib.attrNames positiveCfg.nixling._bundle.minijailProfiles;
   expectedNixosRuntime = {
     kind = "nixos";
@@ -651,6 +653,23 @@ in
       noGuestControl = true;
       noMediaPathInArgv = true;
       noVhostNetPathInArgv = true;
+    };
+  };
+
+  "external-vm-kind/qemu-media-tap-sync-lock-uses-resource-id" = {
+    expr = {
+      id = positiveQemuTapLock.id or null;
+      kind = positiveQemuTapLock.kind or null;
+      pathTemplate = positiveQemuTapLock.pathTemplate or null;
+      resourceId = positiveQemuTapLock.resourceId or null;
+      normalizedPath = positiveQemuTapLock.acquireOrder.normalizedPath or null;
+    };
+    expected = {
+      id = "lock:qemu-media-tap:media";
+      kind = "kernel-object";
+      pathTemplate = null;
+      resourceId = "tap:work-l42";
+      normalizedPath = "tap/work-l42";
     };
   };
 


### PR DESCRIPTION
## Summary
- render qemu-media TAP sync locks as `resourceId` instead of non-path `pathTemplate` values
- add nix-unit coverage so qemu-media TAP locks remain parseable by the Rust `SyncJson` DTO

## Validation
- `nix build --no-link .#checks.$(nix eval --raw --impure --expr builtins.currentSystem).fixture-smoke` and parsed the rendered `sync.json` through `nixling_core::sync::SyncJson`
- `nix build --no-link .#checks.$(nix eval --raw --impure --expr builtins.currentSystem).nix-unit-misc`

## Notes
- This fixes the deployed `nixlingd` failure: `could not parse manifest artifact sync.json (opaque reason: parse-failed)`.
