### PR TITLE
Fix security-key UHID event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,9 @@ deprecations ship one minor release before removal.
   listener world-accessible.
 - Security-key guest frontend now writes the full UHID_CREATE2 payload,
   including `dev_flags` and padding fields required by current Linux kernels.
+- Security-key guest frontend now uses the correct Linux UHID event type
+  numbers (`CREATE2 = 11`, `INPUT2 = 12`) so the virtual FIDO HID device is
+  actually created rather than sending an input report to no device.
 - Store-sync activation now creates newly declared per-VM `/run/d2b/<vm>`
   leaves before writing `next-generation`, without recursively creating or
   changing the `/run/d2b` parent posture.

--- a/packages/d2b-sk-frontend/src/uhid.rs
+++ b/packages/d2b-sk-frontend/src/uhid.rs
@@ -32,19 +32,19 @@ use crate::framing::CTAPHID_REPORT_LEN;
 // ---------------------------------------------------------------------------
 
 /// Create the virtual HID device (UHID_CREATE2).
-const UHID_CREATE2: u32 = 12;
+const UHID_CREATE2: u32 = 11;
 /// Inject an input report (device→kernel→userspace) (UHID_INPUT2).
-const UHID_INPUT2: u32 = 11;
+const UHID_INPUT2: u32 = 12;
 /// Kernel sends an output report (userspace→kernel→device) to us.
 const UHID_OUTPUT: u32 = 6;
 /// Kernel signals device start (first client opened it).
-const UHID_START: u32 = 4;
+const UHID_START: u32 = 2;
 /// Kernel signals device stop (last client closed it).
-const UHID_STOP: u32 = 5;
+const UHID_STOP: u32 = 3;
 /// A userspace client opened the device.
-const UHID_OPEN: u32 = 7;
+const UHID_OPEN: u32 = 4;
 /// A userspace client closed the device.
-const UHID_CLOSE: u32 = 8;
+const UHID_CLOSE: u32 = 5;
 /// Kernel requests a GET_REPORT from the device.
 const UHID_GET_REPORT: u32 = 9;
 
@@ -299,6 +299,18 @@ fn build_get_report_reply_error(id: u32) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn uhid_event_type_values_match_kernel_uapi() {
+        assert_eq!(UHID_START, 2);
+        assert_eq!(UHID_STOP, 3);
+        assert_eq!(UHID_OPEN, 4);
+        assert_eq!(UHID_CLOSE, 5);
+        assert_eq!(UHID_OUTPUT, 6);
+        assert_eq!(UHID_GET_REPORT, 9);
+        assert_eq!(UHID_CREATE2, 11);
+        assert_eq!(UHID_INPUT2, 12);
+    }
 
     #[test]
     fn create2_event_length() {


### PR DESCRIPTION
## Summary

- Correct d2b-sk-frontend UHID event type constants to match Linux UAPI (`CREATE2 = 11`, `INPUT2 = 12`, lifecycle 2-5).
- Add explicit kernel-value assertions.
- Update the changelog.

## Why

Live validation showed the frontend saying `virtual FIDO HID device created` while the guest had no `/dev/hidraw*`; the old constants made it send an input report to no device instead of creating the UHID device.

## Validation

- `cargo test --manifest-path packages/d2b-sk-frontend/Cargo.toml --quiet`
- `make test-rust`
