### PR TITLE
Accept short UHID events in security-key frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,9 @@ deprecations ship one minor release before removal.
 - Security-key guest frontend now uses the correct Linux UHID event type
   numbers (`CREATE2 = 11`, `INPUT2 = 12`) so the virtual FIDO HID device is
   actually created rather than sending an input report to no device.
+- Security-key guest frontend now zero-extends short UHID events from the kernel
+  instead of treating lifecycle events shorter than the maximum union size as
+  fatal.
 - Store-sync activation now creates newly declared per-VM `/run/d2b/<vm>`
   leaves before writing `next-generation`, without recursively creating or
   changing the `/run/d2b` parent posture.

--- a/packages/d2b-sk-frontend/src/uhid.rs
+++ b/packages/d2b-sk-frontend/src/uhid.rs
@@ -158,12 +158,6 @@ impl UhidDevice {
                 format!("short uhid event header: {n} bytes"),
             ));
         }
-        if n < UHID_EVENT_SIZE {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                format!("short uhid event: expected {UHID_EVENT_SIZE} bytes, got {n}"),
-            ));
-        }
         let event_type = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
         let payload = &buf[4..];
         let event = match event_type {
@@ -402,5 +396,16 @@ mod tests {
     #[test]
     fn fido_descriptor_is_valid_length() {
         assert_eq!(FIDO_HID_DESCRIPTOR.len(), 34);
+    }
+
+    #[test]
+    fn short_lifecycle_event_is_zero_extended() {
+        let mut buf = [0u8; UHID_EVENT_SIZE];
+        buf[..4].copy_from_slice(&UHID_START.to_le_bytes());
+        let event_type = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+        assert!(matches!(
+            event_type,
+            UHID_START | UHID_STOP | UHID_OPEN | UHID_CLOSE
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Accept and zero-extend short UHID events from the kernel in d2b-sk-frontend.
- Keep rejecting truly short headers.
- Update the changelog.

## Why

Live validation showed the virtual HID device appearing, then the frontend immediately recreating it with `short uhid event: expected 4384 bytes, got 4380`. The Linux UHID UAPI explicitly says kernel-written short events should be zero-extended by userspace.

## Validation

- `cargo test --manifest-path packages/d2b-sk-frontend/Cargo.toml --quiet`
- `make test-rust`
