### PR TITLE
Fix USB detach cleanup recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ deprecations ship one minor release before removal.
   `usb_json_contract`; and 3 network-scoping contract tests in
   `usb_network_scoping`.
 
+### Fixed
+
+- `nixling usb detach <vm> <busid> --apply` now reaches the broker
+  `UsbipUnbind` cleanup path instead of stopping at a hardcoded ambiguous-flow
+  refusal, so stale USBIP host claims can be released and subsequent attaches can
+  recover without raw `usbip` commands.
+
 ### Changed
 
 - Public daemon list/status handling now uses a request-scoped artifact snapshot

--- a/packages/nixling-contract-tests/tests/usbip_explicit_attach_contract.rs
+++ b/packages/nixling-contract-tests/tests/usbip_explicit_attach_contract.rs
@@ -307,18 +307,44 @@ fn sysfs_presence_check_is_fail_closed_before_broker_dispatch() {
 }
 
 // ---------------------------------------------------------------------------
-// Broker ops are registered as Unimplemented stubs in layer1-bootstrap
+// Broker ops are registered in the runtime dispatch
 // ---------------------------------------------------------------------------
 
 #[test]
-fn explicit_ops_appear_in_broker_runtime_as_unimplemented_stubs() {
+fn explicit_ops_appear_in_broker_runtime_dispatch() {
     let runtime = read_repo_file("packages/nixling-priv-broker/src/runtime.rs");
     assert!(
         runtime.contains("UsbipExplicitBind"),
-        "broker runtime.rs must handle UsbipExplicitBind (at least as Unimplemented stub)"
+        "broker runtime.rs must handle UsbipExplicitBind"
     );
     assert!(
         runtime.contains("UsbipExplicitFirewallRule"),
-        "broker runtime.rs must handle UsbipExplicitFirewallRule (at least as Unimplemented stub)"
+        "broker runtime.rs must handle UsbipExplicitFirewallRule"
+    );
+}
+
+#[test]
+fn usb_detach_dispatches_host_unbind_instead_of_static_ambiguous_refusal() {
+    let lib_rs = read_repo_file("packages/nixlingd/src/lib.rs");
+    let detach_start = lib_rs
+        .find("fn dispatch_broker_usbip_unbind")
+        .expect("dispatch_broker_usbip_unbind exists");
+    let detach_end = lib_rs[detach_start..]
+        .find("fn vm_is_qemu_media")
+        .map(|offset| detach_start + offset)
+        .expect("next function after dispatch_broker_usbip_unbind exists");
+    let detach_body = &lib_rs[detach_start..detach_end];
+
+    assert!(
+        detach_body.contains("BrokerRequest::UsbipUnbind"),
+        "nixling usb detach must dispatch the broker UsbipUnbind path so stale host claims can be released"
+    );
+    assert!(
+        detach_body.contains("preserve_durable_claim: false"),
+        "explicit detach must release the durable host claim after host cleanup succeeds"
+    );
+    assert!(
+        !detach_body.contains("UsbipProxyFlowObservation::SharedOrAmbiguous"),
+        "nixling usb detach must not hardcode an ambiguous-flow refusal before trying broker cleanup"
     );
 }

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -3652,10 +3652,6 @@ fn dispatch_broker_usbip_bind(
         }
     } else {
         // Explicit path: no static bundle intents required.
-        // Use UsbipExplicitBind + UsbipExplicitFirewallRule broker stubs.
-        // These ops are typed stubs (Unimplemented) until the live per-device
-        // backend handler is wired in the broker; the daemon returns a clear
-        // error so the operator knows the explicit path is not yet fully live.
         let host_uplink_ip = vm_entry
             .and_then(|e| e.usbipd_host_ip.as_deref())
             .unwrap_or("")
@@ -4558,37 +4554,59 @@ fn dispatch_broker_usbip_unbind(
     if let Err(response) = validate_usbip_bus_id_for_daemon(VERB, &request.bus_id) {
         return Ok(response);
     }
-    if let Err(response) =
-        usbip_bind_intent_ref_for_daemon(&resolver, &request.vm, &request.bus_id, VERB)
-    {
-        return Ok(response);
-    }
-    let revocation_plan = usbip_reconcile_state::plan_usbip_revocation_flow_termination(
-        usbip_reconcile_state::UsbipProxyFlowObservation::SharedOrAmbiguous,
-    );
-    Ok(usbip_revocation_not_isolated_response(
-        VERB,
+    let intent_ref =
+        match usbip_bind_intent_ref_for_daemon(&resolver, &request.vm, &request.bus_id, VERB) {
+            Ok(intent_ref) => intent_ref,
+            Err(response) => return Ok(response),
+        };
+
+    if let Err(summary) = run_guest_usbip_import(
+        state,
+        &resolver,
         &request.vm,
         &request.bus_id,
-        revocation_plan
-            .fail_closed_reason
-            .unwrap_or(usbip_reconcile_state::UsbipRevocationFlowFailure::MissingExactTuple),
-    ))
-}
-
-fn usbip_revocation_not_isolated_response(
-    verb: &str,
-    vm: &str,
-    busid: &str,
-    reason: usbip_reconcile_state::UsbipRevocationFlowFailure,
-) -> Value {
-    let envelope = TypedError::UsbipRevocationNotIsolated {
-        vm: vm.to_owned(),
-        busid: busid.to_owned(),
-        reason,
+        guest_control_health::GuestUsbipAction::Detach,
+    ) {
+        tracing::warn!(
+            vm = %request.vm,
+            bus_id = %request.bus_id,
+            summary = %summary,
+            "USBIP guest detach failed; continuing host-side detach cleanup"
+        );
     }
-    .to_envelope();
-    broker_failure_response(verb, envelope.message, envelope.remediation, None)
+
+    if let Err(response) = dispatch_broker_ack_request(
+        state,
+        VERB,
+        "UsbipUnbind",
+        BrokerRequest::UsbipUnbind(BrokerUsbipUnbindRequest {
+            bundle_usbip_bind_intent_ref: intent_ref,
+            preserve_durable_claim: false,
+            tracing_span_id: None,
+        }),
+    ) {
+        return Ok(response);
+    }
+
+    if let Err(response) = dispatch_broker_ack_request(
+        state,
+        VERB,
+        "UsbipProxyReconcile",
+        BrokerRequest::UsbipProxyReconcile(BrokerUsbipProxyReconcileRequest {
+            scope_id: ScopeId::new(format!("vm:{}", request.vm)),
+            tracing_span_id: None,
+        }),
+    ) {
+        return Ok(response);
+    }
+
+    Ok(applied_response(
+        VERB,
+        format!(
+            "nixling usb detach --apply: detached busid '{}' from vm '{}' and released the host claim",
+            request.bus_id, request.vm
+        ),
+    ))
 }
 
 fn vm_is_qemu_media(resolver: &BundleResolver, vm: &str) -> Result<bool, TypedError> {


### PR DESCRIPTION
## Summary
- route `nixling usb detach` through the broker `UsbipUnbind` cleanup path instead of hardcoded ambiguous-flow refusal
- keep host-side cleanup moving if guest detach is unavailable, so stale host USBIP claims can recover
- add a contract regression for detach dispatch

## Validation
- `cargo test -p nixling-contract-tests --test usbip_explicit_attach_contract -- --nocapture`
- `cargo test -p nixlingd usb_attach_apply_stopped_vm_returns_actionable_start_remediation -- --nocapture`