### PR TITLE
runtime: preserve nixlingd ACL mask after activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ deprecations ship one minor release before removal.
   instead of an imperative root `ExecStartPre`; the tmpfiles rules keep the ACL
   mask writable for the daemon while the `nixling` operator group remains
   narrowed to traversal by the explicit group ACL.
+- Host activation now preserves the `/run/nixling` ACL mask as `rwx` when
+  reasserting runtime directory posture, preventing switch-time activation from
+  clipping the `nixlingd` daemon's write access to `r-x`.
 - USB probe/status no longer marks a declared USBIP device `degraded` with
   `probe-incomplete` after guest-control confirms that the busid is already
   imported in the guest.

--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -1058,7 +1058,7 @@ in
         # daemon-created, and inheriting default:g::r-x makes the
         # owning nixling group read-only even after chmod 0660.
         ${pkgs.acl}/bin/setfacl -k /run/nixling 2>/dev/null || true
-        ${pkgs.acl}/bin/setfacl -m "g::r-x,m::r-x" /run/nixling 2>/dev/null || true
+        ${pkgs.acl}/bin/setfacl -m "u:nixlingd:rwx,g::r-x,m::rwx" /run/nixling 2>/dev/null || true
         ${activationHelper} enforce-dir-posture \
           --path /run/nixling/locks \
           --uid "$nixlingd_uid" --gid "$nixlingd_gid" --mode 0700 2>/dev/null || true

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -152,6 +152,13 @@ in
     expected = true;
   };
 
+  "activation-runtime-tmpfiles/activation-preserves-run-parent-daemon-mask" = {
+    expr =
+      lib.hasInfix ''setfacl -m "u:nixlingd:rwx,g::r-x,m::rwx" /run/nixling 2>/dev/null || true'' runtimePostureText
+      && !(lib.hasInfix ''setfacl -m "g::r-x,m::r-x" /run/nixling 2>/dev/null || true'' runtimePostureText);
+    expected = true;
+  };
+
   "activation-runtime-tmpfiles/gpu-parent" = {
     expr = lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/nixling-gpu 0750 root nixling -"


### PR DESCRIPTION
## Summary

- keep host activation from clipping /run/nixling ACL mask after tmpfiles
- preserve nixlingd rwx access while keeping launcher group traversal-only access
- add nix eval coverage for the activation script text

## Validation

- `make test-proofs`
- `make test-flake`
- `make test-drift`

This fixes the Wave 15 real host-switch validation failure where nixlingd exited with `internal-lock-parent-invalid` because /run/nixling had effective mode 0750 after activation.