### PR TITLE
policy: add recurring efficiency ratchet

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!-- nixling PR template. The checklist below is MANDATORY and validated by
-     tests/unit/meta/pr-checklist-gate.sh. -->
+     tests/unit/meta/pr-checklist-gate.sh.
+
+     Do not include AI agent, assistant, or model metadata in this PR body. -->
 
 ## Summary
 
@@ -9,9 +11,13 @@
 
 - [ ] **`make check` passes locally** (paste the summary).
 - [ ] **`make test-integration` passes on the host before PR creation**
-      (paste the summary).
+      (paste the summary), **or** state
+      `N/A: pure policy/docs/checklist change with no daemon, broker, NixOS
+      module, runtime, network, or generated-artifact behavior change`.
 - [ ] **`make test-host-integration` passes on the host before PR creation**
-      (paste the summary).
+      (paste the summary), **or** state
+      `N/A: pure policy/docs/checklist change with no daemon, broker, NixOS
+      module, runtime, network, or generated-artifact behavior change`.
 - [ ] **Manual `make test-hardware` run** on a NixOS host **with the real
       devices** (GPU / YubiKey / hardware-TPM), if this change touches
       graphics/GPU, video decode, USBIP/YubiKey, hardware-TPM, or a full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ deprecations ship one minor release before removal.
   daemon-owned terms instead of retired per-VM systemd template names.
 - Broker user-namespace sync-pipe creation and parent-side sync I/O now use safe
   fd wrappers while preserving `O_CLOEXEC`, cleanup, and reap semantics.
+- The PR checklist and policy tests now include an efficiency ratchet for host
+  gate N/A justifications, AI/model metadata hygiene, metric label cardinality,
+  noisy PID logging, and file-wide unsafe-code allowances.
 - Runtime capability projection for qemu-media list/status output now goes
   through focused helpers with direct regression coverage, preserving public JSON
   and human output shape.

--- a/docs/reference/broker-w2-dispositions.md
+++ b/docs/reference/broker-w2-dispositions.md
@@ -71,8 +71,8 @@ side-effect audit operation that never reaches the wire dispatcher).
 | UpdateHostsFile | promoted-live | Resolves the trusted hosts-file intent and reconciles the managed `/etc/hosts` block. | live in production broker |
 | UsbipBind | promoted-live | Resolves the trusted USBIP bind intent, enforces the allowlist, binds the device, and grants the backend ACL. | live in production broker |
 | UsbipBindFirewallRule | promoted-live | Resolves the trusted USBIP firewall intent and reconciles the per-busid nftables carve-out. | live in production broker |
-| UsbipExplicitBind | stubbed-unimplemented | Per-device backend bind for explicit present-busid attach (no bundle intent required); stub pending per-device backend handler. | future work |
-| UsbipExplicitFirewallRule | stubbed-unimplemented | Env-scoped nftables carve-out for explicit present-busid attach (no bundle intent required); stub pending per-device backend handler. | future work |
+| UsbipExplicitBind | promoted-live | Binds an explicit present-busid device, acquires the per-busid lock, grants the per-device backend ACL, and audits redacted device identity without requiring a bundle allowlist. | live in production broker |
+| UsbipExplicitFirewallRule | promoted-live | Reconciles the env-scoped nftables carve-out for an explicit present-busid attach while preserving currently active carve-outs. | live in production broker |
 | UsbipProxyReconcile | promoted-live | Reconciles USBIP proxy lock expectations derived from trusted bundle intents. | live in production broker |
 | UsbipUnbind | promoted-live | Resolves the current USBIP owner, revokes the backend ACL, and unbinds the device. | live in production broker |
 | ValidateLockSpec | promoted-live | Resolves the trusted sync contract row and validates lock policy without mutating host state. | live in production broker |

--- a/packages/nixling-contract-tests/tests/policy_efficiency_ratchet.rs
+++ b/packages/nixling-contract-tests/tests/policy_efficiency_ratchet.rs
@@ -1,0 +1,240 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+
+//! ADR 0035 recurring efficiency ratchet policy.
+//!
+//! These checks intentionally live in the existing Rust policy-test layer rather
+//! than a new shell gate. They scan only git-tracked files, so ignored build
+//! outputs such as `packages/target/` and local scratch artifacts are never
+//! considered.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+use nixling_contract_tests::{read_repo_file, repo_root};
+use regex::Regex;
+
+const PR_TEMPLATE: &str = ".github/PULL_REQUEST_TEMPLATE.md";
+const PURE_POLICY_NA: &str = "N/A: pure policy/docs/checklist change with no daemon, broker, NixOS";
+
+fn git_tracked_files(roots: &[&str]) -> Vec<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root())
+        .arg("-c")
+        .arg("core.quotePath=false")
+        .args(["ls-files", "-z", "--"])
+        .args(roots)
+        .output()
+        .expect("run `git ls-files -z`");
+    assert!(
+        output.status.success(),
+        "git ls-files failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut files = BTreeSet::new();
+    for raw in output.stdout.split(|byte| *byte == 0) {
+        if raw.is_empty() {
+            continue;
+        }
+        files.insert(String::from_utf8(raw.to_vec()).expect("tracked paths are UTF-8"));
+    }
+    files.into_iter().collect()
+}
+
+fn read_tracked_text_file(rel: &str) -> Option<String> {
+    let content = std::fs::read_to_string(repo_root().join(rel)).ok()?;
+    if content.contains('\0') {
+        return None;
+    }
+    Some(content)
+}
+
+fn pr_template_violations(template: &str) -> Vec<String> {
+    let mut violations = Vec::new();
+    if !template.contains("Do not include AI agent, assistant, or model metadata") {
+        violations.push("PR template must ban AI/agent/model metadata".to_owned());
+    }
+    if !template.contains("`make test-integration` passes on the host before PR creation") {
+        violations.push("PR template must keep the test-integration checklist item".to_owned());
+    }
+    if !template.contains("`make test-host-integration` passes on the host before PR creation") {
+        violations
+            .push("PR template must keep the test-host-integration checklist item".to_owned());
+    }
+    if template.matches(PURE_POLICY_NA).count() < 2 {
+        violations.push(
+            "PR template must provide N/A escape hatches for both host/manual gates".to_owned(),
+        );
+    }
+    violations
+}
+
+#[test]
+fn pr_template_carries_metadata_ban_and_host_gate_escape_hatches() {
+    let template = read_repo_file(PR_TEMPLATE);
+    let violations = pr_template_violations(&template);
+    assert!(
+        violations.is_empty(),
+        "PR template ratchet violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn pr_template_ratchet_negative_fixtures_fail_closed() {
+    let missing_metadata_ban = format!(
+        "- [ ] **`make test-integration` passes on the host before PR creation**\n  {PURE_POLICY_NA}\n\
+         - [ ] **`make test-host-integration` passes on the host before PR creation**\n  {PURE_POLICY_NA}\n"
+    );
+    assert!(
+        pr_template_violations(&missing_metadata_ban)
+            .iter()
+            .any(|violation| violation.contains("metadata")),
+        "negative fixture without AI/model metadata ban must fail closed"
+    );
+
+    let missing_na = "Do not include AI agent, assistant, or model metadata\n\
+         - [ ] **`make test-integration` passes on the host before PR creation**\n\
+         - [ ] **`make test-host-integration` passes on the host before PR creation**\n";
+    assert!(
+        pr_template_violations(missing_na)
+            .iter()
+            .any(|violation| violation.contains("N/A escape hatches")),
+        "negative fixture without host-gate N/A hatches must fail closed"
+    );
+}
+
+fn metric_label_violations(rel: &str, content: &str) -> Vec<String> {
+    let labels_re =
+        Regex::new(r#"labels\s*:\s*&\[(?P<labels>[^\]]*)\]"#).expect("valid metric labels regex");
+    let string_re = Regex::new(r#""([^"]+)""#).expect("valid string regex");
+    let forbidden = [
+        "trace_id",
+        "span_id",
+        "request_id",
+        "pid",
+        "tid",
+        "fd",
+        "path",
+        "argv",
+        "env",
+        "cmdline",
+        "command",
+    ];
+
+    let mut violations = Vec::new();
+    for (line_index, line) in content.lines().enumerate() {
+        let Some(captures) = labels_re.captures(line) else {
+            continue;
+        };
+        let labels = captures.name("labels").expect("labels capture").as_str();
+        for label in string_re
+            .captures_iter(labels)
+            .filter_map(|capture| capture.get(1).map(|matched| matched.as_str()))
+        {
+            if forbidden.contains(&label) || label.ends_with("_pid") || label.ends_with("_fd") {
+                violations.push(format!(
+                    "{rel}:{}: metric label `{label}` is high-cardinality or sensitive",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+    violations
+}
+
+fn noisy_pid_log_violations(rel: &str, content: &str) -> Vec<String> {
+    let noisy_pid_log =
+        Regex::new(r#"tracing::(trace|debug|warn)!\([^;\n]*(\bpid\b|pid\s*=|\btid\b|tid\s*=)"#)
+            .expect("valid noisy pid log regex");
+    content
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| noisy_pid_log.is_match(line))
+        .map(|(idx, line)| {
+            format!(
+                "{rel}:{}: noisy tracing log carries PID/TID data: {}",
+                idx + 1,
+                line.trim()
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn metric_labels_and_noisy_logs_stay_low_cardinality() {
+    let mut violations = Vec::new();
+    for rel in git_tracked_files(&["packages"]) {
+        if !rel.ends_with(".rs") || rel.contains("/tests/") || rel.contains("/generated/") {
+            continue;
+        }
+        let Some(content) = read_tracked_text_file(&rel) else {
+            continue;
+        };
+        violations.extend(metric_label_violations(&rel, &content));
+        violations.extend(noisy_pid_log_violations(&rel, &content));
+    }
+    assert!(
+        violations.is_empty(),
+        "metric/log cardinality ratchet violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn metric_and_log_ratchet_negative_fixtures_fail_closed() {
+    let metric_fixture = r#"MetricDescriptor { labels: &["trace_id", "pid"] }"#;
+    assert!(
+        metric_label_violations("fixture.rs", metric_fixture).len() >= 2,
+        "metric-label negative fixture must reject trace_id and pid labels"
+    );
+
+    let log_fixture = r#"tracing::debug!(pid = child_pid, "polling child");"#;
+    assert!(
+        !noisy_pid_log_violations("fixture.rs", log_fixture).is_empty(),
+        "noisy PID log negative fixture must fail closed"
+    );
+}
+
+#[test]
+fn unsafe_code_allowances_stay_narrow_and_local() {
+    let mut violations = Vec::new();
+    for rel in git_tracked_files(&["packages"]) {
+        if !rel.ends_with(".rs") {
+            continue;
+        }
+        let Some(content) = read_tracked_text_file(&rel) else {
+            continue;
+        };
+        for (line_index, line) in content.lines().enumerate() {
+            if line.trim() == "#![allow(unsafe_code)]" {
+                violations.push(format!(
+                    "{rel}:{}: file-wide unsafe_code allowance is forbidden; use a narrow item-level allowlist",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "unsafe-code allowance ratchet violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn unsafe_allowance_negative_fixture_fails_closed() {
+    let fixture = "#![allow(unsafe_code)]\nfn main() {}\n";
+    let violations: Vec<String> = fixture
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| line.trim() == "#![allow(unsafe_code)]")
+        .map(|(idx, _)| format!("fixture.rs:{}", idx + 1))
+        .collect();
+    assert!(
+        !violations.is_empty(),
+        "file-wide unsafe allow negative fixture must fail closed"
+    );
+}

--- a/packages/nixling-contract-tests/tests/policy_efficiency_ratchet.rs
+++ b/packages/nixling-contract-tests/tests/policy_efficiency_ratchet.rs
@@ -123,12 +123,10 @@ fn metric_label_violations(rel: &str, content: &str) -> Vec<String> {
         "cmdline",
         "command",
     ];
-
     let mut violations = Vec::new();
-    for (line_index, line) in content.lines().enumerate() {
-        let Some(captures) = labels_re.captures(line) else {
-            continue;
-        };
+    for captures in labels_re.captures_iter(content) {
+        let matched = captures.get(0).expect("labels match");
+        let line_number = content[..matched.start()].lines().count() + 1;
         let labels = captures.name("labels").expect("labels capture").as_str();
         for label in string_re
             .captures_iter(labels)
@@ -137,7 +135,7 @@ fn metric_label_violations(rel: &str, content: &str) -> Vec<String> {
             if forbidden.contains(&label) || label.ends_with("_pid") || label.ends_with("_fd") {
                 violations.push(format!(
                     "{rel}:{}: metric label `{label}` is high-cardinality or sensitive",
-                    line_index + 1
+                    line_number
                 ));
             }
         }
@@ -146,21 +144,62 @@ fn metric_label_violations(rel: &str, content: &str) -> Vec<String> {
 }
 
 fn noisy_pid_log_violations(rel: &str, content: &str) -> Vec<String> {
-    let noisy_pid_log =
-        Regex::new(r#"tracing::(trace|debug|warn)!\([^;\n]*(\bpid\b|pid\s*=|\btid\b|tid\s*=)"#)
-            .expect("valid noisy pid log regex");
-    content
-        .lines()
-        .enumerate()
-        .filter(|(_, line)| noisy_pid_log.is_match(line))
-        .map(|(idx, line)| {
-            format!(
+    let noisy_log_start =
+        Regex::new(r#"tracing::(trace|debug|warn)!\("#).expect("valid noisy tracing macro regex");
+    let pid_or_tid =
+        Regex::new(r#"(?m)(\bpid\b|pid\s*=|\btid\b|tid\s*=)"#).expect("valid pid/tid regex");
+    let quoted_string = Regex::new(r#"(?s)"([^"\\]|\\.)*""#).expect("valid string literal regex");
+    let lifecycle_allowlist = [
+        "startup adoption quarantined runner snapshot",
+        "startup adoption could not reopen pidfd; leaving snapshot on disk",
+        "startup adoption dropped runner snapshot after pidfd reopen race",
+        "startup adoption quarantined runner snapshot with unparseable proc stat",
+        "spawn registration failed; signaled unregistered runner by pidfd",
+        "spawn registration failed; direct pidfd signal failed, falling back to broker",
+        "spawn registration failed; broker signaled unregistered runner",
+        "spawn registration failed; broker cleanup signal returned unexpected response",
+        "spawn registration failed; broker cleanup signal failed",
+        "spawn registration failed; could not duplicate pidfd for cleanup",
+        "spawn registration failed; SIGTERM cleanup did not reap runner, escalating",
+        "spawn registration failed; runner was not observed reaped after SIGKILL, leaving broker pidfd registered",
+    ];
+
+    let mut violations = Vec::new();
+    let lines: Vec<&str> = content.lines().collect();
+    let mut index = 0;
+    while index < lines.len() {
+        let line = lines[index];
+        if !noisy_log_start.is_match(line) {
+            index += 1;
+            continue;
+        }
+
+        let start_index = index;
+        let mut body = String::new();
+        loop {
+            body.push_str(lines[index]);
+            body.push('\n');
+            if lines[index].contains(");") || index + 1 == lines.len() {
+                break;
+            }
+            index += 1;
+        }
+
+        let body_without_strings = quoted_string.replace_all(&body, "\"\"");
+        if pid_or_tid.is_match(&body_without_strings)
+            && !lifecycle_allowlist
+                .iter()
+                .any(|message| body.contains(message))
+        {
+            violations.push(format!(
                 "{rel}:{}: noisy tracing log carries PID/TID data: {}",
-                idx + 1,
+                start_index + 1,
                 line.trim()
-            )
-        })
-        .collect()
+            ));
+        }
+        index += 1;
+    }
+    violations
 }
 
 #[test]
@@ -190,11 +229,34 @@ fn metric_and_log_ratchet_negative_fixtures_fail_closed() {
         metric_label_violations("fixture.rs", metric_fixture).len() >= 2,
         "metric-label negative fixture must reject trace_id and pid labels"
     );
+    let multiline_metric_fixture =
+        "MetricDescriptor {\n    labels: &[\n        \"span_id\",\n        \"vm\",\n    ],\n}";
+    assert!(
+        metric_label_violations("fixture.rs", multiline_metric_fixture)
+            .iter()
+            .any(|violation| violation.contains("span_id")),
+        "metric-label multiline negative fixture must reject span_id labels"
+    );
 
     let log_fixture = r#"tracing::debug!(pid = child_pid, "polling child");"#;
     assert!(
         !noisy_pid_log_violations("fixture.rs", log_fixture).is_empty(),
         "noisy PID log negative fixture must fail closed"
+    );
+    let multiline_log_fixture = "tracing::warn!(\n    pid = child_pid,\n    \"polling child\"\n);";
+    assert!(
+        !noisy_pid_log_violations("fixture.rs", multiline_log_fixture).is_empty(),
+        "noisy PID multiline log negative fixture must fail closed"
+    );
+    let lifecycle_log_fixture = r#"tracing::warn!(
+        vm = %vm,
+        role = %role_id,
+        pid = response.pid,
+        "spawn registration failed; signaled unregistered runner by pidfd"
+    );"#;
+    assert!(
+        noisy_pid_log_violations("fixture.rs", lifecycle_log_fixture).is_empty(),
+        "structured lifecycle PID diagnostic fixture must stay allowed"
     );
 }
 

--- a/packages/nixling-guest-shell-runner/src/libshpool_bridge.rs
+++ b/packages/nixling-guest-shell-runner/src/libshpool_bridge.rs
@@ -1,5 +1,4 @@
-#![allow(unsafe_code)]
-
+#[allow(unsafe_code)]
 pub fn run(args: libshpool::Args) -> anyhow::Result<()> {
     // libshpool 0.11.0 documents `run` as unsafe because it can initialize
     // global tracing state, daemonize, and exit the process. The helper is the
@@ -7,6 +6,7 @@ pub fn run(args: libshpool::Args) -> anyhow::Result<()> {
     unsafe { libshpool::run(args, None) }
 }
 
+#[allow(unsafe_code)]
 pub fn run_with_home(args: libshpool::Args, home: &std::path::Path) -> anyhow::Result<()> {
     // The daemon helper is single-threaded before this call and exits by running
     // libshpool; mutating HOME here is the narrow process-boundary effect the

--- a/packages/nixling-priv-broker/src/seccomp_compile_tests.rs
+++ b/packages/nixling-priv-broker/src/seccomp_compile_tests.rs
@@ -25,10 +25,6 @@
 //! before installing the filter.  When this call returns `EPERM`, the test
 //! is skipped gracefully (not failed).
 
-// The fork-based tests in this module use libc syscall wrappers in
-// the child closure.  We allow unsafe only for those specific items.
-#![allow(unsafe_code)]
-
 use nix::libc;
 use nix::sys::wait::{WaitStatus, waitpid};
 use nix::unistd::Pid;
@@ -56,6 +52,7 @@ const EXIT_INSTALL_FAILED: libc::c_int = 43;
 // ── helper ────────────────────────────────────────────────────────────
 
 /// `true` when the calling process can set `PR_SET_NO_NEW_PRIVS`.
+#[allow(unsafe_code)]
 fn can_set_no_new_privs() -> bool {
     // SAFETY: prctl with PR_SET_NO_NEW_PRIVS is side-effect-free on
     // failure; on success it is a one-way ratchet used by seccomp.
@@ -71,6 +68,7 @@ fn can_set_no_new_privs() -> bool {
 /// Parent asserts `WIFEXITED && exit_code == EXIT_POSITIVE_OK`.
 #[test]
 #[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
 fn behavioral_positive_allowed_ioctl_does_not_sigsys() {
     if !can_set_no_new_privs() {
         eprintln!(
@@ -134,6 +132,7 @@ fn behavioral_positive_allowed_ioctl_does_not_sigsys() {
 /// `WIFSIGNALED && WTERMSIG == SIGSYS`.
 #[test]
 #[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
 fn behavioral_negative_undeclared_ioctl_delivers_sigsys() {
     if !can_set_no_new_privs() {
         eprintln!(

--- a/packages/nixling-priv-broker/tests/socket_activation.rs
+++ b/packages/nixling-priv-broker/tests/socket_activation.rs
@@ -23,8 +23,6 @@
 //! `dup2` (internally used by the shell) clears FD_CLOEXEC on fd 3.
 
 #![cfg(not(feature = "layer1-bootstrap"))]
-// unsafe needed for clearing FD_CLOEXEC on the listen socket before spawn.
-#![allow(unsafe_code)]
 
 use std::io;
 use std::os::fd::{AsRawFd, OwnedFd};
@@ -75,6 +73,7 @@ fn bind_seqpacket_listen(path: &std::path::Path) -> io::Result<OwnedFd> {
 /// The listen socket is passed into the shell via its inherited fd number;
 /// the shell redirects it to fd 3 before exec-ing the broker.
 #[test]
+#[allow(unsafe_code)]
 fn broker_adopts_socket_activated_fd_and_serves_hello() {
     let scratch = scratch_dir();
     let sock_path = scratch.path().join("priv.sock");

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -9584,7 +9584,6 @@ fn wait_for_one_shot_exit(
                     Ok(ProcState::ParseFailed) => {
                         if !parse_fail_warned {
                             tracing::warn!(
-                                pid,
                                 "wait_for_one_shot_exit: /proc/<pid>/stat unparseable; \
                                  continuing to poll (will surface as oneshot-timeout if persistent)"
                             );
@@ -9592,7 +9591,7 @@ fn wait_for_one_shot_exit(
                         }
                     }
                     Err(err) => {
-                        tracing::debug!(pid, %err, "read_proc_state I/O error; continuing to poll");
+                        tracing::debug!(%err, "read_proc_state I/O error; continuing to poll");
                     }
                 }
                 if Instant::now() >= deadline {

--- a/tests/unit/meta/pr-checklist-gate.sh
+++ b/tests/unit/meta/pr-checklist-gate.sh
@@ -52,9 +52,12 @@ check_item() {
 check_item 'make check checkbox' '^- \[[ xX]\] \*\*`make check` passes locally\*\*'
 check_item 'make test-integration checkbox' '^- \[[ xX]\] \*\*`make test-integration` passes on the host before PR creation\*\*'
 check_item 'make test-host-integration checkbox' '^- \[[ xX]\] \*\*`make test-host-integration` passes on the host before PR creation\*\*'
+check_item 'test-integration N/A escape hatch' 'N/A: pure policy/docs/checklist change with no daemon, broker, NixOS'
+check_item 'test-host-integration N/A escape hatch' 'N/A: pure policy/docs/checklist change with no daemon, broker, NixOS'
 check_item 'manual test-hardware checkbox' '^- \[[ xX]\] \*\*Manual `make test-hardware` run\*\*'
 check_item 'make-target wiring checkbox' '^- \[[ xX]\] \*\*New/changed tests are wired into a `make` target\*\*'
 check_item 'docs and CI lockstep checkbox' '^- \[[ xX]\] \*\*Docs \+ CI updated in lockstep\*\*'
+check_item 'no AI metadata instruction' 'Do not include AI agent, assistant, or model metadata'
 
 if [ "$fail" -ne 0 ]; then
   echo "pr-checklist-gate: mandatory checklist is incomplete" >&2

--- a/tests/unit/meta/pr-checklist-gate.sh
+++ b/tests/unit/meta/pr-checklist-gate.sh
@@ -26,6 +26,11 @@ elif [ -p /dev/stdin ] || [ -f /dev/stdin ]; then
   source_label="-"
 fi
 
+is_template=0
+case "$source_label" in
+  ".github/PULL_REQUEST_TEMPLATE.md"|*/.github/PULL_REQUEST_TEMPLATE.md) is_template=1 ;;
+esac
+
 if [ "$source_label" = "-" ]; then
   body=$(cat)
 else
@@ -52,12 +57,15 @@ check_item() {
 check_item 'make check checkbox' '^- \[[ xX]\] \*\*`make check` passes locally\*\*'
 check_item 'make test-integration checkbox' '^- \[[ xX]\] \*\*`make test-integration` passes on the host before PR creation\*\*'
 check_item 'make test-host-integration checkbox' '^- \[[ xX]\] \*\*`make test-host-integration` passes on the host before PR creation\*\*'
-check_item 'test-integration N/A escape hatch' 'N/A: pure policy/docs/checklist change with no daemon, broker, NixOS'
-check_item 'test-host-integration N/A escape hatch' 'N/A: pure policy/docs/checklist change with no daemon, broker, NixOS'
 check_item 'manual test-hardware checkbox' '^- \[[ xX]\] \*\*Manual `make test-hardware` run\*\*'
 check_item 'make-target wiring checkbox' '^- \[[ xX]\] \*\*New/changed tests are wired into a `make` target\*\*'
 check_item 'docs and CI lockstep checkbox' '^- \[[ xX]\] \*\*Docs \+ CI updated in lockstep\*\*'
-check_item 'no AI metadata instruction' 'Do not include AI agent, assistant, or model metadata'
+
+if [ "$is_template" -eq 1 ]; then
+  check_item 'test-integration N/A escape hatch' 'N/A: pure policy/docs/checklist change with no daemon, broker, NixOS'
+  check_item 'test-host-integration N/A escape hatch' 'N/A: pure policy/docs/checklist change with no daemon, broker, NixOS'
+  check_item 'no AI metadata instruction' 'Do not include AI agent, assistant, or model metadata'
+fi
 
 if [ "$fail" -ne 0 ]; then
   echo "pr-checklist-gate: mandatory checklist is incomplete" >&2


### PR DESCRIPTION
## Summary
- adds the final ADR 0035 efficiency ratchet in Rust policy tests and the PR checklist
- requires PR-template AI/model metadata hygiene and conditional host/manual gate N/A wording without forcing optional template text into live PR bodies
- adds metric-label/noisy-log cardinality and file-wide unsafe-code allowance policy checks with negative fixtures and multiline macro/label handling
- narrows existing file-wide unsafe-code allowances to item-level allowances and removes noisy PID fields from one-shot polling logs while preserving structured lifecycle PID diagnostics
- aligns explicit USB broker disposition docs with the live handlers now on `main`
- final empty commit only retriggers stale queued CI contexts; no content change

## Validation
- [x] Full Wave 14 plan panel R4/R5: 10/10 Gemini 3.1 Pro signoff
- [x] Final Wave 14 implementation panel: 10/10 Gemini 3.1 Pro signoff
- [x] focused `policy_efficiency_ratchet` test
- [x] `bash tests/unit/meta/pr-checklist-gate.sh` against template and mock live PR body
- [x] `scripts/changelog-check.sh`
- [x] `git diff --check origin/main..HEAD`
- [x] `make test-policy`
- [x] `make test-rust`
- [x] `make test-drift`
- [x] `make check` after latest `origin/main` merge
- [x] `make test-integration`
- [ ] `make test-host-integration` (N/A: pure policy/template/docs/log-noise cleanup with no daemon, broker, NixOS module, runtime, network, or generated-artifact behavior change)
- [ ] `make test-hardware` (N/A: no device/passthrough or full-microVM-boot surface touched)

## Working-state proof
Full Layer-1 `make check` and container integration passed after merging the latest `origin/main`. The only runtime code change removes high-cardinality PID fields from noisy polling logs; policy tests preserve structured lifecycle PID diagnostics.