### PR TITLE
Set security-key listener socket mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,9 @@ deprecations ship one minor release before removal.
 - Security-key guest frontend now emits the correct UHID_CREATE2 layout
   (`bus` is a 16-bit field), allowing the virtual FIDO HID device to register
   with the guest kernel.
+- Security-key host listener sockets now use mode `0770` so inherited per-VM
+  ACLs can grant Cloud Hypervisor write/connect access without making the
+  listener world-accessible.
 - Store-sync activation now creates newly declared per-VM `/run/d2b/<vm>`
   leaves before writing `next-generation`, without recursively creating or
   changing the `/run/d2b` parent posture.

--- a/packages/d2bd/src/security_key.rs
+++ b/packages/d2bd/src/security_key.rs
@@ -51,6 +51,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::os::fd::OwnedFd;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixListener as StdUnixListener;
 use std::path::Path;
 use std::sync::Arc;
@@ -582,7 +583,9 @@ pub fn bind_accept_socket(path: &Path) -> std::io::Result<StdUnixListener> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error),
     }
-    StdUnixListener::bind(path)
+    let listener = StdUnixListener::bind(path)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o770))?;
+    Ok(listener)
 }
 
 pub struct SkAcceptAbort {
@@ -1231,6 +1234,12 @@ mod tests {
         let _listener = bind_accept_socket(&socket_path).expect("bind accept socket");
 
         assert!(socket_path.exists(), "socket path should exist after bind");
+        let mode = fs::metadata(&socket_path)
+            .expect("socket metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o770);
 
         let _ = fs::remove_file(&socket_path);
         let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- Set the security-key host listener socket mode to `0770` after bind.
- Keep relying on inherited per-VM ACLs for Cloud Hypervisor access instead of world-opening the listener.
- Update the changelog.

## Why

Live validation showed the host listener existed, but guest VSOCK connects were reset until the socket was chmodded. The VM state directory already carries named ACLs for the Cloud Hypervisor uid; the listener needs group/ACL write permission (`0770`) so those ACLs can grant connect access.

## Validation

- `cargo test -p d2bd -- security_key --quiet`
- `make test-rust`
