### PR TITLE
flake: export d2b-clipd package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ deprecations ship one minor release before removal.
   best-effort attribution cache behavior, and fallback arming state-machine tests.
 - `d2b-clipd` now has a real desktop notification backend for bounded,
   content-free fallback-ready and failure notifications.
+- The flake now exports `packages.<system>.d2b-clipd` so host configurations can
+  wire the clipboard authority user service without local package workarounds.
 - Added clipboard architecture Nix/docs/schema scaffolding: a default-off
   `d2b.site.clipboard` module, user-service wiring for externally packaged
   `d2b-clipd`, explicit picker package/path configuration with no bundled GPL

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,22 @@
 
       packages = forAllSystems (system: let
         pkgs = nixpkgsFor.${system};
+        rustPackagesSrc = pkgs.runCommand "d2b-rust-src" { } ''
+          mkdir -p $out/packages
+          cp -r ${./packages}/. $out/packages/
+        '';
+        rustWorkspace = args: pkgs.rustPlatform.buildRustPackage ({
+          pname = "d2b-rust-workspace";
+          version = "0.0.0-bootstrap";
+          src = rustPackagesSrc;
+          sourceRoot = "d2b-rust-src/packages";
+          cargoLock = {
+            lockFile = ./packages/Cargo.lock;
+            outputHashes."wl-proxy-0.1.2" = "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
+          };
+          RUSTC_WRAPPER = "";
+          SCCACHE_DIR = "";
+        } // args);
         guestRustPackagesSrc = pkgs.runCommand "d2b-guest-rust-src" { } ''
           mkdir -p $out/packages
           cp -r ${./packages/d2b-constellation-core} $out/packages/d2b-constellation-core
@@ -225,6 +241,11 @@
         d2b-exec-runner-static =
           guestStaticPackage "d2b-exec-runner" "d2b-exec-runner";
         d2b-guest-shell-runner-static = guestShellRunnerStatic;
+        d2b-clipd = rustWorkspace {
+          pname = "d2b-clipd";
+          cargoBuildFlags = [ "--package" "d2b-clipd" "--bin" "d2b-clipd" ];
+          doCheck = false;
+        };
 
         signoz = import ./pkgs/signoz { inherit pkgs; };
         signozOtelCollector = import ./pkgs/signoz-otel-collector { inherit pkgs; };


### PR DESCRIPTION
## Summary
- export packages.<system>.d2b-clipd from the d2b flake
- document the package export in CHANGELOG.md

## Validation
- nix build .#d2b-clipd --no-link --print-build-logs
- git diff --check