### PR TITLE
Fix nixlingd switch-time ACL startup race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ deprecations ship one minor release before removal.
   `UsbipUnbind` cleanup path instead of stopping at a hardcoded ambiguous-flow
   refusal, so stale USBIP host claims can be released and subsequent attaches can
   recover without raw `usbip` commands.
+- `nixlingd.service` now reasserts the `/run/nixling` mode and ACL mask in a
+  root `ExecStartPre`, preventing NixOS switch-time restarts from racing
+  `systemd-tmpfiles-resetup` and starting with `nixlingd` write access clipped to
+  effective `r-x`.
 
 ### Changed
 

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -438,6 +438,10 @@ in
         # subtree to the daemon user").
         User = "nixlingd";
         Group = "nixlingd";
+        ExecStartPre = [
+          "+${pkgs.coreutils}/bin/chmod 1770 /run/nixling"
+          "+${pkgs.acl}/bin/setfacl -m g::r-x,u:nixlingd:rwx,m::rwx /run/nixling"
+        ];
         ExecStart = "${nixlingdPackage}/bin/nixlingd serve --config /etc/nixling/daemon-config.json";
         ExecStop = "+${hostShutdownHook}";
         TimeoutStopSec = lib.mkDefault "${toString nixlingdStopTimeoutSeconds}s";

--- a/tests/unit/nix/cases/nixlingd-startup-smoke.nix
+++ b/tests/unit/nix/cases/nixlingd-startup-smoke.nix
@@ -183,6 +183,19 @@ in
     expected = "nixlingd";
   };
 
+  "nixlingd-startup-smoke/daemon-prestart-reasserts-run-nixling-acl" = {
+    expr = {
+      asRoot = builtins.all (cmd: lib.hasPrefix "+" cmd) daemonService.serviceConfig.ExecStartPre;
+      chmod = builtins.any (cmd: lib.hasInfix "chmod 1770 /run/nixling" cmd) daemonService.serviceConfig.ExecStartPre;
+      acl = builtins.any (cmd: lib.hasInfix "setfacl -m g::r-x,u:nixlingd:rwx,m::rwx /run/nixling" cmd) daemonService.serviceConfig.ExecStartPre;
+    };
+    expected = {
+      asRoot = true;
+      chmod = true;
+      acl = true;
+    };
+  };
+
   "nixlingd-startup-smoke/daemon-restrict-address-families" = {
     expr = daemonService.serviceConfig.RestrictAddressFamilies;
     expected = [ "AF_UNIX" "AF_INET" "AF_INET6" ];


### PR DESCRIPTION
## Summary
- add a root `ExecStartPre` to reassert `/run/nixling` mode and ACL mask before nixlingd starts
- cover the pre-start ACL reassertion in the nixlingd startup nix-unit smoke case
- document the switch-time startup race fix in CHANGELOG

## Validation
- `make check-tier0`
- `make test-nix-unit` is running locally; completed shards so far: nix-unit, nix-unit-daemon, nix-unit-guest, nix-unit-misc, nix-unit-network, nix-unit-runtime