### PR TITLE
wayland: add proxy-drawn VM borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Default proxy-drawn VM-name labels now render in a dedicated top band while
+  preserving the default 4-pixel side and bottom border thickness.
+- `d2b-wayland-proxy` now preserves the last committed surface size after a
+  guest destroys the current buffer object, while still clearing decorations on
+  committed `attach(NULL)`.
 - USBIP driver helper retries now treat transient `ETXTBSY` / "text file busy"
   spawn failures as retryable instead of reporting the helper as missing.
 - `d2b-wayland-proxy` now advertises its virtual clipboard manager even when
@@ -95,6 +100,10 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- `d2b-wayland-proxy` now draws compositor-agnostic, per-VM colored borders
+  with an optional VM-name label for proxied graphics windows. Borders use the
+  existing `d2b.vms.<vm>.ui.border` color model, are enabled by default with
+  the Wayland proxy, and can be disabled per VM.
 - Added the `d2b-clipd` Rust crate with picker NDJSON DTOs, bounded framing,
   clipboard policy primitives, FD safety models, picker supervision,
   fail-closed audit / droppable metrics queues, host data-control integration,

--- a/docs/how-to/migrate-to-wayland-proxy.md
+++ b/docs/how-to/migrate-to-wayland-proxy.md
@@ -32,6 +32,28 @@ pattern `^d2b\.work\.`.
 The window title prefix `[<vm>] ` behavior is preserved for
 compositors that rely on title-based VM disambiguation.
 
+### Disable proxy-drawn borders when needed
+
+When the host-side Wayland proxy is enabled, d2b draws a colored VM identity
+border around proxied Wayland toplevels by default, including qemu-media host
+windows routed through the proxy. The color comes from the same
+`d2b.vms.<vm>.ui.border` model used by generated compositor artifacts, and the
+default label is the authenticated VM name. The configured border thickness
+controls the side and bottom edges; when labels are enabled, the proxy reserves a
+taller top label band so the default label is visible.
+
+Disable the proxy-drawn border for a VM with:
+
+```nix
+d2b.vms.work.graphics.waylandProxy.border.enable = false;
+```
+
+Disable only the label while keeping the colored border with:
+
+```nix
+d2b.vms.work.graphics.waylandProxy.border.label.enable = false;
+```
+
 ### Xwayland must be disabled before the migration
 
 `graphics.xwayland.enable = true` is not supported during the
@@ -103,7 +125,7 @@ window-rule {
 }
 ```
 
-Or use the generated include file (see
+For non-proxied host windows, use the generated include file (see
 [Set up niri window borders for d2b VMs](./niri-vm-borders.md)):
 
 ```nix
@@ -115,9 +137,17 @@ d2b.site.ui.compositors.niri.enable = true;
 include "/etc/d2b/niri-vm-borders.kdl"
 ```
 
-The generated rules use the prefix regex `^d2b\.<vm>\.` so they
-match all windows from a given VM regardless of their original
-app-ids.
+The generated rules use the prefix regex `^d2b\.<vm>\.` for VM windows that
+need compositor-native borders. Graphics and qemu-media VMs whose proxy-drawn
+border is effective are omitted from the generated niri border rules so the same
+window does not get two borders.
+
+If you prefer niri-native borders for a proxied VM, disable the proxy border
+for that VM:
+
+```nix
+d2b.vms.work.graphics.waylandProxy.border.enable = false;
+```
 
 ### 5. Restart the VM
 
@@ -146,6 +176,15 @@ Every window from the VM should have `app_id` starting with
 `d2b.<vm>.`.  If the original app-id appears without the prefix,
 confirm `crossDomainTrusted = true` and that the Wayland proxy is
 running (`d2b vm status <vm>`).
+
+### Check the proxy-drawn border
+
+Launch a Wayland client in the VM. The window should show a border using the
+VM's resolved `ui.border.activeColor`/`inactiveColor`, and should show the VM
+name label unless `graphics.waylandProxy.border.label.enable = false`.
+
+The border is drawn from a proxy-owned decoration buffer. It does not require
+the proxy to read or copy guest application buffers.
 
 ### Check the host compositor socket ownership
 

--- a/docs/how-to/niri-vm-borders.md
+++ b/docs/how-to/niri-vm-borders.md
@@ -1,9 +1,10 @@
 # Set up niri window borders for d2b VMs
 
 This guide covers enabling d2b's opt-in niri KDL window-rule
-generator so each graphics VM and qemu-media host window gets a
-distinct border color and the crosvm GPU sidecar's scanout window is
-hidden on the host compositor.
+generator so VMs that use compositor-native borders get a distinct
+border color and the crosvm GPU sidecar's scanout window is hidden on
+the host compositor. Graphics and qemu-media windows that already use
+proxy-drawn borders are omitted by default to avoid double borders.
 
 ## Prerequisites
 
@@ -63,10 +64,10 @@ window-rule {
 
 ### Per-VM border rules
 
-Each enabled graphics VM gets a `window-rule` block that matches its
-app-id prefix.  The host-side Wayland proxy rewrites guest
-app-ids to `d2b.<vm>.<original-app-id>`, so the regex
-`^d2b\.<vm>\.` reliably selects only windows from that VM:
+Enabled graphics VMs whose proxy-drawn border is disabled get a
+`window-rule` block that matches their app-id prefix. The host-side
+Wayland proxy rewrites guest app-ids to `d2b.<vm>.<original-app-id>`,
+so the regex `^d2b\.<vm>\.` reliably selects only windows from that VM:
 
 ```kdl
 window-rule {
@@ -87,10 +88,10 @@ color; set them in d2b if you prefer a neutral inactive color.
 
 ### qemu-media host-window rules
 
-Each enabled qemu-media VM routes the host QEMU window through the
-d2b Wayland proxy. The generated `window-rule` block matches
-the proxy-rewritten app-id prefix `d2b.<vm>.`, just like graphics VM
-windows:
+Each enabled qemu-media VM routes the host QEMU window through the d2b
+Wayland proxy. When the proxy-drawn border is disabled for that VM, the
+generated `window-rule` block matches the proxy-rewritten app-id prefix
+`d2b.<vm>.`, just like graphics VM windows:
 
 ```kdl
 window-rule {
@@ -120,6 +121,13 @@ d2b.vms.media.ui.border.activeColor = "#800080";
 ```
 
 The value must be a six-digit hex color (e.g. `#rrggbb`).
+
+To make the generated niri rule draw the visible border for a proxied VM, first
+disable the proxy-drawn border for that VM:
+
+```nix
+d2b.vms.work.graphics.waylandProxy.border.enable = false;
+```
 
 To use a different inactive or urgent color, set:
 
@@ -178,8 +186,9 @@ Then update the `include` line in `config.kdl` accordingly.
    not be running. For qemu-media VMs, qemu-media itself should start
    only after the per-VM Wayland proxy is ready.
 
-4. Confirm the border rule is active by switching focus to a VM
-   window — the active border should appear in the configured color.
+4. If proxy-drawn borders are disabled for that VM, confirm the niri
+   border rule is active by switching focus to a VM window — the
+   active border should appear in the configured color.
 
 ## Why `crossDomainTrusted` is required for app-id matching
 
@@ -190,9 +199,9 @@ proxy absent, guest windows retain their original app-ids and the
 cannot match.
 
 If you enable the niri backend for a VM whose `crossDomainTrusted` is
-false, the border rule is generated but will not match any window.
-Set `crossDomainTrusted = true` to activate app-id rewriting for
-that VM.
+false, and you also disable the proxy-drawn border, the niri border rule is
+generated but will not match any window. Set `crossDomainTrusted = true` to
+activate app-id rewriting for that VM.
 
 ## Legacy options
 

--- a/docs/how-to/qemu-media.md
+++ b/docs/how-to/qemu-media.md
@@ -113,9 +113,10 @@ d2b status dark-live
 The dry-run should show `host-reconcile → qemu-media`. After start,
 status should show the qemu-media runner, QMP readiness, source refs,
 source kind/format/read-only policy, and registry state. The host QEMU
-window is routed through the d2b Wayland proxy, so the niri
-border rule matches the proxy-rewritten app-id prefix
-`d2b.dark-live.`.
+window is routed through the d2b Wayland proxy, which draws the default
+VM identity border itself. If you intentionally disable the proxy border,
+the generated niri rule can match the proxy-rewritten app-id prefix
+`d2b.dark-live.` instead.
 
 ## 4. Hotplug configured media
 

--- a/docs/reference/ui-colors.md
+++ b/docs/reference/ui-colors.md
@@ -48,6 +48,34 @@ window loses focus. Operators who prefer a neutral inactive border should
 set `d2b.vms.<vm>.ui.border.inactiveColor` once in d2b instead of
 adding compositor-local override rules.
 
+## Wayland proxy borders
+
+For graphics VMs using the host-side Wayland proxy, and for qemu-media host
+windows routed through that proxy, d2b can draw the VM identity border inside
+`d2b-wayland-proxy` itself. Proxy-drawn borders are enabled by default when the
+proxy is active and can be disabled per VM:
+
+```nix
+d2b.vms.work.graphics.waylandProxy.border.enable = false;
+```
+
+The proxy uses the same resolved VM border colors documented above. It draws
+only proxy-owned decoration pixels; guest application buffers and dma-bufs stay
+forwarded as Wayland objects and file descriptors and are not copied or sampled
+to render the border. The configured border thickness applies to the side and
+bottom edges; with labels enabled, the proxy reserves a taller top label band
+so the authenticated VM-name label is visible at the default thickness.
+
+Proxy borders are visual-only. They do not intercept pointer input, and
+popup/menu positioning remains based on the guest surface geometry.
+
+The default label is the authenticated VM name. Disable the label while keeping
+the colored border with:
+
+```nix
+d2b.vms.work.graphics.waylandProxy.border.label.enable = false;
+```
+
 ## JSON artifact
 
 When enabled, d2b writes `/etc/d2b/ui-colors.json` by default.
@@ -134,6 +162,16 @@ d2b.site.ui.compositors.niri.enable = true;
 D2b writes `/etc/d2b/niri-vm-borders.kdl` by default. The KDL
 renders `active-color`, `inactive-color`, and `urgent-color` from the same
 resolved VM border model used by the JSON and GTK CSS artifacts.
+
+The niri backend remains useful for host windows that do not pass through
+`d2b-wayland-proxy`, and for operators who prefer compositor-native rules.
+Wayland toplevels routed through the host-side proxy get compositor-agnostic
+proxy borders by default.
+
+Generated niri rules omit graphics and qemu-media VMs whose proxy-drawn border
+is effective, so enabling the niri backend does not create two borders for the
+same proxied window. To use niri-native borders for such a VM instead, disable
+the proxy border for that VM.
 
 The legacy `d2b.site.niriVmBorders` and `d2b.vms.<vm>.graphics.niriBorderColor`
 options remain compatibility inputs for one release, but new

--- a/docs/reference/wayland-proxy-warnings.md
+++ b/docs/reference/wayland-proxy-warnings.md
@@ -1,27 +1,45 @@
 # `graphics.waylandProxy` warning catalog
 
-> **Reference** for the advisory runtime diagnostics the d2b
-> Wayland proxy emits when operator configuration deviates from
-> the secure baseline or touches a rule d2b classifies as required
-> high-risk, clipboard-boundary, or unclassified.
+> **Reference** for the advisory runtime diagnostics the d2b Wayland
+> proxy emits for policy overrides and operational proxy events.
 
 > **Status:** live for
-> `d2b.vms.<vm>.graphics.waylandProxy.{enable,denyGlobals,allowGlobals,maxVersions,dmabufAllow,dmabufDeny,debugLogging,byteLogging}`.
+> `d2b.vms.<vm>.graphics.waylandProxy.{enable,denyGlobals,allowGlobals,maxVersions,dmabufAllow,dmabufDeny,debugLogging,byteLogging,border.*}`.
 > The proxy emits these diagnostics at runtime in the
 > `d2b-wayland-proxy` journal stream. They are not NixOS eval-time
 > `config.warnings`.
 
 Warnings are **advisory**: the NixOS configuration still evaluates and
-builds when a warning condition is met. The warning is emitted by the
-host-side proxy process when the VM starts.
+builds when a warning condition is met. Policy warnings are emitted by the
+host-side proxy process when the VM starts; operational diagnostics are emitted
+when the corresponding runtime event occurs.
 
 Secure defaults emit **zero** `waylandProxy` warnings. A clean
 configuration with no overrides produces no output from this catalog.
 
 The `W-*` names below are emitted in `d2b-wayland-proxy` policy-warning
-messages and are stable grep targets for operator diagnostics.
+messages. Operational event/reason pairs, such as
+`border-decoration / draw-failed`, are also stable grep targets for operator
+diagnostics.
 
 ## Warning conditions
+
+### border-decoration / draw-failed
+
+**Trigger:** the proxy could not allocate or submit its own border decoration
+buffer for a guest toplevel.
+
+**Why it exists:** Decoration drawing is intentionally best-effort. Guest
+application buffers continue through the normal Wayland path, while d2b skips
+or removes the proxy-owned border for that surface. The diagnostic is
+rate-limited and does not include guest window titles, app IDs, or buffer
+contents.
+
+**How to override intentionally:** No configuration is required. If this repeats
+for ordinary window sizes, report it as a bug; if it appears only for extremely
+large guest surfaces, d2b is enforcing its resource-exhaustion guard.
+
+---
 
 ### W-DENY-BASELINE
 

--- a/nixos-modules/niri-vm-borders.nix
+++ b/nixos-modules/niri-vm-borders.nix
@@ -28,20 +28,32 @@ let
   niriEnabled = cfg.enable || legacyCfg.enable;
   outputPath = if cfg.enable then cfg.outputPath else legacyCfg.outputPath;
 
-  # All enabled graphics VMs, sorted by name for a stable output order.
+  proxyBorderEffective = vm:
+    if isQemuMediaVm vm
+    then config.d2b.site.waylandUser != null && vm.graphics.waylandProxy.border.enable
+    else
+      vm.graphics.enable
+      && vm.graphics.crossDomainTrusted
+      && vm.graphics.waylandProxy.enable
+      && vm.graphics.waylandProxy.border.enable;
+
+  # All enabled graphics VMs that still need compositor-native niri borders,
+  # sorted by name for a stable output order. VMs with proxy-drawn borders are
+  # omitted so operators do not get two visible borders by default.
   graphicsVmNames = builtins.sort (a: b: a < b) (
     lib.attrNames (
       lib.filterAttrs
-        (name: vm: vm.enable && vm.graphics.enable)
+        (name: vm: vm.enable && vm.graphics.enable && !proxyBorderEffective vm)
         vmsCfg
     )
   );
 
-  # All enabled qemu-media VMs, sorted by name for a stable output order.
+  # All enabled qemu-media VMs that still need compositor-native niri borders,
+  # sorted by name for a stable output order.
   qemuMediaVmNames = builtins.sort (a: b: a < b) (
     lib.attrNames (
       lib.filterAttrs
-        (name: vm: vm.enable && isQemuMediaVm vm)
+        (name: vm: vm.enable && isQemuMediaVm vm && !proxyBorderEffective vm)
         vmsCfg
     )
   );

--- a/nixos-modules/options-vms.nix
+++ b/nixos-modules/options-vms.nix
@@ -622,6 +622,55 @@ in
           '';
         };
 
+        graphics.waylandProxy.border = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Enable proxy-drawn VM identity borders for this VM's
+              host-side Wayland proxy. This is effective only when the
+              `wayland-proxy` DAG node is emitted.
+            '';
+          };
+
+          thickness = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 4;
+            example = 6;
+            description = ''
+              Thickness, in logical pixels, of the side and bottom
+              proxy-drawn VM identity border. When the label is enabled,
+              the proxy reserves a taller top label band as needed so
+              the label remains visible without changing this thickness.
+            '';
+          };
+
+          label = {
+            enable = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Show a VM identity label inside the proxy-drawn border.";
+            };
+
+            text = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              example = "Work";
+              description = ''
+                Optional label text for the proxy-drawn VM identity border.
+                When null, the authenticated VM name is used. An empty string
+                suppresses the label text while leaving the border enabled.
+              '';
+            };
+
+            position = lib.mkOption {
+              type = lib.types.enum [ "top-left" "top-center" ];
+              default = "top-left";
+              description = "Position of the proxy-drawn VM identity label.";
+            };
+          };
+        };
+
         graphics.waylandProxy.denyGlobals = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -617,6 +617,20 @@ EOF
       bridgeSock = "${config.d2b.site.clipboard.runtime.bridgeRoot}/${waylandUid}/bridge/${vmName}/${config.d2b.site.clipboard.runtime.bridgeSocketName}";
       appIdPrefix = "d2b.${vmName}.";
       titlePrefix = "[${vmName}] ";
+      border = vm.graphics.waylandProxy.border;
+      borderColors = cfg._uiColors.vms.${vmName}.border;
+      borderLabelText = if border.label.text == null then vmName else border.label.text;
+      borderLabelArgs = lib.optionals (border.label.enable && borderLabelText != "") [
+        "--border-label" borderLabelText
+        "--border-label-position" border.label.position
+      ];
+      borderArgs = lib.optionals border.enable ([
+        "--border-enable"
+        "--border-color-active" borderColors.active
+        "--border-color-inactive" borderColors.inactive
+        "--border-color-urgent" borderColors.urgent
+        "--border-thickness" (toString border.thickness)
+      ] ++ borderLabelArgs);
       denyArgs = lib.concatMap (g: [ "--deny-global" g ]) vm.graphics.waylandProxy.denyGlobals;
       allowArgs = lib.concatMap (g: [ "--allow-global" g ]) vm.graphics.waylandProxy.allowGlobals;
       maxVersionArgs = lib.concatMap
@@ -645,7 +659,7 @@ EOF
         "--vm-name" vmName
         "--app-id-prefix" appIdPrefix
         "--title-prefix" titlePrefix
-      ] ++ lib.optionals config.d2b.site.clipboard.enable [
+      ] ++ borderArgs ++ lib.optionals config.d2b.site.clipboard.enable [
         "--clipd-bridge-socket" bridgeSock
       ] ++ denyArgs ++ allowArgs ++ maxVersionArgs ++ dmabufAllowArgs ++ dmabufDenyArgs;
     };

--- a/packages/d2b-host/src/wayland_proxy_argv.rs
+++ b/packages/d2b-host/src/wayland_proxy_argv.rs
@@ -23,6 +23,8 @@
 //!
 //! Crate invariant `#![forbid(unsafe_code)]` is honoured.
 
+use std::num::NonZeroU32;
+
 use serde::{Deserialize, Serialize};
 
 // =========================================================================
@@ -51,6 +53,69 @@ pub struct WaylandProxyArgvInput {
     ///
     /// Default: `[<vm>] `
     pub title_prefix: String,
+    /// Effective VM identity border configuration.
+    ///
+    /// Default: `None` (no border flags emitted). Nix enables borders by
+    /// passing a populated config when the wayland-proxy node is emitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub border: Option<WaylandProxyBorderConfig>,
+}
+
+/// Effective proxy-drawn VM identity border settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WaylandProxyBorderConfig {
+    /// Active/focused border color as `#rrggbb`.
+    pub active_color: String,
+    /// Inactive/unfocused border color as `#rrggbb`.
+    pub inactive_color: String,
+    /// Urgent border color as `#rrggbb`.
+    pub urgent_color: String,
+    /// Side/bottom border thickness in logical pixels.
+    pub thickness: NonZeroU32,
+    /// Label configuration. Defaults to enabled VM-name label.
+    #[serde(default)]
+    pub label: WaylandProxyBorderLabelConfig,
+}
+
+/// Proxy-drawn VM identity label settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WaylandProxyBorderLabelConfig {
+    /// Whether to emit label argv.
+    pub enable: bool,
+    /// Optional label override. `None` means the authenticated VM name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Label position.
+    pub position: WaylandProxyBorderLabelPosition,
+}
+
+impl Default for WaylandProxyBorderLabelConfig {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            text: None,
+            position: WaylandProxyBorderLabelPosition::TopLeft,
+        }
+    }
+}
+
+/// Proxy-drawn VM identity label position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WaylandProxyBorderLabelPosition {
+    TopLeft,
+    TopCenter,
+}
+
+impl WaylandProxyBorderLabelPosition {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::TopLeft => "top-left",
+            Self::TopCenter => "top-center",
+        }
+    }
 }
 
 impl WaylandProxyArgvInput {
@@ -67,6 +132,7 @@ impl WaylandProxyArgvInput {
             upstream_socket,
             app_id_prefix,
             title_prefix,
+            border: None,
         }
     }
 }
@@ -116,6 +182,27 @@ pub fn generate_wayland_proxy_argv(
         argv.push("--title-prefix".to_owned());
         argv.push(input.title_prefix.clone());
     }
+    if let Some(border) = &input.border {
+        argv.push("--border-enable".to_owned());
+        argv.push("--border-color-active".to_owned());
+        argv.push(border.active_color.clone());
+        argv.push("--border-color-inactive".to_owned());
+        argv.push(border.inactive_color.clone());
+        argv.push("--border-color-urgent".to_owned());
+        argv.push(border.urgent_color.clone());
+        argv.push("--border-thickness".to_owned());
+        argv.push(border.thickness.to_string());
+
+        if border.label.enable {
+            let label = border.label.text.as_deref().unwrap_or(&input.vm_name);
+            if !label.is_empty() {
+                argv.push("--border-label".to_owned());
+                argv.push(label.to_owned());
+                argv.push("--border-label-position".to_owned());
+                argv.push(border.label.position.as_str().to_owned());
+            }
+        }
+    }
 
     Ok(argv)
 }
@@ -123,6 +210,27 @@ pub fn generate_wayland_proxy_argv(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn nonzero(value: u32) -> NonZeroU32 {
+        NonZeroU32::new(value).expect("test thickness must be non-zero")
+    }
+
+    fn border_config() -> WaylandProxyBorderConfig {
+        WaylandProxyBorderConfig {
+            active_color: "#7fc8ff".to_owned(),
+            inactive_color: "#45475a".to_owned(),
+            urgent_color: "#f38ba8".to_owned(),
+            thickness: nonzero(4),
+            label: WaylandProxyBorderLabelConfig::default(),
+        }
+    }
+
+    fn flag_value<'a>(argv: &'a [String], flag: &str) -> Option<&'a str> {
+        argv.iter()
+            .position(|arg| arg == flag)
+            .and_then(|idx| argv.get(idx + 1))
+            .map(String::as_str)
+    }
 
     #[test]
     fn default_argv_shape() {
@@ -136,6 +244,17 @@ mod tests {
         assert_eq!(argv[listen_idx + 1], "/run/d2b-wlproxy/work/wayland-0");
         let connect_idx = argv.iter().position(|a| a == "--connect").unwrap();
         assert_eq!(argv[connect_idx + 1], "/run/d2b-wlproxy/work/upstream");
+    }
+
+    #[test]
+    fn default_argv_omits_border_flags() {
+        let input = WaylandProxyArgvInput::for_vm("work");
+        let argv = generate_wayland_proxy_argv(&input).expect("valid input");
+        assert!(!argv.contains(&"--border-enable".to_owned()));
+        assert!(flag_value(&argv, "--border-color-active").is_none());
+        assert!(flag_value(&argv, "--border-thickness").is_none());
+        assert!(flag_value(&argv, "--border-label").is_none());
+        assert!(flag_value(&argv, "--border-label-position").is_none());
     }
 
     #[test]
@@ -180,5 +299,58 @@ mod tests {
         let argv = generate_wayland_proxy_argv(&input).expect("valid");
         let prefix_idx = argv.iter().position(|a| a == "--title-prefix").unwrap();
         assert_eq!(argv[prefix_idx + 1], "[dev] ");
+    }
+
+    #[test]
+    fn enabled_border_flags_include_colors_thickness_and_default_label() {
+        let mut input = WaylandProxyArgvInput::for_vm("work");
+        input.border = Some(border_config());
+
+        let argv = generate_wayland_proxy_argv(&input).expect("valid");
+
+        assert!(argv.contains(&"--border-enable".to_owned()));
+        assert_eq!(flag_value(&argv, "--border-color-active"), Some("#7fc8ff"));
+        assert_eq!(
+            flag_value(&argv, "--border-color-inactive"),
+            Some("#45475a")
+        );
+        assert_eq!(flag_value(&argv, "--border-color-urgent"), Some("#f38ba8"));
+        assert_eq!(flag_value(&argv, "--border-thickness"), Some("4"));
+        assert_eq!(flag_value(&argv, "--border-label"), Some("work"));
+        assert_eq!(
+            flag_value(&argv, "--border-label-position"),
+            Some("top-left")
+        );
+    }
+
+    #[test]
+    fn custom_border_label_and_position_are_emitted() {
+        let mut input = WaylandProxyArgvInput::for_vm("work");
+        let mut border = border_config();
+        border.label.text = Some("Work Desktop".to_owned());
+        border.label.position = WaylandProxyBorderLabelPosition::TopCenter;
+        input.border = Some(border);
+
+        let argv = generate_wayland_proxy_argv(&input).expect("valid");
+
+        assert_eq!(flag_value(&argv, "--border-label"), Some("Work Desktop"));
+        assert_eq!(
+            flag_value(&argv, "--border-label-position"),
+            Some("top-center")
+        );
+    }
+
+    #[test]
+    fn disabled_border_label_omits_label_flags() {
+        let mut input = WaylandProxyArgvInput::for_vm("work");
+        let mut border = border_config();
+        border.label.enable = false;
+        input.border = Some(border);
+
+        let argv = generate_wayland_proxy_argv(&input).expect("valid");
+
+        assert!(argv.contains(&"--border-enable".to_owned()));
+        assert!(flag_value(&argv, "--border-label").is_none());
+        assert!(flag_value(&argv, "--border-label-position").is_none());
     }
 }

--- a/packages/d2b-wayland-proxy/src/decoration.rs
+++ b/packages/d2b-wayland-proxy/src/decoration.rs
@@ -1,0 +1,2129 @@
+//! Proxy-owned Wayland decoration state and drawing helpers.
+//!
+//! The drawing path only consumes resolved configuration, surface dimensions,
+//! and the authenticated VM label. Guest wl_buffers/dma-bufs remain opaque
+//! Wayland objects and are never read or sampled here.
+
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    ffi::CString,
+    fs::File,
+    io::{self, Write},
+    os::fd::OwnedFd,
+    rc::{Rc, Weak},
+    str::FromStr,
+};
+
+use nix::sys::memfd::{MemFdCreateFlag, memfd_create};
+use wl_proxy::{
+    fixed::Fixed,
+    object::{ConcreteObject, ObjectCoreApi},
+    protocols::{
+        ObjectInterface,
+        wayland::{
+            wl_buffer::{WlBuffer, WlBufferHandler},
+            wl_compositor::WlCompositor,
+            wl_output::WlOutputTransform,
+            wl_registry::WlRegistry,
+            wl_shm::WlShmFormat,
+            wl_shm_pool::WlShmPool,
+            wl_subcompositor::WlSubcompositor,
+            wl_subsurface::WlSubsurface,
+            wl_surface::WlSurface,
+        },
+        xdg_shell::xdg_toplevel::XdgToplevelState,
+    },
+};
+
+use crate::diag::{DiagRateLimiter, bounded_error_detail};
+
+pub const DEFAULT_BORDER_THICKNESS: u32 = 4;
+const MAX_LABEL_CHARS: usize = 64;
+const BYTES_PER_PIXEL: u32 = 4;
+const MAX_DECORATION_DIMENSION: u32 = 16_384;
+const MAX_DECORATION_BUFFER_BYTES: usize = 64 * 1024 * 1024;
+const MAX_LABEL_FALLBACK_WIDTH: u32 = 1024;
+const LABEL_PAD_X: u32 = 5;
+const LABEL_PAD_Y: u32 = 3;
+const GLYPH_W: u32 = 5;
+const GLYPH_H: u32 = 7;
+const GLYPH_ADVANCE: u32 = 6;
+const MIN_LABEL_BAND_HEIGHT: u32 = LABEL_PAD_Y + GLYPH_H;
+const MAX_RETIRED_DECORATION_BUFFERS: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+impl Color {
+    pub const BLACK: Self = Self::rgb(0, 0, 0);
+    pub const WHITE: Self = Self::rgb(255, 255, 255);
+
+    pub const fn rgb(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b, a: 255 }
+    }
+
+    fn argb8888_bytes(self) -> [u8; 4] {
+        [self.b, self.g, self.r, self.a]
+    }
+
+    fn readable_text_color(self) -> Self {
+        let luminance = u32::from(self.r) * 299 + u32::from(self.g) * 587 + u32::from(self.b) * 114;
+        if luminance > 128_000 {
+            Self::BLACK
+        } else {
+            Self::WHITE
+        }
+    }
+}
+
+impl FromStr for Color {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_hex_color(s)
+    }
+}
+
+pub fn parse_hex_color(input: &str) -> Result<Color, String> {
+    let value = input
+        .strip_prefix('#')
+        .ok_or_else(|| format!("expected #rrggbb color, got `{input}`"))?;
+    if value.len() != 6 || !value.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!("expected #rrggbb color, got `{input}`"));
+    }
+    let r = u8::from_str_radix(&value[0..2], 16)
+        .map_err(|_| format!("invalid red channel in `{input}`"))?;
+    let g = u8::from_str_radix(&value[2..4], 16)
+        .map_err(|_| format!("invalid green channel in `{input}`"))?;
+    let b = u8::from_str_radix(&value[4..6], 16)
+        .map_err(|_| format!("invalid blue channel in `{input}`"))?;
+    Ok(Color::rgb(r, g, b))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabelPosition {
+    TopLeft,
+    TopCenter,
+}
+
+impl FromStr for LabelPosition {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "top-left" => Ok(Self::TopLeft),
+            "top-center" => Ok(Self::TopCenter),
+            _ => Err(format!("expected top-left|top-center, got `{value}`")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizedLabel(String);
+
+impl SanitizedLabel {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+pub fn sanitize_label(input: &str) -> Option<SanitizedLabel> {
+    let mut out = String::new();
+    let mut pending_space = false;
+    for ch in input.chars() {
+        if out.chars().count() >= MAX_LABEL_CHARS {
+            break;
+        }
+        if ch.is_control() {
+            pending_space = true;
+            continue;
+        }
+        if ch.is_whitespace() {
+            pending_space = true;
+            continue;
+        }
+        if pending_space && !out.is_empty() {
+            out.push(' ');
+        }
+        pending_space = false;
+        if ch.is_ascii_graphic() {
+            out.push(ch);
+        } else {
+            out.push('?');
+        }
+    }
+    let out = out.trim().to_owned();
+    if out.is_empty() {
+        None
+    } else {
+        Some(SanitizedLabel(out))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BorderConfig {
+    pub enabled: bool,
+    pub active: Color,
+    pub inactive: Color,
+    pub urgent: Color,
+    pub thickness: u32,
+    pub label: Option<SanitizedLabel>,
+    pub label_position: LabelPosition,
+}
+
+impl Default for BorderConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            active: Color::rgb(60, 170, 255),
+            inactive: Color::rgb(95, 95, 95),
+            urgent: Color::rgb(255, 86, 86),
+            thickness: DEFAULT_BORDER_THICKNESS,
+            label: None,
+            label_position: LabelPosition::TopLeft,
+        }
+    }
+}
+
+impl BorderConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled && self.thickness > 0
+    }
+
+    fn color_for_state(&self, state: VisualState) -> Color {
+        if state.urgent {
+            self.urgent
+        } else if state.active {
+            self.active
+        } else {
+            self.inactive
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Size {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Size {
+    pub const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.width == 0 || self.height == 0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BorderGeometry {
+    pub content: Size,
+    pub outer: Size,
+    pub content_origin: Point,
+    pub thickness: u32,
+    pub top_thickness: u32,
+}
+
+impl BorderGeometry {
+    pub fn expand(content: Size, thickness: u32) -> Option<Self> {
+        Self::expand_with_label_band(content, thickness, false)
+    }
+
+    pub fn expand_with_label_band(
+        content: Size,
+        thickness: u32,
+        label_present: bool,
+    ) -> Option<Self> {
+        if content.is_empty() || thickness == 0 {
+            return None;
+        }
+        let horizontal = thickness.checked_mul(2)?;
+        let top_thickness = top_border_height(thickness, label_present);
+        let vertical = top_thickness.checked_add(thickness)?;
+        Some(Self {
+            content,
+            outer: Size::new(
+                content.width.checked_add(horizontal)?,
+                content.height.checked_add(vertical)?,
+            ),
+            content_origin: Point {
+                x: i32::try_from(thickness).ok()?,
+                y: i32::try_from(top_thickness).ok()?,
+            },
+            thickness,
+            top_thickness,
+        })
+    }
+
+    fn label_fallback_for_oversized(content: Size, thickness: u32) -> Option<Self> {
+        if content.is_empty() || thickness == 0 {
+            return None;
+        }
+        let horizontal = thickness.checked_mul(2)?;
+        let top_thickness = top_border_height(thickness, true);
+        let outer_width = content
+            .width
+            .checked_add(horizontal)?
+            .min(MAX_LABEL_FALLBACK_WIDTH)
+            .max(horizontal.checked_add(GLYPH_W)?);
+        Some(Self {
+            content,
+            outer: Size::new(outer_width, top_thickness.checked_add(thickness)?),
+            content_origin: Point {
+                x: i32::try_from(thickness).ok()?,
+                y: i32::try_from(top_thickness).ok()?,
+            },
+            thickness,
+            top_thickness,
+        })
+    }
+}
+
+fn top_border_height(thickness: u32, label_present: bool) -> u32 {
+    if label_present {
+        thickness.max(MIN_LABEL_BAND_HEIGHT)
+    } else {
+        thickness
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowGeometry {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl WindowGeometry {
+    pub const fn new(x: i32, y: i32, width: i32, height: i32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+pub fn expand_window_geometry_for_border(
+    geometry: WindowGeometry,
+    thickness: u32,
+) -> Option<WindowGeometry> {
+    expand_window_geometry_for_decoration(geometry, thickness, false)
+}
+
+fn expand_window_geometry_for_decoration(
+    geometry: WindowGeometry,
+    thickness: u32,
+    label_present: bool,
+) -> Option<WindowGeometry> {
+    if geometry.width <= 0 || geometry.height <= 0 || thickness == 0 {
+        return None;
+    }
+    let thickness = i32::try_from(thickness).ok()?;
+    let top_thickness = i32::try_from(top_border_height(
+        u32::try_from(thickness).ok()?,
+        label_present,
+    ))
+    .ok()?;
+    let horizontal = thickness.checked_mul(2)?;
+    let vertical = top_thickness.checked_add(thickness)?;
+    Some(WindowGeometry {
+        x: geometry.x.checked_sub(thickness)?,
+        y: geometry.y.checked_sub(top_thickness)?,
+        width: geometry.width.checked_add(horizontal)?,
+        height: geometry.height.checked_add(vertical)?,
+    })
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct VisualState {
+    pub active: bool,
+    pub urgent: bool,
+    pub fullscreen: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecorationPlan {
+    pub geometry: BorderGeometry,
+    pub color: Color,
+    pub label: Option<SanitizedLabel>,
+    pub label_position: LabelPosition,
+}
+
+pub fn decoration_plan(
+    config: &BorderConfig,
+    content: Size,
+    state: VisualState,
+) -> Option<DecorationPlan> {
+    if !config.enabled() || state.fullscreen {
+        return None;
+    }
+    let mut geometry =
+        BorderGeometry::expand_with_label_band(content, config.thickness, config.label.is_some())?;
+    if decoration_buffer_layout(geometry.outer).is_none() {
+        if config.label.is_some() {
+            geometry = BorderGeometry::label_fallback_for_oversized(content, config.thickness)?;
+            decoration_buffer_layout(geometry.outer)?;
+        } else {
+            return None;
+        }
+    }
+    Some(DecorationPlan {
+        geometry,
+        color: config.color_for_state(state),
+        label: config.label.clone(),
+        label_position: config.label_position,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrawInput {
+    pub geometry: BorderGeometry,
+    pub color: Color,
+    pub label: Option<SanitizedLabel>,
+    pub label_position: LabelPosition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DecorationBufferLayout {
+    width: usize,
+    height: usize,
+    stride: usize,
+    len: usize,
+}
+
+fn decoration_buffer_layout(size: Size) -> Option<DecorationBufferLayout> {
+    if size.is_empty() {
+        return None;
+    }
+    let width = usize::try_from(size.width).ok()?;
+    let height = usize::try_from(size.height).ok()?;
+    let stride = width.checked_mul(BYTES_PER_PIXEL as usize)?;
+    let len = stride.checked_mul(height)?;
+    if size.width > MAX_DECORATION_DIMENSION || size.height > MAX_DECORATION_DIMENSION {
+        return None;
+    }
+    if len > MAX_DECORATION_BUFFER_BYTES {
+        return None;
+    }
+    Some(DecorationBufferLayout {
+        width,
+        height,
+        stride,
+        len,
+    })
+}
+
+pub fn draw_decoration(input: &DrawInput) -> Option<Vec<u8>> {
+    let layout = decoration_buffer_layout(input.geometry.outer)?;
+    let mut pixels = vec![0_u8; layout.len];
+    fill_border(
+        &mut pixels,
+        layout.width,
+        layout.height,
+        input.geometry.thickness as usize,
+        input.geometry.top_thickness as usize,
+        input.color,
+    );
+    if let Some(label) = &input.label {
+        draw_label(
+            &mut pixels,
+            layout.width,
+            layout.height,
+            input.geometry.top_thickness,
+            input.color,
+            label.as_str(),
+            input.label_position,
+        );
+    }
+    Some(pixels)
+}
+
+fn fill_border(
+    pixels: &mut [u8],
+    width: usize,
+    height: usize,
+    thickness: usize,
+    top_thickness: usize,
+    color: Color,
+) {
+    let color = color.argb8888_bytes();
+    for y in 0..height {
+        for x in 0..width {
+            if x < thickness
+                || y < top_thickness
+                || x >= width.saturating_sub(thickness)
+                || y >= height.saturating_sub(thickness)
+            {
+                set_pixel(pixels, width, x, y, color);
+            }
+        }
+    }
+}
+
+fn draw_label(
+    pixels: &mut [u8],
+    width: usize,
+    height: usize,
+    top_thickness: u32,
+    border: Color,
+    label: &str,
+    position: LabelPosition,
+) {
+    let max_label_width = width.saturating_sub((LABEL_PAD_X * 2) as usize);
+    if max_label_width < GLYPH_W as usize || top_thickness < MIN_LABEL_BAND_HEIGHT {
+        return;
+    }
+    let label_height = height.min(top_thickness as usize);
+    let glyphs_that_fit = ((max_label_width as u32) / GLYPH_ADVANCE).max(1) as usize;
+    let text: String = label.chars().take(glyphs_that_fit).collect();
+    let text_width = text.chars().count() as u32 * GLYPH_ADVANCE;
+    let x = match position {
+        LabelPosition::TopLeft => LABEL_PAD_X,
+        LabelPosition::TopCenter => input_center(width as u32, text_width),
+    } as usize;
+    let y = LABEL_PAD_Y as usize;
+    let foreground = border.readable_text_color().argb8888_bytes();
+    let shadow = Color {
+        a: 160,
+        ..Color::BLACK
+    }
+    .argb8888_bytes();
+    draw_text_pixels(pixels, width, label_height, x + 1, y + 1, &text, shadow);
+    draw_text_pixels(pixels, width, label_height, x, y, &text, foreground);
+}
+
+fn input_center(width: u32, text_width: u32) -> u32 {
+    width.saturating_sub(text_width) / 2
+}
+
+fn draw_text_pixels(
+    pixels: &mut [u8],
+    width: usize,
+    height: usize,
+    x: usize,
+    y: usize,
+    text: &str,
+    color: [u8; 4],
+) {
+    let mut cursor = x;
+    for ch in text.chars() {
+        draw_glyph(pixels, width, height, cursor, y, glyph(ch), color);
+        cursor = cursor.saturating_add(GLYPH_ADVANCE as usize);
+    }
+}
+
+fn draw_glyph(
+    pixels: &mut [u8],
+    width: usize,
+    height: usize,
+    x: usize,
+    y: usize,
+    rows: [u8; 7],
+    color: [u8; 4],
+) {
+    for (row, bits) in rows.iter().enumerate() {
+        for col in 0..GLYPH_W as usize {
+            if bits & (1 << (GLYPH_W as usize - 1 - col)) != 0 {
+                let px = x + col;
+                let py = y + row;
+                if px < width && py < height {
+                    set_pixel(pixels, width, px, py, color);
+                }
+            }
+        }
+    }
+}
+
+fn set_pixel(pixels: &mut [u8], width: usize, x: usize, y: usize, color: [u8; 4]) {
+    let offset = (y * width + x) * BYTES_PER_PIXEL as usize;
+    if offset + 4 <= pixels.len() {
+        pixels[offset..offset + 4].copy_from_slice(&color);
+    }
+}
+
+fn glyph(ch: char) -> [u8; 7] {
+    match ch.to_ascii_uppercase() {
+        'A' => [
+            0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001,
+        ],
+        'B' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10001, 0b10001, 0b11110,
+        ],
+        'C' => [
+            0b01110, 0b10001, 0b10000, 0b10000, 0b10000, 0b10001, 0b01110,
+        ],
+        'D' => [
+            0b11110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11110,
+        ],
+        'E' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111,
+        ],
+        'F' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b10000,
+        ],
+        'G' => [
+            0b01110, 0b10001, 0b10000, 0b10111, 0b10001, 0b10001, 0b01110,
+        ],
+        'H' => [
+            0b10001, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001,
+        ],
+        'I' => [
+            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b11111,
+        ],
+        'J' => [
+            0b00111, 0b00010, 0b00010, 0b00010, 0b10010, 0b10010, 0b01100,
+        ],
+        'K' => [
+            0b10001, 0b10010, 0b10100, 0b11000, 0b10100, 0b10010, 0b10001,
+        ],
+        'L' => [
+            0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b11111,
+        ],
+        'M' => [
+            0b10001, 0b11011, 0b10101, 0b10101, 0b10001, 0b10001, 0b10001,
+        ],
+        'N' => [
+            0b10001, 0b11001, 0b10101, 0b10011, 0b10001, 0b10001, 0b10001,
+        ],
+        'O' => [
+            0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110,
+        ],
+        'P' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10000, 0b10000, 0b10000,
+        ],
+        'Q' => [
+            0b01110, 0b10001, 0b10001, 0b10001, 0b10101, 0b10010, 0b01101,
+        ],
+        'R' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001,
+        ],
+        'S' => [
+            0b01111, 0b10000, 0b10000, 0b01110, 0b00001, 0b00001, 0b11110,
+        ],
+        'T' => [
+            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100,
+        ],
+        'U' => [
+            0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110,
+        ],
+        'V' => [
+            0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01010, 0b00100,
+        ],
+        'W' => [
+            0b10001, 0b10001, 0b10001, 0b10101, 0b10101, 0b10101, 0b01010,
+        ],
+        'X' => [
+            0b10001, 0b10001, 0b01010, 0b00100, 0b01010, 0b10001, 0b10001,
+        ],
+        'Y' => [
+            0b10001, 0b10001, 0b01010, 0b00100, 0b00100, 0b00100, 0b00100,
+        ],
+        'Z' => [
+            0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b10000, 0b11111,
+        ],
+        '0' => [
+            0b01110, 0b10001, 0b10011, 0b10101, 0b11001, 0b10001, 0b01110,
+        ],
+        '1' => [
+            0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110,
+        ],
+        '2' => [
+            0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0b01000, 0b11111,
+        ],
+        '3' => [
+            0b11110, 0b00001, 0b00001, 0b01110, 0b00001, 0b00001, 0b11110,
+        ],
+        '4' => [
+            0b00010, 0b00110, 0b01010, 0b10010, 0b11111, 0b00010, 0b00010,
+        ],
+        '5' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b00001, 0b00001, 0b11110,
+        ],
+        '6' => [
+            0b01110, 0b10000, 0b10000, 0b11110, 0b10001, 0b10001, 0b01110,
+        ],
+        '7' => [
+            0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b01000, 0b01000,
+        ],
+        '8' => [
+            0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110,
+        ],
+        '9' => [
+            0b01110, 0b10001, 0b10001, 0b01111, 0b00001, 0b00001, 0b01110,
+        ],
+        '-' => [0, 0, 0, 0b11111, 0, 0, 0],
+        '_' => [0, 0, 0, 0, 0, 0, 0b11111],
+        '.' => [0, 0, 0, 0, 0, 0b01100, 0b01100],
+        ':' => [0, 0b01100, 0b01100, 0, 0b01100, 0b01100, 0],
+        '/' => [
+            0b00001, 0b00010, 0b00010, 0b00100, 0b01000, 0b01000, 0b10000,
+        ],
+        '[' => [
+            0b01110, 0b01000, 0b01000, 0b01000, 0b01000, 0b01000, 0b01110,
+        ],
+        ']' => [
+            0b01110, 0b00010, 0b00010, 0b00010, 0b00010, 0b00010, 0b01110,
+        ],
+        ' ' => [0, 0, 0, 0, 0, 0, 0],
+        _ => [0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0, 0b00100],
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BufferDimensions {
+    pub width: i32,
+    pub height: i32,
+}
+
+impl BufferDimensions {
+    pub fn surface_size(self, scale: i32, transform: WlOutputTransform) -> Option<Size> {
+        if self.width <= 0 || self.height <= 0 || scale <= 0 {
+            return None;
+        }
+        let (width, height) = if transform.0 % 2 == 1 {
+            (self.height, self.width)
+        } else {
+            (self.width, self.height)
+        };
+        Some(Size::new(
+            u32::try_from(width / scale).ok()?,
+            u32::try_from(height / scale).ok()?,
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ViewportSource {
+    width: Fixed,
+    height: Fixed,
+}
+
+impl ViewportSource {
+    fn surface_size(self) -> Option<Size> {
+        Some(Size::new(
+            positive_integral_fixed_to_u32(self.width)?,
+            positive_integral_fixed_to_u32(self.height)?,
+        ))
+    }
+}
+
+#[derive(Debug, Default)]
+struct ViewportState {
+    pending_source: Option<Option<ViewportSource>>,
+    pending_destination: Option<Option<Size>>,
+    current_source: Option<ViewportSource>,
+    current_destination: Option<Size>,
+}
+
+impl ViewportState {
+    fn set_source(&mut self, x: Fixed, y: Fixed, width: Fixed, height: Fixed) {
+        if let Some(source) = viewport_source_from_request(x, y, width, height) {
+            self.pending_source = Some(source);
+        }
+    }
+
+    fn set_destination(&mut self, width: i32, height: i32) {
+        if let Some(destination) = viewport_destination_from_request(width, height) {
+            self.pending_destination = Some(destination);
+        }
+    }
+
+    fn destroy(&mut self) {
+        self.pending_source = Some(None);
+        self.pending_destination = Some(None);
+    }
+
+    fn apply_pending(&mut self) {
+        if let Some(source) = self.pending_source.take() {
+            self.current_source = source;
+        }
+        if let Some(destination) = self.pending_destination.take() {
+            self.current_destination = destination;
+        }
+    }
+
+    fn has_pending(&self) -> bool {
+        self.pending_source.is_some() || self.pending_destination.is_some()
+    }
+}
+
+fn positive_integral_fixed_to_u32(value: Fixed) -> Option<u32> {
+    let raw = value.to_wire();
+    if raw <= 0 || raw % 256 != 0 {
+        return None;
+    }
+    u32::try_from(raw / 256).ok()
+}
+
+fn viewport_source_from_request(
+    x: Fixed,
+    y: Fixed,
+    width: Fixed,
+    height: Fixed,
+) -> Option<Option<ViewportSource>> {
+    let unset = Fixed::from_i32_saturating(-1);
+    if x == unset && y == unset && width == unset && height == unset {
+        return Some(None);
+    }
+    if x < Fixed::ZERO || y < Fixed::ZERO || width <= Fixed::ZERO || height <= Fixed::ZERO {
+        return None;
+    }
+    Some(Some(ViewportSource { width, height }))
+}
+
+fn viewport_destination_from_request(width: i32, height: i32) -> Option<Option<Size>> {
+    if width == -1 && height == -1 {
+        return Some(None);
+    }
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+    Some(Some(Size::new(
+        u32::try_from(width).ok()?,
+        u32::try_from(height).ok()?,
+    )))
+}
+
+#[derive(Debug)]
+struct SurfaceState {
+    pending_buffer: Option<Option<u64>>,
+    current_buffer: Option<u64>,
+    pending_scale: Option<i32>,
+    pending_transform: Option<WlOutputTransform>,
+    current_scale: i32,
+    current_transform: WlOutputTransform,
+    viewport: ViewportState,
+    current_size: Option<Size>,
+    toplevel: bool,
+    visual: VisualState,
+    decoration: Option<DecorationSurface>,
+}
+
+impl Default for SurfaceState {
+    fn default() -> Self {
+        Self {
+            pending_buffer: None,
+            current_buffer: None,
+            pending_scale: None,
+            pending_transform: None,
+            current_scale: 1,
+            current_transform: WlOutputTransform::NORMAL,
+            viewport: ViewportState::default(),
+            current_size: None,
+            toplevel: false,
+            visual: VisualState::default(),
+            decoration: None,
+        }
+    }
+}
+
+impl SurfaceState {
+    fn committed_size(&self, buffers: &HashMap<u64, BufferDimensions>) -> Option<Size> {
+        self.committed_size_with_fallback(buffers, None)
+    }
+
+    fn committed_size_with_fallback(
+        &self,
+        buffers: &HashMap<u64, BufferDimensions>,
+        fallback: Option<Size>,
+    ) -> Option<Size> {
+        let buffer_id = self.current_buffer?;
+        if let Some(destination) = self.viewport.current_destination {
+            return Some(destination);
+        }
+        if let Some(source_size) = self
+            .viewport
+            .current_source
+            .and_then(ViewportSource::surface_size)
+        {
+            return Some(source_size);
+        }
+        buffers
+            .get(&buffer_id)
+            .and_then(|dims| dims.surface_size(self.current_scale, self.current_transform))
+            .or(fallback)
+    }
+
+    fn apply_commit_state(&mut self, buffers: &HashMap<u64, BufferDimensions>) {
+        let previous_size = self.current_size;
+        let pending_buffer = self.pending_buffer.take();
+        let pending_viewport = self.viewport.has_pending();
+        if let Some(scale) = self.pending_scale.take() {
+            self.current_scale = scale;
+        }
+        if let Some(transform) = self.pending_transform.take() {
+            self.current_transform = transform;
+        }
+        if let Some(pending) = pending_buffer {
+            self.current_buffer = pending;
+        }
+        self.viewport.apply_pending();
+        self.current_size = if matches!(pending_buffer, Some(None)) {
+            None
+        } else if pending_buffer.is_some() || pending_viewport {
+            self.committed_size(buffers)
+        } else {
+            self.committed_size_with_fallback(buffers, previous_size)
+        };
+    }
+}
+
+#[derive(Debug)]
+struct DecorationSurface {
+    surface: Rc<WlSurface>,
+    subsurface: Rc<WlSubsurface>,
+    buffer: Option<ProxyDecorationBuffer>,
+    // The compositor may still scan out an attached decoration buffer until it
+    // sends wl_buffer.release. Keep released-aware retired buffers instead of
+    // destroying every replacement immediately, but cap the queue so a guest
+    // cannot force unbounded proxy memfd retention with rapid geometry changes.
+    retired_buffers: Vec<ProxyDecorationBuffer>,
+    key: Option<FrameKey>,
+}
+
+impl DecorationSurface {
+    fn retire_buffer(&mut self, buffer: ProxyDecorationBuffer) {
+        buffer.retire();
+        if !buffer.destroyed() {
+            self.retired_buffers.push(buffer);
+        }
+        self.prune_destroyed_buffers();
+        while self.retired_buffers.len() > MAX_RETIRED_DECORATION_BUFFERS {
+            let buffer = self.retired_buffers.remove(0);
+            buffer.force_destroy();
+        }
+    }
+
+    fn force_destroy_buffers(&mut self) {
+        if let Some(buffer) = self.buffer.take() {
+            buffer.force_destroy();
+        }
+        for buffer in self.retired_buffers.drain(..) {
+            buffer.force_destroy();
+        }
+    }
+
+    fn prune_destroyed_buffers(&mut self) {
+        self.retired_buffers.retain(|buffer| !buffer.destroyed());
+    }
+}
+
+#[derive(Debug)]
+struct ProxyDecorationBuffer {
+    buffer: Rc<WlBuffer>,
+    lifecycle: Rc<DecorationBufferLifecycle>,
+}
+
+impl ProxyDecorationBuffer {
+    fn new(buffer: Rc<WlBuffer>) -> Self {
+        let lifecycle = Rc::new(DecorationBufferLifecycle::default());
+        buffer.set_handler(DecorationBufferHandler {
+            lifecycle: Rc::downgrade(&lifecycle),
+        });
+        Self { buffer, lifecycle }
+    }
+
+    fn wl_buffer(&self) -> &Rc<WlBuffer> {
+        &self.buffer
+    }
+
+    fn retire(&self) {
+        retire_proxy_decoration_buffer(&self.buffer, &self.lifecycle);
+    }
+
+    fn force_destroy(&self) {
+        force_destroy_proxy_decoration_buffer(&self.buffer, &self.lifecycle);
+    }
+
+    fn destroyed(&self) -> bool {
+        self.lifecycle.destroyed.get()
+    }
+}
+
+#[derive(Debug, Default)]
+struct DecorationBufferLifecycle {
+    // Wayland clients should not destroy an attached wl_buffer until the
+    // compositor sends release. The proxy owns these buffers, so it tracks
+    // release/retire/destroy separately and destroys only once the buffer is
+    // both retired and released, unless the bounded retired-buffer queue must
+    // force cleanup for resource-exhaustion protection.
+    released: Cell<bool>,
+    retired: Cell<bool>,
+    destroyed: Cell<bool>,
+}
+
+struct DecorationBufferHandler {
+    lifecycle: Weak<DecorationBufferLifecycle>,
+}
+
+impl WlBufferHandler for DecorationBufferHandler {
+    fn handle_release(&mut self, slf: &Rc<WlBuffer>) {
+        if let Some(lifecycle) = self.lifecycle.upgrade() {
+            release_proxy_decoration_buffer(slf, &lifecycle);
+        }
+    }
+}
+
+trait ProxyDecorationBufferDestroy {
+    fn send_destroy_request(&self);
+    fn delete_proxy_id(&self);
+}
+
+impl ProxyDecorationBufferDestroy for Rc<WlBuffer> {
+    fn send_destroy_request(&self) {
+        self.send_destroy();
+    }
+
+    fn delete_proxy_id(&self) {
+        self.delete_id();
+    }
+}
+
+fn retire_proxy_decoration_buffer(
+    buffer: &impl ProxyDecorationBufferDestroy,
+    lifecycle: &DecorationBufferLifecycle,
+) {
+    lifecycle.retired.set(true);
+    if lifecycle.released.get() {
+        destroy_proxy_decoration_buffer(buffer, lifecycle);
+    }
+}
+
+fn release_proxy_decoration_buffer(
+    buffer: &impl ProxyDecorationBufferDestroy,
+    lifecycle: &DecorationBufferLifecycle,
+) {
+    lifecycle.released.set(true);
+    if lifecycle.retired.get() {
+        destroy_proxy_decoration_buffer(buffer, lifecycle);
+    }
+}
+
+fn force_destroy_proxy_decoration_buffer(
+    buffer: &impl ProxyDecorationBufferDestroy,
+    lifecycle: &DecorationBufferLifecycle,
+) {
+    lifecycle.retired.set(true);
+    destroy_proxy_decoration_buffer(buffer, lifecycle);
+}
+
+fn destroy_proxy_decoration_buffer(
+    buffer: &impl ProxyDecorationBufferDestroy,
+    lifecycle: &DecorationBufferLifecycle,
+) {
+    if lifecycle.destroyed.replace(true) {
+        return;
+    }
+    buffer.send_destroy_request();
+    buffer.delete_proxy_id();
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FrameKey {
+    outer: Size,
+    color: Color,
+    label: Option<SanitizedLabel>,
+    label_position: LabelPosition,
+}
+
+#[derive(Debug)]
+pub struct DecorationManager {
+    config: BorderConfig,
+    diag: Rc<RefCell<DiagRateLimiter>>,
+    compositor: Option<Rc<WlCompositor>>,
+    subcompositor: Option<Rc<WlSubcompositor>>,
+    shm: Option<Rc<wl_proxy::protocols::wayland::wl_shm::WlShm>>,
+    buffers: HashMap<u64, BufferDimensions>,
+    surfaces: HashMap<u64, SurfaceState>,
+    subsurfaces_by_parent: HashMap<u64, Vec<Weak<WlSurface>>>,
+}
+
+impl DecorationManager {
+    pub fn new(config: BorderConfig, diag: Rc<RefCell<DiagRateLimiter>>) -> Self {
+        Self {
+            config,
+            diag,
+            compositor: None,
+            subcompositor: None,
+            shm: None,
+            buffers: HashMap::new(),
+            surfaces: HashMap::new(),
+            subsurfaces_by_parent: HashMap::new(),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.config.enabled()
+    }
+
+    pub fn translate_window_geometry(
+        &self,
+        surface: &Rc<WlSurface>,
+        geometry: WindowGeometry,
+    ) -> WindowGeometry {
+        self.translate_window_geometry_for_surface_id(surface.unique_id(), geometry)
+    }
+
+    fn translate_window_geometry_for_surface_id(
+        &self,
+        surface_id: u64,
+        geometry: WindowGeometry,
+    ) -> WindowGeometry {
+        if !self.config.enabled() {
+            return geometry;
+        }
+        let Some(state) = self.surfaces.get(&surface_id) else {
+            return geometry;
+        };
+        if !state.toplevel || state.visual.fullscreen {
+            return geometry;
+        }
+        expand_window_geometry_for_decoration(
+            geometry,
+            self.config.thickness,
+            self.config.label.is_some(),
+        )
+        .unwrap_or(geometry)
+    }
+
+    pub fn observe_global(
+        &mut self,
+        registry: &Rc<WlRegistry>,
+        name: u32,
+        interface: ObjectInterface,
+        version: u32,
+    ) {
+        if !self.enabled() {
+            return;
+        }
+        match interface {
+            ObjectInterface::WlCompositor if self.compositor.is_none() => {
+                let compositor = registry
+                    .state()
+                    .create_object::<WlCompositor>(version.min(WlCompositor::XML_VERSION));
+                registry.send_bind(name, compositor.clone());
+                self.compositor = Some(compositor);
+            }
+            ObjectInterface::WlSubcompositor if self.subcompositor.is_none() => {
+                let subcompositor = registry
+                    .state()
+                    .create_object::<WlSubcompositor>(version.min(WlSubcompositor::XML_VERSION));
+                registry.send_bind(name, subcompositor.clone());
+                self.subcompositor = Some(subcompositor);
+            }
+            ObjectInterface::WlShm if self.shm.is_none() => {
+                let shm = registry
+                    .state()
+                    .create_object::<wl_proxy::protocols::wayland::wl_shm::WlShm>(
+                        version.min(wl_proxy::protocols::wayland::wl_shm::WlShm::XML_VERSION),
+                    );
+                registry.send_bind(name, shm.clone());
+                self.shm = Some(shm);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn register_surface(&mut self, surface: &Rc<WlSurface>) {
+        if self.enabled() {
+            self.surfaces.entry(surface.unique_id()).or_default();
+        }
+    }
+
+    pub fn mark_toplevel(&mut self, surface: &Rc<WlSurface>) {
+        if let Some(state) = self.surfaces.get_mut(&surface.unique_id()) {
+            state.toplevel = true;
+        }
+    }
+
+    pub fn record_buffer(&mut self, buffer: &Rc<WlBuffer>, width: i32, height: i32) {
+        if self.enabled() && width > 0 && height > 0 {
+            self.buffers
+                .insert(buffer.unique_id(), BufferDimensions { width, height });
+        }
+    }
+
+    pub fn remove_buffer(&mut self, buffer: &Rc<WlBuffer>) {
+        self.buffers.remove(&buffer.unique_id());
+    }
+
+    pub fn surface_attach(&mut self, surface: &Rc<WlSurface>, buffer: Option<&Rc<WlBuffer>>) {
+        if let Some(state) = self.surfaces.get_mut(&surface.unique_id()) {
+            state.pending_buffer = Some(buffer.map(|buffer| buffer.unique_id()));
+        }
+    }
+
+    pub fn surface_set_buffer_scale(&mut self, surface: &Rc<WlSurface>, scale: i32) {
+        if let Some(state) = self.surfaces.get_mut(&surface.unique_id()) {
+            state.pending_scale = Some(scale);
+        }
+    }
+
+    pub fn surface_set_buffer_transform(
+        &mut self,
+        surface: &Rc<WlSurface>,
+        transform: WlOutputTransform,
+    ) {
+        if let Some(state) = self.surfaces.get_mut(&surface.unique_id()) {
+            state.pending_transform = Some(transform);
+        }
+    }
+
+    pub fn surface_get_viewport(&mut self, surface: &Rc<WlSurface>) {
+        if self.enabled() {
+            self.surfaces.entry(surface.unique_id()).or_default();
+        }
+    }
+
+    pub fn surface_viewport_destroyed(&mut self, surface: &Rc<WlSurface>) {
+        if let Some(state) = self.surfaces.get_mut(&surface.unique_id()) {
+            state.viewport.destroy();
+        }
+    }
+
+    pub fn surface_set_viewport_source(
+        &mut self,
+        surface: &Rc<WlSurface>,
+        x: Fixed,
+        y: Fixed,
+        width: Fixed,
+        height: Fixed,
+    ) {
+        if let Some(state) = self.surfaces.get_mut(&surface.unique_id()) {
+            state.viewport.set_source(x, y, width, height);
+        }
+    }
+
+    pub fn surface_set_viewport_destination(
+        &mut self,
+        surface: &Rc<WlSurface>,
+        width: i32,
+        height: i32,
+    ) {
+        if let Some(state) = self.surfaces.get_mut(&surface.unique_id()) {
+            state.viewport.set_destination(width, height);
+        }
+    }
+
+    pub fn surface_commit(&mut self, surface: &Rc<WlSurface>) {
+        let surface_id = surface.unique_id();
+        let Some(state) = self.surfaces.get_mut(&surface_id) else {
+            return;
+        };
+        state.apply_commit_state(&self.buffers);
+        if !state.toplevel {
+            return;
+        }
+        let plan = state
+            .current_size
+            .and_then(|size| decoration_plan(&self.config, size, state.visual));
+        match plan {
+            Some(plan) => self.apply_decoration(surface, surface_id, plan),
+            None => self.remove_decoration(surface_id),
+        }
+    }
+
+    pub fn surface_destroyed(&mut self, surface: &Rc<WlSurface>) {
+        let id = surface.unique_id();
+        self.remove_decoration(id);
+        self.surfaces.remove(&id);
+        self.subsurfaces_by_parent.remove(&id);
+        for siblings in self.subsurfaces_by_parent.values_mut() {
+            siblings.retain(|sibling| {
+                sibling
+                    .upgrade()
+                    .is_some_and(|sibling| sibling.unique_id() != id)
+            });
+        }
+    }
+
+    pub fn register_guest_subsurface(&mut self, surface: &Rc<WlSurface>, parent: &Rc<WlSurface>) {
+        let parent_id = parent.unique_id();
+        let siblings = self.subsurfaces_by_parent.entry(parent_id).or_default();
+        if !siblings.iter().any(|sibling| {
+            sibling
+                .upgrade()
+                .is_some_and(|sibling| sibling.unique_id() == surface.unique_id())
+        }) {
+            siblings.push(Rc::downgrade(surface));
+        }
+        self.raise_decoration_above_guest_subsurfaces(parent);
+    }
+
+    pub fn raise_decoration_above_guest_subsurfaces(&mut self, parent: &Rc<WlSurface>) {
+        let parent_id = parent.unique_id();
+        let Some(state) = self.surfaces.get_mut(&parent_id) else {
+            return;
+        };
+        let Some(decoration) = state.decoration.as_mut() else {
+            return;
+        };
+        decoration.subsurface.send_place_above(parent);
+        if let Some(siblings) = self.subsurfaces_by_parent.get_mut(&parent_id) {
+            siblings.retain(|sibling| sibling.strong_count() > 0);
+            for sibling in siblings.iter().filter_map(Weak::upgrade) {
+                decoration.subsurface.send_place_above(&sibling);
+            }
+        }
+    }
+
+    pub fn toplevel_configure(&mut self, surface_id: u64, states: &[u8]) {
+        if let Some(state) = self.surfaces.get_mut(&surface_id) {
+            state.visual.fullscreen = xdg_state_contains(states, XdgToplevelState::FULLSCREEN.0);
+            state.visual.active = xdg_state_contains(states, XdgToplevelState::ACTIVATED.0);
+        }
+    }
+
+    pub fn toplevel_fullscreen_request(&mut self, surface_id: u64, fullscreen: bool) {
+        if let Some(state) = self.surfaces.get_mut(&surface_id) {
+            state.visual.fullscreen = fullscreen;
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_urgent_for_tests(&mut self, surface_id: u64, urgent: bool) {
+        if let Some(state) = self.surfaces.get_mut(&surface_id) {
+            state.visual.urgent = urgent;
+        }
+    }
+
+    fn apply_decoration(&mut self, parent: &Rc<WlSurface>, surface_id: u64, plan: DecorationPlan) {
+        let key = FrameKey {
+            outer: plan.geometry.outer,
+            color: plan.color,
+            label: plan.label.clone(),
+            label_position: plan.label_position,
+        };
+        let needs_surface = self
+            .surfaces
+            .get(&surface_id)
+            .and_then(|state| state.decoration.as_ref())
+            .is_none();
+        let new_decoration = if needs_surface {
+            self.create_decoration_surface(parent)
+        } else {
+            None
+        };
+        let needs_buffer = self
+            .surfaces
+            .get(&surface_id)
+            .and_then(|state| state.decoration.as_ref())
+            .is_none_or(|decoration| decoration.key.as_ref() != Some(&key));
+        let new_buffer = if needs_buffer {
+            match self.create_buffer_for_plan(&plan) {
+                Ok(buffer) => Some(buffer),
+                Err(error) => {
+                    let error = bounded_error_detail(error.to_string());
+                    self.diag
+                        .borrow_mut()
+                        .warn("border-decoration", "draw-failed", || {
+                            format!(
+                                "[d2b-wlproxy] event=border-decoration reason=draw-failed error={error}"
+                            )
+                        });
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let Some(state) = self.surfaces.get_mut(&surface_id) else {
+            return;
+        };
+        if state.decoration.is_none() {
+            state.decoration = new_decoration;
+        }
+        if let Some(decoration) = state.decoration.as_mut() {
+            decoration.subsurface.send_set_position(
+                -i32::try_from(plan.geometry.thickness).unwrap_or(i32::MAX),
+                -i32::try_from(plan.geometry.top_thickness).unwrap_or(i32::MAX),
+            );
+        } else {
+            return;
+        }
+        self.raise_decoration_above_guest_subsurfaces(parent);
+        if let Some(buffer) = new_buffer {
+            let Some(state) = self.surfaces.get_mut(&surface_id) else {
+                return;
+            };
+            let Some(decoration) = state.decoration.as_mut() else {
+                return;
+            };
+            let old_buffer = decoration.buffer.take();
+            decoration
+                .surface
+                .send_attach(Some(buffer.wl_buffer()), 0, 0);
+            decoration.surface.send_damage_buffer(
+                0,
+                0,
+                plan.geometry.outer.width as i32,
+                plan.geometry.outer.height as i32,
+            );
+            decoration.surface.send_commit();
+            if let Some(old_buffer) = old_buffer {
+                decoration.retire_buffer(old_buffer);
+            } else {
+                decoration.prune_destroyed_buffers();
+            }
+            decoration.buffer = Some(buffer);
+            decoration.key = Some(key);
+        }
+    }
+
+    fn create_decoration_surface(&self, parent: &Rc<WlSurface>) -> Option<DecorationSurface> {
+        let compositor = self.compositor.as_ref()?;
+        let subcompositor = self.subcompositor.as_ref()?;
+        let surface = compositor.new_send_create_surface();
+        let empty = compositor.new_send_create_region();
+        surface.send_set_input_region(Some(&empty));
+        empty.send_destroy();
+        let subsurface = subcompositor.new_send_get_subsurface(&surface, parent);
+        subsurface.send_set_desync();
+        Some(DecorationSurface {
+            surface,
+            subsurface,
+            buffer: None,
+            retired_buffers: Vec::new(),
+            key: None,
+        })
+    }
+
+    fn create_buffer_for_plan(&self, plan: &DecorationPlan) -> io::Result<ProxyDecorationBuffer> {
+        let shm = self
+            .shm
+            .as_ref()
+            .ok_or_else(|| io::Error::other("wl_shm is not available"))?;
+        let layout = decoration_buffer_layout(plan.geometry.outer)
+            .ok_or_else(|| io::Error::other("border buffer exceeds decoration limits"))?;
+        let input = DrawInput {
+            geometry: plan.geometry,
+            color: plan.color,
+            label: plan.label.clone(),
+            label_position: plan.label_position,
+        };
+        let pixels = draw_decoration(&input)
+            .ok_or_else(|| io::Error::other("border buffer exceeds decoration limits"))?;
+        let fd = create_memfd_with_contents(
+            &pixels,
+            u64::try_from(layout.len).map_err(|_| io::Error::other("border buffer too large"))?,
+        )?;
+        let fd = Rc::new(fd);
+        let pool = shm.new_send_create_pool(
+            &fd,
+            i32::try_from(layout.len).map_err(|_| io::Error::other("border buffer too large"))?,
+        );
+        let buffer = pool.new_send_create_buffer(
+            0,
+            i32::try_from(layout.width).map_err(|_| io::Error::other("border width too large"))?,
+            i32::try_from(layout.height)
+                .map_err(|_| io::Error::other("border height too large"))?,
+            i32::try_from(layout.stride)
+                .map_err(|_| io::Error::other("border stride too large"))?,
+            WlShmFormat::ARGB8888,
+        );
+        pool.send_destroy();
+        Ok(ProxyDecorationBuffer::new(buffer))
+    }
+
+    fn remove_decoration(&mut self, surface_id: u64) {
+        let Some(state) = self.surfaces.get_mut(&surface_id) else {
+            return;
+        };
+        if let Some(mut decoration) = state.decoration.take() {
+            decoration.surface.send_attach(None, 0, 0);
+            decoration.surface.send_commit();
+            decoration.force_destroy_buffers();
+            decoration.subsurface.send_destroy();
+            decoration.surface.send_destroy();
+        }
+    }
+}
+
+fn create_memfd_with_contents(contents: &[u8], size: u64) -> io::Result<OwnedFd> {
+    let name = CString::new("d2b-wayland-border").expect("static memfd name has no nul");
+    let fd = memfd_create(name.as_c_str(), MemFdCreateFlag::MFD_CLOEXEC)
+        .map_err(|errno| io::Error::from_raw_os_error(errno as i32))?;
+    let writer_fd = rustix::io::fcntl_dupfd_cloexec(&fd, 0).map_err(io::Error::from)?;
+    let mut file = File::from(writer_fd);
+    file.set_len(size)?;
+    file.write_all(contents)?;
+    Ok(fd)
+}
+
+fn xdg_state_contains(states: &[u8], needle: u32) -> bool {
+    states
+        .chunks_exact(4)
+        .any(|chunk| u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]) == needle)
+}
+
+pub type SharedDecorationManager = Rc<RefCell<DecorationManager>>;
+
+pub fn tracking_buffer_handler(manager: &SharedDecorationManager) -> TrackingBufferHandler {
+    TrackingBufferHandler {
+        manager: Rc::downgrade(manager),
+    }
+}
+
+pub struct TrackingBufferHandler {
+    manager: Weak<RefCell<DecorationManager>>,
+}
+
+impl WlBufferHandler for TrackingBufferHandler {
+    fn handle_destroy(&mut self, slf: &Rc<WlBuffer>) {
+        if let Some(manager) = self.manager.upgrade() {
+            manager.borrow_mut().remove_buffer(slf);
+        }
+        // Ordinary forwarded wl_buffer destruction uses wl-proxy's normal
+        // client/server object lifetime. The explicit delete_id workaround below
+        // is scoped to wl_shm_pool because wl-cross-domain-proxy can reuse pool
+        // IDs immediately after destroy.
+        slf.send_destroy();
+    }
+}
+
+pub fn tracking_shm_pool_handler(manager: &SharedDecorationManager) -> TrackingShmPoolHandler {
+    TrackingShmPoolHandler {
+        manager: Rc::downgrade(manager),
+    }
+}
+
+pub struct TrackingShmPoolHandler {
+    manager: Weak<RefCell<DecorationManager>>,
+}
+
+trait TrackedShmPoolDestroy {
+    fn send_destroy_request(&self);
+    fn delete_proxy_id(&self);
+}
+
+impl TrackedShmPoolDestroy for Rc<WlShmPool> {
+    fn send_destroy_request(&self) {
+        self.send_destroy();
+    }
+
+    fn delete_proxy_id(&self) {
+        self.delete_id();
+    }
+}
+
+fn destroy_tracked_shm_pool(pool: &impl TrackedShmPoolDestroy) {
+    // wl-cross-domain-proxy can reuse wl_shm_pool object IDs immediately after
+    // destroy. Delete the proxy-side ID after forwarding destroy so the reused
+    // ID is accepted instead of colliding with stale tracking state.
+    pool.send_destroy_request();
+    pool.delete_proxy_id();
+}
+
+impl wl_proxy::protocols::wayland::wl_shm_pool::WlShmPoolHandler for TrackingShmPoolHandler {
+    fn handle_create_buffer(
+        &mut self,
+        slf: &Rc<WlShmPool>,
+        id: &Rc<WlBuffer>,
+        offset: i32,
+        width: i32,
+        height: i32,
+        stride: i32,
+        format: WlShmFormat,
+    ) {
+        if let Some(manager) = self.manager.upgrade() {
+            id.set_handler(tracking_buffer_handler(&manager));
+            manager.borrow_mut().record_buffer(id, width, height);
+        }
+        slf.send_create_buffer(id, offset, width, height, stride, format);
+    }
+
+    fn handle_destroy(&mut self, slf: &Rc<WlShmPool>) {
+        destroy_tracked_shm_pool(slf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_diag() -> Rc<RefCell<DiagRateLimiter>> {
+        Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())))
+    }
+
+    #[test]
+    fn parses_strict_hex_colors() {
+        assert_eq!(
+            "#1a2B3c".parse::<Color>().unwrap(),
+            Color::rgb(0x1a, 0x2b, 0x3c)
+        );
+        assert!("1a2b3c".parse::<Color>().is_err());
+        assert!("#12345".parse::<Color>().is_err());
+        assert!("#12345x".parse::<Color>().is_err());
+    }
+
+    #[test]
+    fn tracked_shm_pool_destroy_forwards_before_deleting_id() {
+        #[derive(Default)]
+        struct FakePool {
+            calls: RefCell<Vec<&'static str>>,
+        }
+
+        impl TrackedShmPoolDestroy for FakePool {
+            fn send_destroy_request(&self) {
+                self.calls.borrow_mut().push("destroy");
+            }
+
+            fn delete_proxy_id(&self) {
+                self.calls.borrow_mut().push("delete-id");
+            }
+        }
+
+        let pool = FakePool::default();
+        destroy_tracked_shm_pool(&pool);
+
+        assert_eq!(*pool.calls.borrow(), ["destroy", "delete-id"]);
+    }
+
+    #[test]
+    fn retired_decoration_buffer_waits_for_release_before_destroy() {
+        #[derive(Default)]
+        struct FakeBuffer {
+            calls: RefCell<Vec<&'static str>>,
+        }
+
+        impl ProxyDecorationBufferDestroy for FakeBuffer {
+            fn send_destroy_request(&self) {
+                self.calls.borrow_mut().push("destroy");
+            }
+
+            fn delete_proxy_id(&self) {
+                self.calls.borrow_mut().push("delete-id");
+            }
+        }
+
+        let buffer = FakeBuffer::default();
+        let lifecycle = DecorationBufferLifecycle::default();
+
+        retire_proxy_decoration_buffer(&buffer, &lifecycle);
+        assert!(buffer.calls.borrow().is_empty());
+
+        release_proxy_decoration_buffer(&buffer, &lifecycle);
+        assert_eq!(*buffer.calls.borrow(), ["destroy", "delete-id"]);
+
+        release_proxy_decoration_buffer(&buffer, &lifecycle);
+        force_destroy_proxy_decoration_buffer(&buffer, &lifecycle);
+        assert_eq!(*buffer.calls.borrow(), ["destroy", "delete-id"]);
+    }
+
+    #[test]
+    fn released_decoration_buffer_destroys_when_retired() {
+        #[derive(Default)]
+        struct FakeBuffer {
+            calls: RefCell<Vec<&'static str>>,
+        }
+
+        impl ProxyDecorationBufferDestroy for FakeBuffer {
+            fn send_destroy_request(&self) {
+                self.calls.borrow_mut().push("destroy");
+            }
+
+            fn delete_proxy_id(&self) {
+                self.calls.borrow_mut().push("delete-id");
+            }
+        }
+
+        let buffer = FakeBuffer::default();
+        let lifecycle = DecorationBufferLifecycle::default();
+
+        release_proxy_decoration_buffer(&buffer, &lifecycle);
+        assert!(buffer.calls.borrow().is_empty());
+
+        retire_proxy_decoration_buffer(&buffer, &lifecycle);
+        assert_eq!(*buffer.calls.borrow(), ["destroy", "delete-id"]);
+    }
+
+    #[test]
+    fn force_destroy_decoration_buffer_uses_protocol_order_once() {
+        #[derive(Default)]
+        struct FakeBuffer {
+            calls: RefCell<Vec<&'static str>>,
+        }
+
+        impl ProxyDecorationBufferDestroy for FakeBuffer {
+            fn send_destroy_request(&self) {
+                self.calls.borrow_mut().push("destroy");
+            }
+
+            fn delete_proxy_id(&self) {
+                self.calls.borrow_mut().push("delete-id");
+            }
+        }
+
+        let buffer = FakeBuffer::default();
+        let lifecycle = DecorationBufferLifecycle::default();
+
+        force_destroy_proxy_decoration_buffer(&buffer, &lifecycle);
+        force_destroy_proxy_decoration_buffer(&buffer, &lifecycle);
+
+        assert_eq!(*buffer.calls.borrow(), ["destroy", "delete-id"]);
+    }
+
+    #[test]
+    fn geometry_expand_and_contract_offsets_content() {
+        let expanded = BorderGeometry::expand(Size::new(640, 480), 4).unwrap();
+        assert_eq!(expanded.outer, Size::new(648, 488));
+        assert_eq!(expanded.content_origin, Point { x: 4, y: 4 });
+        assert_eq!(expanded.top_thickness, 4);
+    }
+
+    #[test]
+    fn label_band_keeps_default_side_border_but_makes_label_visible() {
+        let config = BorderConfig {
+            enabled: true,
+            label: sanitize_label("work"),
+            ..BorderConfig::default()
+        };
+        let plan = decoration_plan(&config, Size::new(640, 480), VisualState::default()).unwrap();
+
+        assert_eq!(plan.geometry.thickness, DEFAULT_BORDER_THICKNESS);
+        assert_eq!(plan.geometry.top_thickness, MIN_LABEL_BAND_HEIGHT);
+        assert_eq!(
+            plan.geometry.content_origin,
+            Point {
+                x: DEFAULT_BORDER_THICKNESS as i32,
+                y: MIN_LABEL_BAND_HEIGHT as i32,
+            }
+        );
+        assert_eq!(plan.geometry.outer, Size::new(648, 494));
+
+        let pixels = draw_decoration(&DrawInput {
+            geometry: plan.geometry,
+            color: Color::BLACK,
+            label: plan.label,
+            label_position: plan.label_position,
+        })
+        .unwrap();
+
+        assert!(
+            pixels
+                .chunks_exact(4)
+                .any(|px| px == Color::WHITE.argb8888_bytes())
+        );
+    }
+
+    #[test]
+    fn oversized_labeled_surface_keeps_bounded_label_decoration() {
+        let config = BorderConfig {
+            enabled: true,
+            label: sanitize_label("work"),
+            ..BorderConfig::default()
+        };
+        let plan = decoration_plan(
+            &config,
+            Size::new(MAX_DECORATION_DIMENSION, MAX_DECORATION_DIMENSION),
+            VisualState::default(),
+        )
+        .unwrap();
+
+        assert!(plan.geometry.outer.width <= MAX_LABEL_FALLBACK_WIDTH);
+        assert_eq!(
+            plan.geometry.outer.height,
+            MIN_LABEL_BAND_HEIGHT + DEFAULT_BORDER_THICKNESS
+        );
+        assert!(
+            draw_decoration(&DrawInput {
+                geometry: plan.geometry,
+                color: Color::BLACK,
+                label: plan.label,
+                label_position: plan.label_position,
+            })
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn window_geometry_expansion_covers_outer_border() {
+        assert_eq!(
+            expand_window_geometry_for_border(WindowGeometry::new(8, 9, 100, 50), 4),
+            Some(WindowGeometry::new(4, 5, 108, 58))
+        );
+        assert_eq!(
+            expand_window_geometry_for_decoration(WindowGeometry::new(8, 20, 100, 50), 4, true),
+            Some(WindowGeometry::new(4, 10, 108, 64))
+        );
+    }
+
+    #[test]
+    fn window_geometry_expansion_rejects_invalid_or_overflowing_values() {
+        assert_eq!(
+            expand_window_geometry_for_border(WindowGeometry::new(0, 0, 0, 50), 4),
+            None
+        );
+        assert_eq!(
+            expand_window_geometry_for_border(WindowGeometry::new(i32::MIN, 0, 10, 10), 4),
+            None
+        );
+        assert_eq!(
+            expand_window_geometry_for_border(WindowGeometry::new(0, 0, i32::MAX, 10), 4),
+            None
+        );
+    }
+
+    #[test]
+    fn manager_translates_window_geometry_for_decorated_toplevels_only() {
+        let mut manager = DecorationManager::new(
+            BorderConfig {
+                enabled: true,
+                thickness: 6,
+                ..BorderConfig::default()
+            },
+            test_diag(),
+        );
+        let surface_id = 42;
+        let geometry = WindowGeometry::new(10, 20, 300, 200);
+
+        assert_eq!(
+            manager.translate_window_geometry_for_surface_id(surface_id, geometry),
+            geometry
+        );
+
+        manager.surfaces.insert(surface_id, SurfaceState::default());
+        assert_eq!(
+            manager.translate_window_geometry_for_surface_id(surface_id, geometry),
+            geometry
+        );
+
+        manager.surfaces.get_mut(&surface_id).unwrap().toplevel = true;
+        assert_eq!(
+            manager.translate_window_geometry_for_surface_id(surface_id, geometry),
+            WindowGeometry::new(4, 14, 312, 212)
+        );
+
+        manager
+            .surfaces
+            .get_mut(&surface_id)
+            .unwrap()
+            .visual
+            .fullscreen = true;
+        assert_eq!(
+            manager.translate_window_geometry_for_surface_id(surface_id, geometry),
+            geometry
+        );
+    }
+
+    #[test]
+    fn manager_translates_label_band_for_default_labeled_borders() {
+        let mut manager = DecorationManager::new(
+            BorderConfig {
+                enabled: true,
+                label: sanitize_label("work"),
+                ..BorderConfig::default()
+            },
+            test_diag(),
+        );
+        let surface_id = 42;
+        let geometry = WindowGeometry::new(10, 20, 300, 200);
+
+        manager.surfaces.insert(surface_id, SurfaceState::default());
+        manager.surfaces.get_mut(&surface_id).unwrap().toplevel = true;
+
+        assert_eq!(
+            manager.translate_window_geometry_for_surface_id(surface_id, geometry),
+            WindowGeometry::new(6, 10, 308, 214)
+        );
+    }
+
+    #[test]
+    fn fullscreen_disables_decoration_plan() {
+        let config = BorderConfig {
+            enabled: true,
+            thickness: 3,
+            ..BorderConfig::default()
+        };
+        assert!(decoration_plan(&config, Size::new(100, 100), VisualState::default()).is_some());
+        assert!(
+            decoration_plan(
+                &config,
+                Size::new(100, 100),
+                VisualState {
+                    fullscreen: true,
+                    ..VisualState::default()
+                }
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn decoration_plan_rejects_oversized_outer_dimensions() {
+        let config = BorderConfig {
+            enabled: true,
+            thickness: 1,
+            ..BorderConfig::default()
+        };
+
+        assert!(
+            decoration_plan(
+                &config,
+                Size::new(MAX_DECORATION_DIMENSION, 100),
+                VisualState::default()
+            )
+            .is_none()
+        );
+        assert!(
+            decoration_plan(
+                &config,
+                Size::new(100, MAX_DECORATION_DIMENSION),
+                VisualState::default()
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn decoration_buffer_layout_enforces_allocation_bounds() {
+        assert_eq!(
+            decoration_buffer_layout(Size::new(4096, 4096)).map(|layout| layout.len),
+            Some(MAX_DECORATION_BUFFER_BYTES)
+        );
+        assert!(decoration_buffer_layout(Size::new(4096, 4097)).is_none());
+        assert!(decoration_buffer_layout(Size::new(u32::MAX, u32::MAX)).is_none());
+    }
+
+    #[test]
+    fn draw_decoration_rejects_oversized_geometry_before_allocation() {
+        let input = DrawInput {
+            geometry: BorderGeometry {
+                content: Size::new(u32::MAX, u32::MAX),
+                outer: Size::new(u32::MAX, u32::MAX),
+                content_origin: Point { x: 1, y: 1 },
+                thickness: 1,
+                top_thickness: 1,
+            },
+            color: Color::rgb(1, 2, 3),
+            label: sanitize_label("work"),
+            label_position: LabelPosition::TopLeft,
+        };
+
+        assert!(draw_decoration(&input).is_none());
+    }
+
+    #[test]
+    fn label_sanitization_bounds_and_strips_controls() {
+        let raw = format!("work\nvm\t{}", "x".repeat(100));
+        let label = sanitize_label(&raw).unwrap();
+        assert!(!label.as_str().contains('\n'));
+        assert!(!label.as_str().contains('\t'));
+        assert!(label.as_str().chars().count() <= MAX_LABEL_CHARS);
+        assert_eq!(sanitize_label("\n\t"), None);
+    }
+
+    #[test]
+    fn draw_input_contains_only_proxy_owned_render_data() {
+        let input = DrawInput {
+            geometry: BorderGeometry::expand(Size::new(10, 10), 2).unwrap(),
+            color: Color::rgb(1, 2, 3),
+            label: sanitize_label("work"),
+            label_position: LabelPosition::TopLeft,
+        };
+        let pixels = draw_decoration(&input).unwrap();
+        assert_eq!(pixels.len(), 14 * 14 * 4);
+        assert!(
+            pixels
+                .chunks_exact(4)
+                .any(|px| px == Color::rgb(1, 2, 3).argb8888_bytes())
+        );
+    }
+
+    #[test]
+    fn draw_path_takes_no_guest_buffer_or_fd_inputs() {
+        fn accepts_only_render_metadata(_: DrawInput) {}
+
+        accepts_only_render_metadata(DrawInput {
+            geometry: BorderGeometry::expand(Size::new(32, 24), 4).unwrap(),
+            color: Color::rgb(10, 20, 30),
+            label: sanitize_label("work"),
+            label_position: LabelPosition::TopCenter,
+        });
+    }
+
+    #[test]
+    fn buffer_dimensions_apply_scale_and_transform_without_reading_buffer() {
+        let dims = BufferDimensions {
+            width: 200,
+            height: 100,
+        };
+        assert_eq!(
+            dims.surface_size(2, WlOutputTransform::NORMAL),
+            Some(Size::new(100, 50))
+        );
+        assert_eq!(
+            dims.surface_size(2, WlOutputTransform::_90),
+            Some(Size::new(50, 100))
+        );
+    }
+
+    #[test]
+    fn viewport_destination_then_source_then_buffer_size_priority() {
+        let mut buffers = HashMap::new();
+        buffers.insert(
+            1,
+            BufferDimensions {
+                width: 400,
+                height: 200,
+            },
+        );
+        let mut state = SurfaceState {
+            current_buffer: Some(1),
+            current_scale: 2,
+            viewport: ViewportState {
+                current_source: Some(ViewportSource {
+                    width: Fixed::from_i32_saturating(120),
+                    height: Fixed::from_i32_saturating(80),
+                }),
+                current_destination: Some(Size::new(50, 40)),
+                ..ViewportState::default()
+            },
+            ..SurfaceState::default()
+        };
+
+        assert_eq!(state.committed_size(&buffers), Some(Size::new(50, 40)));
+
+        state.viewport.current_destination = None;
+        assert_eq!(state.committed_size(&buffers), Some(Size::new(120, 80)));
+
+        state.viewport.current_source = None;
+        assert_eq!(state.committed_size(&buffers), Some(Size::new(200, 100)));
+    }
+
+    #[test]
+    fn viewport_destroy_queues_reset_to_buffer_size() {
+        let mut buffers = HashMap::new();
+        buffers.insert(
+            1,
+            BufferDimensions {
+                width: 300,
+                height: 150,
+            },
+        );
+        let mut state = SurfaceState {
+            current_buffer: Some(1),
+            viewport: ViewportState {
+                current_source: Some(ViewportSource {
+                    width: Fixed::from_i32_saturating(90),
+                    height: Fixed::from_i32_saturating(60),
+                }),
+                current_destination: Some(Size::new(45, 30)),
+                ..ViewportState::default()
+            },
+            ..SurfaceState::default()
+        };
+
+        assert_eq!(state.committed_size(&buffers), Some(Size::new(45, 30)));
+
+        state.viewport.destroy();
+        state.viewport.apply_pending();
+
+        assert_eq!(state.viewport.current_source, None);
+        assert_eq!(state.viewport.current_destination, None);
+        assert_eq!(state.committed_size(&buffers), Some(Size::new(300, 150)));
+    }
+
+    #[test]
+    fn destroyed_current_buffer_dimensions_preserve_last_committed_size() {
+        let mut buffers = HashMap::new();
+        buffers.insert(
+            1,
+            BufferDimensions {
+                width: 400,
+                height: 200,
+            },
+        );
+        let mut state = SurfaceState {
+            pending_buffer: Some(Some(1)),
+            ..SurfaceState::default()
+        };
+
+        state.apply_commit_state(&buffers);
+        assert_eq!(state.current_size, Some(Size::new(400, 200)));
+
+        buffers.remove(&1);
+        state.apply_commit_state(&buffers);
+
+        assert_eq!(state.current_buffer, Some(1));
+        assert_eq!(state.current_size, Some(Size::new(400, 200)));
+    }
+
+    #[test]
+    fn committed_attach_none_clears_last_committed_size() {
+        let mut buffers = HashMap::new();
+        buffers.insert(
+            1,
+            BufferDimensions {
+                width: 400,
+                height: 200,
+            },
+        );
+        let mut state = SurfaceState {
+            current_buffer: Some(1),
+            current_size: Some(Size::new(400, 200)),
+            pending_buffer: Some(None),
+            ..SurfaceState::default()
+        };
+
+        state.apply_commit_state(&buffers);
+
+        assert_eq!(state.current_buffer, None);
+        assert_eq!(state.current_size, None);
+    }
+
+    #[test]
+    fn viewport_unset_requests_clear_pending_state() {
+        let mut viewport = ViewportState {
+            current_source: Some(ViewportSource {
+                width: Fixed::from_i32_saturating(90),
+                height: Fixed::from_i32_saturating(60),
+            }),
+            current_destination: Some(Size::new(45, 30)),
+            ..ViewportState::default()
+        };
+
+        viewport.set_source(
+            Fixed::from_i32_saturating(-1),
+            Fixed::from_i32_saturating(-1),
+            Fixed::from_i32_saturating(-1),
+            Fixed::from_i32_saturating(-1),
+        );
+        viewport.set_destination(-1, -1);
+        viewport.apply_pending();
+
+        assert_eq!(viewport.current_source, None);
+        assert_eq!(viewport.current_destination, None);
+    }
+
+    #[test]
+    fn xdg_state_parser_detects_active_fullscreen() {
+        let mut states = Vec::new();
+        states.extend_from_slice(&XdgToplevelState::ACTIVATED.0.to_ne_bytes());
+        states.extend_from_slice(&XdgToplevelState::FULLSCREEN.0.to_ne_bytes());
+        assert!(xdg_state_contains(&states, XdgToplevelState::ACTIVATED.0));
+        assert!(xdg_state_contains(&states, XdgToplevelState::FULLSCREEN.0));
+        assert!(!xdg_state_contains(&states, 999));
+    }
+}

--- a/packages/d2b-wayland-proxy/src/dmabuf.rs
+++ b/packages/d2b-wayland-proxy/src/dmabuf.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     ffi::CString,
     fs::File,
     io::{self, Seek, SeekFrom, Write},
@@ -22,7 +22,10 @@ use wl_proxy::protocols::{
     wayland::{wl_buffer::WlBuffer, wl_surface::WlSurface},
 };
 
-use crate::diag::DiagRateLimiter;
+use crate::{
+    decoration::{SharedDecorationManager, tracking_buffer_handler},
+    diag::DiagRateLimiter,
+};
 
 pub const LINEAR_MODIFIER: u64 = 0;
 pub const INVALID_MODIFIER: u64 = 0x00ff_ffff_ffff_ffff;
@@ -204,11 +207,20 @@ fn parse_u64(s: &str) -> Option<u64> {
 pub struct DmabufHandler {
     filters: Arc<DmabufFilterList>,
     diag: Rc<RefCell<DiagRateLimiter>>,
+    decoration: Option<SharedDecorationManager>,
 }
 
 impl DmabufHandler {
-    pub fn new(filters: Arc<DmabufFilterList>, diag: Rc<RefCell<DiagRateLimiter>>) -> Self {
-        Self { filters, diag }
+    pub fn new(
+        filters: Arc<DmabufFilterList>,
+        diag: Rc<RefCell<DiagRateLimiter>>,
+        decoration: Option<SharedDecorationManager>,
+    ) -> Self {
+        Self {
+            filters,
+            diag,
+            decoration,
+        }
     }
 }
 
@@ -265,6 +277,7 @@ impl ZwpLinuxDmabufV1Handler for DmabufHandler {
         params_id.set_handler(DmabufBufferParamsHandler::new(
             self.filters.clone(),
             self.diag.clone(),
+            self.decoration.clone(),
         ));
         slf.send_create_params(params_id);
     }
@@ -289,8 +302,16 @@ impl DmabufPlane {
 struct DmabufBufferParamsHandler {
     filters: Arc<DmabufFilterList>,
     diag: Rc<RefCell<DiagRateLimiter>>,
+    decoration: Option<SharedDecorationManager>,
     planes: Vec<DmabufPlane>,
     invalid_plane_count: usize,
+    pending_create_dimensions: VecDeque<BufferDimensions>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BufferDimensions {
+    width: i32,
+    height: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -303,12 +324,18 @@ enum DmabufCreateAction {
 }
 
 impl DmabufBufferParamsHandler {
-    fn new(filters: Arc<DmabufFilterList>, diag: Rc<RefCell<DiagRateLimiter>>) -> Self {
+    fn new(
+        filters: Arc<DmabufFilterList>,
+        diag: Rc<RefCell<DiagRateLimiter>>,
+        decoration: Option<SharedDecorationManager>,
+    ) -> Self {
         Self {
             filters,
             diag,
+            decoration,
             planes: Vec::new(),
             invalid_plane_count: 0,
+            pending_create_dimensions: VecDeque::new(),
         }
     }
 
@@ -495,7 +522,7 @@ impl DmabufCreateSink for ProxyCreateSink<'_> {
 impl ZwpLinuxBufferParamsV1Handler for DmabufBufferParamsHandler {
     fn handle_add(
         &mut self,
-        _slf: &Rc<ZwpLinuxBufferParamsV1>,
+        slf: &Rc<ZwpLinuxBufferParamsV1>,
         fd: &Rc<OwnedFd>,
         plane_idx: u32,
         offset: u32,
@@ -503,6 +530,10 @@ impl ZwpLinuxBufferParamsV1Handler for DmabufBufferParamsHandler {
         modifier_hi: u32,
         modifier_lo: u32,
     ) {
+        if self.filters.is_empty() {
+            slf.send_add(fd, plane_idx, offset, stride, modifier_hi, modifier_lo);
+            return;
+        }
         self.store_plane(fd, plane_idx, offset, stride, modifier_hi, modifier_lo);
     }
 
@@ -514,11 +545,21 @@ impl ZwpLinuxBufferParamsV1Handler for DmabufBufferParamsHandler {
         format: u32,
         flags: ZwpLinuxBufferParamsV1Flags,
     ) {
+        if self.filters.is_empty() {
+            self.pending_create_dimensions
+                .push_back(BufferDimensions { width, height });
+            slf.send_create(width, height, format, flags);
+            return;
+        }
         let mut sink = ProxyCreateSink {
             params: slf,
             buffer: None,
             diag: self.diag.clone(),
         };
+        if matches!(self.create_action(format), DmabufCreateAction::Forward) {
+            self.pending_create_dimensions
+                .push_back(BufferDimensions { width, height });
+        }
         self.handle_create_with_sink(&mut sink, width, height, format, flags);
     }
 
@@ -531,12 +572,47 @@ impl ZwpLinuxBufferParamsV1Handler for DmabufBufferParamsHandler {
         format: u32,
         flags: ZwpLinuxBufferParamsV1Flags,
     ) {
+        if self.filters.is_empty() {
+            if let Some(decoration) = &self.decoration {
+                buffer_id.set_handler(tracking_buffer_handler(decoration));
+                decoration
+                    .borrow_mut()
+                    .record_buffer(buffer_id, width, height);
+            }
+            slf.send_create_immed(buffer_id, width, height, format, flags);
+            return;
+        }
         let mut sink = ProxyCreateSink {
             params: slf,
             buffer: Some(buffer_id),
             diag: self.diag.clone(),
         };
+        if matches!(self.create_action(format), DmabufCreateAction::Forward)
+            && let Some(decoration) = &self.decoration
+        {
+            buffer_id.set_handler(tracking_buffer_handler(decoration));
+            decoration
+                .borrow_mut()
+                .record_buffer(buffer_id, width, height);
+        }
         self.handle_create_immed_with_sink(&mut sink, width, height, format, flags);
+    }
+
+    fn handle_created(&mut self, slf: &Rc<ZwpLinuxBufferParamsV1>, buffer: &Rc<WlBuffer>) {
+        if let (Some(dimensions), Some(decoration)) =
+            (self.pending_create_dimensions.pop_front(), &self.decoration)
+        {
+            buffer.set_handler(tracking_buffer_handler(decoration));
+            decoration
+                .borrow_mut()
+                .record_buffer(buffer, dimensions.width, dimensions.height);
+        }
+        slf.send_created(buffer);
+    }
+
+    fn handle_failed(&mut self, slf: &Rc<ZwpLinuxBufferParamsV1>) {
+        self.pending_create_dimensions.pop_front();
+        slf.send_failed();
     }
 }
 
@@ -837,7 +913,7 @@ mod tests {
                 modifier: Some(LINEAR_MODIFIER),
             }],
         ));
-        let mut handler = DmabufBufferParamsHandler::new(filters, diag());
+        let mut handler = DmabufBufferParamsHandler::new(filters, diag(), None);
         handler.planes.push(DmabufPlane {
             fd: Rc::new(OwnedFd::from(File::open("/dev/null").unwrap())),
             plane_idx: 0,
@@ -957,6 +1033,96 @@ mod tests {
     }
 
     #[test]
+    fn create_dimensions_are_queued_for_multiple_async_creates() {
+        let filters = Arc::new(DmabufFilterList::default());
+        let mut handler = DmabufBufferParamsHandler::new(filters, diag(), None);
+
+        handler
+            .pending_create_dimensions
+            .push_back(BufferDimensions {
+                width: 640,
+                height: 480,
+            });
+        handler
+            .pending_create_dimensions
+            .push_back(BufferDimensions {
+                width: 800,
+                height: 600,
+            });
+
+        assert_eq!(
+            handler.pending_create_dimensions.pop_front(),
+            Some(BufferDimensions {
+                width: 640,
+                height: 480
+            })
+        );
+        assert_eq!(
+            handler.pending_create_dimensions.pop_front(),
+            Some(BufferDimensions {
+                width: 800,
+                height: 600
+            })
+        );
+    }
+
+    #[test]
+    fn failed_create_drops_oldest_pending_dimensions() {
+        let filters = Arc::new(DmabufFilterList::default());
+        let mut handler = DmabufBufferParamsHandler::new(filters, diag(), None);
+        handler
+            .pending_create_dimensions
+            .push_back(BufferDimensions {
+                width: 640,
+                height: 480,
+            });
+        handler
+            .pending_create_dimensions
+            .push_back(BufferDimensions {
+                width: 800,
+                height: 600,
+            });
+
+        handler.pending_create_dimensions.pop_front();
+
+        assert_eq!(
+            handler.pending_create_dimensions.pop_front(),
+            Some(BufferDimensions {
+                width: 800,
+                height: 600,
+            })
+        );
+    }
+
+    #[test]
+    fn invalid_create_dimensions_still_reserve_queue_slot() {
+        let filters = Arc::new(DmabufFilterList::default());
+        let mut handler = DmabufBufferParamsHandler::new(filters, diag(), None);
+        handler
+            .pending_create_dimensions
+            .push_back(BufferDimensions {
+                width: 0,
+                height: 480,
+            });
+        handler
+            .pending_create_dimensions
+            .push_back(BufferDimensions {
+                width: 800,
+                height: 600,
+            });
+
+        handler.pending_create_dimensions.pop_front();
+
+        assert_eq!(
+            handler.pending_create_dimensions.pop_front(),
+            Some(BufferDimensions {
+                width: 800,
+                height: 600,
+            })
+        );
+    }
+
+    #[test]
     fn allowed_create_immed_forwards_planes_before_create_immed() {
         let mut sink = FakeCreateSink::default();
         handler_with_plane(0x0100_0000_0000_0001).handle_create_immed_with_sink(
@@ -1055,7 +1221,7 @@ mod tests {
     fn invalid_plane_set_fails_create_without_unbounded_examples() {
         let format = 0x3432_5258u32;
         let filters = Arc::new(DmabufFilterList::new(&[], &[]));
-        let mut handler = DmabufBufferParamsHandler::new(filters, diag());
+        let mut handler = DmabufBufferParamsHandler::new(filters, diag(), None);
         handler.invalid_plane_count = 100;
 
         assert_eq!(

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -20,9 +20,11 @@ use std::{
 };
 use wl_proxy::{
     client::{Client, ClientHandler},
+    fixed::Fixed,
     object::{Object, ObjectCoreApi, ObjectRcUtils},
     protocols::{
         ObjectInterface,
+        drm::wl_drm::{WlDrm, WlDrmHandler},
         linux_dmabuf_v1::zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1,
         stream::{
             wl_eglstream::WlEglstreamHandleType,
@@ -30,14 +32,25 @@ use wl_proxy::{
                 WlEglstreamDisplay, WlEglstreamDisplayCap, WlEglstreamDisplayHandler,
             },
         },
+        viewporter::{
+            wp_viewport::{WpViewport, WpViewportHandler},
+            wp_viewporter::{WpViewporter, WpViewporterHandler},
+        },
         wayland::{
             wl_buffer::WlBuffer,
+            wl_compositor::{WlCompositor, WlCompositorHandler},
             wl_data_device::{WlDataDevice, WlDataDeviceHandler},
             wl_data_device_manager::{WlDataDeviceManager, WlDataDeviceManagerHandler},
             wl_data_offer::{WlDataOffer, WlDataOfferHandler},
             wl_data_source::{WlDataSource, WlDataSourceHandler},
             wl_display::{WlDisplay, WlDisplayHandler},
+            wl_output::WlOutputTransform,
             wl_registry::{WlRegistry, WlRegistryHandler},
+            wl_shm::{WlShm, WlShmHandler},
+            wl_shm_pool::WlShmPool,
+            wl_subcompositor::{WlSubcompositor, WlSubcompositorHandler},
+            wl_subsurface::{WlSubsurface, WlSubsurfaceHandler},
+            wl_surface::{WlSurface, WlSurfaceHandler},
         },
         xdg_shell::{
             xdg_surface::{XdgSurface, XdgSurfaceHandler},
@@ -57,6 +70,7 @@ use crate::{
         ClipboardGlobalDisposition, ClipboardMimePolicy, ClipboardRoute, MimeDecision,
         global_disposition,
     },
+    decoration::{SharedDecorationManager, WindowGeometry, tracking_shm_pool_handler},
     diag::{DiagRateLimiter, DropReason, bounded_error_detail},
     dmabuf::DmabufHandler,
     policy::FilterPolicy,
@@ -70,6 +84,7 @@ pub struct FilterStateHandler {
     policy: Rc<FilterPolicy>,
     diag: Rc<RefCell<DiagRateLimiter>>,
     clipboard: Rc<RefCell<VirtualClipboardState>>,
+    decoration: Option<SharedDecorationManager>,
 }
 
 impl FilterStateHandler {
@@ -77,11 +92,13 @@ impl FilterStateHandler {
         policy: Rc<FilterPolicy>,
         diag: Rc<RefCell<DiagRateLimiter>>,
         clipboard: Rc<RefCell<VirtualClipboardState>>,
+        decoration: Option<SharedDecorationManager>,
     ) -> Self {
         Self {
             policy,
             diag,
             clipboard,
+            decoration,
         }
     }
 }
@@ -93,6 +110,7 @@ impl StateHandler for FilterStateHandler {
             self.policy.clone(),
             self.diag.clone(),
             self.clipboard.clone(),
+            self.decoration.clone(),
         );
     }
 }
@@ -108,11 +126,13 @@ pub fn install_client_handlers(
     policy: Rc<FilterPolicy>,
     diag: Rc<RefCell<DiagRateLimiter>>,
     clipboard: Rc<RefCell<VirtualClipboardState>>,
+    decoration: Option<SharedDecorationManager>,
 ) {
     let handler = FilterDisplayHandler {
         policy: policy.clone(),
         diag,
         clipboard,
+        decoration,
     };
     client.display().set_handler(handler);
     log::debug!("[d2b-wlproxy] vm={} new client connected", policy.vm_name);
@@ -123,6 +143,7 @@ struct FilterDisplayHandler {
     policy: Rc<FilterPolicy>,
     diag: Rc<RefCell<DiagRateLimiter>>,
     clipboard: Rc<RefCell<VirtualClipboardState>>,
+    decoration: Option<SharedDecorationManager>,
 }
 
 impl WlDisplayHandler for FilterDisplayHandler {
@@ -135,6 +156,7 @@ impl WlDisplayHandler for FilterDisplayHandler {
             self.policy.clone(),
             self.diag.clone(),
             self.clipboard.clone(),
+            self.decoration.clone(),
         ));
     }
 }
@@ -890,6 +912,7 @@ pub struct FilterRegistryHandler {
     policy: Rc<FilterPolicy>,
     diag: Rc<RefCell<DiagRateLimiter>>,
     clipboard: Rc<RefCell<VirtualClipboardState>>,
+    decoration: Option<SharedDecorationManager>,
     /// Server global names intentionally hidden from this client.
     hidden_globals: HashSet<u32>,
     /// Server global names actually advertised to this client, with the
@@ -924,11 +947,13 @@ impl FilterRegistryHandler {
         policy: Rc<FilterPolicy>,
         diag: Rc<RefCell<DiagRateLimiter>>,
         clipboard: Rc<RefCell<VirtualClipboardState>>,
+        decoration: Option<SharedDecorationManager>,
     ) -> Self {
         Self {
             policy,
             diag,
             clipboard,
+            decoration,
             hidden_globals: HashSet::new(),
             advertised_globals: HashMap::new(),
             synthetic_clipboard_name: None,
@@ -1052,6 +1077,11 @@ impl WlRegistryHandler for FilterRegistryHandler {
         interface: ObjectInterface,
         version: u32,
     ) {
+        if let Some(decoration) = &self.decoration {
+            decoration
+                .borrow_mut()
+                .observe_global(slf, name, interface, version);
+        }
         let (synthetic, decision) = self.prepare_global(name, interface, version);
         if let Some(global) = synthetic {
             slf.send_global(global.name, global.interface, global.version);
@@ -1133,6 +1163,7 @@ impl WlRegistryHandler for FilterRegistryHandler {
             Some(wm_base) => {
                 wm_base.set_handler(FilterXdgWmBaseHandler {
                     policy: self.policy.clone(),
+                    decoration: self.decoration.clone(),
                 });
             }
             _ => match id.try_downcast::<WlEglstreamDisplay>() {
@@ -1140,16 +1171,57 @@ impl WlRegistryHandler for FilterRegistryHandler {
                     eglstream_display.set_handler(FilterEglstreamDisplayHandler {
                         vm: self.policy.vm_name.clone(),
                         diag: self.diag.clone(),
+                        decoration: self.decoration.clone(),
                     });
                 }
                 _ => {
+                    if let Some(compositor) = id.try_downcast::<WlCompositor>() {
+                        compositor.set_handler(FilterCompositorHandler {
+                            decoration: self.decoration.clone(),
+                        });
+                        slf.send_bind(name, compositor);
+                        return;
+                    }
+                    if let Some(shm) = id.try_downcast::<WlShm>() {
+                        shm.set_handler(FilterShmHandler {
+                            decoration: self.decoration.clone(),
+                        });
+                        slf.send_bind(name, shm);
+                        return;
+                    }
+                    if let Some(subcompositor) = id.try_downcast::<WlSubcompositor>() {
+                        if let Some(decoration) = &self.decoration {
+                            subcompositor.set_handler(FilterSubcompositorHandler {
+                                decoration: decoration.clone(),
+                            });
+                        }
+                        slf.send_bind(name, subcompositor);
+                        return;
+                    }
+                    if let Some(viewporter) = id.try_downcast::<WpViewporter>()
+                        && let Some(decoration) = &self.decoration
+                    {
+                        viewporter.set_handler(FilterViewporterHandler {
+                            decoration: decoration.clone(),
+                        });
+                    }
                     if let Some(dmabuf) = id.try_downcast::<ZwpLinuxDmabufV1>()
-                        && !self.policy.dmabuf_filters.is_empty()
+                        && (!self.policy.dmabuf_filters.is_empty() || self.decoration.is_some())
                     {
                         dmabuf.set_handler(DmabufHandler::new(
                             self.policy.dmabuf_filters.clone(),
                             self.diag.clone(),
+                            self.decoration.clone(),
                         ));
+                    }
+                    if let Some(drm) = id.try_downcast::<WlDrm>() {
+                        if let Some(decoration) = &self.decoration {
+                            drm.set_handler(FilterDrmHandler {
+                                decoration: decoration.clone(),
+                            });
+                        }
+                        slf.send_bind(name, drm);
+                        return;
                     }
                 }
             },
@@ -1336,10 +1408,234 @@ impl WlDataOfferHandler for VirtualOfferHandler {
     }
 }
 
+struct FilterCompositorHandler {
+    decoration: Option<SharedDecorationManager>,
+}
+
+impl WlCompositorHandler for FilterCompositorHandler {
+    fn handle_create_surface(&mut self, slf: &Rc<WlCompositor>, id: &Rc<WlSurface>) {
+        if let Some(decoration) = &self.decoration {
+            decoration.borrow_mut().register_surface(id);
+            id.set_handler(FilterSurfaceHandler {
+                decoration: decoration.clone(),
+            });
+        }
+        slf.send_create_surface(id);
+    }
+}
+
+struct FilterSubcompositorHandler {
+    decoration: SharedDecorationManager,
+}
+
+impl WlSubcompositorHandler for FilterSubcompositorHandler {
+    fn handle_destroy(&mut self, slf: &Rc<WlSubcompositor>) {
+        slf.send_destroy();
+    }
+
+    fn handle_get_subsurface(
+        &mut self,
+        slf: &Rc<WlSubcompositor>,
+        id: &Rc<WlSubsurface>,
+        surface: &Rc<WlSurface>,
+        parent: &Rc<WlSurface>,
+    ) {
+        id.set_handler(FilterSubsurfaceHandler {
+            decoration: self.decoration.clone(),
+            parent: Rc::downgrade(parent),
+            surface: Rc::downgrade(surface),
+        });
+        slf.send_get_subsurface(id, surface, parent);
+        self.decoration
+            .borrow_mut()
+            .register_guest_subsurface(surface, parent);
+    }
+}
+
+struct FilterSubsurfaceHandler {
+    decoration: SharedDecorationManager,
+    parent: Weak<WlSurface>,
+    surface: Weak<WlSurface>,
+}
+
+impl FilterSubsurfaceHandler {
+    fn raise_decoration(&self) {
+        if let Some(parent) = self.parent.upgrade() {
+            if let Some(surface) = self.surface.upgrade() {
+                self.decoration
+                    .borrow_mut()
+                    .register_guest_subsurface(&surface, &parent);
+            } else {
+                self.decoration
+                    .borrow_mut()
+                    .raise_decoration_above_guest_subsurfaces(&parent);
+            }
+        }
+    }
+}
+
+impl WlSubsurfaceHandler for FilterSubsurfaceHandler {
+    fn handle_destroy(&mut self, slf: &Rc<WlSubsurface>) {
+        slf.send_destroy();
+        self.raise_decoration();
+    }
+
+    fn handle_set_position(&mut self, slf: &Rc<WlSubsurface>, x: i32, y: i32) {
+        slf.send_set_position(x, y);
+    }
+
+    fn handle_place_above(&mut self, slf: &Rc<WlSubsurface>, sibling: &Rc<WlSurface>) {
+        slf.send_place_above(sibling);
+        self.raise_decoration();
+    }
+
+    fn handle_place_below(&mut self, slf: &Rc<WlSubsurface>, sibling: &Rc<WlSurface>) {
+        slf.send_place_below(sibling);
+        self.raise_decoration();
+    }
+
+    fn handle_set_sync(&mut self, slf: &Rc<WlSubsurface>) {
+        slf.send_set_sync();
+    }
+
+    fn handle_set_desync(&mut self, slf: &Rc<WlSubsurface>) {
+        slf.send_set_desync();
+    }
+}
+
+struct FilterViewporterHandler {
+    decoration: SharedDecorationManager,
+}
+
+impl WpViewporterHandler for FilterViewporterHandler {
+    fn handle_destroy(&mut self, slf: &Rc<WpViewporter>) {
+        slf.send_destroy();
+    }
+
+    fn handle_get_viewport(
+        &mut self,
+        slf: &Rc<WpViewporter>,
+        id: &Rc<WpViewport>,
+        surface: &Rc<WlSurface>,
+    ) {
+        self.decoration.borrow_mut().surface_get_viewport(surface);
+        id.set_handler(FilterViewportHandler {
+            decoration: self.decoration.clone(),
+            surface: Rc::downgrade(surface),
+        });
+        slf.send_get_viewport(id, surface);
+    }
+}
+
+struct FilterViewportHandler {
+    decoration: SharedDecorationManager,
+    surface: Weak<WlSurface>,
+}
+
+impl WpViewportHandler for FilterViewportHandler {
+    fn handle_destroy(&mut self, slf: &Rc<WpViewport>) {
+        if let Some(surface) = self.surface.upgrade() {
+            self.decoration
+                .borrow_mut()
+                .surface_viewport_destroyed(&surface);
+        }
+        slf.send_destroy();
+    }
+
+    fn handle_set_source(
+        &mut self,
+        slf: &Rc<WpViewport>,
+        x: Fixed,
+        y: Fixed,
+        width: Fixed,
+        height: Fixed,
+    ) {
+        if let Some(surface) = self.surface.upgrade() {
+            self.decoration
+                .borrow_mut()
+                .surface_set_viewport_source(&surface, x, y, width, height);
+        }
+        slf.send_set_source(x, y, width, height);
+    }
+
+    fn handle_set_destination(&mut self, slf: &Rc<WpViewport>, width: i32, height: i32) {
+        if let Some(surface) = self.surface.upgrade() {
+            self.decoration
+                .borrow_mut()
+                .surface_set_viewport_destination(&surface, width, height);
+        }
+        slf.send_set_destination(width, height);
+    }
+}
+
+struct FilterShmHandler {
+    decoration: Option<SharedDecorationManager>,
+}
+
+impl WlShmHandler for FilterShmHandler {
+    fn handle_create_pool(
+        &mut self,
+        slf: &Rc<WlShm>,
+        id: &Rc<WlShmPool>,
+        fd: &Rc<OwnedFd>,
+        size: i32,
+    ) {
+        if let Some(decoration) = &self.decoration {
+            id.set_handler(tracking_shm_pool_handler(decoration));
+        }
+        slf.send_create_pool(id, fd, size);
+    }
+}
+
+struct FilterSurfaceHandler {
+    decoration: SharedDecorationManager,
+}
+
+impl WlSurfaceHandler for FilterSurfaceHandler {
+    fn handle_destroy(&mut self, slf: &Rc<WlSurface>) {
+        self.decoration.borrow_mut().surface_destroyed(slf);
+        // Ordinary forwarded wl_surface destruction uses wl-proxy's normal
+        // object lifetime. The shm-pool tracker owns the only cross-domain
+        // delete_id workaround because wl-cross-domain-proxy reuses pool IDs.
+        slf.send_destroy();
+    }
+
+    fn handle_attach(
+        &mut self,
+        slf: &Rc<WlSurface>,
+        buffer: Option<&Rc<WlBuffer>>,
+        x: i32,
+        y: i32,
+    ) {
+        self.decoration.borrow_mut().surface_attach(slf, buffer);
+        slf.send_attach(buffer, x, y);
+    }
+
+    fn handle_set_buffer_transform(&mut self, slf: &Rc<WlSurface>, transform: WlOutputTransform) {
+        self.decoration
+            .borrow_mut()
+            .surface_set_buffer_transform(slf, transform);
+        slf.send_set_buffer_transform(transform);
+    }
+
+    fn handle_set_buffer_scale(&mut self, slf: &Rc<WlSurface>, scale: i32) {
+        self.decoration
+            .borrow_mut()
+            .surface_set_buffer_scale(slf, scale);
+        slf.send_set_buffer_scale(scale);
+    }
+
+    fn handle_commit(&mut self, slf: &Rc<WlSurface>) {
+        slf.send_commit();
+        self.decoration.borrow_mut().surface_commit(slf);
+    }
+}
+
 /// Handler for `xdg_wm_base`: intercepts `get_xdg_surface` to install our
 /// surface handler on each new `xdg_surface`.
 struct FilterXdgWmBaseHandler {
     policy: Rc<FilterPolicy>,
+    decoration: Option<SharedDecorationManager>,
 }
 
 impl XdgWmBaseHandler for FilterXdgWmBaseHandler {
@@ -1347,13 +1643,15 @@ impl XdgWmBaseHandler for FilterXdgWmBaseHandler {
         &mut self,
         slf: &Rc<XdgWmBase>,
         xdg_surface: &Rc<XdgSurface>,
-        _surface: &Rc<wl_proxy::protocols::wayland::wl_surface::WlSurface>,
+        surface: &Rc<WlSurface>,
     ) {
         xdg_surface.set_handler(FilterXdgSurfaceHandler {
             policy: self.policy.clone(),
+            decoration: self.decoration.clone(),
+            surface: Rc::downgrade(surface),
         });
         // Forward to the compositor.
-        slf.send_get_xdg_surface(xdg_surface, _surface);
+        slf.send_get_xdg_surface(xdg_surface, surface);
     }
 }
 
@@ -1361,20 +1659,51 @@ impl XdgWmBaseHandler for FilterXdgWmBaseHandler {
 /// toplevel handler.
 struct FilterXdgSurfaceHandler {
     policy: Rc<FilterPolicy>,
+    decoration: Option<SharedDecorationManager>,
+    surface: Weak<WlSurface>,
 }
 
 impl XdgSurfaceHandler for FilterXdgSurfaceHandler {
     fn handle_get_toplevel(&mut self, slf: &Rc<XdgSurface>, toplevel: &Rc<XdgToplevel>) {
         toplevel.set_handler(FilterXdgToplevelHandler {
             policy: self.policy.clone(),
+            decoration: self.decoration.clone(),
+            surface_id: self.surface.upgrade().map(|surface| {
+                if let Some(decoration) = &self.decoration {
+                    decoration.borrow_mut().mark_toplevel(&surface);
+                }
+                surface.unique_id()
+            }),
         });
         slf.send_get_toplevel(toplevel);
+    }
+
+    fn handle_set_window_geometry(
+        &mut self,
+        slf: &Rc<XdgSurface>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    ) {
+        let geometry = WindowGeometry::new(x, y, width, height);
+        let geometry = self.decoration.as_ref().zip(self.surface.upgrade()).map_or(
+            geometry,
+            |(decoration, surface)| {
+                decoration
+                    .borrow()
+                    .translate_window_geometry(&surface, geometry)
+            },
+        );
+        slf.send_set_window_geometry(geometry.x, geometry.y, geometry.width, geometry.height);
     }
 }
 
 /// Handler for `xdg_toplevel`: rewrites app-id and title.
 struct FilterXdgToplevelHandler {
     policy: Rc<FilterPolicy>,
+    decoration: Option<SharedDecorationManager>,
+    surface_id: Option<u64>,
 }
 
 impl XdgToplevelHandler for FilterXdgToplevelHandler {
@@ -1387,6 +1716,37 @@ impl XdgToplevelHandler for FilterXdgToplevelHandler {
         let rewritten = self.policy.rewrite_title(title);
         slf.send_set_title(&rewritten);
     }
+
+    fn handle_set_fullscreen(
+        &mut self,
+        slf: &Rc<XdgToplevel>,
+        output: Option<&Rc<wl_proxy::protocols::wayland::wl_output::WlOutput>>,
+    ) {
+        if let (Some(decoration), Some(surface_id)) = (&self.decoration, self.surface_id) {
+            decoration
+                .borrow_mut()
+                .toplevel_fullscreen_request(surface_id, true);
+        }
+        slf.send_set_fullscreen(output);
+    }
+
+    fn handle_unset_fullscreen(&mut self, slf: &Rc<XdgToplevel>) {
+        if let (Some(decoration), Some(surface_id)) = (&self.decoration, self.surface_id) {
+            decoration
+                .borrow_mut()
+                .toplevel_fullscreen_request(surface_id, false);
+        }
+        slf.send_unset_fullscreen();
+    }
+
+    fn handle_configure(&mut self, slf: &Rc<XdgToplevel>, width: i32, height: i32, states: &[u8]) {
+        if let (Some(decoration), Some(surface_id)) = (&self.decoration, self.surface_id) {
+            decoration
+                .borrow_mut()
+                .toplevel_configure(surface_id, states);
+        }
+        slf.send_configure(width, height, states);
+    }
 }
 
 /// Handler for `wl_eglstream_display`: keep NVIDIA EGLStream constrained to
@@ -1396,6 +1756,7 @@ impl XdgToplevelHandler for FilterXdgToplevelHandler {
 struct FilterEglstreamDisplayHandler {
     vm: String,
     diag: Rc<RefCell<DiagRateLimiter>>,
+    decoration: Option<SharedDecorationManager>,
 }
 
 impl WlEglstreamDisplayHandler for FilterEglstreamDisplayHandler {
@@ -1414,6 +1775,10 @@ impl WlEglstreamDisplayHandler for FilterEglstreamDisplayHandler {
         attribs: &[u8],
     ) {
         if eglstream_handle_is_fd(r#type) {
+            if let Some(decoration) = &self.decoration {
+                id.set_handler(crate::decoration::tracking_buffer_handler(decoration));
+                decoration.borrow_mut().record_buffer(id, width, height);
+            }
             slf.send_create_stream(id, width, height, handle, r#type, attribs);
             return;
         }
@@ -1430,6 +1795,81 @@ impl WlEglstreamDisplayHandler for FilterEglstreamDisplayHandler {
         if let Some(client) = id.client() {
             client.disconnect();
         }
+    }
+}
+
+struct FilterDrmHandler {
+    decoration: SharedDecorationManager,
+}
+
+impl WlDrmHandler for FilterDrmHandler {
+    fn handle_authenticate(&mut self, slf: &Rc<WlDrm>, id: u32) {
+        slf.send_authenticate(id);
+    }
+
+    fn handle_create_buffer(
+        &mut self,
+        slf: &Rc<WlDrm>,
+        id: &Rc<WlBuffer>,
+        name: u32,
+        width: i32,
+        height: i32,
+        stride: u32,
+        format: u32,
+    ) {
+        id.set_handler(crate::decoration::tracking_buffer_handler(&self.decoration));
+        self.decoration
+            .borrow_mut()
+            .record_buffer(id, width, height);
+        slf.send_create_buffer(id, name, width, height, stride, format);
+    }
+
+    fn handle_create_planar_buffer(
+        &mut self,
+        slf: &Rc<WlDrm>,
+        id: &Rc<WlBuffer>,
+        name: u32,
+        width: i32,
+        height: i32,
+        format: u32,
+        offset0: i32,
+        stride0: i32,
+        offset1: i32,
+        stride1: i32,
+        offset2: i32,
+        stride2: i32,
+    ) {
+        id.set_handler(crate::decoration::tracking_buffer_handler(&self.decoration));
+        self.decoration
+            .borrow_mut()
+            .record_buffer(id, width, height);
+        slf.send_create_planar_buffer(
+            id, name, width, height, format, offset0, stride0, offset1, stride1, offset2, stride2,
+        );
+    }
+
+    fn handle_create_prime_buffer(
+        &mut self,
+        slf: &Rc<WlDrm>,
+        id: &Rc<WlBuffer>,
+        name: &Rc<OwnedFd>,
+        width: i32,
+        height: i32,
+        format: u32,
+        offset0: i32,
+        stride0: i32,
+        offset1: i32,
+        stride1: i32,
+        offset2: i32,
+        stride2: i32,
+    ) {
+        id.set_handler(crate::decoration::tracking_buffer_handler(&self.decoration));
+        self.decoration
+            .borrow_mut()
+            .record_buffer(id, width, height);
+        slf.send_create_prime_buffer(
+            id, name, width, height, format, offset0, stride0, offset1, stride1, offset2, stride2,
+        );
     }
 }
 
@@ -1596,7 +2036,7 @@ mod tests {
             "work".to_owned(),
             diag,
             BridgeConfig::from_parts(
-                Some(PathBuf::from("/tmp/d2b-nonexistent-bridge.sock")),
+                Some(PathBuf::from("target/d2b-nonexistent-bridge.sock")),
                 std::path::Path::new("/run/d2b/clipd"),
                 None,
                 "work",
@@ -1696,8 +2136,8 @@ mod tests {
 
     #[test]
     fn queued_handoff_failure_preserves_queue_and_respects_backoff() {
-        let root = std::env::temp_dir().join(format!(
-            "d2b-wlproxy-reconnect-test-{}-{}",
+        let root = PathBuf::from("target").join(format!(
+            "wlp-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -1767,7 +2207,7 @@ mod tests {
     #[test]
     fn filtered_globals_preserve_original_global_names() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
 
         handler.advertised_globals.insert(
             7,
@@ -1796,7 +2236,7 @@ mod tests {
     #[test]
     fn registry_handler_records_bind_denials_in_shared_limiter() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let handler = FilterRegistryHandler::new(policy(), diag.clone(), clipboard());
+        let handler = FilterRegistryHandler::new(policy(), diag.clone(), clipboard(), None);
 
         for name in 0..6 {
             handler.diag.borrow_mut().bind_denied(
@@ -1818,7 +2258,7 @@ mod tests {
     #[test]
     fn standard_clipboard_global_is_advertised_as_synthetic() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
         // The generated WlRegistry send path needs a real object/client, so assert
         // the policy decision helper that handle_global uses for the synthetic path.
         let interface = ObjectInterface::WlDataDeviceManager;
@@ -1839,7 +2279,7 @@ mod tests {
     #[test]
     fn synthetic_clipboard_global_uses_reserved_high_name() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
 
         assert_eq!(handler.allocate_synthetic_clipboard_name(7), u32::MAX);
     }
@@ -1847,7 +2287,7 @@ mod tests {
     #[test]
     fn synthetic_clipboard_global_avoids_server_and_existing_names() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
         handler.advertised_globals.insert(
             u32::MAX,
             AdvertisedGlobal {
@@ -1866,7 +2306,7 @@ mod tests {
     #[test]
     fn prepare_global_hides_late_host_collision_with_synthetic_clipboard_name() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
         let (synthetic, first) = handler.prepare_global(7, ObjectInterface::WlCompositor, 6);
         assert_eq!(
             synthetic,
@@ -1893,7 +2333,7 @@ mod tests {
     #[test]
     fn prepare_global_remove_ignores_synthetic_clipboard_name() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
         let (_synthetic, _first) = handler.prepare_global(7, ObjectInterface::WlCompositor, 6);
 
         assert!(!handler.prepare_global_remove(u32::MAX));
@@ -1906,7 +2346,7 @@ mod tests {
     #[test]
     fn prepare_global_hides_host_data_device_manager() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
         let (_synthetic, decision) =
             handler.prepare_global(11, ObjectInterface::WlDataDeviceManager, 3);
 
@@ -1923,7 +2363,7 @@ mod tests {
             allow_globals: vec!["zwp_primary_selection_device_manager_v1".to_owned()],
             ..Default::default()
         }));
-        let mut handler = FilterRegistryHandler::new(policy, diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy, diag, clipboard(), None);
         let (_synthetic, decision) =
             handler.prepare_global(13, ObjectInterface::ZwpPrimarySelectionDeviceManagerV1, 1);
 
@@ -1935,7 +2375,7 @@ mod tests {
     #[test]
     fn prepare_global_hides_text_input_v3() {
         let diag = Rc::new(RefCell::new(DiagRateLimiter::new("work".to_owned())));
-        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard());
+        let mut handler = FilterRegistryHandler::new(policy(), diag, clipboard(), None);
         let (_synthetic, decision) =
             handler.prepare_global(12, ObjectInterface::ZwpTextInputManagerV3, 1);
 

--- a/packages/d2b-wayland-proxy/src/lib.rs
+++ b/packages/d2b-wayland-proxy/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod attribution;
 pub mod bridge;
 pub mod clipboard;
+pub mod decoration;
 pub mod diag;
 pub mod dmabuf;
 pub mod filter;

--- a/packages/d2b-wayland-proxy/src/main.rs
+++ b/packages/d2b-wayland-proxy/src/main.rs
@@ -27,6 +27,7 @@ use d2b_wayland_proxy::filter::{
 };
 use d2b_wayland_proxy::{
     bridge::{BridgeConfig, BridgeReconnectPolicy},
+    decoration::{BorderConfig, Color, DecorationManager, LabelPosition, sanitize_label},
     diag::{DiagRateLimiter, bounded_error_detail},
     dmabuf::{DmabufFilter, parse_filter as parse_dmabuf_filter},
     policy::{FilterPolicy, PolicyInput},
@@ -108,6 +109,50 @@ struct Args {
     /// Maximum reconnect backoff for the future d2b-clipd bridge.
     #[arg(long = "clipd-bridge-reconnect-max-ms", default_value_t = 5000)]
     clipd_bridge_reconnect_max_ms: u64,
+
+    /// Enable proxy-owned VM identity borders.
+    #[arg(long = "border-enable", default_value_t = false)]
+    border_enable: bool,
+
+    /// Border color when the VM window is active.
+    #[arg(
+        long = "border-color-active",
+        value_name = "#rrggbb",
+        default_value = "#3caaff"
+    )]
+    border_color_active: Color,
+
+    /// Border color when the VM window is inactive.
+    #[arg(
+        long = "border-color-inactive",
+        value_name = "#rrggbb",
+        default_value = "#5f5f5f"
+    )]
+    border_color_inactive: Color,
+
+    /// Border color reserved for urgent VM windows.
+    #[arg(
+        long = "border-color-urgent",
+        value_name = "#rrggbb",
+        default_value = "#ff5656"
+    )]
+    border_color_urgent: Color,
+
+    /// Side/bottom border thickness in surface-local pixels.
+    #[arg(long = "border-thickness", value_parser = parse_positive_u32, default_value_t = d2b_wayland_proxy::decoration::DEFAULT_BORDER_THICKNESS)]
+    border_thickness: u32,
+
+    /// Optional text rendered into the top border.
+    #[arg(long = "border-label", value_name = "TEXT")]
+    border_label: Option<String>,
+
+    /// Position of the optional border label.
+    #[arg(
+        long = "border-label-position",
+        value_name = "top-left|top-center",
+        default_value = "top-left"
+    )]
+    border_label_position: LabelPosition,
 }
 
 fn parse_max_version(s: &str) -> Result<(String, u32), String> {
@@ -125,6 +170,17 @@ fn parse_dmabuf_filters(values: &[String]) -> Result<Vec<DmabufFilter>, String> 
         .iter()
         .map(|value| parse_dmabuf_filter(value))
         .collect::<Result<Vec<_>, _>>()
+}
+
+fn parse_positive_u32(value: &str) -> Result<u32, String> {
+    let parsed: u32 = value
+        .parse()
+        .map_err(|_| format!("expected positive u32, got `{value}`"))?;
+    if parsed == 0 {
+        Err("border thickness must be positive".to_owned())
+    } else {
+        Ok(parsed)
+    }
 }
 
 fn main() {
@@ -199,6 +255,27 @@ fn main() {
         );
     }
 
+    let border_config = BorderConfig {
+        enabled: args.border_enable,
+        active: args.border_color_active,
+        inactive: args.border_color_inactive,
+        urgent: args.border_color_urgent,
+        thickness: args.border_thickness,
+        label: args.border_label.as_deref().and_then(sanitize_label),
+        label_position: args.border_label_position,
+    };
+    if border_config.enabled() {
+        log::info!(
+            "[d2b-wlproxy] vm={} border-decoration=enabled thickness={} label={}",
+            args.vm_name,
+            border_config.thickness,
+            border_config
+                .label
+                .as_ref()
+                .map_or("disabled", |_| "enabled")
+        );
+    }
+
     // Step 3: prove the upstream compositor is reachable before exposing a
     // listen socket. Each accepted client gets its own upstream connection below.
     match build_state(&args.connect) {
@@ -245,7 +322,7 @@ fn main() {
     );
 
     // Step 5: dispatch loop.
-    accept_loop(listener, args.connect, policy, bridge_config);
+    accept_loop(listener, args.connect, policy, bridge_config, border_config);
 }
 
 fn accept_loop(
@@ -253,6 +330,7 @@ fn accept_loop(
     upstream: String,
     policy: FilterPolicy,
     bridge_config: BridgeConfig,
+    border_config: BorderConfig,
 ) {
     if let Err(e) = listener.set_nonblocking(true) {
         eprintln!("d2b-wayland-proxy: failed to set listen socket nonblocking: {e}");
@@ -267,6 +345,12 @@ fn accept_loop(
         diag.clone(),
         bridge_config,
     )));
+    let decoration = border_config.enabled().then(|| {
+        Rc::new(RefCell::new(DecorationManager::new(
+            border_config,
+            diag.clone(),
+        )))
+    });
     let state = match build_state(&upstream) {
         Ok(s) => s,
         Err(e) => {
@@ -280,6 +364,7 @@ fn accept_loop(
         policy.clone(),
         diag.clone(),
         clipboard.clone(),
+        decoration.clone(),
     ));
     VirtualClipboardState::drive_bridge_io(&clipboard, false);
 
@@ -368,6 +453,7 @@ fn accept_loop(
                             policy.clone(),
                             diag.clone(),
                             clipboard.clone(),
+                            decoration.clone(),
                         );
                     }
                     Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
@@ -484,6 +570,62 @@ fn error_source_chain(error: &dyn std::error::Error) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn border_cli_defaults_keep_decorations_disabled() {
+        let args = Args::try_parse_from([
+            "d2b-wayland-proxy",
+            "--listen",
+            "target/test.sock",
+            "--connect",
+            "wayland-1",
+            "--vm-name",
+            "work",
+        ])
+        .expect("parse args");
+
+        assert!(!args.border_enable);
+        assert_eq!(
+            args.border_thickness,
+            d2b_wayland_proxy::decoration::DEFAULT_BORDER_THICKNESS
+        );
+        assert!(args.border_label.is_none());
+    }
+
+    #[test]
+    fn border_cli_parses_colors_thickness_and_label_position() {
+        let args = Args::try_parse_from([
+            "d2b-wayland-proxy",
+            "--listen",
+            "target/test.sock",
+            "--connect",
+            "wayland-1",
+            "--vm-name",
+            "work",
+            "--border-enable",
+            "--border-color-active",
+            "#112233",
+            "--border-color-inactive",
+            "#445566",
+            "--border-color-urgent",
+            "#778899",
+            "--border-thickness",
+            "9",
+            "--border-label",
+            "work vm",
+            "--border-label-position",
+            "top-center",
+        ])
+        .expect("parse args");
+
+        assert!(args.border_enable);
+        assert_eq!(args.border_color_active, Color::rgb(0x11, 0x22, 0x33));
+        assert_eq!(args.border_color_inactive, Color::rgb(0x44, 0x55, 0x66));
+        assert_eq!(args.border_color_urgent, Color::rgb(0x77, 0x88, 0x99));
+        assert_eq!(args.border_thickness, 9);
+        assert_eq!(args.border_label.as_deref(), Some("work vm"));
+        assert_eq!(args.border_label_position, LabelPosition::TopCenter);
+    }
 
     #[test]
     fn interrupted_accept_is_recoverable() {

--- a/tests/unit/nix/cases/external-vm-kind.nix
+++ b/tests/unit/nix/cases/external-vm-kind.nix
@@ -631,6 +631,19 @@ in
           "d2b.media."
           "--title-prefix"
           "[media] "
+          "--border-enable"
+          "--border-color-active"
+          "#c8a0e0"
+          "--border-color-inactive"
+          "#c8a0e0"
+          "--border-color-urgent"
+          "#c8a0e0"
+          "--border-thickness"
+          "4"
+          "--border-label"
+          "media"
+          "--border-label-position"
+          "top-left"
         ];
       };
     };
@@ -656,6 +669,11 @@ in
       noMediaPathInArgv = true;
       noVhostNetPathInArgv = true;
     };
+  };
+
+  "external-vm-kind/qemu-media-reports-no-guest-wayland-proxy-capability" = {
+    expr = positiveManifest.runtime.operationCapabilities.display.waylandProxy;
+    expected = false;
   };
 
   "external-vm-kind/qemu-media-tap-sync-lock-uses-resource-id" = {

--- a/tests/unit/nix/cases/niri-vm-borders.nix
+++ b/tests/unit/nix/cases/niri-vm-borders.nix
@@ -76,12 +76,23 @@ let
   };
 
   etcOf = overrides: (mkEval ([ base ] ++ overrides)).config.environment.etc;
+  cfgOf = overrides: (mkEval ([ base ] ++ overrides)).config;
   kdlKey = "d2b/niri-vm-borders.kdl";
   jsonKey = "d2b/ui-colors.json";
   cssKey = "d2b/ui-colors.css";
   kdlText = etc: if builtins.hasAttr kdlKey etc then etc.${kdlKey}.text else "";
   jsonText = etc: if builtins.hasAttr jsonKey etc then etc.${jsonKey}.text else "";
   cssText = etc: if builtins.hasAttr cssKey etc then etc.${cssKey}.text else "";
+  processDag = cfg: builtins.head (builtins.filter (dag: dag.vm == "work") cfg.d2b._bundle.processesJson.data.vms);
+  processNode = cfg: id: builtins.head (builtins.filter (node: node.id == id) (processDag cfg).nodes);
+  flagValue = flag: argv:
+    let
+      positions =
+        builtins.filter
+          (i: builtins.elemAt argv i == flag)
+          (builtins.genList (i: i) (builtins.length argv));
+    in
+    if positions == [ ] then null else builtins.elemAt argv ((builtins.head positions) + 1);
 
   disabledEtc = etcOf [ ];
   uiEtc = etcOf [ ({ ... }: { d2b.site.ui.enable = true; }) ];
@@ -89,20 +100,34 @@ let
   uiCss = cssText uiEtc;
   newNiriEtc = etcOf [ ({ ... }: { d2b.site.ui.compositors.niri.enable = true; }) ];
   newNiriKdl = kdlText newNiriEtc;
+  niriOptOutKdl = kdlText (etcOf [
+    ({ ... }: {
+      d2b.site.ui.compositors.niri.enable = true;
+      d2b.vms.work.graphics.waylandProxy.border.enable = false;
+    })
+  ]);
   enabledEtc = etcOf [ ({ ... }: { d2b.site.niriVmBorders.enable = true; }) ];
   enabledKdl = kdlText enabledEtc;
   colorKdl = kdlText (etcOf [
     ({ ... }: {
       d2b.site.ui.compositors.niri.enable = true;
+      d2b.vms.work.graphics.waylandProxy.border.enable = false;
       d2b.vms.work.ui.border = {
         activeColor = "#AABBCC";
         urgentColor = "#112233";
       };
     })
   ]);
+  niriNativeWorkKdl = kdlText (etcOf [
+    ({ ... }: {
+      d2b.site.niriVmBorders.enable = true;
+      d2b.vms.work.graphics.waylandProxy.border.enable = false;
+    })
+  ]);
   qemuMediaColorKdl = kdlText (etcOf [
     ({ ... }: {
       d2b.site.niriVmBorders.enable = true;
+      d2b.vms.media.graphics.waylandProxy.border.enable = false;
       d2b.vms.media.qemuMedia.window.niriBorderColor = "#800080";
     })
   ]);
@@ -111,6 +136,23 @@ let
       d2b.site.niriVmBorders.enable = true;
       d2b.site.niriVmBorders.outputPath = "/etc/d2b/custom-borders.kdl";
     })
+  ];
+  proxyDefaultCfg = cfgOf [ ];
+  proxyDefaultArgv = (processNode proxyDefaultCfg "wayland-proxy").argv;
+  proxyDefaultColors = proxyDefaultCfg.d2b._uiColors.vms.work.border;
+  proxyDisabledArgv = (processNode (cfgOf [
+    ({ ... }: {
+      d2b.vms.work.graphics.waylandProxy.border.enable = false;
+    })
+  ]) "wayland-proxy").argv;
+  proxyBorderFlags = [
+    "--border-enable"
+    "--border-color-active"
+    "--border-color-inactive"
+    "--border-color-urgent"
+    "--border-thickness"
+    "--border-label"
+    "--border-label-position"
   ];
 in
 {
@@ -192,8 +234,8 @@ in
   };
   "niri-vm-borders/new-backend-renders-inactive-and-urgent" = {
     expr =
-      lib.hasInfix ''inactive-color "#7fc8ff"'' newNiriKdl
-      && lib.hasInfix ''urgent-color "#7fc8ff"'' newNiriKdl;
+      lib.hasInfix ''inactive-color "#7fc8ff"'' niriOptOutKdl
+      && lib.hasInfix ''urgent-color "#7fc8ff"'' niriOptOutKdl;
     expected = true;
   };
   "niri-vm-borders/enabled-has-kdl" = {
@@ -202,6 +244,10 @@ in
   };
   "niri-vm-borders/enabled-work-rule" = {
     expr = lib.hasInfix "// Borders for VM: work" enabledKdl;
+    expected = false;
+  };
+  "niri-vm-borders/proxy-border-disabled-restores-work-rule" = {
+    expr = lib.hasInfix "// Borders for VM: work" niriNativeWorkKdl;
     expected = true;
   };
   "niri-vm-borders/enabled-headless-no-rule" = {
@@ -210,11 +256,11 @@ in
   };
   "niri-vm-borders/enabled-qemu-media-host-rule" = {
     expr = lib.hasInfix "// Borders for qemu-media VM host window: media" enabledKdl;
-    expected = true;
+    expected = false;
   };
   "niri-vm-borders/enabled-qemu-media-stable-title-match" = {
     expr = lib.hasInfix ''match app-id=r#"^d2b\.media\."#'' enabledKdl;
-    expected = true;
+    expected = false;
   };
   "niri-vm-borders/enabled-qemu-media-no-guest-app-id-rule" = {
     expr = lib.hasInfix ''match app-id=r#"^qemu$"#'' enabledKdl;
@@ -246,11 +292,11 @@ in
     # derivation #7fc8ff; asserting the concrete value is a stronger
     # faithful successor than the bash's two-process equality check
     # (vacuous under pure single-eval).
-    expr = lib.hasInfix ''active-color "#7fc8ff"'' enabledKdl;
+    expr = lib.hasInfix ''active-color "#7fc8ff"'' niriNativeWorkKdl;
     expected = true;
   };
   "niri-vm-borders/default-inactive-color-is-identity" = {
-    expr = lib.hasInfix ''inactive-color "#7fc8ff"'' enabledKdl;
+    expr = lib.hasInfix ''inactive-color "#7fc8ff"'' niriNativeWorkKdl;
     expected = true;
   };
   "niri-vm-borders/kdl-mode" = {
@@ -264,6 +310,30 @@ in
   "niri-vm-borders/custom-output-path-default-absent" = {
     expr = builtins.hasAttr "d2b/niri-vm-borders.kdl" customEtc;
     expected = false;
+  };
+  "niri-vm-borders/wayland-proxy-border-default-uses-resolved-colors" = {
+    expr = {
+      enabled = builtins.elem "--border-enable" proxyDefaultArgv;
+      active = flagValue "--border-color-active" proxyDefaultArgv;
+      inactive = flagValue "--border-color-inactive" proxyDefaultArgv;
+      urgent = flagValue "--border-color-urgent" proxyDefaultArgv;
+      thickness = flagValue "--border-thickness" proxyDefaultArgv;
+      label = flagValue "--border-label" proxyDefaultArgv;
+      labelPosition = flagValue "--border-label-position" proxyDefaultArgv;
+    };
+    expected = {
+      enabled = true;
+      active = proxyDefaultColors.active;
+      inactive = proxyDefaultColors.inactive;
+      urgent = proxyDefaultColors.urgent;
+      thickness = "4";
+      label = "work";
+      labelPosition = "top-left";
+    };
+  };
+  "niri-vm-borders/wayland-proxy-border-disable-omits-border-flags" = {
+    expr = builtins.all (flag: !(builtins.elem flag proxyDisabledArgv)) proxyBorderFlags;
+    expected = true;
   };
 }
 )

--- a/tests/unit/nix/cases/requested-vm-config.nix
+++ b/tests/unit/nix/cases/requested-vm-config.nix
@@ -4,6 +4,12 @@ let
   requested = mkEval [
     (import (flakeRoot + "/examples/qemu-media-dark-live.nix"))
   ];
+  requestedNiriNative = mkEval [
+    (import (flakeRoot + "/examples/qemu-media-dark-live.nix"))
+    ({ ... }: {
+      d2b.vms."dark-live".graphics.waylandProxy.border.enable = false;
+    })
+  ];
   cfg = requested.config;
   vm = cfg.d2b.vms."dark-live";
   hostJson = cfg.d2b._bundle.hostJson.data;
@@ -13,6 +19,7 @@ let
   netProcess = lib.findFirst (entry: entry.vm == "sys-dark-net") null processes;
   netCloudHypervisorNode = lib.findFirst (node: node.id == "cloud-hypervisor") null netProcess.nodes;
   kdl = cfg.environment.etc."d2b/niri-vm-borders.kdl".text;
+  niriNativeKdl = requestedNiriNative.config.environment.etc."d2b/niri-vm-borders.kdl".text;
   rawArtifactText = builtins.toJSON {
     inherit (hostJson) qemuMedia vmRuntimes;
     niri = kdl;
@@ -187,9 +194,9 @@ in
 
   "requested-vm-config/purple-qemu-media-niri-border" = {
     expr =
-      lib.hasInfix "// Borders for qemu-media VM host window: dark-live" kdl
-      && lib.hasInfix ''match app-id=r#"^d2b\.dark-live\."#'' kdl
-      && lib.hasInfix ''active-color "#301934"'' kdl;
+      lib.hasInfix "// Borders for qemu-media VM host window: dark-live" niriNativeKdl
+      && lib.hasInfix ''match app-id=r#"^d2b\.dark-live\."#'' niriNativeKdl
+      && lib.hasInfix ''active-color "#301934"'' niriNativeKdl;
     expected = true;
   };
 }


### PR DESCRIPTION
## Summary
- add proxy-drawn per-VM identity borders and labels to d2b-wayland-proxy
- wire default-on per-VM border options through processes.json and d2b-host argv generation
- preserve no-copy semantics by drawing only proxy-owned SHM decoration buffers while tracking guest buffer dimensions across shm, dmabuf, wl_drm, and EGLStream paths
- avoid double borders by omitting generated niri rules when proxy borders are effective for graphics and qemu-media VMs

## Validation
- cargo test -p d2b-wayland-proxy
- cargo test -p d2b-host wayland_proxy_argv
- nix build --no-link .#checks.$(nix eval --raw --impure --expr builtins.currentSystem).nix-unit-runtime
- make test-flake
- make test-rust

## Review
- Full Gemini 3.1 Pro panel signoff after follow-up fixes: software, test, nixos, networking, security, rust, product, docs, observability, kernel.