### PR TITLE
Initialize security-key listener inside Tokio runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,8 @@ deprecations ship one minor release before removal.
 - Security-key accept loops now run on a daemon-owned runtime thread so the
   per-VM VSOCK socket remains listening after the VM-start readiness transaction
   returns.
+- Security-key accept-loop listener initialization now happens inside the
+  daemon-owned Tokio runtime context instead of before the runtime is entered.
 - Store-sync activation now creates newly declared per-VM `/run/d2b/<vm>`
   leaves before writing `next-generation`, without recursively creating or
   changing the `/run/d2b` parent posture.

--- a/packages/d2bd/src/security_key.rs
+++ b/packages/d2bd/src/security_key.rs
@@ -666,14 +666,14 @@ pub fn spawn_accept_loop(
                     return;
                 }
             };
-            let listener = match tokio::net::UnixListener::from_std(listener) {
-                Ok(listener) => listener,
-                Err(error) => {
-                    info!(vm = %thread_vm_id, error = %error, "security-key: accept listener init failed");
-                    return;
-                }
-            };
             runtime.block_on(async move {
+                let listener = match tokio::net::UnixListener::from_std(listener) {
+                    Ok(listener) => listener,
+                    Err(error) => {
+                        info!(vm = %thread_vm_id, error = %error, "security-key: accept listener init failed");
+                        return;
+                    }
+                };
         loop {
                     tokio::select! {
                         _ = &mut stop_rx => {


### PR DESCRIPTION
## Summary

- Initialize the security-key accept-loop Unix listener inside the dedicated Tokio runtime context instead of before entering it.
- Update the changelog.

## Why

Live validation after #227 showed the `d2b-sk-accept-personal-dev` thread panicking with `there is no reactor running` at `tokio::net::UnixListener::from_std`. That conversion must happen inside the runtime context.

## Validation

- `cargo test -p d2bd -- security_key --quiet`
- `make test-rust`
