### PR TITLE
wayland: fix wrapper input delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ deprecations ship one minor release before removal.
 - `d2b-wayland-proxy` now tears down proxy-owned wrapper toplevels when guests
   destroy the XDG role or disconnect abruptly, preventing dead VM identity rails
   from outliving the guest window.
+- `d2b-wayland-proxy` now translates pointer focus and motion from wrapper
+  content coordinates into guest-surface coordinates while suppressing only the
+  trusted rail, preventing clicks in wrapped guest windows from crashing clients.
 - `d2b-wayland-proxy` now presents proxy-drawn VM identity rails through a
   proxy-owned wrapper toplevel, so host compositor borders and focus rings wrap
   the VM rail and guest content together without copying guest buffers.

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -47,7 +47,7 @@ use wl_proxy::{
             wl_keyboard::{
                 WlKeyboard, WlKeyboardHandler, WlKeyboardKeyState, WlKeyboardKeymapFormat,
             },
-            wl_output::WlOutputTransform,
+            wl_output::{WlOutput, WlOutputTransform},
             wl_pointer::{
                 WlPointer, WlPointerAxis, WlPointerAxisRelativeDirection, WlPointerAxisSource,
                 WlPointerButtonState, WlPointerHandler,
@@ -1960,12 +1960,19 @@ fn receiver_has_client(receiver: Option<Rc<Client>>) -> bool {
 }
 
 fn surface_belongs_to_receiver(surface: &Rc<WlSurface>, receiver: Option<Rc<Client>>) -> bool {
+    object_belongs_to_receiver(surface, receiver)
+}
+
+fn object_belongs_to_receiver<T>(object: &Rc<T>, receiver: Option<Rc<Client>>) -> bool
+where
+    T: ObjectCoreApi,
+{
     let Some(receiver) = receiver else {
         return false;
     };
-    surface
+    object
         .client()
-        .is_some_and(|surface_client| Rc::ptr_eq(&surface_client, &receiver))
+        .is_some_and(|object_client| Rc::ptr_eq(&object_client, &receiver))
 }
 
 struct FilterSubcompositorHandler {
@@ -2172,6 +2179,18 @@ impl WlSurfaceHandler for FilterSurfaceHandler {
     fn handle_commit(&mut self, slf: &Rc<WlSurface>) {
         slf.send_commit();
         self.decoration.borrow_mut().surface_commit(slf);
+    }
+
+    fn handle_enter(&mut self, slf: &Rc<WlSurface>, output: &Rc<WlOutput>) {
+        if object_belongs_to_receiver(output, slf.client()) {
+            slf.send_enter(output);
+        }
+    }
+
+    fn handle_leave(&mut self, slf: &Rc<WlSurface>, output: &Rc<WlOutput>) {
+        if object_belongs_to_receiver(output, slf.client()) {
+            slf.send_leave(output);
+        }
     }
 }
 

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -1613,6 +1613,11 @@ impl WlPointerHandler for FilterPointerHandler {
         surface_x: Fixed,
         surface_y: Fixed,
     ) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1628,6 +1633,11 @@ impl WlPointerHandler for FilterPointerHandler {
         button: u32,
         state: WlPointerButtonState,
     ) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1636,6 +1646,11 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis(&mut self, slf: &Rc<WlPointer>, time: u32, axis: WlPointerAxis, value: Fixed) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1644,6 +1659,11 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_frame(&mut self, slf: &Rc<WlPointer>) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if !self.pending_forwarded_frame {
             return;
         }
@@ -1652,6 +1672,11 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_source(&mut self, slf: &Rc<WlPointer>, axis_source: WlPointerAxisSource) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1660,6 +1685,11 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_stop(&mut self, slf: &Rc<WlPointer>, time: u32, axis: WlPointerAxis) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1668,6 +1698,11 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_discrete(&mut self, slf: &Rc<WlPointer>, axis: WlPointerAxis, discrete: i32) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1676,6 +1711,11 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_value120(&mut self, slf: &Rc<WlPointer>, axis: WlPointerAxis, value120: i32) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1689,6 +1729,11 @@ impl WlPointerHandler for FilterPointerHandler {
         axis: WlPointerAxis,
         direction: WlPointerAxisRelativeDirection,
     ) {
+        if !receiver_has_client(slf.client_id()) {
+            self.rail_focus = false;
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.rail_focus {
             return;
         }
@@ -1715,6 +1760,12 @@ impl WlTouchHandler for FilterTouchHandler {
         x: Fixed,
         y: Fixed,
     ) {
+        if !receiver_has_client(slf.client_id()) {
+            self.suppressed_ids.clear();
+            self.forwarded_ids.clear();
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
             if surface_belongs_to_receiver(&target, slf.client_id()) {
                 self.suppressed_ids.insert(id);
@@ -1730,6 +1781,12 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_up(&mut self, slf: &Rc<WlTouch>, serial: u32, time: u32, id: i32) {
+        if !receiver_has_client(slf.client_id()) {
+            self.suppressed_ids.clear();
+            self.forwarded_ids.clear();
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.suppressed_ids.remove(&id) {
             return;
         }
@@ -1739,6 +1796,12 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_motion(&mut self, slf: &Rc<WlTouch>, time: u32, id: i32, x: Fixed, y: Fixed) {
+        if !receiver_has_client(slf.client_id()) {
+            self.suppressed_ids.clear();
+            self.forwarded_ids.clear();
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.suppressed_ids.contains(&id) {
             return;
         }
@@ -1747,6 +1810,12 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_shape(&mut self, slf: &Rc<WlTouch>, id: i32, major: Fixed, minor: Fixed) {
+        if !receiver_has_client(slf.client_id()) {
+            self.suppressed_ids.clear();
+            self.forwarded_ids.clear();
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.suppressed_ids.contains(&id) {
             return;
         }
@@ -1755,6 +1824,12 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_orientation(&mut self, slf: &Rc<WlTouch>, id: i32, orientation: Fixed) {
+        if !receiver_has_client(slf.client_id()) {
+            self.suppressed_ids.clear();
+            self.forwarded_ids.clear();
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.suppressed_ids.contains(&id) {
             return;
         }
@@ -1763,6 +1838,12 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_cancel(&mut self, slf: &Rc<WlTouch>) {
+        if !receiver_has_client(slf.client_id()) {
+            self.suppressed_ids.clear();
+            self.forwarded_ids.clear();
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if self.forwarded_ids.is_empty() {
             self.suppressed_ids.clear();
             self.pending_forwarded_frame = false;
@@ -1775,6 +1856,12 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_frame(&mut self, slf: &Rc<WlTouch>) {
+        if !receiver_has_client(slf.client_id()) {
+            self.suppressed_ids.clear();
+            self.forwarded_ids.clear();
+            self.pending_forwarded_frame = false;
+            return;
+        }
         if !self.pending_forwarded_frame {
             return;
         }
@@ -1783,8 +1870,12 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 }
 
+fn receiver_has_client(receiver_client_id: Option<u32>) -> bool {
+    receiver_client_id.is_some()
+}
+
 fn surface_belongs_to_receiver(surface: &Rc<WlSurface>, receiver_client_id: Option<u32>) -> bool {
-    receiver_client_id.is_some() && surface.client_id() == receiver_client_id
+    receiver_has_client(receiver_client_id) && surface.client_id() == receiver_client_id
 }
 
 struct FilterSubcompositorHandler {

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -1506,7 +1506,7 @@ impl WlSeatHandler for FilterSeatHandler {
     fn handle_get_pointer(&mut self, slf: &Rc<WlSeat>, id: &Rc<WlPointer>) {
         id.set_handler(FilterPointerHandler {
             decoration: self.decoration.clone(),
-            rail_focus: false,
+            focus: PointerFocus::None,
             pending_forwarded_frame: false,
         });
         slf.send_get_pointer(id);
@@ -1564,8 +1564,32 @@ impl WlKeyboardHandler for FilterKeyboardHandler {
 
 struct FilterPointerHandler {
     decoration: SharedDecorationManager,
-    rail_focus: bool,
+    focus: PointerFocus,
     pending_forwarded_frame: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum PointerFocus {
+    #[default]
+    None,
+    Direct,
+    WrapperContent,
+    Rail,
+}
+
+fn wrapper_content_pointer_x(surface_x: Fixed) -> Option<Fixed> {
+    let rail_width = Fixed::from_i32_saturating(WRAPPER_RAIL_WIDTH as i32);
+    (surface_x >= rail_width).then_some(surface_x - rail_width)
+}
+
+fn pointer_motion_x_for_focus(focus: PointerFocus, surface_x: Fixed) -> Option<Fixed> {
+    match focus {
+        PointerFocus::Direct => Some(surface_x),
+        PointerFocus::WrapperContent => {
+            Some(surface_x - Fixed::from_i32_saturating(WRAPPER_RAIL_WIDTH as i32))
+        }
+        PointerFocus::None | PointerFocus::Rail => None,
+    }
 }
 
 impl WlPointerHandler for FilterPointerHandler {
@@ -1579,29 +1603,43 @@ impl WlPointerHandler for FilterPointerHandler {
     ) {
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
             if surface_belongs_to_receiver(&target, slf.client_id()) {
-                self.rail_focus = true;
+                if let Some(x) = wrapper_content_pointer_x(surface_x) {
+                    self.focus = PointerFocus::WrapperContent;
+                    self.pending_forwarded_frame = true;
+                    slf.send_enter(serial, &target, x, surface_y);
+                } else {
+                    self.focus = PointerFocus::Rail;
+                }
+            } else {
+                self.focus = PointerFocus::None;
             }
             return;
         }
         if !surface_belongs_to_receiver(surface, slf.client_id()) {
+            self.focus = PointerFocus::None;
             return;
         }
-        self.rail_focus = false;
+        self.focus = PointerFocus::Direct;
         self.pending_forwarded_frame = true;
         slf.send_enter(serial, surface, surface_x, surface_y);
     }
 
     fn handle_leave(&mut self, slf: &Rc<WlPointer>, serial: u32, surface: &Rc<WlSurface>) {
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
-            if surface_belongs_to_receiver(&target, slf.client_id()) {
-                self.rail_focus = false;
+            if surface_belongs_to_receiver(&target, slf.client_id())
+                && self.focus == PointerFocus::WrapperContent
+            {
+                self.pending_forwarded_frame = true;
+                slf.send_leave(serial, &target);
             }
+            self.focus = PointerFocus::None;
             return;
         }
         if !surface_belongs_to_receiver(surface, slf.client_id()) {
+            self.focus = PointerFocus::None;
             return;
         }
-        self.rail_focus = false;
+        self.focus = PointerFocus::None;
         self.pending_forwarded_frame = true;
         slf.send_leave(serial, surface);
     }
@@ -1614,15 +1652,15 @@ impl WlPointerHandler for FilterPointerHandler {
         surface_y: Fixed,
     ) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        let Some(x) = pointer_motion_x_for_focus(self.focus, surface_x) else {
             return;
-        }
+        };
         self.pending_forwarded_frame = true;
-        slf.send_motion(time, surface_x, surface_y);
+        slf.send_motion(time, x, surface_y);
     }
 
     fn handle_button(
@@ -1634,11 +1672,11 @@ impl WlPointerHandler for FilterPointerHandler {
         state: WlPointerButtonState,
     ) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        if self.focus == PointerFocus::Rail || self.focus == PointerFocus::None {
             return;
         }
         self.pending_forwarded_frame = true;
@@ -1647,11 +1685,11 @@ impl WlPointerHandler for FilterPointerHandler {
 
     fn handle_axis(&mut self, slf: &Rc<WlPointer>, time: u32, axis: WlPointerAxis, value: Fixed) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        if self.focus == PointerFocus::Rail || self.focus == PointerFocus::None {
             return;
         }
         self.pending_forwarded_frame = true;
@@ -1660,7 +1698,7 @@ impl WlPointerHandler for FilterPointerHandler {
 
     fn handle_frame(&mut self, slf: &Rc<WlPointer>) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
@@ -1673,11 +1711,11 @@ impl WlPointerHandler for FilterPointerHandler {
 
     fn handle_axis_source(&mut self, slf: &Rc<WlPointer>, axis_source: WlPointerAxisSource) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        if self.focus == PointerFocus::Rail || self.focus == PointerFocus::None {
             return;
         }
         self.pending_forwarded_frame = true;
@@ -1686,11 +1724,11 @@ impl WlPointerHandler for FilterPointerHandler {
 
     fn handle_axis_stop(&mut self, slf: &Rc<WlPointer>, time: u32, axis: WlPointerAxis) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        if self.focus == PointerFocus::Rail || self.focus == PointerFocus::None {
             return;
         }
         self.pending_forwarded_frame = true;
@@ -1699,11 +1737,11 @@ impl WlPointerHandler for FilterPointerHandler {
 
     fn handle_axis_discrete(&mut self, slf: &Rc<WlPointer>, axis: WlPointerAxis, discrete: i32) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        if self.focus == PointerFocus::Rail || self.focus == PointerFocus::None {
             return;
         }
         self.pending_forwarded_frame = true;
@@ -1712,11 +1750,11 @@ impl WlPointerHandler for FilterPointerHandler {
 
     fn handle_axis_value120(&mut self, slf: &Rc<WlPointer>, axis: WlPointerAxis, value120: i32) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        if self.focus == PointerFocus::Rail || self.focus == PointerFocus::None {
             return;
         }
         self.pending_forwarded_frame = true;
@@ -1730,11 +1768,11 @@ impl WlPointerHandler for FilterPointerHandler {
         direction: WlPointerAxisRelativeDirection,
     ) {
         if !receiver_has_client(slf.client_id()) {
-            self.rail_focus = false;
+            self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
         }
-        if self.rail_focus {
+        if self.focus == PointerFocus::Rail || self.focus == PointerFocus::None {
             return;
         }
         self.pending_forwarded_frame = true;
@@ -2733,6 +2771,42 @@ mod tests {
             diag,
             BridgeConfig::disabled(),
         )))
+    }
+
+    #[test]
+    fn wrapper_pointer_enter_translates_content_but_suppresses_rail() {
+        let rail_edge = Fixed::from_i32_saturating(WRAPPER_RAIL_WIDTH as i32);
+        let content_x = Fixed::from_i32_saturating(WRAPPER_RAIL_WIDTH as i32 + 42);
+
+        assert_eq!(wrapper_content_pointer_x(Fixed::ZERO), None);
+        assert_eq!(wrapper_content_pointer_x(rail_edge), Some(Fixed::ZERO));
+        assert_eq!(
+            wrapper_content_pointer_x(content_x),
+            Some(Fixed::from_i32_saturating(42))
+        );
+    }
+
+    #[test]
+    fn pointer_motion_translation_matches_current_focus() {
+        let wrapper_x = Fixed::from_i32_saturating(WRAPPER_RAIL_WIDTH as i32 + 10);
+        let direct_x = Fixed::from_i32_saturating(10);
+
+        assert_eq!(
+            pointer_motion_x_for_focus(PointerFocus::WrapperContent, wrapper_x),
+            Some(Fixed::from_i32_saturating(10))
+        );
+        assert_eq!(
+            pointer_motion_x_for_focus(PointerFocus::Direct, direct_x),
+            Some(direct_x)
+        );
+        assert_eq!(
+            pointer_motion_x_for_focus(PointerFocus::Rail, wrapper_x),
+            None
+        );
+        assert_eq!(
+            pointer_motion_x_for_focus(PointerFocus::None, wrapper_x),
+            None
+        );
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -44,7 +44,9 @@ use wl_proxy::{
             wl_data_offer::{WlDataOffer, WlDataOfferHandler},
             wl_data_source::{WlDataSource, WlDataSourceHandler},
             wl_display::{WlDisplay, WlDisplayHandler},
-            wl_keyboard::{WlKeyboard, WlKeyboardHandler},
+            wl_keyboard::{
+                WlKeyboard, WlKeyboardHandler, WlKeyboardKeyState, WlKeyboardKeymapFormat,
+            },
             wl_output::WlOutputTransform,
             wl_pointer::{
                 WlPointer, WlPointerAxis, WlPointerAxisRelativeDirection, WlPointerAxisSource,
@@ -1535,6 +1537,18 @@ struct FilterKeyboardHandler {
 }
 
 impl WlKeyboardHandler for FilterKeyboardHandler {
+    fn handle_keymap(
+        &mut self,
+        slf: &Rc<WlKeyboard>,
+        format: WlKeyboardKeymapFormat,
+        fd: &Rc<OwnedFd>,
+        size: u32,
+    ) {
+        if receiver_has_client(slf.client()) {
+            slf.send_keymap(format, fd, size);
+        }
+    }
+
     fn handle_enter(
         &mut self,
         slf: &Rc<WlKeyboard>,
@@ -1543,21 +1557,54 @@ impl WlKeyboardHandler for FilterKeyboardHandler {
         keys: &[u8],
     ) {
         if let Some(surface) = self.decoration.borrow().wrapper_input_target(surface) {
-            if surface_belongs_to_receiver(&surface, slf.client_id()) {
+            if surface_belongs_to_receiver(&surface, slf.client()) {
                 slf.send_enter(serial, &surface, keys);
             }
-        } else if surface_belongs_to_receiver(surface, slf.client_id()) {
+        } else if surface_belongs_to_receiver(surface, slf.client()) {
             slf.send_enter(serial, surface, keys);
         }
     }
 
     fn handle_leave(&mut self, slf: &Rc<WlKeyboard>, serial: u32, surface: &Rc<WlSurface>) {
         if let Some(surface) = self.decoration.borrow().wrapper_input_target(surface) {
-            if surface_belongs_to_receiver(&surface, slf.client_id()) {
+            if surface_belongs_to_receiver(&surface, slf.client()) {
                 slf.send_leave(serial, &surface);
             }
-        } else if surface_belongs_to_receiver(surface, slf.client_id()) {
+        } else if surface_belongs_to_receiver(surface, slf.client()) {
             slf.send_leave(serial, surface);
+        }
+    }
+
+    fn handle_key(
+        &mut self,
+        slf: &Rc<WlKeyboard>,
+        serial: u32,
+        time: u32,
+        key: u32,
+        state: WlKeyboardKeyState,
+    ) {
+        if receiver_has_client(slf.client()) {
+            slf.send_key(serial, time, key, state);
+        }
+    }
+
+    fn handle_modifiers(
+        &mut self,
+        slf: &Rc<WlKeyboard>,
+        serial: u32,
+        mods_depressed: u32,
+        mods_latched: u32,
+        mods_locked: u32,
+        group: u32,
+    ) {
+        if receiver_has_client(slf.client()) {
+            slf.send_modifiers(serial, mods_depressed, mods_latched, mods_locked, group);
+        }
+    }
+
+    fn handle_repeat_info(&mut self, slf: &Rc<WlKeyboard>, rate: i32, delay: i32) {
+        if receiver_has_client(slf.client()) {
+            slf.send_repeat_info(rate, delay);
         }
     }
 }
@@ -1602,7 +1649,7 @@ impl WlPointerHandler for FilterPointerHandler {
         surface_y: Fixed,
     ) {
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
-            if surface_belongs_to_receiver(&target, slf.client_id()) {
+            if surface_belongs_to_receiver(&target, slf.client()) {
                 if let Some(x) = wrapper_content_pointer_x(surface_x) {
                     self.focus = PointerFocus::WrapperContent;
                     self.pending_forwarded_frame = true;
@@ -1615,7 +1662,7 @@ impl WlPointerHandler for FilterPointerHandler {
             }
             return;
         }
-        if !surface_belongs_to_receiver(surface, slf.client_id()) {
+        if !surface_belongs_to_receiver(surface, slf.client()) {
             self.focus = PointerFocus::None;
             return;
         }
@@ -1626,7 +1673,7 @@ impl WlPointerHandler for FilterPointerHandler {
 
     fn handle_leave(&mut self, slf: &Rc<WlPointer>, serial: u32, surface: &Rc<WlSurface>) {
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
-            if surface_belongs_to_receiver(&target, slf.client_id())
+            if surface_belongs_to_receiver(&target, slf.client())
                 && self.focus == PointerFocus::WrapperContent
             {
                 self.pending_forwarded_frame = true;
@@ -1635,7 +1682,7 @@ impl WlPointerHandler for FilterPointerHandler {
             self.focus = PointerFocus::None;
             return;
         }
-        if !surface_belongs_to_receiver(surface, slf.client_id()) {
+        if !surface_belongs_to_receiver(surface, slf.client()) {
             self.focus = PointerFocus::None;
             return;
         }
@@ -1651,7 +1698,7 @@ impl WlPointerHandler for FilterPointerHandler {
         surface_x: Fixed,
         surface_y: Fixed,
     ) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1671,7 +1718,7 @@ impl WlPointerHandler for FilterPointerHandler {
         button: u32,
         state: WlPointerButtonState,
     ) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1684,7 +1731,7 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis(&mut self, slf: &Rc<WlPointer>, time: u32, axis: WlPointerAxis, value: Fixed) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1697,7 +1744,7 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_frame(&mut self, slf: &Rc<WlPointer>) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1710,7 +1757,7 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_source(&mut self, slf: &Rc<WlPointer>, axis_source: WlPointerAxisSource) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1723,7 +1770,7 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_stop(&mut self, slf: &Rc<WlPointer>, time: u32, axis: WlPointerAxis) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1736,7 +1783,7 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_discrete(&mut self, slf: &Rc<WlPointer>, axis: WlPointerAxis, discrete: i32) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1749,7 +1796,7 @@ impl WlPointerHandler for FilterPointerHandler {
     }
 
     fn handle_axis_value120(&mut self, slf: &Rc<WlPointer>, axis: WlPointerAxis, value120: i32) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1767,7 +1814,7 @@ impl WlPointerHandler for FilterPointerHandler {
         axis: WlPointerAxis,
         direction: WlPointerAxisRelativeDirection,
     ) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
             self.pending_forwarded_frame = false;
             return;
@@ -1798,19 +1845,19 @@ impl WlTouchHandler for FilterTouchHandler {
         x: Fixed,
         y: Fixed,
     ) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
-            if surface_belongs_to_receiver(&target, slf.client_id()) {
+            if surface_belongs_to_receiver(&target, slf.client()) {
                 self.suppressed_ids.insert(id);
             }
             return;
         }
-        if !surface_belongs_to_receiver(surface, slf.client_id()) {
+        if !surface_belongs_to_receiver(surface, slf.client()) {
             return;
         }
         self.forwarded_ids.insert(id);
@@ -1819,7 +1866,7 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_up(&mut self, slf: &Rc<WlTouch>, serial: u32, time: u32, id: i32) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
             self.pending_forwarded_frame = false;
@@ -1834,7 +1881,7 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_motion(&mut self, slf: &Rc<WlTouch>, time: u32, id: i32, x: Fixed, y: Fixed) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
             self.pending_forwarded_frame = false;
@@ -1848,7 +1895,7 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_shape(&mut self, slf: &Rc<WlTouch>, id: i32, major: Fixed, minor: Fixed) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
             self.pending_forwarded_frame = false;
@@ -1862,7 +1909,7 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_orientation(&mut self, slf: &Rc<WlTouch>, id: i32, orientation: Fixed) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
             self.pending_forwarded_frame = false;
@@ -1876,7 +1923,7 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_cancel(&mut self, slf: &Rc<WlTouch>) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
             self.pending_forwarded_frame = false;
@@ -1894,7 +1941,7 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 
     fn handle_frame(&mut self, slf: &Rc<WlTouch>) {
-        if !receiver_has_client(slf.client_id()) {
+        if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
             self.pending_forwarded_frame = false;
@@ -1908,12 +1955,17 @@ impl WlTouchHandler for FilterTouchHandler {
     }
 }
 
-fn receiver_has_client(receiver_client_id: Option<u32>) -> bool {
-    receiver_client_id.is_some()
+fn receiver_has_client(receiver: Option<Rc<Client>>) -> bool {
+    receiver.is_some()
 }
 
-fn surface_belongs_to_receiver(surface: &Rc<WlSurface>, receiver_client_id: Option<u32>) -> bool {
-    receiver_has_client(receiver_client_id) && surface.client_id() == receiver_client_id
+fn surface_belongs_to_receiver(surface: &Rc<WlSurface>, receiver: Option<Rc<Client>>) -> bool {
+    let Some(receiver) = receiver else {
+        return false;
+    };
+    surface
+        .client()
+        .is_some_and(|surface_client| Rc::ptr_eq(&surface_client, &receiver))
 }
 
 struct FilterSubcompositorHandler {


### PR DESCRIPTION
## Summary\n- translate pointer enter/motion from wrapper content coordinates to guest surface coordinates while suppressing only the trusted rail\n- compare actual wl-proxy client handles for keyboard/pointer/touch/surface event ownership instead of Wayland object IDs\n- drop stale input/output events after wl-proxy detaches a client\n- add focused unit coverage for wrapper pointer translation and document the fix in CHANGELOG\n\n## Validation\n- cargo fmt --check\n- cargo test -p d2b-wayland-proxy\n- cargo clippy -p d2b-wayland-proxy --all-targets -- -D warnings\n- offline Weston/Xvfb + d2b-wayland-proxy + foot harness: content click and rail click both keep foot alive; typed text reaches a guest file; no bad proxy input warnings\n- live host switched with d2b override; work-aad restarted; WAYLAND_DEBUG foot showed keyboard enter/key events and typed text reached a guest file with no proxy input warnings