### PR TITLE
Prefix security-key hidraw writes with report ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,8 @@ deprecations ship one minor release before removal.
 - Security-key guest frontend now zero-extends short UHID events from the kernel
   instead of treating lifecycle events shorter than the maximum union size as
   fatal.
+- Security-key host relay now prefixes physical hidraw writes with a zero report
+  ID byte, matching Linux hidraw/libfido2 behavior for unnumbered FIDO reports.
 - Store-sync activation now creates newly declared per-VM `/run/d2b/<vm>`
   leaves before writing `next-generation`, without recursively creating or
   changing the `/run/d2b` parent posture.

--- a/packages/d2bd/src/security_key.rs
+++ b/packages/d2bd/src/security_key.rs
@@ -432,7 +432,9 @@ impl HidrawDevice {
     /// Blocking write of a single 64-byte CTAPHID report to the
     /// physical token. Call from `tokio::task::spawn_blocking`.
     pub fn write_report(&self, report: &CtaphidReport) -> std::io::Result<()> {
-        (&self.file).write_all(report)
+        let mut hidraw_report = [0u8; CTAPHID_REPORT_SIZE + 1];
+        hidraw_report[1..].copy_from_slice(report);
+        (&self.file).write_all(&hidraw_report)
     }
 }
 
@@ -1202,6 +1204,32 @@ mod tests {
         let device = HidrawDevice::from_owned_fd(fd);
         let report = build_error_report(1, CTAPHID_ERR_INVALID_CMD);
         device.write_report(&report).expect("write to /dev/null");
+    }
+
+    #[test]
+    fn hidraw_device_write_report_prefixes_report_id() {
+        let dir = test_scratch_dir("hidraw-write-prefix");
+        let path = dir.join("hidraw.out");
+        let file = File::options()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)
+            .expect("scratch file writable");
+        let fd: OwnedFd = file.into();
+        let device = HidrawDevice::from_owned_fd(fd);
+        let report = build_init_packet(CTAPHID_BROADCAST_CID, CTAPHID_INIT, 8, &[1, 2, 3, 4]);
+
+        device.write_report(&report).expect("write report");
+        drop(device);
+
+        let written = fs::read(&path).expect("read scratch file");
+        assert_eq!(written.len(), CTAPHID_REPORT_SIZE + 1);
+        assert_eq!(written[0], 0, "hidraw write must include report ID prefix");
+        assert_eq!(&written[1..], &report);
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir_all(&dir);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Prefix physical hidraw writes with a zero report ID byte before the 64-byte CTAPHID payload.
- Add a unit test that verifies the 65-byte hidraw write shape.
- Update the changelog.

## Why

Live validation showed the virtual key enumerating, but CTAP info hung. A direct `strace` of `fido2-token -I /dev/hidraw3` showed Linux hidraw writes are 65 bytes: a leading report ID byte followed by the 64-byte CTAPHID report. The proxy was writing only the 64-byte CTAPHID payload.

## Validation

- `cargo test -p d2bd -- security_key --quiet`
- `make test-rust`
