### PR TITLE
runtime: keep nixlingd ACL mask writable

### DIFF
--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -264,6 +264,11 @@ in
     (tmpfilesDir "/run/nixling-wlproxy" "0750" "root" "nixling")
     perVmRuntimeTraversalAcls
     perQemuMediaRuntimeTraversalAcls
+    # The traversal ACLs above add many --x named users. systemd-tmpfiles
+    # recalculates the ACL mask after each a+ rule, so reassert m::rwx after
+    # those entries or nixlingd's named rwx ACL becomes effectively r-x and the
+    # daemon cannot open /run/nixling/daemon.lock after a switch.
+    (tmpfilesAcl "/run/nixling" "m::rwx")
     perNormalVmPostureTmpfiles
     perQemuMediaPostureTmpfiles
   ];

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -140,6 +140,17 @@ in
     expected = true;
   };
 
+  "activation-runtime-tmpfiles/run-parent-mask-after-traversal-acls" = {
+    expr =
+      let
+        runNixlingRules = rulesForPath "/run/nixling";
+      in
+      builtins.elem "a+ /run/nixling - - - - u:nixlingd:rwx" runNixlingRules
+      && builtins.elem "a+ /run/nixling - - - - u:nixling-corp-vm-snd:--x" runNixlingRules
+      && lib.last runNixlingRules == "a+ /run/nixling - - - - m::rwx";
+    expected = true;
+  };
+
   "activation-runtime-tmpfiles/gpu-parent" = {
     expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling-gpu 0750 root nixling -"


### PR DESCRIPTION
## Summary
- reassert `/run/nixling` ACL mask after per-VM traversal ACL entries so nixlingd keeps effective rwx access after host switch
- add nix-unit coverage that the final `/run/nixling` tmpfiles rule restores `m::rwx` after traversal ACLs

## Validation
- `make test-nix-unit` initially reproduced the new assertion failure before the fix
- rerun progressed past the new assertion but hit a local Nix store source-missing error while evaluating bootstrap derivations (`mes/sources.json`), so PR CI is the authoritative validation for the hotfix

## Context
After updating /etc/nixos to PR #187, host switch completed but nixlingd restart failed because `/run/nixling` ACL mask was recomputed to r-x by later traversal ACL entries.