### PR TITLE
Fix USB probe status after guest import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ deprecations ship one minor release before removal.
   root `ExecStartPre`, preventing NixOS switch-time restarts from racing
   `systemd-tmpfiles-resetup` and starting with `nixlingd` write access clipped to
   effective `r-x`.
+- USB probe/status no longer marks a declared USBIP device `degraded` with
+  `probe-incomplete` after guest-control confirms that the busid is already
+  imported in the guest.
 
 ### Changed
 

--- a/packages/nixling-contract-tests/tests/usbip_explicit_attach_contract.rs
+++ b/packages/nixling-contract-tests/tests/usbip_explicit_attach_contract.rs
@@ -348,3 +348,26 @@ fn usb_detach_dispatches_host_unbind_instead_of_static_ambiguous_refusal() {
         "nixling usb detach must not hardcode an ambiguous-flow refusal before trying broker cleanup"
     );
 }
+
+#[test]
+fn usb_probe_does_not_mark_imported_devices_probe_incomplete() {
+    let lib_rs = read_repo_file("packages/nixlingd/src/lib.rs");
+    let probe_start = lib_rs
+        .find("fn usbip_probe_entry_from_intent")
+        .expect("usbip_probe_entry_from_intent exists");
+    let probe_end = lib_rs[probe_start..]
+        .find("fn push_guest_usbip_status_error")
+        .map(|offset| probe_start + offset)
+        .expect("next function after usbip_probe_entry_from_intent exists");
+    let probe_body = &lib_rs[probe_start..probe_end];
+
+    assert!(
+        probe_body.contains("GuestImportState::Imported"),
+        "USB probe must inspect whether guest status confirms the busid is imported"
+    );
+    assert!(
+        probe_body
+            .contains("!matches!(guest_import, public_wire::UsbipGuestImportState::Imported)"),
+        "USB probe must not add probe-incomplete degradation for devices already imported in the guest"
+    );
+}

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -4861,6 +4861,7 @@ fn usbip_probe_entry_from_intent(
                 )),
             ));
         }
+        let guest_status_requested = guest_status_timeout.is_some();
         if let Some(guest_status_timeout) = guest_status_timeout {
             match run_guest_usbip_status(
                 state,
@@ -4905,14 +4906,18 @@ fn usbip_probe_entry_from_intent(
                 ),
             }
         }
-        degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
-            usbip_reconcile_state::UsbipDegradedReason::ProbeIncomplete,
-            Some(format!(
-                "Run `nixling usb attach {vm} {bus} --apply` to reconcile host and guest USB state.",
-                vm = intent.vm_name,
-                bus = intent.bus_id
-            )),
-        ));
+        if !guest_status_requested
+            || !matches!(guest_import, public_wire::UsbipGuestImportState::Imported)
+        {
+            degraded_reasons.push(usbip_probe_degraded_reason_from_internal(
+                usbip_reconcile_state::UsbipDegradedReason::ProbeIncomplete,
+                Some(format!(
+                    "Run `nixling usb attach {vm} {bus} --apply` to reconcile host and guest USB state.",
+                    vm = intent.vm_name,
+                    bus = intent.bus_id
+                )),
+            ));
+        }
     } else if matches!(
         durable_state,
         public_wire::UsbipDurableClaimState::HeldByOtherOwner


### PR DESCRIPTION
## Summary
- stop adding `probe-incomplete` degradation when guest-control confirms a USBIP busid is imported
- add a contract regression so imported devices can report bound instead of permanently degraded
- document the probe/status fix

## Validation
- `make check-tier0`
- `cargo test -p nixling-contract-tests --test usbip_explicit_attach_contract -- --nocapture`