### PR TITLE
Expose VM guest closure paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ deprecations ship one minor release before removal.
   addition to `/proc/modules` and `modules.builtin`. Built-in virtio/KVM
   modules compiled as `=y` are now correctly detected as present without
   the `NIXLING_SKIP_KERNEL_MODULE_CHECK` operator override.
+- `nixling list --json` now exposes `guestClosureOutPath` for VMs whose
+  bundle closure metadata is available, giving host-side scanners a public
+  VM-to-guest-closure mapping for `sbomnix` without private path conventions.
 
 ### Fixed
 

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -112,10 +112,13 @@ sys-work-net       work      false     false false   192.0.2.1       running (ne
 `list` is a daemon-native, read-only inventory query. When nixlingd is
 reachable, the CLI queries the public socket and reports declared VM
 metadata, daemon-derived lifecycle state, and the VM guest closure out
-path when bundle closure metadata is available. If the public socket is
-unavailable or does not support the request, the CLI falls back to the
-static manifest/local status path and may still populate
-`guestClosureOutPath` when the caller can read the local bundle.
+path when closure metadata is available. For a running VM with
+`status = "pending-restart"`, `guestClosureOutPath` points at the
+booted closure so scanners inspect the running guest generation. If the
+public socket is unavailable or does not support the request, the CLI
+falls back to the static manifest/local status path and may still
+populate `guestClosureOutPath` when the caller can read local closure
+metadata.
 
 **Native**
 

--- a/docs/reference/cli-contract.md
+++ b/docs/reference/cli-contract.md
@@ -90,7 +90,8 @@ sys-work-net       work      false     false false   192.0.2.1       running (ne
     "usbip": false,
     "staticIp": "10.20.0.10",
     "status": "running",
-    "isNetVm": false
+    "isNetVm": false,
+    "guestClosureOutPath": "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-nixos-system-corp-vm"
   },
   {
     "name": "sys-work-net",
@@ -100,7 +101,8 @@ sys-work-net       work      false     false false   192.0.2.1       running (ne
     "usbip": false,
     "staticIp": "192.0.2.1",
     "status": "running",
-    "isNetVm": true
+    "isNetVm": true,
+    "guestClosureOutPath": "/nix/store/ffffffffffffffffffffffffffffffff-nixos-system-sys-work-net"
   }
 ]
 ```
@@ -109,9 +111,11 @@ sys-work-net       work      false     false false   192.0.2.1       running (ne
 
 `list` is a daemon-native, read-only inventory query. When nixlingd is
 reachable, the CLI queries the public socket and reports declared VM
-metadata plus daemon-derived lifecycle state. If the public socket is
+metadata, daemon-derived lifecycle state, and the VM guest closure out
+path when bundle closure metadata is available. If the public socket is
 unavailable or does not support the request, the CLI falls back to the
-static manifest/local status path.
+static manifest/local status path and may still populate
+`guestClosureOutPath` when the caller can read the local bundle.
 
 **Native**
 

--- a/docs/reference/cli-output/list.md
+++ b/docs/reference/cli-output/list.md
@@ -18,7 +18,7 @@ status.
 | `staticIp` | string or `null` | Declared static IPv4 address. Present and `null` for DHCP-backed shapes. | Stable wire contract. |
 | `status` | string enum | One of `stopped`, `running`, `pending-restart`, `failed`, or `unknown`. | Stable wire contract. |
 | `isNetVm` | boolean | True only for auto-declared per-env net VMs. | Stable wire contract. |
-| `guestClosureOutPath` | string | Absolute Nix store path of the VM's guest system closure. Present when the daemon or local fallback can read the bundle closure metadata. | Additive stable wire contract. |
+| `guestClosureOutPath` | string | Absolute Nix store path of the VM's effective guest system closure. For a running VM with `status = "pending-restart"`, this is the booted closure; otherwise it is the declared bundle closure. Present when the daemon or local fallback can read closure metadata. | Additive stable wire contract. |
 
 ## Ordering and null handling
 

--- a/docs/reference/cli-output/list.md
+++ b/docs/reference/cli-output/list.md
@@ -18,12 +18,15 @@ status.
 | `staticIp` | string or `null` | Declared static IPv4 address. Present and `null` for DHCP-backed shapes. | Stable wire contract. |
 | `status` | string enum | One of `stopped`, `running`, `pending-restart`, `failed`, or `unknown`. | Stable wire contract. |
 | `isNetVm` | boolean | True only for auto-declared per-env net VMs. | Stable wire contract. |
+| `guestClosureOutPath` | string | Absolute Nix store path of the VM's guest system closure. Present when the daemon or local fallback can read the bundle closure metadata. | Additive stable wire contract. |
 
 ## Ordering and null handling
 
 - The top-level array is ordered by `name`.
-- No fields are omitted.
-- `env` and `staticIp` are the only nullable fields.
+- Core inventory fields are not omitted. Additive capability fields such as
+  `guestClosureOutPath` may be omitted when the active generation predates the
+  field or the static fallback cannot read bundle metadata.
+- `env` and `staticIp` are the only nullable core fields.
 
 ## Stability promise
 
@@ -52,7 +55,8 @@ sys-work-net       work      false     false false   192.0.2.1       stopped (ne
     "usbip": false,
     "staticIp": "10.20.0.10",
     "status": "stopped",
-    "isNetVm": false
+    "isNetVm": false,
+    "guestClosureOutPath": "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-nixos-system-corp-vm"
   },
   {
     "name": "sys-work-net",
@@ -62,7 +66,8 @@ sys-work-net       work      false     false false   192.0.2.1       stopped (ne
     "usbip": false,
     "staticIp": "192.0.2.1",
     "status": "stopped",
-    "isNetVm": true
+    "isNetVm": true,
+    "guestClosureOutPath": "/nix/store/ffffffffffffffffffffffffffffffff-nixos-system-sys-work-net"
   }
 ]
 ```

--- a/docs/reference/cli-output/list.schema.json
+++ b/docs/reference/cli-output/list.schema.json
@@ -36,6 +36,12 @@
         "graphics": {
           "type": "boolean"
         },
+        "guestClosureOutPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "isNetVm": {
           "type": "boolean"
         },

--- a/docs/reference/daemon-api.md
+++ b/docs/reference/daemon-api.md
@@ -388,7 +388,7 @@ running live guest activation.
 
 | Type | Kind | Rust definition | Shape |
 | --- | --- | --- | --- |
-| `VmLifecycleState` | enum | [`VmLifecycleState`](../../packages/nixling-contracts/src/public_wire.rs#L1943) | `Stopped`; `Starting`; `Booted`; `Running`; `Stopping`; `Restarting`; `Failed`; `Unknown` |
+| `VmLifecycleState` | enum | [`VmLifecycleState`](../../packages/nixling-contracts/src/public_wire.rs#L1945) | `Stopped`; `Starting`; `Booted`; `Running`; `Stopping`; `Restarting`; `Failed`; `Unknown` |
 
 ### Other documented enums
 
@@ -460,7 +460,7 @@ running live guest activation.
 | `UsbProbeEntryKind` | enum | [`UsbProbeEntryKind`](../../packages/nixling-contracts/src/public_wire.rs#L1753) | `Usbip`; `QemuMediaSlot` |
 | `AuditFormat` | enum | [`AuditFormat`](../../packages/nixling-contracts/src/public_wire.rs#L1817) | `Human`; `Json` |
 | `AuthRole` | enum | [`AuthRole`](../../packages/nixling-contracts/src/public_wire.rs#L1825) | `None`; `Launcher`; `Admin` |
-| `HostFindingSeverity` | enum | [`HostFindingSeverity`](../../packages/nixling-contracts/src/public_wire.rs#L2032) | `Pass`; `Warn`; `Fail` |
+| `HostFindingSeverity` | enum | [`HostFindingSeverity`](../../packages/nixling-contracts/src/public_wire.rs#L2034) | `Pass`; `Warn`; `Fail` |
 | `TerminalStream` | enum | [`TerminalStream`](../../packages/nixling-contracts/src/terminal_wire.rs#L19) | `Stdout`; `Stderr` |
 | `TerminalStatus` | enum | [`TerminalStatus`](../../packages/nixling-contracts/src/terminal_wire.rs#L197) | `Exited` — struct { `code`: `i32` }; `Signaled` — struct { `signal`: `u32` }; `Error` — struct { `slug`: `String` } |
 | `PathClass` | enum | [`PathClass`](../../packages/nixling-contracts/src/types.rs#L171) | `Vm`; `Runtime` |

--- a/docs/reference/schemas/v2/wire-protocol.json
+++ b/docs/reference/schemas/v2/wire-protocol.json
@@ -5169,6 +5169,12 @@
         "graphics": {
           "type": "boolean"
         },
+        "guestClosureOutPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "isNetVm": {
           "type": "boolean"
         },

--- a/packages/nixling-contracts/src/cli_output.rs
+++ b/packages/nixling-contracts/src/cli_output.rs
@@ -19,6 +19,8 @@ pub struct ListItemOutputV2 {
     pub status: String,
     pub is_net_vm: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guest_closure_out_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub autostart: Option<crate::public_wire::VmAutostartPosture>,

--- a/packages/nixling-contracts/src/public_wire.rs
+++ b/packages/nixling-contracts/src/public_wire.rs
@@ -1851,6 +1851,8 @@ pub struct ListEntry {
     pub lifecycle: VmLifecycle,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guest_closure_out_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub autostart: Option<VmAutostartPosture>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub qemu_media: Option<QemuMediaStatus>,

--- a/packages/nixling-core/src/bundle_resolver.rs
+++ b/packages/nixling-core/src/bundle_resolver.rs
@@ -110,6 +110,7 @@ pub struct BundleResolver {
     activation_intents: BTreeMap<String, ResolvedActivationIntent>,
     store_view_intents: BTreeMap<String, ResolvedStoreViewIntent>,
     gc_intents: BTreeMap<String, ResolvedGcIntent>,
+    closure_toplevels: BTreeMap<String, String>,
     keys_rotate_intents: BTreeMap<String, ResolvedKeysRotateIntent>,
     host_key_trust_intents: BTreeMap<String, ResolvedHostKeyTrustIntent>,
     rotate_known_host_intents: BTreeMap<String, ResolvedRotateKnownHostIntent>,
@@ -996,6 +997,10 @@ impl BundleResolver {
         let activation_intents = build_activation_intents(&closures, &manifest);
         let store_view_intents = build_store_view_intents(&closures, &manifest);
         let gc_intents = build_gc_intents(&closures);
+        let closure_toplevels = closures
+            .iter()
+            .map(|closure| (closure.vm.clone(), closure.toplevel.clone()))
+            .collect();
         let keys_rotate_intents = build_keys_rotate_intents(&bundle, &manifest);
         let host_key_trust_intents = build_host_key_trust_intents(&bundle, &manifest);
         let rotate_known_host_intents = build_rotate_known_host_intents(&bundle, &manifest);
@@ -1022,6 +1027,7 @@ impl BundleResolver {
             activation_intents,
             store_view_intents,
             gc_intents,
+            closure_toplevels,
             keys_rotate_intents,
             host_key_trust_intents,
             rotate_known_host_intents,
@@ -1162,6 +1168,10 @@ impl BundleResolver {
 
     pub fn find_store_view_intent(&self, vm: &str) -> Option<&ResolvedStoreViewIntent> {
         self.store_view_intents.get(&intent_id_store_view(vm))
+    }
+
+    pub fn find_guest_closure_out_path(&self, vm: &str) -> Option<&str> {
+        self.closure_toplevels.get(vm).map(String::as_str)
     }
 
     pub fn find_gc_intent(&self, id: &str) -> Option<&ResolvedGcIntent> {

--- a/packages/nixling-daemon-access/src/lib.rs
+++ b/packages/nixling-daemon-access/src/lib.rs
@@ -596,6 +596,8 @@ pub struct DaemonVmListEntry {
     pub is_net_vm: bool,
     pub lifecycle: DaemonVmLifecycle,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guest_closure_out_path: Option<String>,
     pub runtime: DaemonRuntimeSummary,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runtime_capabilities: Vec<String>,
@@ -617,6 +619,7 @@ impl From<ListEntry> for DaemonVmListEntry {
             is_net_vm: entry.is_net_vm,
             lifecycle: entry.lifecycle.into(),
             name: entry.name,
+            guest_closure_out_path: entry.guest_closure_out_path,
             runtime: entry.runtime.into(),
             runtime_capabilities: entry.runtime_capabilities,
             services: entry.services.into(),
@@ -1771,6 +1774,7 @@ mod tests {
                 state,
             },
             name: vm.to_owned(),
+            guest_closure_out_path: None,
             autostart: None,
             qemu_media: None,
             runtime: RuntimeSummary {

--- a/packages/nixling/src/lib.rs
+++ b/packages/nixling/src/lib.rs
@@ -14838,6 +14838,7 @@ mod host_install_dispatch_tests {
                 state: nixling_contracts::public_wire::VmLifecycleState::Running,
             },
             name: "vm-a".to_owned(),
+            guest_closure_out_path: Some("/nix/store/vm-a-system".to_owned()),
             autostart: None,
             qemu_media: None,
             runtime: nixling_contracts::public_wire::RuntimeSummary {
@@ -14862,6 +14863,10 @@ mod host_install_dispatch_tests {
         assert_eq!(output.0.len(), 1);
         assert_eq!(output.0[0].name, "vm-a");
         assert_eq!(output.0[0].status, "running");
+        assert_eq!(
+            output.0[0].guest_closure_out_path.as_deref(),
+            Some("/nix/store/vm-a-system")
+        );
         assert!(output.0[0].graphics);
         assert!(output.0[0].usbip);
     }
@@ -14907,6 +14912,7 @@ mod host_install_dispatch_tests {
             static_ip: Some("192.168.100.2".to_owned()),
             status: "stopped".to_owned(),
             is_net_vm: true,
+            guest_closure_out_path: None,
             runtime_kind: None,
             autostart: None,
             runtime_capabilities: Vec::new(),

--- a/packages/nixling/src/status_read_model.rs
+++ b/packages/nixling/src/status_read_model.rs
@@ -67,8 +67,8 @@ pub(crate) fn list_output_from_manifest(
                     guest_closure_out_path: if pending_restart {
                         booted
                             .as_ref()
-                            .filter(|path| path.is_absolute())
-                            .map(|path| path.to_string_lossy().into_owned())
+                            .filter(|path| path.starts_with('/'))
+                            .cloned()
                             .or(declared_guest_closure_out_path)
                     } else {
                         declared_guest_closure_out_path

--- a/packages/nixling/src/status_read_model.rs
+++ b/packages/nixling/src/status_read_model.rs
@@ -52,6 +52,9 @@ pub(crate) fn list_output_from_manifest(
                 let pending_restart =
                     is_pending_restart(vm, &services, current.as_deref(), booted.as_deref());
                 let qemu_media = qemu_media_status(context, vm, bundle, process_vm, &services);
+                let declared_guest_closure_out_path = bundle
+                    .and_then(|bundle| bundle.closures.get(&vm.name))
+                    .map(|closure| closure.toplevel.clone());
                 ListItemOutputV2 {
                     name: vm.name.clone(),
                     env: vm.env.clone(),
@@ -61,9 +64,15 @@ pub(crate) fn list_output_from_manifest(
                     static_ip: vm.static_ip.clone(),
                     status: list_status_label(vm, &services, pending_restart),
                     is_net_vm: vm.is_net_vm,
-                    guest_closure_out_path: bundle
-                        .and_then(|bundle| bundle.closures.get(&vm.name))
-                        .map(|closure| closure.toplevel.clone()),
+                    guest_closure_out_path: if pending_restart {
+                        booted
+                            .as_ref()
+                            .filter(|path| path.is_absolute())
+                            .map(|path| path.to_string_lossy().into_owned())
+                            .or(declared_guest_closure_out_path)
+                    } else {
+                        declared_guest_closure_out_path
+                    },
                     runtime_kind: output_runtime_kind(vm),
                     autostart: output_autostart_posture(vm),
                     runtime_capabilities: output_runtime_capabilities(vm),

--- a/packages/nixling/src/status_read_model.rs
+++ b/packages/nixling/src/status_read_model.rs
@@ -61,6 +61,9 @@ pub(crate) fn list_output_from_manifest(
                     static_ip: vm.static_ip.clone(),
                     status: list_status_label(vm, &services, pending_restart),
                     is_net_vm: vm.is_net_vm,
+                    guest_closure_out_path: bundle
+                        .and_then(|bundle| bundle.closures.get(&vm.name))
+                        .map(|closure| closure.toplevel.clone()),
                     runtime_kind: output_runtime_kind(vm),
                     autostart: output_autostart_posture(vm),
                     runtime_capabilities: output_runtime_capabilities(vm),
@@ -92,6 +95,11 @@ pub(crate) fn list_output_from_public_entries(
                 static_ip: entry.static_ip.clone(),
                 status: public_lifecycle_list_status_label(&entry.lifecycle),
                 is_net_vm: entry.is_net_vm,
+                guest_closure_out_path: entry.guest_closure_out_path.clone().or_else(|| {
+                    bundle
+                        .and_then(|bundle| bundle.closures.get(&entry.vm))
+                        .map(|closure| closure.toplevel.clone())
+                }),
                 runtime_kind: entry.runtime.kind.clone(),
                 autostart: entry.autostart.clone(),
                 runtime_capabilities: entry.runtime_capabilities.clone(),

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -15737,9 +15737,9 @@ fn public_request_resolver_load(
     include_usb_status: bool,
     include_closure_metadata: bool,
 ) -> PublicResolverLoad {
-    if qemu_media_declared || include_closure_metadata {
+    if qemu_media_declared {
         PublicResolverLoad::Required
-    } else if include_usb_status {
+    } else if include_usb_status || include_closure_metadata {
         PublicResolverLoad::Optional
     } else {
         PublicResolverLoad::NotNeeded
@@ -15831,11 +15831,16 @@ fn build_public_list(
             .map(|(name, value)| {
                 let process_vm = processes.vms.iter().find(|entry| entry.vm == *name);
                 let host = host.as_ref();
-                let guest_closure_out_path = closure_resolver
+                let declared_guest_closure_out_path = closure_resolver
                     .and_then(|resolver| resolver.find_guest_closure_out_path(name))
                     .map(str::to_owned);
                 scope.spawn(move || {
                     let lifecycle = public_vm_lifecycle(state, name, value, process_vm);
+                    let guest_closure_out_path = public_guest_closure_out_path(
+                        value,
+                        &lifecycle,
+                        declared_guest_closure_out_path,
+                    );
                     let runtime_kind = public_runtime_kind(value);
                     let services = public_service_states(state, name, value, process_vm);
                     let service_capabilities = public_service_capabilities(&services);
@@ -16122,6 +16127,25 @@ fn public_pending_restart(manifest_entry: &Value) -> bool {
     let current = fs::read_link(state_dir.join("current")).ok();
     let booted = fs::read_link(state_dir.join("booted")).ok();
     matches!((current, booted), (Some(current), Some(booted)) if current != booted)
+}
+
+fn public_guest_closure_out_path(
+    manifest_entry: &Value,
+    lifecycle: &Value,
+    declared: Option<String>,
+) -> Option<String> {
+    let pending_restart = lifecycle
+        .get("pendingRestart")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if pending_restart
+        && let Some(state_dir) = manifest_entry.get("stateDir").and_then(Value::as_str)
+        && let Ok(booted) = fs::read_link(Path::new(state_dir).join("booted"))
+        && booted.is_absolute()
+    {
+        return Some(booted.to_string_lossy().into_owned());
+    }
+    declared
 }
 
 fn public_runtime_summary(lifecycle: &Value, manifest_entry: &Value) -> Value {
@@ -17528,8 +17552,8 @@ mod public_status_tests {
         );
         assert_eq!(
             public_request_resolver_load(false, false, true),
-            PublicResolverLoad::Required,
-            "public VM closure metadata comes from the trusted bundle resolver"
+            PublicResolverLoad::Optional,
+            "public VM closure metadata is additive and must not make list fail when the resolver is unavailable"
         );
     }
 
@@ -18450,6 +18474,48 @@ mod public_status_tests {
                 .pointer("/status/entries/1/lifecycle/state")
                 .and_then(Value::as_str),
             Some("Running")
+        );
+    }
+
+    #[test]
+    fn dispatch_list_uses_booted_closure_when_vm_is_pending_restart() {
+        let root = tempfile::tempdir().expect("artifact root");
+        let old_toplevel = "/nix/store/old-running-vm-a-system";
+        let new_toplevel = "/nix/store/new-declared-vm-a-system";
+        let state_dir = make_generation_links(root.path(), new_toplevel, old_toplevel);
+        let artifacts = write_public_status_artifacts_with_state_dir(root.path(), Some(&state_dir));
+        let (state, _dir) = test_state_with_config(DaemonConfig {
+            artifacts,
+            ..DaemonConfig::default()
+        });
+        state
+            .pidfd_table
+            .register(
+                "vm-a".to_owned(),
+                VM_RUNNER_ROLE_ID.to_owned(),
+                current_process_entry(),
+            )
+            .expect("register vm-a runner");
+
+        let list = dispatch_list(
+            &state,
+            public_wire::ListRequest {
+                env: Some("work".to_owned()),
+                vm: None,
+            },
+        )
+        .expect("list dispatch");
+
+        assert_eq!(
+            list.pointer("/vms/0/lifecycle/pendingRestart")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            list.pointer("/vms/0/guestClosureOutPath")
+                .and_then(Value::as_str),
+            Some(old_toplevel),
+            "running pending-restart VMs must report the booted closure for vulnerability scanning"
         );
     }
 

--- a/packages/nixlingd/src/lib.rs
+++ b/packages/nixlingd/src/lib.rs
@@ -15418,8 +15418,9 @@ enum PublicResolverLoad {
 fn public_request_resolver_load(
     qemu_media_declared: bool,
     include_usb_status: bool,
+    include_closure_metadata: bool,
 ) -> PublicResolverLoad {
-    if qemu_media_declared {
+    if qemu_media_declared || include_closure_metadata {
         PublicResolverLoad::Required
     } else if include_usb_status {
         PublicResolverLoad::Optional
@@ -15431,6 +15432,7 @@ fn public_request_resolver_load(
 fn load_public_request_artifacts(
     state: &ServerState,
     include_usb_status: bool,
+    include_closure_metadata: bool,
 ) -> Result<PublicRequestArtifacts, TypedError> {
     let manifest = load_manifest(&state.config.artifacts.public_manifest_path)?;
     let host = load_json::<HostJson>(&state.config.artifacts.host_path).ok();
@@ -15439,7 +15441,11 @@ fn load_public_request_artifacts(
         .as_ref()
         .and_then(|host| host.qemu_media.as_ref())
         .is_some();
-    let resolver = match public_request_resolver_load(qemu_media_declared, include_usb_status) {
+    let resolver = match public_request_resolver_load(
+        qemu_media_declared,
+        include_usb_status,
+        include_closure_metadata,
+    ) {
         PublicResolverLoad::NotNeeded => None,
         PublicResolverLoad::Optional => load_bundle_resolver(state).ok(),
         PublicResolverLoad::Required => Some(load_bundle_resolver(state)?),
@@ -15490,8 +15496,9 @@ fn build_public_list(
         manifest,
         host,
         processes,
-        resolver: _,
-    } = load_public_request_artifacts(state, false)?;
+        resolver,
+    } = load_public_request_artifacts(state, false, true)?;
+    let closure_resolver = resolver.as_ref();
     let vms = std::thread::scope(|scope| {
         let workers = manifest
             .iter()
@@ -15507,6 +15514,9 @@ fn build_public_list(
             .map(|(name, value)| {
                 let process_vm = processes.vms.iter().find(|entry| entry.vm == *name);
                 let host = host.as_ref();
+                let guest_closure_out_path = closure_resolver
+                    .and_then(|resolver| resolver.find_guest_closure_out_path(name))
+                    .map(str::to_owned);
                 scope.spawn(move || {
                     let lifecycle = public_vm_lifecycle(state, name, value, process_vm);
                     let runtime_kind = public_runtime_kind(value);
@@ -15523,6 +15533,7 @@ fn build_public_list(
                         "tpm": value.get("tpm").cloned().unwrap_or(Value::Bool(false)),
                         "usbip": value.get("usbipYubikey").cloned().unwrap_or(Value::Bool(false)),
                         "lifecycle": lifecycle,
+                        "guestClosureOutPath": guest_closure_out_path,
                         "runtime": public_runtime_summary(&lifecycle, value),
                         "autostart": public_autostart_posture(value),
                         "runtimeCapabilities": public_runtime_capabilities(value),
@@ -15601,7 +15612,7 @@ fn build_public_status(
         host,
         processes,
         resolver,
-    } = load_public_request_artifacts(state, true)?;
+    } = load_public_request_artifacts(state, true, false)?;
     let requested_vm = request.vm.clone();
 
     let statuses = std::thread::scope(|scope| {
@@ -16880,17 +16891,41 @@ mod public_status_tests {
             &public_manifest_path,
             serde_json::to_vec_pretty(&json!({
                 "_manifest": { "manifestVersion": 6 },
+                "_observability": {
+                    "enabled": false,
+                    "signozUrl": "http://127.0.0.1:8080",
+                    "signozOtlpGrpcPort": 4317,
+                    "signozOtlpHttpPort": 4318,
+                    "obsVsockCid": 1000,
+                    "obsVsockHostSocket": "/run/nixling/obs.sock",
+                    "vmName": "sys-obs"
+                },
                 "vm-a": {
                     "name": "vm-a",
+                    "apiSocket": "/run/nixling/vm-a.sock",
+                    "audioService": null,
+                    "audioStateFile": null,
+                    "bridge": "br-work-lan",
                     "env": "work",
+                    "gpuSocket": "/run/nixling/vm-a-gpu.sock",
                     "staticIp": "10.20.0.10",
                     "sshUser": "alice",
                     "isNetVm": false,
+                    "netVm": "sys-work-net",
                     "stateDir": vm_a_state_dir,
                     "graphics": true,
                     "tpm": false,
+                    "tpmSocket": null,
                     "usbipYubikey": true,
+                    "usbipdHostIp": "10.20.0.1",
                     "audio": false,
+                    "tap": "work-l2",
+                    "observability": {
+                        "agentSocket": "/run/nixling/otlp.sock",
+                        "enabled": false,
+                        "vsockCid": 110,
+                        "vsockHostSocket": "/run/nixling/vm-a-vsock.sock"
+                    },
                     "runtime": {
                         "kind": "nixos",
                         "provider": {
@@ -16914,14 +16949,30 @@ mod public_status_tests {
                 },
                 "vm-b": {
                     "name": "vm-b",
+                    "apiSocket": "/run/nixling/vm-b.sock",
+                    "audioService": null,
+                    "audioStateFile": null,
+                    "bridge": "br-personal-lan",
                     "env": "personal",
+                    "gpuSocket": null,
                     "staticIp": "10.30.0.10",
                     "sshUser": "bob",
                     "isNetVm": false,
+                    "netVm": "sys-personal-net",
+                    "stateDir": root.join("vm-b-state").display().to_string(),
                     "graphics": false,
                     "tpm": false,
+                    "tpmSocket": null,
                     "usbipYubikey": false,
+                    "usbipdHostIp": null,
                     "audio": false,
+                    "tap": "personal-l2",
+                    "observability": {
+                        "agentSocket": "/run/nixling/otlp.sock",
+                        "enabled": false,
+                        "vsockCid": 210,
+                        "vsockHostSocket": "/run/nixling/vm-b-vsock.sock"
+                    },
                     "runtime": {
                         "kind": "nixos",
                         "provider": {
@@ -16974,16 +17025,70 @@ mod public_status_tests {
         )
         .expect("write privileges");
 
+        let vm_a_toplevel = root.join("store/vm-a-system");
+        let vm_b_toplevel = root.join("store/vm-b-system");
+        let vm_a_db = root.join("vm-a.db.dump");
+        let vm_b_db = root.join("vm-b.db.dump");
+        fs::create_dir_all(&vm_a_toplevel).expect("create vm-a toplevel");
+        fs::create_dir_all(&vm_b_toplevel).expect("create vm-b toplevel");
+        fs::write(&vm_a_db, b"vm-a-db").expect("write vm-a db dump");
+        fs::write(&vm_b_db, b"vm-b-db").expect("write vm-b db dump");
+        fs::write(
+            closures_dir.join("vm-a.json"),
+            serde_json::to_vec_pretty(&json!({
+                "schemaVersion": "v2",
+                "vm": "vm-a",
+                "toplevel": vm_a_toplevel.display().to_string(),
+                "closurePaths": [vm_a_toplevel.display().to_string()],
+                "dbDumpPath": vm_a_db.display().to_string(),
+                "declaredRunner": "",
+                "runnerParityPath": "",
+                "runnerParityOk": true,
+                "generation": {
+                    "hostGeneration": 11,
+                    "vmGeneration": null,
+                    "sourceRevision": null,
+                    "generatedAt": null
+                }
+            }))
+            .expect("vm-a closure json"),
+        )
+        .expect("write vm-a closure");
+        fs::write(
+            closures_dir.join("vm-b.json"),
+            serde_json::to_vec_pretty(&json!({
+                "schemaVersion": "v2",
+                "vm": "vm-b",
+                "toplevel": vm_b_toplevel.display().to_string(),
+                "closurePaths": [vm_b_toplevel.display().to_string()],
+                "dbDumpPath": vm_b_db.display().to_string(),
+                "declaredRunner": "",
+                "runnerParityPath": "",
+                "runnerParityOk": true,
+                "generation": {
+                    "hostGeneration": 12,
+                    "vmGeneration": null,
+                    "sourceRevision": null,
+                    "generatedAt": null
+                }
+            }))
+            .expect("vm-b closure json"),
+        )
+        .expect("write vm-b closure");
+
         fs::write(
             &bundle_path,
             serde_json::to_vec_pretty(&json!({
                 "bundleVersion": 4,
-                "schemaVersion": "v2",
+                "schemaVersion": "v1",
                 "publicManifestPath": public_manifest_path.display().to_string(),
                 "hostPath": host_path.display().to_string(),
                 "processesPath": processes_path.display().to_string(),
                 "privilegesPath": privileges_path.display().to_string(),
-                "closures": [],
+                "closures": [
+                    { "vm": "vm-a", "path": "closures/vm-a.json" },
+                    { "vm": "vm-b", "path": "closures/vm-b.json" }
+                ],
                 "minijailProfiles": [],
                 "managedKeys": {},
                 "generation": {
@@ -17002,6 +17107,8 @@ mod public_status_tests {
             &privileges_path,
             &processes_path,
             &public_manifest_path,
+            &closures_dir.join("vm-a.json"),
+            &closures_dir.join("vm-b.json"),
         ] {
             fs::set_permissions(path, fs::Permissions::from_mode(0o640))
                 .expect("chmod public status test artifact");
@@ -17083,24 +17190,29 @@ mod public_status_tests {
     #[test]
     fn public_request_resolver_load_is_request_scoped_and_minimal() {
         assert_eq!(
-            public_request_resolver_load(false, false),
+            public_request_resolver_load(false, false, false),
             PublicResolverLoad::NotNeeded,
-            "list/status paths without qemu-media or USB status do not need a bundle resolver"
+            "status paths without qemu-media, USB status, or closure metadata do not need a bundle resolver"
         );
         assert_eq!(
-            public_request_resolver_load(false, true),
+            public_request_resolver_load(false, true, false),
             PublicResolverLoad::Optional,
             "USB status may use the resolver but must preserve status output when it is unavailable"
         );
         assert_eq!(
-            public_request_resolver_load(true, false),
+            public_request_resolver_load(true, false, false),
             PublicResolverLoad::Required,
             "qemu-media registry refresh needs the trusted bundle resolver"
         );
         assert_eq!(
-            public_request_resolver_load(true, true),
+            public_request_resolver_load(true, true, false),
             PublicResolverLoad::Required,
             "qemu-media plus USB status shares one required per-request resolver"
+        );
+        assert_eq!(
+            public_request_resolver_load(false, false, true),
+            PublicResolverLoad::Required,
+            "public VM closure metadata comes from the trusted bundle resolver"
         );
     }
 
@@ -17736,6 +17848,12 @@ mod public_status_tests {
         assert_eq!(vms.len(), 1);
         let vm = &vms[0];
         assert_eq!(vm.get("vm").and_then(Value::as_str), Some("vm-a"));
+        assert!(
+            vm.get("guestClosureOutPath")
+                .and_then(Value::as_str)
+                .is_some_and(|path| path.ends_with("/store/vm-a-system")),
+            "list response must expose the VM guest closure out path"
+        );
         assert_eq!(vm.get("graphics").and_then(Value::as_bool), Some(true));
         assert_eq!(vm.get("usbip").and_then(Value::as_bool), Some(true));
         assert_eq!(
@@ -17972,6 +18090,16 @@ mod public_status_tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(list_names, vec!["vm-a", "vm-b"]);
+        assert!(
+            list.pointer("/vms/0/guestClosureOutPath")
+                .and_then(Value::as_str)
+                .is_some_and(|path| path.ends_with("/store/vm-a-system"))
+        );
+        assert!(
+            list.pointer("/vms/1/guestClosureOutPath")
+                .and_then(Value::as_str)
+                .is_some_and(|path| path.ends_with("/store/vm-b-system"))
+        );
         assert_eq!(
             list.pointer("/vms/1/lifecycle/state")
                 .and_then(Value::as_str),


### PR DESCRIPTION
## Summary

- Expose `guestClosureOutPath` on `nixling list --json` and daemon public list responses.
- Source the value from bundle closure metadata, with graceful omission if optional bundle metadata is unavailable.
- Report the booted closure for running VMs in pending-restart state so scanners inspect the active guest generation.
- Update generated CLI/wire schemas and reference docs.

Fixes #170.

## Validation

- `cargo test --manifest-path packages/Cargo.toml -p nixlingd public_status_tests:: -- --nocapture`
- `cargo test --manifest-path packages/Cargo.toml -p nixling --lib host_install_dispatch_tests:: -- --nocapture`
- `cargo test --manifest-path packages/Cargo.toml -p nixling-daemon-access --lib -- --nocapture`
- `make test-drift`
- `make check`

## Review

Full implementation panel signoff completed after follow-up fixes for resolver fallback, pending-restart closure selection, and scanner path anchoring.
