### PR TITLE
wayland: tear down wrapper on guest role destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- `d2b-wayland-proxy` now tears down proxy-owned wrapper toplevels when guests
+  destroy the XDG role or disconnect abruptly, preventing dead VM identity rails
+  from outliving the guest window.
 - `d2b-wayland-proxy` now presents proxy-drawn VM identity rails through a
   proxy-owned wrapper toplevel, so host compositor borders and focus rings wrap
   the VM rail and guest content together without copying guest buffers.

--- a/packages/d2b-wayland-proxy/src/decoration.rs
+++ b/packages/d2b-wayland-proxy/src/decoration.rs
@@ -1961,6 +1961,15 @@ impl DecorationManager {
         }
     }
 
+    pub fn toplevel_destroyed(&mut self, surface_id: u64) {
+        self.remove_decoration(surface_id);
+        if let Some(state) = self.surfaces.get_mut(&surface_id) {
+            state.toplevel = false;
+            state.pending_window_geometry = None;
+            state.current_window_geometry = None;
+        }
+    }
+
     pub fn register_guest_subsurface(&mut self, surface: &Rc<WlSurface>, parent: &Rc<WlSurface>) {
         let parent_id = parent.unique_id();
         let siblings = self.subsurfaces_by_parent.entry(parent_id).or_default();

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -1546,7 +1546,7 @@ impl WlKeyboardHandler for FilterKeyboardHandler {
             if surface_belongs_to_receiver(&surface, slf.client_id()) {
                 slf.send_enter(serial, &surface, keys);
             }
-        } else {
+        } else if surface_belongs_to_receiver(surface, slf.client_id()) {
             slf.send_enter(serial, surface, keys);
         }
     }
@@ -1556,7 +1556,7 @@ impl WlKeyboardHandler for FilterKeyboardHandler {
             if surface_belongs_to_receiver(&surface, slf.client_id()) {
                 slf.send_leave(serial, &surface);
             }
-        } else {
+        } else if surface_belongs_to_receiver(surface, slf.client_id()) {
             slf.send_leave(serial, surface);
         }
     }
@@ -1583,6 +1583,9 @@ impl WlPointerHandler for FilterPointerHandler {
             }
             return;
         }
+        if !surface_belongs_to_receiver(surface, slf.client_id()) {
+            return;
+        }
         self.rail_focus = false;
         self.pending_forwarded_frame = true;
         slf.send_enter(serial, surface, surface_x, surface_y);
@@ -1593,6 +1596,9 @@ impl WlPointerHandler for FilterPointerHandler {
             if surface_belongs_to_receiver(&target, slf.client_id()) {
                 self.rail_focus = false;
             }
+            return;
+        }
+        if !surface_belongs_to_receiver(surface, slf.client_id()) {
             return;
         }
         self.rail_focus = false;
@@ -1713,6 +1719,9 @@ impl WlTouchHandler for FilterTouchHandler {
             if surface_belongs_to_receiver(&target, slf.client_id()) {
                 self.suppressed_ids.insert(id);
             }
+            return;
+        }
+        if !surface_belongs_to_receiver(surface, slf.client_id()) {
             return;
         }
         self.forwarded_ids.insert(id);

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -142,6 +142,11 @@ pub fn install_client_handlers(
     clipboard: Rc<RefCell<VirtualClipboardState>>,
     decoration: Option<SharedDecorationManager>,
 ) {
+    client.set_handler(FilterClientHandler::new(
+        policy.vm_name.clone(),
+        Rc::downgrade(client),
+        decoration.clone(),
+    ));
     let handler = FilterDisplayHandler {
         policy: policy.clone(),
         diag,
@@ -2153,6 +2158,17 @@ impl FilterXdgSurfaceHandler {
 }
 
 impl XdgSurfaceHandler for FilterXdgSurfaceHandler {
+    fn handle_destroy(&mut self, slf: &Rc<XdgSurface>) {
+        if let (Some(decoration), Some(surface)) = (&self.decoration, self.surface.upgrade()) {
+            decoration
+                .borrow_mut()
+                .toplevel_destroyed(surface.unique_id());
+        }
+        if self.server_xdg_surface_created {
+            slf.send_destroy();
+        }
+    }
+
     fn handle_get_toplevel(&mut self, slf: &Rc<XdgSurface>, toplevel: &Rc<XdgToplevel>) {
         let surface = self.surface.upgrade();
         let surface_id = surface.as_ref().map(|surface| surface.unique_id());
@@ -2252,6 +2268,18 @@ struct FilterXdgToplevelHandler {
 }
 
 impl XdgToplevelHandler for FilterXdgToplevelHandler {
+    fn handle_destroy(&mut self, slf: &Rc<XdgToplevel>) {
+        if let (Some(decoration), Some(surface_id)) = (&self.decoration, self.surface_id) {
+            let mut decoration = decoration.borrow_mut();
+            if decoration.has_wrapper(surface_id) {
+                decoration.toplevel_destroyed(surface_id);
+                return;
+            }
+            decoration.toplevel_destroyed(surface_id);
+        }
+        slf.send_destroy();
+    }
+
     fn handle_set_app_id(&mut self, slf: &Rc<XdgToplevel>, app_id: &str) {
         let rewritten = self.policy.rewrite_app_id(app_id);
         if let (Some(decoration), Some(surface_id)) = (&self.decoration, self.surface_id)
@@ -2531,16 +2559,42 @@ fn errno_to_io(error: nix::errno::Errno) -> std::io::Error {
 /// Minimal `ClientHandler` that logs disconnections for debugging.
 pub struct FilterClientHandler {
     vm: String,
+    client: Weak<Client>,
+    decoration: Option<SharedDecorationManager>,
 }
 
 impl FilterClientHandler {
-    pub fn new(vm: String) -> Self {
-        Self { vm }
+    pub fn new(
+        vm: String,
+        client: Weak<Client>,
+        decoration: Option<SharedDecorationManager>,
+    ) -> Self {
+        Self {
+            vm,
+            client,
+            decoration,
+        }
     }
 }
 
 impl ClientHandler for FilterClientHandler {
     fn disconnected(self: Box<Self>) {
+        if let (Some(client), Some(decoration)) = (self.client.upgrade(), self.decoration.as_ref())
+        {
+            let mut objects: Vec<Rc<dyn Object>> = Vec::new();
+            client.objects(&mut objects);
+            let mut decoration = decoration.borrow_mut();
+            for object in &objects {
+                if let Some(surface) = object.try_downcast::<WlSurface>() {
+                    decoration.surface_destroyed(&surface);
+                }
+            }
+            for object in &objects {
+                if let Some(buffer) = object.try_downcast::<WlBuffer>() {
+                    decoration.remove_buffer(&buffer);
+                }
+            }
+        }
         log::debug!("[d2b-wlproxy] vm={} client disconnected", self.vm);
     }
 }

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -1543,7 +1543,9 @@ impl WlKeyboardHandler for FilterKeyboardHandler {
         keys: &[u8],
     ) {
         if let Some(surface) = self.decoration.borrow().wrapper_input_target(surface) {
-            slf.send_enter(serial, &surface, keys);
+            if surface_belongs_to_receiver(&surface, slf.client_id()) {
+                slf.send_enter(serial, &surface, keys);
+            }
         } else {
             slf.send_enter(serial, surface, keys);
         }
@@ -1551,7 +1553,9 @@ impl WlKeyboardHandler for FilterKeyboardHandler {
 
     fn handle_leave(&mut self, slf: &Rc<WlKeyboard>, serial: u32, surface: &Rc<WlSurface>) {
         if let Some(surface) = self.decoration.borrow().wrapper_input_target(surface) {
-            slf.send_leave(serial, &surface);
+            if surface_belongs_to_receiver(&surface, slf.client_id()) {
+                slf.send_leave(serial, &surface);
+            }
         } else {
             slf.send_leave(serial, surface);
         }
@@ -1573,13 +1577,10 @@ impl WlPointerHandler for FilterPointerHandler {
         surface_x: Fixed,
         surface_y: Fixed,
     ) {
-        if self
-            .decoration
-            .borrow()
-            .wrapper_input_target(surface)
-            .is_some()
-        {
-            self.rail_focus = true;
+        if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
+            if surface_belongs_to_receiver(&target, slf.client_id()) {
+                self.rail_focus = true;
+            }
             return;
         }
         self.rail_focus = false;
@@ -1588,13 +1589,10 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_leave(&mut self, slf: &Rc<WlPointer>, serial: u32, surface: &Rc<WlSurface>) {
-        if self
-            .decoration
-            .borrow()
-            .wrapper_input_target(surface)
-            .is_some()
-        {
-            self.rail_focus = false;
+        if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
+            if surface_belongs_to_receiver(&target, slf.client_id()) {
+                self.rail_focus = false;
+            }
             return;
         }
         self.rail_focus = false;
@@ -1711,13 +1709,10 @@ impl WlTouchHandler for FilterTouchHandler {
         x: Fixed,
         y: Fixed,
     ) {
-        if self
-            .decoration
-            .borrow()
-            .wrapper_input_target(surface)
-            .is_some()
-        {
-            self.suppressed_ids.insert(id);
+        if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
+            if surface_belongs_to_receiver(&target, slf.client_id()) {
+                self.suppressed_ids.insert(id);
+            }
             return;
         }
         self.forwarded_ids.insert(id);
@@ -1777,6 +1772,10 @@ impl WlTouchHandler for FilterTouchHandler {
         self.pending_forwarded_frame = false;
         slf.send_frame();
     }
+}
+
+fn surface_belongs_to_receiver(surface: &Rc<WlSurface>, receiver_client_id: Option<u32>) -> bool {
+    receiver_client_id.is_some() && surface.client_id() == receiver_client_id
 }
 
 struct FilterSubcompositorHandler {

--- a/packages/d2b-wayland-proxy/src/main.rs
+++ b/packages/d2b-wayland-proxy/src/main.rs
@@ -22,8 +22,7 @@ use std::{
 
 use clap::Parser;
 use d2b_wayland_proxy::filter::{
-    FilterClientHandler, FilterStateHandler, VirtualClipboardState, build_state,
-    install_client_handlers,
+    FilterStateHandler, VirtualClipboardState, build_state, install_client_handlers,
 };
 use d2b_wayland_proxy::{
     bridge::{BridgeConfig, BridgeReconnectPolicy},
@@ -446,7 +445,6 @@ fn accept_loop(
                                 continue;
                             }
                         };
-                        client.set_handler(FilterClientHandler::new(vm.clone()));
                         install_client_handlers(
                             &client,
                             policy.clone(),


### PR DESCRIPTION
## Summary\n- tear down proxy-owned wrapper toplevels when a guest destroys its XDG toplevel/surface role\n- clean proxy decorations for all client-owned surfaces when a wl-proxy client disconnects abruptly\n- document the stale wrapper fix in CHANGELOG\n\n## Validation\n- cargo fmt --check\n- cargo test -p d2b-wayland-proxy\n- cargo clippy -p d2b-wayland-proxy --all-targets -- -D warnings