### PR TITLE
wlproxy: restore guest clipboard and app launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ deprecations ship one minor release before removal.
 
 - USBIP driver helper retries now treat transient `ETXTBSY` / "text file busy"
   spawn failures as retryable instead of reporting the helper as missing.
+- `d2b-wayland-proxy` now advertises its virtual clipboard manager even when
+  the host compositor omits `wl_data_device_manager`, and denies unstable
+  text-input v3 forwarding by default to avoid guest app crashes on invalid
+  seat-bound requests.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ deprecations ship one minor release before removal.
 - `d2b-wayland-proxy` now advertises its virtual clipboard manager even when
   the host compositor omits `wl_data_device_manager`, and denies unstable
   text-input v3 forwarding by default to avoid guest app crashes on invalid
-  seat-bound requests.
+  seat-bound requests. Clipboard-boundary allow overrides now remain denied
+  and emit stable `W-*` diagnostics.
 
 ### Added
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ The contracts. Stable interfaces a consumer can depend on.
 - [`reference/display-io-capabilities.md`](./reference/display-io-capabilities.md) —
   display, clipboard, audio, USB/HID, GPU, video, and provider display
   lifecycle capability boundaries.
-- [`reference/clipboard-architecture.md`](./reference/clipboard-architecture.md) —
+- [`explanation/clipboard-architecture.md`](./explanation/clipboard-architecture.md) —
   trusted clipboard authority, picker split, Niri integration, and bridge
   runtime path contract.
 - [`reference/clipboard-picker-protocol.md`](./reference/clipboard-picker-protocol.md) —

--- a/docs/explanation/clipboard-architecture.md
+++ b/docs/explanation/clipboard-architecture.md
@@ -1,6 +1,6 @@
 # Clipboard architecture
 
-**Diataxis category:** reference.
+**Diataxis category:** explanation.
 
 D2b clipboard support is a split-trust design. The trusted d2b control plane
 owns clipboard authority; the picker is only a UI client.

--- a/docs/how-to/migrate-to-wayland-proxy.md
+++ b/docs/how-to/migrate-to-wayland-proxy.md
@@ -195,6 +195,11 @@ longer apply.
 - **Multi-output enumeration** works through the proxy; verify with
   `wayland-info` inside the guest if you use a multi-monitor setup.
 - **Clipboard and DnD** are policy-owned by d2b. The standard clipboard
-  (`wl_data_device_manager`) is virtualized by `d2b-wayland-proxy`; primary
+  (`wl_data_device_manager`) is synthetically advertised by
+  `d2b-wayland-proxy` even when the host compositor omits that global. Primary
   selection, privileged clipboard-control globals, and DnD are explicitly
   denied by the proxy policy.
+- **Wayland text-input v3** (`zwp_text_input_manager_v3`) is denied by default.
+  This disables guest IME/text-input protocol features until the proxy can
+  validate seat-bound requests, but prevents apps from crashing on invalid
+  forwarded text-input requests.

--- a/docs/how-to/migrate-to-wayland-proxy.md
+++ b/docs/how-to/migrate-to-wayland-proxy.md
@@ -200,6 +200,4 @@ longer apply.
   selection, privileged clipboard-control globals, and DnD are explicitly
   denied by the proxy policy.
 - **Wayland text-input v3** (`zwp_text_input_manager_v3`) is denied by default.
-  This disables guest IME/text-input protocol features until the proxy can
-  validate seat-bound requests, but prevents apps from crashing on invalid
-  forwarded text-input requests.
+  Guest IME/text-input protocol features are disabled by default.

--- a/docs/reference/clipboard-architecture.md
+++ b/docs/reference/clipboard-architecture.md
@@ -54,6 +54,15 @@ sufficient for per-VM `d2b-<vm>-wlproxy` ACLs or lifecycle cleanup.
 The bridge is local-only, validates peer credentials, and may use `SCM_RIGHTS`
 between d2b components. Transfer FDs never go to the picker.
 
+## Guest Wayland clipboard virtualization
+
+`d2b-wayland-proxy` always exposes a synthetic `wl_data_device_manager` to
+guest clients. It does this even when the host compositor omits the standard
+clipboard global, because the guest clipboard namespace is implemented by d2b
+and is not inherited from the host compositor. If the host does advertise its
+own `wl_data_device_manager`, the proxy hides that host global and keeps guest
+`wl_data_*` objects local to the virtual clipboard path.
+
 ## Niri and paste intent
 
 `d2b-clipd` connects directly to `$NIRI_SOCKET` and speaks Niri JSON IPC. It

--- a/docs/reference/components-graphics.md
+++ b/docs/reference/components-graphics.md
@@ -38,7 +38,7 @@ runners. The GPU sidecar runs as the dedicated per-VM
 | `d2b.vms.<vm>.graphics.waylandProxy.debugLogging` | bool | `false` | Enable verbose `wl-proxy` protocol tracing for this VM's host-side proxy runner. The trace goes to the runner stderr stream and can include app metadata such as titles, app IDs, registry names, object IDs, and fd numbers; use only for short-lived debugging. |
 | `d2b.vms.<vm>.graphics.waylandProxy.byteLogging` | bool | `false` | Enable raw `wl-proxy` recv/send hexdump diagnostics for this VM's host-side proxy runner. Logs byte prefixes capped at 256 bytes per message plus fd counts; use only for short-lived corruption debugging and turn it back off after capture. |
 | `d2b.vms.<vm>.graphics.waylandProxy.denyGlobals` | list of str | `[]` | Additional Wayland globals to hide from the guest. |
-| `d2b.vms.<vm>.graphics.waylandProxy.allowGlobals` | list of str | `[]` | Globals to allow even if denied by the secure defaults. The proxy emits runtime advisory diagnostics for boundary-narrowing overrides. |
+| `d2b.vms.<vm>.graphics.waylandProxy.allowGlobals` | list of str | `[]` | Globals to allow even if denied by the secure defaults. Clipboard-boundary globals cannot be passed through and emit `W-ALLOW-CLIPBOARD-BOUNDARY` instead. |
 | `d2b.vms.<vm>.graphics.waylandProxy.maxVersions` | attrs of positive int | `{}` | Per-interface advertised version caps passed as `--max-version INTERFACE=VERSION`. |
 | `d2b.vms.<vm>.graphics.waylandProxy.dmabufAllow` | list of str | `[]` | dmabuf format/modifier filters to allow unconditionally, in `FORMAT[:MODIFIER]` form. Allow rules override deny rules. |
 | `d2b.vms.<vm>.graphics.waylandProxy.dmabufDeny` | list of str | `[]` | dmabuf format/modifier filters to hide from legacy modifier events and v4/v5 feedback tranches unless explicitly allowed. |
@@ -56,6 +56,11 @@ keep dmabuf feedback v4/v5 visible while hiding linear modifiers:
 ```nix
 d2b.vms.work.graphics.waylandProxy.dmabufDeny = [ "all:linear" ];
 ```
+
+`zwp_text_input_manager_v3` is denied by default. Guest IME/text-input
+protocol features remain disabled until the proxy can validate seat-bound
+requests safely, avoiding guest application crashes from invalid forwarded
+text-input requests under Niri-backed cross-domain Wayland.
 
 Site-level dependency:
 

--- a/docs/reference/display-io-capabilities.md
+++ b/docs/reference/display-io-capabilities.md
@@ -76,7 +76,7 @@ targets, and ACA sandboxes — is documented in
 - [Provider-managed sandboxes](./provider-managed-sandboxes.md) documents the
   Azure Container Apps adapter and its absent display/I/O capabilities.
 - [Graphics](./components-graphics.md) documents local Wayland forwarding.
-- [Clipboard architecture](./clipboard-architecture.md) documents the separate
+- [Clipboard architecture](../explanation/clipboard-architecture.md) documents the separate
   clipboard authority and picker split.
 - [Video](./components-video.md) documents the video sidecar.
 - [Audio](./components-audio.md) documents sound sidecar grants.

--- a/docs/reference/wayland-proxy-warnings.md
+++ b/docs/reference/wayland-proxy-warnings.md
@@ -112,6 +112,14 @@ document in the host configuration why the global is safe for this VM.
 Consider filing an issue or PR to have d2b classify the global so the
 warning is resolved upstream.
 
+## Default-denied app protocols
+
+Some classified app protocols are denied by default without producing an
+advisory warning. `zwp_text_input_manager_v3` is currently in this set: guest
+IME/text-input protocol features remain disabled until the proxy can validate
+seat-bound requests safely. This avoids forwarding invalid text-input requests
+that can crash guest applications under Niri-backed cross-domain Wayland.
+
 ## Warning vs. hard assertion
 
 Warnings never become hard assertions. Every warning condition still

--- a/docs/reference/wayland-proxy-warnings.md
+++ b/docs/reference/wayland-proxy-warnings.md
@@ -114,7 +114,7 @@ warning is resolved upstream.
 
 ---
 
-### W-CLIPBOARD-BOUNDARY-OVERRIDE-IGNORED
+### W-ALLOW-CLIPBOARD-BOUNDARY
 
 **Trigger:** `allowGlobals` includes a global that d2b classifies as a
 clipboard-boundary global.

--- a/docs/reference/wayland-proxy-warnings.md
+++ b/docs/reference/wayland-proxy-warnings.md
@@ -3,7 +3,7 @@
 > **Reference** for the advisory runtime diagnostics the d2b
 > Wayland proxy emits when operator configuration deviates from
 > the secure baseline or touches a rule d2b classifies as required
-> or high-risk.
+> high-risk, clipboard-boundary, or unclassified.
 
 > **Status:** live for
 > `d2b.vms.<vm>.graphics.waylandProxy.{enable,denyGlobals,allowGlobals,maxVersions,dmabufAllow,dmabufDeny,debugLogging,byteLogging}`.
@@ -18,8 +18,8 @@ host-side proxy process when the VM starts.
 Secure defaults emit **zero** `waylandProxy` warnings. A clean
 configuration with no overrides produces no output from this catalog.
 
-The `W-*` names below are documentation anchors. The Rust policy engine
-currently emits human-readable `PolicyWarning` messages.
+The `W-*` names below are emitted in `d2b-wayland-proxy` policy-warning
+messages and are stable grep targets for operator diagnostics.
 
 ## Warning conditions
 
@@ -79,7 +79,6 @@ high risk and denies by default.
 |---|---|
 | Screen capture | Screen/image capture globals allow guest apps to capture the host display. |
 | Virtual input | Virtual keyboard and pointer globals allow guest apps to inject arbitrary host input events. |
-| Clipboard control | Privileged data-control globals allow guest apps to read or modify arbitrary host clipboard content. |
 | Desktop shell | Layer-shell and privileged shell-surface globals give guest apps elevated compositor privileges. |
 | Session control | Session lock, output power, output management, and workspace management globals give guest apps broad compositor control. |
 | Security context | Wayland security-context extension is disabled until a concrete safe use case is identified. |
@@ -130,14 +129,6 @@ cannot bypass d2b policy.
 **How to override intentionally:** There is no passthrough override for these
 globals. Use the d2b clipboard architecture or disable the Wayland proxy for the
 VM while accepting the loss of d2b's cross-domain Wayland protections.
-
-## Default-denied app protocols
-
-Some classified app protocols are denied by default without producing an
-advisory warning. `zwp_text_input_manager_v3` is currently in this set: guest
-IME/text-input protocol features remain disabled until the proxy can validate
-seat-bound requests safely. This avoids forwarding invalid text-input requests
-that can crash guest applications under Niri-backed cross-domain Wayland.
 
 ## Warning vs. hard assertion
 

--- a/docs/reference/wayland-proxy-warnings.md
+++ b/docs/reference/wayland-proxy-warnings.md
@@ -112,6 +112,25 @@ document in the host configuration why the global is safe for this VM.
 Consider filing an issue or PR to have d2b classify the global so the
 warning is resolved upstream.
 
+---
+
+### W-CLIPBOARD-BOUNDARY-OVERRIDE-IGNORED
+
+**Trigger:** `allowGlobals` includes a global that d2b classifies as a
+clipboard-boundary global.
+
+**Affected globals:** standard clipboard, primary-selection, privileged
+data-control, and drag-and-drop globals.
+
+**Why it exists:** These globals are owned by d2b's virtual clipboard
+architecture. Operator `allowGlobals` entries for them are reported as ignored
+rather than forwarded to the host compositor, so guest clipboard and DnD objects
+cannot bypass d2b policy.
+
+**How to override intentionally:** There is no passthrough override for these
+globals. Use the d2b clipboard architecture or disable the Wayland proxy for the
+VM while accepting the loss of d2b's cross-domain Wayland protections.
+
 ## Default-denied app protocols
 
 Some classified app protocols are denied by default without producing an

--- a/nixos-modules/options-vms.nix
+++ b/nixos-modules/options-vms.nix
@@ -647,8 +647,8 @@ in
             Clipboard-boundary globals (standard clipboard, primary selection,
             privileged data-control, and DnD) are owned by d2b's virtual
             clipboard architecture and cannot be passed through; listing them
-            here is ignored by the proxy and emits
-            `W-CLIPBOARD-BOUNDARY-OVERRIDE-IGNORED`.
+            here is ignored by the proxy and emits a runtime advisory
+            diagnostic.
           '';
         };
 

--- a/nixos-modules/options-vms.nix
+++ b/nixos-modules/options-vms.nix
@@ -644,6 +644,11 @@ in
             defaults. Each entry is passed as `--allow-global` to the Wayland
             proxy. The proxy emits runtime advisory diagnostics when
             used; the operator is explicitly narrowing the security boundary.
+            Clipboard-boundary globals (standard clipboard, primary selection,
+            privileged data-control, and DnD) are owned by d2b's virtual
+            clipboard architecture and cannot be passed through; listing them
+            here is ignored by the proxy and emits
+            `W-CLIPBOARD-BOUNDARY-OVERRIDE-IGNORED`.
           '';
         };
 

--- a/nixos-modules/options-vms.nix
+++ b/nixos-modules/options-vms.nix
@@ -647,8 +647,8 @@ in
             Clipboard-boundary globals (standard clipboard, primary selection,
             privileged data-control, and DnD) are owned by d2b's virtual
             clipboard architecture and cannot be passed through; listing them
-            here is ignored by the proxy and emits a runtime advisory
-            diagnostic.
+            here is ignored by the proxy and emits the
+            `W-ALLOW-CLIPBOARD-BOUNDARY` runtime advisory diagnostic.
           '';
         };
 

--- a/packages/d2b-wayland-proxy/src/diag.rs
+++ b/packages/d2b-wayland-proxy/src/diag.rs
@@ -126,13 +126,14 @@ impl DiagRateLimiter {
 
     /// Log a bind-denial event (security boundary enforcement).
     /// Always emits via `log::warn`; rate-limited per (vm, event, interface).
-    pub fn bind_denied(&mut self, reason: DropReason, registry_name: u32) {
+    pub fn bind_denied(&mut self, reason: DropReason, registry_name: u32, interface: &str) {
         let reason_str = reason.as_str();
         let vm = self.vm.clone();
-        self.emit("bind-denied", reason_str, || {
+        let iface = interface.to_owned();
+        self.emit("bind-denied", interface, || {
             format!(
                 "[d2b-wlproxy] vm={vm} event=bind-denied reason={reason_str} \
-                 registry-name={registry_name}"
+                 interface={iface} registry-name={registry_name}"
             )
         });
     }
@@ -233,5 +234,30 @@ mod tests {
     #[test]
     fn bounded_error_detail_scrubs_control_characters() {
         assert_eq!(bounded_error_detail("line1\nline2\r\0"), "line1?line2??");
+    }
+
+    #[test]
+    fn bind_denied_rate_limits_by_interface() {
+        let mut rl = DiagRateLimiter::new("vm".to_owned());
+        for name in 0..MAX_PER_WINDOW as u32 {
+            rl.bind_denied(
+                DropReason::BindDeniedUnadvertised,
+                name,
+                "zwp_text_input_manager_v3",
+            );
+        }
+        rl.bind_denied(
+            DropReason::BindDeniedUnadvertised,
+            100,
+            "zwp_text_input_manager_v3",
+        );
+        assert_eq!(rl.suppressed_total_for_tests(), 1);
+
+        rl.bind_denied(
+            DropReason::BindDeniedUnadvertised,
+            101,
+            "wl_data_device_manager",
+        );
+        assert_eq!(rl.suppressed_total_for_tests(), 1);
     }
 }

--- a/packages/d2b-wayland-proxy/src/diag.rs
+++ b/packages/d2b-wayland-proxy/src/diag.rs
@@ -129,11 +129,10 @@ impl DiagRateLimiter {
     pub fn bind_denied(&mut self, reason: DropReason, registry_name: u32, interface: &str) {
         let reason_str = reason.as_str();
         let vm = self.vm.clone();
-        let iface = interface.to_owned();
         self.emit("bind-denied", interface, || {
             format!(
                 "[d2b-wlproxy] vm={vm} event=bind-denied reason={reason_str} \
-                 interface={iface} registry-name={registry_name}"
+                 interface={interface} registry-name={registry_name}"
             )
         });
     }
@@ -141,9 +140,8 @@ impl DiagRateLimiter {
     /// Log a global-filtered event (advertisement filtered; opt-in via `--log-filtered-globals`).
     pub fn global_filtered(&mut self, interface: &str) {
         let vm = self.vm.clone();
-        let iface = interface.to_owned();
         self.emit("global-filtered", interface, || {
-            format!("[d2b-wlproxy] vm={vm} event=global-filtered interface={iface}")
+            format!("[d2b-wlproxy] vm={vm} event=global-filtered interface={interface}")
         });
     }
 

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -53,7 +53,10 @@ use crate::{
         BridgeConfig, BridgeConnectionState, BridgeHandoff, BridgeReconnectMachine,
         BridgeTransferMetadata,
     },
-    clipboard::{ClipboardMimePolicy, ClipboardRoute, MimeDecision},
+    clipboard::{
+        ClipboardGlobalDisposition, ClipboardMimePolicy, ClipboardRoute, MimeDecision,
+        global_disposition,
+    },
     diag::{DiagRateLimiter, DropReason, bounded_error_detail},
     dmabuf::DmabufHandler,
     policy::FilterPolicy,
@@ -613,14 +616,10 @@ impl FilterRegistryHandler {
                 synthetic_clipboard: true,
             },
         );
-        self.diag
-            .borrow_mut()
-            .warn("synthetic-clipboard", "advertised", || {
-                format!(
-                    "[d2b-wlproxy] vm={} event=synthetic-clipboard-advertised interface=wl_data_device_manager registry-name={name} version={version}",
-                    self.policy.vm_name
-                )
-            });
+        log::info!(
+            "[d2b-wlproxy] vm={} event=synthetic-clipboard-advertised interface=wl_data_device_manager registry-name={name} version={version}",
+            self.policy.vm_name
+        );
         Some(GlobalAdvertisement {
             name,
             interface,
@@ -655,7 +654,10 @@ impl FilterRegistryHandler {
             }
             return (synthetic, IncomingGlobalDecision::Hide);
         }
-        if iface_name == "wl_data_device_manager" {
+        if matches!(
+            global_disposition(iface_name),
+            ClipboardGlobalDisposition::VirtualizeLocally | ClipboardGlobalDisposition::DenyGlobal
+        ) {
             self.hidden_globals.insert(name);
             if self.policy.log_filtered_globals {
                 self.diag.borrow_mut().global_filtered(iface_name);
@@ -1358,6 +1360,23 @@ mod tests {
         assert_eq!(decision, IncomingGlobalDecision::Hide);
         assert!(handler.hidden_globals.contains(&11));
         assert!(!handler.advertised_globals.contains_key(&11));
+    }
+
+    #[test]
+    fn prepare_global_hides_clipboard_boundary_even_when_policy_allows_it() {
+        let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
+        let policy = Rc::new(FilterPolicy::build(crate::policy::PolicyInput {
+            vm_name: "work".to_owned(),
+            allow_globals: vec!["zwp_primary_selection_device_manager_v1".to_owned()],
+            ..Default::default()
+        }));
+        let mut handler = FilterRegistryHandler::new(policy, diag, clipboard());
+        let (_synthetic, decision) =
+            handler.prepare_global(13, ObjectInterface::ZwpPrimarySelectionDeviceManagerV1, 1);
+
+        assert_eq!(decision, IncomingGlobalDecision::Hide);
+        assert!(handler.hidden_globals.contains(&13));
+        assert!(!handler.advertised_globals.contains_key(&13));
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -555,6 +555,7 @@ pub struct FilterRegistryHandler {
     /// interface and version we advertised. Bind requests above this version
     /// are rejected even if the client guessed the original compositor version.
     advertised_globals: HashMap<u32, AdvertisedGlobal>,
+    synthetic_clipboard_name: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -576,7 +577,39 @@ impl FilterRegistryHandler {
             clipboard,
             hidden_globals: HashSet::new(),
             advertised_globals: HashMap::new(),
+            synthetic_clipboard_name: None,
         }
+    }
+
+    fn ensure_synthetic_clipboard_global(&mut self, slf: &Rc<WlRegistry>, reserved_name: u32) {
+        if self.synthetic_clipboard_name.is_some() {
+            return;
+        }
+        let name = self.allocate_synthetic_clipboard_name(reserved_name);
+        let interface = ObjectInterface::WlDataDeviceManager;
+        let version = 3;
+        self.synthetic_clipboard_name = Some(name);
+        self.advertised_globals.insert(
+            name,
+            AdvertisedGlobal {
+                interface,
+                version,
+                synthetic_clipboard: true,
+            },
+        );
+        slf.send_global(name, interface, version);
+    }
+
+    fn allocate_synthetic_clipboard_name(&self, reserved_name: u32) -> u32 {
+        for name in (0..=u32::MAX).rev() {
+            if name != reserved_name
+                && !self.advertised_globals.contains_key(&name)
+                && !self.hidden_globals.contains(&name)
+            {
+                return name;
+            }
+        }
+        unreachable!("Wayland registry exhausted every u32 global name")
     }
 }
 
@@ -589,17 +622,9 @@ impl WlRegistryHandler for FilterRegistryHandler {
         version: u32,
     ) {
         let iface_name = interface.name();
+        self.ensure_synthetic_clipboard_global(slf, name);
         if iface_name == "wl_data_device_manager" {
-            let adv_version = version.min(3);
-            self.advertised_globals.insert(
-                name,
-                AdvertisedGlobal {
-                    interface,
-                    version: adv_version,
-                    synthetic_clipboard: true,
-                },
-            );
-            slf.send_global(name, interface, adv_version);
+            self.hidden_globals.insert(name);
             return;
         }
 
@@ -1182,6 +1207,33 @@ mod tests {
         let advertised = handler.advertised_globals.get(&11).expect("synthetic");
         assert!(advertised.synthetic_clipboard);
         assert_eq!(advertised.interface, ObjectInterface::WlDataDeviceManager);
+    }
+
+    #[test]
+    fn synthetic_clipboard_global_uses_reserved_high_name() {
+        let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
+        let handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+
+        assert_eq!(handler.allocate_synthetic_clipboard_name(7), u32::MAX);
+    }
+
+    #[test]
+    fn synthetic_clipboard_global_avoids_server_and_existing_names() {
+        let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        handler.advertised_globals.insert(
+            u32::MAX,
+            AdvertisedGlobal {
+                interface: ObjectInterface::WlCompositor,
+                version: 6,
+                synthetic_clipboard: false,
+            },
+        );
+
+        assert_eq!(
+            handler.allocate_synthetic_clipboard_name(u32::MAX - 1),
+            u32::MAX - 2
+        );
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -755,8 +755,8 @@ impl WlRegistryHandler for FilterRegistryHandler {
         };
 
         if !bind_matches_advertised_cap(advertised, id.interface(), id.version()) {
-            let vm = self.policy.vm_name.clone();
-            let iface = advertised.interface.name().to_owned();
+            let vm = &self.policy.vm_name;
+            let iface = advertised.interface.name();
             let requested = id.version();
             let advertised_version = advertised.version;
             self.diag

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -565,6 +565,19 @@ struct AdvertisedGlobal {
     synthetic_clipboard: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct GlobalAdvertisement {
+    name: u32,
+    interface: ObjectInterface,
+    version: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IncomingGlobalDecision {
+    Advertise(GlobalAdvertisement),
+    Hide,
+}
+
 impl FilterRegistryHandler {
     pub fn new(
         policy: Rc<FilterPolicy>,
@@ -581,9 +594,12 @@ impl FilterRegistryHandler {
         }
     }
 
-    fn ensure_synthetic_clipboard_global(&mut self, slf: &Rc<WlRegistry>, reserved_name: u32) {
+    fn ensure_synthetic_clipboard_global(
+        &mut self,
+        reserved_name: u32,
+    ) -> Option<GlobalAdvertisement> {
         if self.synthetic_clipboard_name.is_some() {
-            return;
+            return None;
         }
         let name = self.allocate_synthetic_clipboard_name(reserved_name);
         let interface = ObjectInterface::WlDataDeviceManager;
@@ -597,7 +613,19 @@ impl FilterRegistryHandler {
                 synthetic_clipboard: true,
             },
         );
-        slf.send_global(name, interface, version);
+        self.diag
+            .borrow_mut()
+            .warn("synthetic-clipboard", "advertised", || {
+                format!(
+                    "[d2b-wlproxy] vm={} event=synthetic-clipboard-advertised interface=wl_data_device_manager registry-name={name} version={version}",
+                    self.policy.vm_name
+                )
+            });
+        Some(GlobalAdvertisement {
+            name,
+            interface,
+            version,
+        })
     }
 
     fn allocate_synthetic_clipboard_name(&self, reserved_name: u32) -> u32 {
@@ -611,21 +639,28 @@ impl FilterRegistryHandler {
         }
         unreachable!("Wayland registry exhausted every u32 global name")
     }
-}
 
-impl WlRegistryHandler for FilterRegistryHandler {
-    fn handle_global(
+    fn prepare_global(
         &mut self,
-        slf: &Rc<WlRegistry>,
         name: u32,
         interface: ObjectInterface,
         version: u32,
-    ) {
+    ) -> (Option<GlobalAdvertisement>, IncomingGlobalDecision) {
+        let synthetic = self.ensure_synthetic_clipboard_global(name);
         let iface_name = interface.name();
-        self.ensure_synthetic_clipboard_global(slf, name);
+        if Some(name) == self.synthetic_clipboard_name {
+            self.hidden_globals.insert(name);
+            if self.policy.log_filtered_globals {
+                self.diag.borrow_mut().global_filtered(iface_name);
+            }
+            return (synthetic, IncomingGlobalDecision::Hide);
+        }
         if iface_name == "wl_data_device_manager" {
             self.hidden_globals.insert(name);
-            return;
+            if self.policy.log_filtered_globals {
+                self.diag.borrow_mut().global_filtered(iface_name);
+            }
+            return (synthetic, IncomingGlobalDecision::Hide);
         }
 
         let (action, _) = self.policy.lookup(iface_name);
@@ -635,7 +670,7 @@ impl WlRegistryHandler for FilterRegistryHandler {
                 self.diag.borrow_mut().global_filtered(iface_name);
             }
             self.hidden_globals.insert(name);
-            return;
+            return (synthetic, IncomingGlobalDecision::Hide);
         };
 
         let adv_version = self.policy.advertised_version(iface_name, version);
@@ -647,15 +682,49 @@ impl WlRegistryHandler for FilterRegistryHandler {
                 synthetic_clipboard: false,
             },
         );
-        slf.send_global(name, interface, adv_version);
+        (
+            synthetic,
+            IncomingGlobalDecision::Advertise(GlobalAdvertisement {
+                name,
+                interface,
+                version: adv_version,
+            }),
+        )
+    }
+
+    fn prepare_global_remove(&mut self, name: u32) -> bool {
+        if Some(name) == self.synthetic_clipboard_name {
+            return false;
+        }
+        if self.hidden_globals.remove(&name) {
+            return false;
+        }
+        self.advertised_globals.remove(&name);
+        true
+    }
+}
+
+impl WlRegistryHandler for FilterRegistryHandler {
+    fn handle_global(
+        &mut self,
+        slf: &Rc<WlRegistry>,
+        name: u32,
+        interface: ObjectInterface,
+        version: u32,
+    ) {
+        let (synthetic, decision) = self.prepare_global(name, interface, version);
+        if let Some(global) = synthetic {
+            slf.send_global(global.name, global.interface, global.version);
+        }
+        if let IncomingGlobalDecision::Advertise(global) = decision {
+            slf.send_global(global.name, global.interface, global.version);
+        }
     }
 
     fn handle_global_remove(&mut self, slf: &Rc<WlRegistry>, name: u32) {
-        if self.hidden_globals.remove(&name) {
-            return;
+        if self.prepare_global_remove(name) {
+            slf.send_global_remove(name);
         }
-        self.advertised_globals.remove(&name);
-        slf.send_global_remove(name);
     }
 
     fn handle_bind(&mut self, slf: &Rc<WlRegistry>, name: u32, id: Rc<dyn Object>) {
@@ -667,7 +736,9 @@ impl WlRegistryHandler for FilterRegistryHandler {
             } else {
                 DropReason::BindDeniedUnadvertised
             };
-            self.diag.borrow_mut().bind_denied(reason, name);
+            self.diag
+                .borrow_mut()
+                .bind_denied(reason, name, id.interface().name());
             // The wl-proxy decoder has already registered the newly requested
             // client object ID before this handler runs. Since the bind is not
             // forwarded, keeping the client alive would leak that ID in the
@@ -1173,10 +1244,11 @@ mod tests {
         let handler = FilterRegistryHandler::new(policy(), diag.clone(), clipboard());
 
         for name in 0..6 {
-            handler
-                .diag
-                .borrow_mut()
-                .bind_denied(crate::diag::DropReason::BindDeniedUnadvertised, name);
+            handler.diag.borrow_mut().bind_denied(
+                crate::diag::DropReason::BindDeniedUnadvertised,
+                name,
+                "zwp_text_input_manager_v3",
+            );
         }
 
         let suppressed_before_flush = diag.borrow().suppressed_total_for_tests();
@@ -1234,6 +1306,70 @@ mod tests {
             handler.allocate_synthetic_clipboard_name(u32::MAX - 1),
             u32::MAX - 2
         );
+    }
+
+    #[test]
+    fn prepare_global_hides_late_host_collision_with_synthetic_clipboard_name() {
+        let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let (synthetic, first) = handler.prepare_global(7, ObjectInterface::WlCompositor, 6);
+        assert_eq!(
+            synthetic,
+            Some(GlobalAdvertisement {
+                name: u32::MAX,
+                interface: ObjectInterface::WlDataDeviceManager,
+                version: 3,
+            })
+        );
+        assert!(matches!(first, IncomingGlobalDecision::Advertise(_)));
+
+        let (synthetic, colliding) = handler.prepare_global(u32::MAX, ObjectInterface::WlSeat, 9);
+        assert_eq!(synthetic, None);
+        assert_eq!(colliding, IncomingGlobalDecision::Hide);
+        let advertised = handler
+            .advertised_globals
+            .get(&u32::MAX)
+            .expect("synthetic remains advertised");
+        assert_eq!(advertised.interface, ObjectInterface::WlDataDeviceManager);
+        assert!(advertised.synthetic_clipboard);
+        assert!(handler.hidden_globals.contains(&u32::MAX));
+    }
+
+    #[test]
+    fn prepare_global_remove_ignores_synthetic_clipboard_name() {
+        let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let (_synthetic, _first) = handler.prepare_global(7, ObjectInterface::WlCompositor, 6);
+
+        assert!(!handler.prepare_global_remove(u32::MAX));
+        assert!(
+            handler.advertised_globals.contains_key(&u32::MAX),
+            "synthetic clipboard global must remain advertised"
+        );
+    }
+
+    #[test]
+    fn prepare_global_hides_host_data_device_manager() {
+        let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let (_synthetic, decision) =
+            handler.prepare_global(11, ObjectInterface::WlDataDeviceManager, 3);
+
+        assert_eq!(decision, IncomingGlobalDecision::Hide);
+        assert!(handler.hidden_globals.contains(&11));
+        assert!(!handler.advertised_globals.contains_key(&11));
+    }
+
+    #[test]
+    fn prepare_global_hides_text_input_v3() {
+        let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let (_synthetic, decision) =
+            handler.prepare_global(12, ObjectInterface::ZwpTextInputManagerV3, 1);
+
+        assert_eq!(decision, IncomingGlobalDecision::Hide);
+        assert!(handler.hidden_globals.contains(&12));
+        assert!(!handler.advertised_globals.contains_key(&12));
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/policy.rs
+++ b/packages/d2b-wayland-proxy/src/policy.rs
@@ -205,7 +205,7 @@ impl FilterPolicy {
         let mut warnings: Vec<PolicyWarning> = Vec::new();
 
         // Check required baseline globals.
-        for (iface, entry) in &entries {
+        for (iface, entry) in &mut entries {
             if entry.classification == Classification::RequiredBaseline
                 && entry.action == GlobalAction::Deny
             {
@@ -233,6 +233,7 @@ impl FilterPolicy {
                 warnings.push(PolicyWarning::ClipboardBoundaryOverrideIgnored {
                     interface: iface.clone(),
                 });
+                entry.action = GlobalAction::Deny;
             }
             if entry.classification == Classification::Unclassified
                 && entry.action == GlobalAction::Allow
@@ -641,16 +642,37 @@ mod tests {
 
     #[test]
     fn enable_clipboard_boundary_global_reports_ignored_override() {
+        let boundary_globals = [
+            "wl_data_device_manager",
+            "ext_data_control_manager_v1",
+            "zwlr_data_control_manager_v1",
+            "zwp_primary_selection_device_manager_v1",
+            "wp_primary_selection_device_manager_v1",
+            "gtk_primary_selection_device_manager",
+            "xdg_toplevel_drag_manager_v1",
+        ];
         let p = FilterPolicy::build(PolicyInput {
             vm_name: "work".to_owned(),
-            allow_globals: vec!["wl_data_device_manager".to_owned()],
+            allow_globals: boundary_globals
+                .iter()
+                .map(|iface| (*iface).to_owned())
+                .collect(),
             ..Default::default()
         });
-        assert!(p.warnings.iter().any(|w| matches!(
-            w,
-            PolicyWarning::ClipboardBoundaryOverrideIgnored { interface }
-            if interface == "wl_data_device_manager"
-        )));
+        for iface in boundary_globals {
+            assert!(
+                p.warnings.iter().any(|w| matches!(
+                    w,
+                    PolicyWarning::ClipboardBoundaryOverrideIgnored { interface }
+                    if interface == iface
+                )),
+                "missing ignored-override warning for {iface}"
+            );
+            assert!(
+                !p.is_allowed(iface),
+                "clipboard-boundary allow override must be ignored for {iface}"
+            );
+        }
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/policy.rs
+++ b/packages/d2b-wayland-proxy/src/policy.rs
@@ -404,7 +404,7 @@ fn default_classified_entries() -> HashMap<String, PolicyEntry> {
     entry!("zwp_pointer_constraints_v1", Allow, AppDefault);
     entry!("zwp_pointer_gestures_v1", Allow, AppDefault);
     entry!("zwp_tablet_manager_v2", Allow, AppDefault);
-    entry!("zwp_text_input_manager_v3", Allow, AppDefault);
+    entry!("zwp_text_input_manager_v3", Deny, AppDefault);
     entry!("zwp_input_timestamps_manager_v1", Allow, AppDefault);
     entry!(
         "zwp_keyboard_shortcuts_inhibit_manager_v1",
@@ -543,6 +543,15 @@ mod tests {
                 "clipboard boundary global `{iface}` must be denied until virtualized"
             );
         }
+    }
+
+    #[test]
+    fn unstable_text_input_global_is_denied_by_default() {
+        let p = policy_for("work");
+        assert!(
+            !p.is_allowed("zwp_text_input_manager_v3"),
+            "text-input v3 is denied until the proxy can validate seat-bound requests"
+        );
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/policy.rs
+++ b/packages/d2b-wayland-proxy/src/policy.rs
@@ -431,9 +431,9 @@ fn default_classified_entries() -> HashMap<String, PolicyEntry> {
     entry!("zwp_virtual_keyboard_manager_v1", Deny, HighRisk);
     entry!("zwlr_virtual_pointer_manager_v1", Deny, HighRisk);
 
-    // --- clipboard-control (disabled by default, high-risk) ---
-    entry!("ext_data_control_manager_v1", Deny, HighRisk);
-    entry!("zwlr_data_control_manager_v1", Deny, HighRisk);
+    // --- clipboard-control (disabled by default, architecture-enforced boundary) ---
+    entry!("ext_data_control_manager_v1", Deny, ClipboardBoundary);
+    entry!("zwlr_data_control_manager_v1", Deny, ClipboardBoundary);
     entry!(
         "zwp_primary_selection_device_manager_v1",
         Deny,
@@ -517,7 +517,6 @@ mod tests {
         for iface in &[
             "zwlr_screencopy_manager_v1",
             "zwp_virtual_keyboard_manager_v1",
-            "ext_data_control_manager_v1",
             "zwlr_layer_shell_v1",
             "ext_session_lock_manager_v1",
         ] {
@@ -533,6 +532,8 @@ mod tests {
         let p = policy_for("work");
         for iface in &[
             "wl_data_device_manager",
+            "ext_data_control_manager_v1",
+            "zwlr_data_control_manager_v1",
             "zwp_primary_selection_device_manager_v1",
             "wp_primary_selection_device_manager_v1",
             "gtk_primary_selection_device_manager",

--- a/packages/d2b-wayland-proxy/src/policy.rs
+++ b/packages/d2b-wayland-proxy/src/policy.rs
@@ -53,7 +53,7 @@ pub enum PolicyWarning {
     RequiredGlobalDenied { interface: String },
     AcceleratedRenderingDisabled { interface: String },
     HighRiskGlobalEnabled { interface: String },
-    ClipboardBoundaryBypassEnabled { interface: String },
+    ClipboardBoundaryOverrideIgnored { interface: String },
     AppIdPrefixNotVmPrefix { vm: String, prefix: String },
     TitlePrefixDisabled,
     UnclassifiedGlobalAllowed { interface: String },
@@ -74,9 +74,9 @@ impl PolicyWarning {
                 "waylandProxy: high-risk global `{interface}` is enabled; \
                  this global has elevated access to host compositor state"
             ),
-            Self::ClipboardBoundaryBypassEnabled { interface } => format!(
-                "waylandProxy: clipboard boundary global `{interface}` is enabled; \
-                 guest clipboard/DND objects may bypass d2b virtualization policy"
+            Self::ClipboardBoundaryOverrideIgnored { interface } => format!(
+                "waylandProxy: clipboard boundary global `{interface}` override ignored; \
+                 d2b enforces virtualized clipboard, primary-selection, and DND boundaries"
             ),
             Self::AppIdPrefixNotVmPrefix { vm, prefix } => format!(
                 "waylandProxy: appIdPrefix is `{prefix}` rather than the default \
@@ -230,7 +230,7 @@ impl FilterPolicy {
             if entry.classification == Classification::ClipboardBoundary
                 && entry.action == GlobalAction::Allow
             {
-                warnings.push(PolicyWarning::ClipboardBoundaryBypassEnabled {
+                warnings.push(PolicyWarning::ClipboardBoundaryOverrideIgnored {
                     interface: iface.clone(),
                 });
             }
@@ -639,7 +639,7 @@ mod tests {
     }
 
     #[test]
-    fn enable_clipboard_boundary_global_produces_warning() {
+    fn enable_clipboard_boundary_global_reports_ignored_override() {
         let p = FilterPolicy::build(PolicyInput {
             vm_name: "work".to_owned(),
             allow_globals: vec!["wl_data_device_manager".to_owned()],
@@ -647,7 +647,7 @@ mod tests {
         });
         assert!(p.warnings.iter().any(|w| matches!(
             w,
-            PolicyWarning::ClipboardBoundaryBypassEnabled { interface }
+            PolicyWarning::ClipboardBoundaryOverrideIgnored { interface }
             if interface == "wl_data_device_manager"
         )));
     }

--- a/packages/d2b-wayland-proxy/src/policy.rs
+++ b/packages/d2b-wayland-proxy/src/policy.rs
@@ -60,37 +60,69 @@ pub enum PolicyWarning {
 }
 
 impl PolicyWarning {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::RequiredGlobalDenied { .. } => "W-DENY-BASELINE",
+            Self::AcceleratedRenderingDisabled { .. } => "W-DENY-ACCEL",
+            Self::HighRiskGlobalEnabled { .. } => "W-ALLOW-HIGH-RISK",
+            Self::ClipboardBoundaryOverrideIgnored { .. } => "W-ALLOW-CLIPBOARD-BOUNDARY",
+            Self::AppIdPrefixNotVmPrefix { .. } => "W-APP-ID-PREFIX",
+            Self::TitlePrefixDisabled => "W-TITLE-PREFIX",
+            Self::UnclassifiedGlobalAllowed { .. } => "W-ALLOW-UNCLASSIFIED",
+        }
+    }
+
+    fn sort_key(&self) -> (&'static str, &str) {
+        match self {
+            Self::RequiredGlobalDenied { interface }
+            | Self::AcceleratedRenderingDisabled { interface }
+            | Self::HighRiskGlobalEnabled { interface }
+            | Self::ClipboardBoundaryOverrideIgnored { interface }
+            | Self::UnclassifiedGlobalAllowed { interface } => (self.code(), interface.as_str()),
+            Self::AppIdPrefixNotVmPrefix { prefix, .. } => (self.code(), prefix.as_str()),
+            Self::TitlePrefixDisabled => (self.code(), ""),
+        }
+    }
+
     /// Human-readable runtime advisory emitted by d2b-wayland-proxy.
     pub fn message(&self) -> String {
         match self {
             Self::RequiredGlobalDenied { interface } => format!(
-                "waylandProxy: required global `{interface}` is denied; graphics path may break"
+                "waylandProxy: [{}] required global `{interface}` is denied; graphics path may break",
+                self.code()
             ),
             Self::AcceleratedRenderingDisabled { interface } => format!(
-                "waylandProxy: accelerated-rendering global `{interface}` is denied; \
-                 apps may fall back to software rendering"
+                "waylandProxy: [{}] accelerated-rendering global `{interface}` is denied; \
+                 apps may fall back to software rendering",
+                self.code()
             ),
             Self::HighRiskGlobalEnabled { interface } => format!(
-                "waylandProxy: high-risk global `{interface}` is enabled; \
-                 this global has elevated access to host compositor state"
+                "waylandProxy: [{}] high-risk global `{interface}` is enabled; \
+                 this global has elevated access to host compositor state",
+                self.code()
             ),
             Self::ClipboardBoundaryOverrideIgnored { interface } => format!(
-                "waylandProxy: clipboard boundary global `{interface}` override ignored; \
-                 d2b enforces virtualized clipboard, primary-selection, and DND boundaries"
+                "waylandProxy: [{}] clipboard boundary global `{interface}` override ignored; \
+                 d2b enforces virtualized clipboard, primary-selection, and DND boundaries",
+                self.code()
             ),
             Self::AppIdPrefixNotVmPrefix { vm, prefix } => format!(
-                "waylandProxy: appIdPrefix is `{prefix}` rather than the default \
+                "waylandProxy: [{}] appIdPrefix is `{prefix}` rather than the default \
                  `d2b.{vm}.`; generated niri border rules will not match unless \
-                 overridden too"
+                 overridden too",
+                self.code()
             ),
             Self::TitlePrefixDisabled => {
-                "waylandProxy: titlePrefix is empty; non-niri compositors lose VM \
-                 disambiguation"
-                    .to_owned()
+                format!(
+                    "waylandProxy: [{}] titlePrefix is empty; non-niri compositors lose VM \
+                     disambiguation",
+                    self.code()
+                )
             }
             Self::UnclassifiedGlobalAllowed { interface } => format!(
-                "waylandProxy: unclassified global `{interface}` is explicitly allowed; \
-                 d2b has not reviewed this protocol's security posture"
+                "waylandProxy: [{}] unclassified global `{interface}` is explicitly allowed; \
+                 d2b has not reviewed this protocol's security posture",
+                self.code()
             ),
         }
     }
@@ -254,6 +286,7 @@ impl FilterPolicy {
         if title_prefix.is_empty() {
             warnings.push(PolicyWarning::TitlePrefixDisabled);
         }
+        warnings.sort_by(|left, right| left.sort_key().cmp(&right.sort_key()));
 
         Self {
             entries,
@@ -537,6 +570,7 @@ mod tests {
             "zwlr_data_control_manager_v1",
             "zwp_primary_selection_device_manager_v1",
             "wp_primary_selection_device_manager_v1",
+            "wp_primary_selection_unstable_v1",
             "gtk_primary_selection_device_manager",
             "xdg_toplevel_drag_manager_v1",
         ] {
@@ -648,6 +682,7 @@ mod tests {
             "zwlr_data_control_manager_v1",
             "zwp_primary_selection_device_manager_v1",
             "wp_primary_selection_device_manager_v1",
+            "wp_primary_selection_unstable_v1",
             "gtk_primary_selection_device_manager",
             "xdg_toplevel_drag_manager_v1",
         ];
@@ -673,6 +708,39 @@ mod tests {
                 "clipboard-boundary allow override must be ignored for {iface}"
             );
         }
+    }
+
+    #[test]
+    fn warning_messages_include_stable_codes_and_order() {
+        let p = FilterPolicy::build(PolicyInput {
+            vm_name: "work".to_owned(),
+            deny_globals: vec!["wl_compositor".to_owned()],
+            allow_globals: vec![
+                "wl_data_device_manager".to_owned(),
+                "zwlr_screencopy_manager_v1".to_owned(),
+                "completely_unknown_v1".to_owned(),
+            ],
+            ..Default::default()
+        });
+        let messages = p
+            .warnings
+            .iter()
+            .map(PolicyWarning::message)
+            .collect::<Vec<_>>();
+        for code in [
+            "W-ALLOW-CLIPBOARD-BOUNDARY",
+            "W-ALLOW-HIGH-RISK",
+            "W-ALLOW-UNCLASSIFIED",
+            "W-DENY-BASELINE",
+        ] {
+            assert!(
+                messages.iter().any(|message| message.contains(code)),
+                "missing warning code {code} in {messages:?}"
+            );
+        }
+        let mut sorted = messages.clone();
+        sorted.sort();
+        assert_eq!(messages, sorted);
     }
 
     #[test]


### PR DESCRIPTION
Fixes live host validation regressions found after PR #211 merged.\n\nChanges:\n- Always advertises the synthetic virtual wl_data_device_manager global from d2b-wayland-proxy, even when the host compositor does not expose the standard clipboard global.\n- Keeps any host wl_data_device_manager hidden so guest clipboard traffic remains virtualized locally.\n- Denies zwp_text_input_manager_v3 by default to prevent guest apps from crashing on invalid/null seat-bound text-input requests through the proxy.\n\nValidation:\n- cargo test --manifest-path packages/Cargo.toml -p d2b-wayland-proxy --no-default-features\n\nLive symptom reproduced before fix on merged PR #211 host switch:\n- work-aad foot launched but reported no clipboard manager.\n- work-aad Firefox crashed with Wayland text-input get_text_input null-seat protocol error.