### PR TITLE
Grant d2bd host PipeWire ACL for audio controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ deprecations ship one minor release before removal.
 - The `with-entra-id` eval workflow now overrides GitHub inputs to the
   committed lock revisions and authenticates Nix fetches with the Actions token
   to avoid transient unauthenticated API rate limits.
+- Host activation grants `d2bd` narrow access to the Wayland user's
+  PipeWire/Pulse sockets so daemon-owned audio policy enforcement does not
+  depend on host-local ACL overrides.
 - Renamed the project to **d2b: Double Dutch Bus** as an intentional breaking
   change. Commands, packages, services, sockets, Nix options, runtime paths,
   schemas, telemetry identifiers, and generated artifacts now use only `d2b`

--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -778,6 +778,23 @@ in
                 if [ -n "$wuid" ]; then
                   rdir="/run/user/$wuid"
                   if [ -d "$rdir" ]; then
+                    # d2bd performs host-side audio policy enforcement by
+                    # resolving and mutating PipeWire nodes with pw-dump/wpctl.
+                    # Grant only the audio session sockets, never Wayland.
+                    ${activationHelper} setfacl-on-path \
+                      --path "$rdir" \
+                      --acl-spec "u:d2bd:rx" \
+                      --require-kind directory \
+                      --setfacl-bin "${pkgs.acl}/bin/setfacl" \
+                      2>/dev/null || true
+                    for sock in pipewire-0 pulse/native; do
+                      ${activationHelper} setfacl-on-path \
+                        --path "$rdir/$sock" \
+                        --acl-spec "u:d2bd:rwx" \
+                        --require-kind socket \
+                        --setfacl-bin "${pkgs.acl}/bin/setfacl" \
+                        2>/dev/null || true
+                    done
                     if echo "$wlproxy_wayland_uids" | ${pkgs.gnugrep}/bin/grep -qx "$uid"; then
                       # wlproxy: traversal on dir + rwx on Wayland socket only
                       ${activationHelper} setfacl-on-path \

--- a/packages/d2b-contract-tests/tests/minijail_swtpm_video.rs
+++ b/packages/d2b-contract-tests/tests/minijail_swtpm_video.rs
@@ -537,6 +537,8 @@ fn video_host_activation_runtime_and_session_acls() {
         r#"select(.role == "gpu" or .role == "gpu-render-node")"#,
         r#"select(.role == "audio")"#,
         r#"select(.role == "cloud-hypervisor-runner" or .role == "video")"#,
+        r#"--acl-spec "u:d2bd:rx""#,
+        r#"--acl-spec "u:d2bd:rwx""#,
         r#"setfacl -d -x "u:$uid" /run/d2b-video"#,
         "u:$uid:---",
         "stale_video_uid=",


### PR DESCRIPTION
## Summary
- Grants d2bd narrow access to the Wayland user PipeWire/Pulse sockets for daemon-owned host audio enforcement.
- Keeps Wayland denied to d2bd and leaves per-role session socket split intact.
- Adds source policy coverage for the d2bd PipeWire ACL.

## Validation
- cargo fmt --manifest-path packages/Cargo.toml --all -- --check
- cargo test --manifest-path packages/Cargo.toml -p d2b-contract-tests --test minijail_swtpm_video video_host_activation_runtime_and_session_acls