### PR TITLE
security-key: fix guest hidraw permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,9 +187,9 @@ deprecations ship one minor release before removal.
 - Security-key guest frontend now drives `/dev/uhid` through nonblocking
   `AsyncFd` I/O instead of `tokio::fs::File`, avoiding `ESPIPE` failures on
   character devices during CTAPHID response injection.
-- d2b guest activation now creates `/etc` before NixOS user/group activation,
+- d2b guests now refresh declarative users/groups immediately after switch-root,
   preventing fresh microVM root overlays from booting without `/etc/passwd` and
-  `/etc/group`.
+  `/etc/group` when cold-boot activation ran in the initrd.
 - Security-key proxy broker now accepts descriptor-verified FIDO hidraw devices
   even when the host udev group is not one of the fallback FIDO groups. The
   group allowlist remains required only for the descriptor-unreadable fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,8 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Guest VMs now cap persistent systemd journals by default so `/var/log/journal`
+  cannot fill small per-VM `/var` images and corrupt NixOS activation state.
 - Security-key guest udev rules now match the virtual UHID FIDO device by its
   HID parent identity and grant the standard `plugdev` browser/FIDO access group
   so Firefox and libfido2 can open the guest `/dev/hidraw*` node without root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,8 @@ deprecations ship one minor release before removal.
 ### Fixed
 
 - Security-key guest udev rules now match the virtual UHID FIDO device by its
-  HID parent identity so Firefox and libfido2 can open the guest `/dev/hidraw*`
-  node without root.
+  HID parent identity and grant the standard `plugdev` browser/FIDO access group
+  so Firefox and libfido2 can open the guest `/dev/hidraw*` node without root.
 - Security-key proxy broker now accepts descriptor-verified FIDO hidraw devices
   even when the host udev group is not one of the fallback FIDO groups. The
   group allowlist remains required only for the descriptor-unreadable fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,9 +187,6 @@ deprecations ship one minor release before removal.
 - Security-key guest frontend now drives `/dev/uhid` through nonblocking
   `AsyncFd` I/O instead of `tokio::fs::File`, avoiding `ESPIPE` failures on
   character devices during CTAPHID response injection.
-- d2b guests now refresh declarative users/groups immediately after switch-root,
-  preventing fresh microVM root overlays from booting without `/etc/passwd` and
-  `/etc/group` when cold-boot activation ran in the initrd.
 - Security-key proxy broker now accepts descriptor-verified FIDO hidraw devices
   even when the host udev group is not one of the fallback FIDO groups. The
   group allowlist remains required only for the descriptor-unreadable fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,9 +183,9 @@ deprecations ship one minor release before removal.
 
 - Guest VMs now cap persistent systemd journals by default so `/var/log/journal`
   cannot fill small per-VM `/var` images and corrupt NixOS activation state.
-- Security-key host relay now runs blocking physical hidraw reads on a blocking
-  worker thread so the single-thread per-VM accept-loop runtime can still forward
-  guest CTAPHID requests to the token.
+- Security-key host relay now drives the physical hidraw fd through
+  cancellation-safe `AsyncFd` I/O so guest disconnects cannot leave orphaned
+  reader threads racing future sessions.
 - Security-key guest frontend now strips the kernel-supplied zero report-ID byte
   from UHID output reports before forwarding CTAPHID frames to the host broker.
 - Security-key guest udev rules now match the virtual UHID FIDO device by its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,9 @@ deprecations ship one minor release before removal.
 
 - Guest VMs now cap persistent systemd journals by default so `/var/log/journal`
   cannot fill small per-VM `/var` images and corrupt NixOS activation state.
+- Security-key host relay now runs blocking physical hidraw reads on a blocking
+  worker thread so the single-thread per-VM accept-loop runtime can still forward
+  guest CTAPHID requests to the token.
 - Security-key guest udev rules now match the virtual UHID FIDO device by its
   HID parent identity and grant the standard `plugdev` browser/FIDO access group
   so Firefox and libfido2 can open the guest `/dev/hidraw*` node without root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Security-key guest udev rules now match the virtual UHID FIDO device by its
+  HID parent identity so Firefox and libfido2 can open the guest `/dev/hidraw*`
+  node without root.
 - Security-key proxy broker now accepts descriptor-verified FIDO hidraw devices
   even when the host udev group is not one of the fallback FIDO groups. The
   group allowlist remains required only for the descriptor-unreadable fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,9 @@ deprecations ship one minor release before removal.
 - Security-key guest frontend now drives `/dev/uhid` through nonblocking
   `AsyncFd` I/O instead of `tokio::fs::File`, avoiding `ESPIPE` failures on
   character devices during CTAPHID response injection.
+- d2b guest activation now creates `/etc` before NixOS user/group activation,
+  preventing fresh microVM root overlays from booting without `/etc/passwd` and
+  `/etc/group`.
 - Security-key proxy broker now accepts descriptor-verified FIDO hidraw devices
   even when the host udev group is not one of the fallback FIDO groups. The
   group allowlist remains required only for the descriptor-unreadable fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,9 @@ deprecations ship one minor release before removal.
 - Security-key guest udev rules now match the virtual UHID FIDO device by its
   HID parent identity and grant the standard `plugdev` browser/FIDO access group
   so Firefox and libfido2 can open the guest `/dev/hidraw*` node without root.
+- Security-key guest frontend now drives `/dev/uhid` through nonblocking
+  `AsyncFd` I/O instead of `tokio::fs::File`, avoiding `ESPIPE` failures on
+  character devices during CTAPHID response injection.
 - Security-key proxy broker now accepts descriptor-verified FIDO hidraw devices
   even when the host udev group is not one of the fallback FIDO groups. The
   group allowlist remains required only for the descriptor-unreadable fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,8 @@ deprecations ship one minor release before removal.
 - Security-key host relay now runs blocking physical hidraw reads on a blocking
   worker thread so the single-thread per-VM accept-loop runtime can still forward
   guest CTAPHID requests to the token.
+- Security-key guest frontend now strips the kernel-supplied zero report-ID byte
+  from UHID output reports before forwarding CTAPHID frames to the host broker.
 - Security-key guest udev rules now match the virtual UHID FIDO device by its
   HID parent identity and grant the standard `plugdev` browser/FIDO access group
   so Firefox and libfido2 can open the guest `/dev/hidraw*` node without root.

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -86,19 +86,42 @@ in
   system.stateVersion = lib.mkDefault "26.05";
 
   # d2b guests boot from a minimal root overlay where /etc may not exist yet.
-  # Create it before NixOS' user/group activation, then refresh users/groups
-  # once more after static /etc setup. The generated users script is idempotent;
-  # the second pass keeps /etc/passwd and /etc/group as writable files even on
-  # fresh VM roots where /etc/static is created during the same activation.
+  # Create it before NixOS' user/group activation for normal switch paths.
   system.activationScripts.d2bEnsureEtcForUsers = ''
     mkdir -p /etc
     chmod 0755 /etc
   '';
   system.activationScripts.users.deps = lib.mkBefore [ "d2bEnsureEtcForUsers" ];
-  system.activationScripts.d2bRefreshUsersAfterEtc = {
-    deps = [ "etc" ];
-    supportsDryActivation = true;
-    text = config.system.activationScripts.users.text;
+
+  # On d2b microVM cold boots the activation script runs during initrd before
+  # switch-root, so the standard users snippet can write passwd/group data into
+  # the transient initrd root. Re-run the idempotent generated users snippet
+  # early after switch-root and before socket/basic units resolve users/groups.
+  systemd.services.d2b-refresh-users-after-switch-root = {
+    description = "Refresh declarative users/groups after switch-root";
+    wantedBy = [ "sysinit.target" ];
+    after = [ "local-fs.target" ];
+    before = [ "sysinit.target" "sockets.target" "basic.target" ];
+    path = [
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.getent
+      pkgs.glibc.bin
+      pkgs.gnugrep
+      pkgs.shadow
+      pkgs.util-linux
+    ];
+    unitConfig.DefaultDependencies = false;
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = pkgs.writeShellScript "d2b-refresh-users-after-switch-root" ''
+        set -euo pipefail
+        mkdir -p /etc
+        chmod 0755 /etc
+        ${config.system.activationScripts.users.text}
+      '';
+    };
   };
 
   # ---------------------------------------------------------------------------

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -115,11 +115,15 @@ in
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
+      StandardOutput = "journal+console";
+      StandardError = "journal+console";
       ExecStart = pkgs.writeShellScript "d2b-refresh-users-after-switch-root" ''
-        set -euo pipefail
+        set -euxo pipefail
         mkdir -p /etc
         chmod 0755 /etc
         ${config.system.activationScripts.users.text}
+        test -s /etc/passwd
+        test -s /etc/group
       '';
     };
   };

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -158,7 +158,7 @@ in
         ls -ld / /etc /var /var/lib || true
         mkdir -p /etc
         chmod 0755 /etc
-        printf '%s\n' '${usersGroupsJson}' > /run/d2b-users-groups.json
+        printf '%s\n' ${lib.escapeShellArg usersGroupsJson} > /run/d2b-users-groups.json
         wc -c /run/d2b-users-groups.json
         od -An -tx1 -N32 /run/d2b-users-groups.json
         echo "d2b-refresh-users: before generated users snippet"

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -85,6 +85,16 @@ in
 
   system.stateVersion = lib.mkDefault "26.05";
 
+  # NixOS' generated `users` activation snippet writes /etc/passwd and
+  # /etc/group before the generated `etc` snippet runs. d2b guests boot from a
+  # minimal root overlay where /etc may not exist yet, so create it explicitly
+  # before user/group activation.
+  system.activationScripts.d2bEnsureEtcForUsers = ''
+    mkdir -p /etc
+    chmod 0755 /etc
+  '';
+  system.activationScripts.users.deps = lib.mkBefore [ "d2bEnsureEtcForUsers" ];
+
   # ---------------------------------------------------------------------------
   # Per-VM nix store: load the db.dump from the host-injected
   # /run/d2b-store-meta share into the guest's local Nix DB

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -158,6 +158,12 @@ in
         ls -ld / /etc /var /var/lib || true
         mkdir -p /etc
         chmod 0755 /etc
+        mkdir -p /var/lib/nixos
+        for map in /var/lib/nixos/uid-map /var/lib/nixos/gid-map /var/lib/nixos/auto-subuid-map; do
+          if [ -e "$map" ] && ! head -c 1 "$map" | grep -q '{'; then
+            mv "$map" "$map.corrupt.$(date +%s)"
+          fi
+        done
         printf '%s\n' ${lib.escapeShellArg usersGroupsJson} > /run/d2b-users-groups.json
         wc -c /run/d2b-users-groups.json
         od -An -tx1 -N32 /run/d2b-users-groups.json

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -10,39 +10,6 @@
 
 let
   cfg = config.d2b;
-  usersGroupsJsonPath =
-    let
-      matches = builtins.match ".*update-users-groups\\.pl ([^[:space:]\n]+).*" config.system.activationScripts.users.text;
-    in
-    if matches == null then null else builtins.head matches;
-  usersGroupsJson = builtins.toJSON {
-    inherit (config.users) mutableUsers;
-    groups = lib.mapAttrsToList (name: group: {
-      inherit name;
-      gid = group.gid or null;
-      members = group.members or [ ];
-    }) config.users.groups;
-    users = lib.mapAttrsToList (name: user: {
-      inherit name;
-      autoSubUidGidRange = user.autoSubUidGidRange or false;
-      createHome = user.createHome or false;
-      description = user.description or "";
-      expires = user.expires or null;
-      group = user.group or "nogroup";
-      hashedPassword = user.hashedPassword or null;
-      hashedPasswordFile = user.hashedPasswordFile or null;
-      home = user.home or "/var/empty";
-      homeMode = user.homeMode or "700";
-      initialHashedPassword = user.initialHashedPassword or null;
-      initialPassword = user.initialPassword or null;
-      isSystemUser = user.isSystemUser or false;
-      password = user.password or null;
-      shell = user.shell or null;
-      subGidRanges = user.subGidRanges or [ ];
-      subUidRanges = user.subUidRanges or [ ];
-      uid = user.uid or null;
-    }) config.users.users;
-  };
 in
 {
   options.d2b.sshUser = lib.mkOption {
@@ -117,69 +84,6 @@ in
   i18n.defaultLocale = lib.mkDefault "en_US.UTF-8";
 
   system.stateVersion = lib.mkDefault "26.05";
-
-  # d2b guests boot from a minimal root overlay where /etc may not exist yet.
-  # Create it before NixOS' user/group activation for normal switch paths.
-  system.activationScripts.d2bEnsureEtcForUsers = ''
-    mkdir -p /etc
-    chmod 0755 /etc
-  '';
-  system.activationScripts.users.deps = lib.mkBefore [ "d2bEnsureEtcForUsers" ];
-
-  # On d2b microVM cold boots the activation script runs during initrd before
-  # switch-root, so the standard users snippet can write passwd/group data into
-  # the transient initrd root. Re-run the idempotent generated users snippet
-  # early after switch-root and before socket/basic units resolve users/groups.
-  systemd.services.d2b-refresh-users-after-switch-root = {
-    description = "Refresh declarative users/groups after switch-root";
-    wantedBy = [ "sysinit.target" ];
-    after = [ "local-fs.target" ];
-    before = [ "sysinit.target" "sockets.target" "basic.target" ];
-    path = [
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.getent
-      pkgs.glibc.bin
-      pkgs.gnugrep
-      pkgs.shadow
-      pkgs.util-linux
-    ];
-    unitConfig.DefaultDependencies = false;
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      StandardOutput = "journal+console";
-      StandardError = "journal+console";
-      ExecStart = pkgs.writeShellScript "d2b-refresh-users-after-switch-root" ''
-        set -euxo pipefail
-        exec > >(tee /dev/console) 2>&1
-        echo "d2b-refresh-users: start"
-        pwd
-        ls -ld / /etc /var /var/lib || true
-        mkdir -p /etc
-        chmod 0755 /etc
-        mkdir -p /var/lib/nixos
-        for map in /var/lib/nixos/uid-map /var/lib/nixos/gid-map /var/lib/nixos/auto-subuid-map; do
-          if [ -e "$map" ] && ! head -c 1 "$map" | grep -q '{'; then
-            mv "$map" "$map.corrupt.$(date +%s)"
-          fi
-        done
-        printf '%s\n' ${lib.escapeShellArg usersGroupsJson} > /run/d2b-users-groups.json
-        wc -c /run/d2b-users-groups.json
-        od -An -tx1 -N32 /run/d2b-users-groups.json
-        echo "d2b-refresh-users: before generated users snippet"
-        ${builtins.replaceStrings
-          (lib.optional (usersGroupsJsonPath != null) usersGroupsJsonPath)
-          (lib.optional (usersGroupsJsonPath != null) "/run/d2b-users-groups.json")
-          config.system.activationScripts.users.text}
-        echo "d2b-refresh-users: after generated users snippet"
-        ls -l /etc/passwd /etc/group /etc/shadow || true
-        test -s /etc/passwd
-        test -s /etc/group
-        echo "d2b-refresh-users: complete"
-      '';
-    };
-  };
 
   # ---------------------------------------------------------------------------
   # Per-VM nix store: load the db.dump from the host-injected

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -80,6 +80,14 @@ in
   networking.firewall.enable = lib.mkDefault true;
   networking.firewall.allowedTCPPorts = [ 22 ];
 
+  # d2b VMs commonly persist /var in a small ext4 image. Keep journals bounded
+  # so logs cannot starve NixOS activation state such as /var/lib/nixos/*-map.
+  services.journald.extraConfig = lib.mkDefault ''
+    SystemMaxUse=512M
+    SystemKeepFree=512M
+    RuntimeMaxUse=128M
+  '';
+
   time.timeZone = lib.mkDefault "America/Los_Angeles";
   i18n.defaultLocale = lib.mkDefault "en_US.UTF-8";
 

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -119,11 +119,19 @@ in
       StandardError = "journal+console";
       ExecStart = pkgs.writeShellScript "d2b-refresh-users-after-switch-root" ''
         set -euxo pipefail
+        exec > >(tee /dev/console) 2>&1
+        echo "d2b-refresh-users: start"
+        pwd
+        ls -ld / /etc /var /var/lib || true
         mkdir -p /etc
         chmod 0755 /etc
+        echo "d2b-refresh-users: before generated users snippet"
         ${config.system.activationScripts.users.text}
+        echo "d2b-refresh-users: after generated users snippet"
+        ls -l /etc/passwd /etc/group /etc/shadow || true
         test -s /etc/passwd
         test -s /etc/group
+        echo "d2b-refresh-users: complete"
       '';
     };
   };

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -85,15 +85,15 @@ in
 
   system.stateVersion = lib.mkDefault "26.05";
 
-  # NixOS' generated `users` activation snippet writes /etc/passwd and
-  # /etc/group before the generated `etc` snippet runs. d2b guests boot from a
-  # minimal root overlay where /etc may not exist yet, so create it explicitly
-  # before user/group activation.
+  # d2b guests boot from a minimal root overlay where /etc may not exist yet.
+  # Create it before static /etc setup, then run user/group activation after the
+  # static /etc links are in place so /etc/passwd and /etc/group remain real
+  # writable files instead of being overwritten during first boot.
   system.activationScripts.d2bEnsureEtcForUsers = ''
     mkdir -p /etc
     chmod 0755 /etc
   '';
-  system.activationScripts.users.deps = lib.mkBefore [ "d2bEnsureEtcForUsers" ];
+  system.activationScripts.users.deps = lib.mkAfter [ "etc" ];
 
   # ---------------------------------------------------------------------------
   # Per-VM nix store: load the db.dump from the host-injected

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -86,14 +86,20 @@ in
   system.stateVersion = lib.mkDefault "26.05";
 
   # d2b guests boot from a minimal root overlay where /etc may not exist yet.
-  # Create it before static /etc setup, then run user/group activation after the
-  # static /etc links are in place so /etc/passwd and /etc/group remain real
-  # writable files instead of being overwritten during first boot.
+  # Create it before NixOS' user/group activation, then refresh users/groups
+  # once more after static /etc setup. The generated users script is idempotent;
+  # the second pass keeps /etc/passwd and /etc/group as writable files even on
+  # fresh VM roots where /etc/static is created during the same activation.
   system.activationScripts.d2bEnsureEtcForUsers = ''
     mkdir -p /etc
     chmod 0755 /etc
   '';
-  system.activationScripts.users.deps = lib.mkAfter [ "etc" ];
+  system.activationScripts.users.deps = lib.mkBefore [ "d2bEnsureEtcForUsers" ];
+  system.activationScripts.d2bRefreshUsersAfterEtc = {
+    deps = [ "etc" ];
+    supportsDryActivation = true;
+    text = config.system.activationScripts.users.text;
+  };
 
   # ---------------------------------------------------------------------------
   # Per-VM nix store: load the db.dump from the host-injected

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -10,6 +10,39 @@
 
 let
   cfg = config.d2b;
+  usersGroupsJsonPath =
+    let
+      matches = builtins.match ".*update-users-groups\\.pl ([^[:space:]\n]+).*" config.system.activationScripts.users.text;
+    in
+    if matches == null then null else builtins.head matches;
+  usersGroupsJson = builtins.toJSON {
+    inherit (config.users) mutableUsers;
+    groups = lib.mapAttrsToList (name: group: {
+      inherit name;
+      gid = group.gid or null;
+      members = group.members or [ ];
+    }) config.users.groups;
+    users = lib.mapAttrsToList (name: user: {
+      inherit name;
+      autoSubUidGidRange = user.autoSubUidGidRange or false;
+      createHome = user.createHome or false;
+      description = user.description or "";
+      expires = user.expires or null;
+      group = user.group or "nogroup";
+      hashedPassword = user.hashedPassword or null;
+      hashedPasswordFile = user.hashedPasswordFile or null;
+      home = user.home or "/var/empty";
+      homeMode = user.homeMode or "700";
+      initialHashedPassword = user.initialHashedPassword or null;
+      initialPassword = user.initialPassword or null;
+      isSystemUser = user.isSystemUser or false;
+      password = user.password or null;
+      shell = user.shell or null;
+      subGidRanges = user.subGidRanges or [ ];
+      subUidRanges = user.subUidRanges or [ ];
+      uid = user.uid or null;
+    }) config.users.users;
+  };
 in
 {
   options.d2b.sshUser = lib.mkOption {
@@ -125,8 +158,14 @@ in
         ls -ld / /etc /var /var/lib || true
         mkdir -p /etc
         chmod 0755 /etc
+        cat > /run/d2b-users-groups.json <<'D2B_USERS_GROUPS_JSON'
+        ${usersGroupsJson}
+        D2B_USERS_GROUPS_JSON
         echo "d2b-refresh-users: before generated users snippet"
-        ${config.system.activationScripts.users.text}
+        ${builtins.replaceStrings
+          (lib.optional (usersGroupsJsonPath != null) usersGroupsJsonPath)
+          (lib.optional (usersGroupsJsonPath != null) "/run/d2b-users-groups.json")
+          config.system.activationScripts.users.text}
         echo "d2b-refresh-users: after generated users snippet"
         ls -l /etc/passwd /etc/group /etc/shadow || true
         test -s /etc/passwd

--- a/nixos-modules/base.nix
+++ b/nixos-modules/base.nix
@@ -158,9 +158,9 @@ in
         ls -ld / /etc /var /var/lib || true
         mkdir -p /etc
         chmod 0755 /etc
-        cat > /run/d2b-users-groups.json <<'D2B_USERS_GROUPS_JSON'
-        ${usersGroupsJson}
-        D2B_USERS_GROUPS_JSON
+        printf '%s\n' '${usersGroupsJson}' > /run/d2b-users-groups.json
+        wc -c /run/d2b-users-groups.json
+        od -An -tx1 -N32 /run/d2b-users-groups.json
         echo "d2b-refresh-users: before generated users snippet"
         ${builtins.replaceStrings
           (lib.optional (usersGroupsJsonPath != null) usersGroupsJsonPath)

--- a/nixos-modules/components/security-key-guest.nix
+++ b/nixos-modules/components/security-key-guest.nix
@@ -49,19 +49,15 @@ in
     # libfido2 and Firefox use this group for hidraw access.
     users.groups.fido = { };
 
-    # udev rule: grant the `fido` group read/write access to every HID raw
-    # device that presents the FIDO Alliance usage page. This matches both
-    # real and virtual FIDO/CTAPHID devices so the same rule works during
-    # development (physical key via USBIP or direct) and in production (the
-    # virtual device created by d2b-sk-frontend).
+    # udev rule: grant the `fido` group read/write access to the virtual
+    # FIDO/CTAPHID HID raw device created by d2b-sk-frontend.
     #
-    # The rule fires on SUBSYSTEM=="hidraw" with the FIDO usage page. The
-    # kernel exposes the top-level HID usage page in the uevent ATTRS so
-    # uaccess-style matching is not needed — group ownership is enough.
+    # The virtual device is a UHID HID parent whose kernel name encodes the
+    # Yubico FIDO vendor/product pair used by d2b-sk-frontend.
     services.udev.extraRules = ''
       # d2b security-key: grant fido group access to FIDO/CTAPHID HID raw nodes.
-      # Match only the virtual FIDO device created by d2b-sk-frontend.
-      KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{phys}=="d2b-sk*", GROUP="fido", MODE="0660"
+      # Match the virtual FIDO device created by d2b-sk-frontend.
+      KERNEL=="hidraw*", SUBSYSTEM=="hidraw", SUBSYSTEMS=="hid", KERNELS=="0003:1050:0407.*", GROUP="fido", MODE="0660"
     '';
 
     # The d2b-sk-frontend service runs as the guest's login user so it has

--- a/nixos-modules/components/security-key-guest.nix
+++ b/nixos-modules/components/security-key-guest.nix
@@ -4,7 +4,7 @@
 #
 # This module wires:
 #   - The `uhid` kernel module so the frontend binary can open /dev/uhid.
-#   - A `fido` group and udev rules granting group-readable access to
+#   - A `plugdev` group and udev rules granting group-readable access to
 #     /dev/hidraw* nodes so Firefox/libfido2 can access the virtual key
 #     without root.
 #   - The `d2b-sk-frontend` static binary from the framework packages.
@@ -45,19 +45,19 @@ in
     # Load the UHID kernel module so /dev/uhid is available.
     boot.kernelModules = [ "uhid" ];
 
-    # Create the fido group if not already declared.
-    # libfido2 and Firefox use this group for hidraw access.
-    users.groups.fido = { };
+    # Create the plugdev group if not already declared. Workload users that run
+    # browsers/libfido2 should join this same group for hidraw access.
+    users.groups.plugdev = { };
 
-    # udev rule: grant the `fido` group read/write access to the virtual
+    # udev rule: grant the `plugdev` group read/write access to the virtual
     # FIDO/CTAPHID HID raw device created by d2b-sk-frontend.
     #
     # The virtual device is a UHID HID parent whose kernel name encodes the
     # Yubico FIDO vendor/product pair used by d2b-sk-frontend.
     services.udev.extraRules = ''
-      # d2b security-key: grant fido group access to FIDO/CTAPHID HID raw nodes.
+      # d2b security-key: grant plugdev access to FIDO/CTAPHID HID raw nodes.
       # Match the virtual FIDO device created by d2b-sk-frontend.
-      KERNEL=="hidraw*", SUBSYSTEM=="hidraw", SUBSYSTEMS=="hid", KERNELS=="0003:1050:0407.*", GROUP="fido", MODE="0660"
+      KERNEL=="hidraw*", SUBSYSTEM=="hidraw", SUBSYSTEMS=="hid", KERNELS=="0003:1050:0407.*", GROUP="plugdev", MODE="0660"
     '';
 
     # The d2b-sk-frontend service runs as the guest's login user so it has

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
 name = "d2b-sk-frontend"
 version = "0.0.0-bootstrap"
 dependencies = [
+ "libc",
  "tokio",
  "tokio-vsock",
 ]

--- a/packages/d2b-sk-frontend/Cargo.toml
+++ b/packages/d2b-sk-frontend/Cargo.toml
@@ -10,5 +10,6 @@ description = "d2b guest-side virtual FIDO/security-key UHID frontend"
 workspace = true
 
 [dependencies]
+libc = "0.2"
 tokio = { version = "1", features = ["io-util", "macros", "rt-multi-thread", "time", "fs"] }
 tokio-vsock = "0.7.2"

--- a/packages/d2b-sk-frontend/src/uhid.rs
+++ b/packages/d2b-sk-frontend/src/uhid.rs
@@ -168,9 +168,7 @@ impl UhidDevice {
                 //   data[4096], size(__u16), rtype(__u8)
                 let size = u16::from_le_bytes([payload[4096], payload[4097]]) as usize;
                 let rtype = payload[4098];
-                let clamped = size.min(CTAPHID_REPORT_LEN);
-                let mut data = [0u8; CTAPHID_REPORT_LEN];
-                data[..clamped].copy_from_slice(&payload[..clamped]);
+                let data = parse_output_report(payload, size);
                 UhidEvent::Output {
                     _rtype: rtype,
                     data,
@@ -307,6 +305,22 @@ fn build_input2_event(data: &[u8; CTAPHID_REPORT_LEN]) -> Vec<u8> {
     buf
 }
 
+fn parse_output_report(payload: &[u8], size: usize) -> [u8; CTAPHID_REPORT_LEN] {
+    let start = if size == CTAPHID_REPORT_LEN + 1 && payload.first() == Some(&0) {
+        1
+    } else {
+        0
+    };
+    let available = payload.len().saturating_sub(start);
+    let copy_len = size
+        .saturating_sub(start)
+        .min(CTAPHID_REPORT_LEN)
+        .min(available);
+    let mut data = [0u8; CTAPHID_REPORT_LEN];
+    data[..copy_len].copy_from_slice(&payload[start..start + copy_len]);
+    data
+}
+
 fn build_get_report_reply_error(id: u32) -> Vec<u8> {
     // uhid_get_report_reply_req: id(__u32), err(__u16), size(__u16), data[4096]
     // UHID_GET_REPORT_REPLY = 10
@@ -422,6 +436,39 @@ mod tests {
         // data starts at offset 4(type) + 2(size) = 6
         assert_eq!(buf[6], 0xde);
         assert_eq!(buf[6 + 63], 0xad);
+    }
+
+    #[test]
+    fn output_report_preserves_plain_64_byte_report() {
+        let mut payload = [0u8; 4099];
+        payload[0] = 0xff;
+        payload[1] = 0xff;
+        payload[2] = 0xff;
+        payload[3] = 0xff;
+        payload[4] = 0x86;
+        payload[63] = 0xee;
+
+        let report = parse_output_report(&payload, CTAPHID_REPORT_LEN);
+
+        assert_eq!(&report[..5], &[0xff, 0xff, 0xff, 0xff, 0x86]);
+        assert_eq!(report[63], 0xee);
+    }
+
+    #[test]
+    fn output_report_strips_zero_report_id_prefix() {
+        let mut payload = [0u8; 4099];
+        payload[0] = 0x00;
+        payload[1] = 0xff;
+        payload[2] = 0xff;
+        payload[3] = 0xff;
+        payload[4] = 0xff;
+        payload[5] = 0x86;
+        payload[64] = 0xee;
+
+        let report = parse_output_report(&payload, CTAPHID_REPORT_LEN + 1);
+
+        assert_eq!(&report[..5], &[0xff, 0xff, 0xff, 0xff, 0x86]);
+        assert_eq!(report[63], 0xee);
     }
 
     #[test]

--- a/packages/d2b-sk-frontend/src/uhid.rs
+++ b/packages/d2b-sk-frontend/src/uhid.rs
@@ -19,11 +19,11 @@
 //! No `unsafe` code. Struct bytes are constructed/parsed manually using the
 //! documented packed C layout.
 
-use std::io;
+use std::io::{self, Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
-use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::unix::AsyncFd;
 
 use crate::framing::CTAPHID_REPORT_LEN;
 
@@ -122,7 +122,7 @@ pub enum UhidEvent {
 
 /// Manages the lifecycle of a virtual FIDO2 HID device via /dev/uhid.
 pub struct UhidDevice {
-    file: File,
+    file: AsyncFd<std::fs::File>,
 }
 
 impl UhidDevice {
@@ -132,12 +132,14 @@ impl UhidDevice {
     /// immediately after this returns. The caller is responsible for the relay
     /// loop (see [`Self::read_event`] and [`Self::send_input_report`]).
     pub async fn create(uhid_path: &Path, vm_id: &str) -> io::Result<Self> {
-        let file = tokio::fs::OpenOptions::new()
+        let file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
-            .open(uhid_path)
-            .await?;
-        let mut dev = UhidDevice { file };
+            .custom_flags(libc::O_NONBLOCK)
+            .open(uhid_path)?;
+        let mut dev = UhidDevice {
+            file: AsyncFd::new(file)?,
+        };
         dev.write_create2(vm_id).await?;
         Ok(dev)
     }
@@ -148,7 +150,7 @@ impl UhidDevice {
     /// (e.g. the kernel closed the device).
     pub async fn read_event(&mut self) -> io::Result<Option<UhidEvent>> {
         let mut buf = [0u8; UHID_EVENT_SIZE];
-        let n = self.file.read(&mut buf).await?;
+        let n = self.read_nonblocking(&mut buf).await?;
         if n == 0 {
             return Ok(None);
         }
@@ -197,14 +199,14 @@ impl UhidDevice {
     /// Inject a 64-byte CTAPHID input report (token response → browser).
     pub async fn send_input_report(&mut self, data: &[u8; CTAPHID_REPORT_LEN]) -> io::Result<()> {
         let buf = build_input2_event(data);
-        self.file.write_all(&buf).await
+        self.write_all_nonblocking(&buf).await
     }
 
     /// Write a GET_REPORT_REPLY with an error status (no data) for unsolicited
     /// get-report requests we cannot serve.
     pub async fn send_get_report_reply_error(&mut self, id: u32) -> io::Result<()> {
         let buf = build_get_report_reply_error(id);
-        self.file.write_all(&buf).await
+        self.write_all_nonblocking(&buf).await
     }
 
     // -----------------------------------------------------------------------
@@ -213,7 +215,36 @@ impl UhidDevice {
 
     async fn write_create2(&mut self, vm_id: &str) -> io::Result<()> {
         let buf = build_create2_event(vm_id);
-        self.file.write_all(&buf).await
+        self.write_all_nonblocking(&buf).await
+    }
+
+    async fn read_nonblocking(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.file.readable().await?;
+            match guard.try_io(|inner| {
+                let mut file = inner.get_ref();
+                file.read(buf)
+            }) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    async fn write_all_nonblocking(&self, mut buf: &[u8]) -> io::Result<()> {
+        while !buf.is_empty() {
+            let mut guard = self.file.writable().await?;
+            match guard.try_io(|inner| {
+                let mut file = inner.get_ref();
+                file.write(buf)
+            }) {
+                Ok(Ok(0)) => return Err(io::ErrorKind::WriteZero.into()),
+                Ok(Ok(n)) => buf = &buf[n..],
+                Ok(Err(error)) => return Err(error),
+                Err(_would_block) => continue,
+            }
+        }
+        Ok(())
     }
 }
 

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -9959,10 +9959,7 @@ impl VmStartRunner<'_> {
         close_received_fds(&received_fds);
 
         let (selector_resolved, hidraw_fd) = result?;
-        let hidraw = Arc::new(
-            security_key::HidrawDevice::from_owned_fd(hidraw_fd?)
-                .map_err(|error| format!("sk-hidraw-asyncfd:{error}"))?,
-        );
+        let hidraw = security_key::HidrawDevice::from_owned_fd(hidraw_fd?);
         let mut security_key_state = security_key::SecurityKeyState::new(selector_resolved);
         security_key_state.enabled_vms.insert(vm.to_owned());
         let state = Arc::new(parking_lot::Mutex::new(security_key_state));
@@ -9974,7 +9971,7 @@ impl VmStartRunner<'_> {
             expected_uid,
             expected_gid,
             Arc::clone(&state),
-            Arc::clone(&hidraw),
+            hidraw,
         )
         .map_err(|error| format!("sk-accept-loop:{error}"))?;
         self.state

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -9959,7 +9959,10 @@ impl VmStartRunner<'_> {
         close_received_fds(&received_fds);
 
         let (selector_resolved, hidraw_fd) = result?;
-        let hidraw = Arc::new(security_key::HidrawDevice::from_owned_fd(hidraw_fd?));
+        let hidraw = Arc::new(
+            security_key::HidrawDevice::from_owned_fd(hidraw_fd?)
+                .map_err(|error| format!("sk-hidraw-asyncfd:{error}"))?,
+        );
         let mut security_key_state = security_key::SecurityKeyState::new(selector_resolved);
         security_key_state.enabled_vms.insert(vm.to_owned());
         let state = Arc::new(parking_lot::Mutex::new(security_key_state));

--- a/packages/d2bd/src/security_key.rs
+++ b/packages/d2bd/src/security_key.rs
@@ -40,11 +40,11 @@
 //!
 //! ## Blocking I/O
 //!
-//! [`HidrawDevice`] wraps the fd handed off by the broker in
-//! `AsyncFd<std::fs::File>` (a safe `OwnedFd -> File` conversion — this
-//! crate's workspace lints `forbid(unsafe_code)`, so no raw fd reconstruction
-//! is used). Reads/writes are cancellation-safe and rely on the broker opening
-//! the physical hidraw node with `O_NONBLOCK`.
+//! [`HidrawDevice`] wraps the fd handed off by the broker in a plain
+//! `std::fs::File` until the accept-loop runtime starts. The accept loop then
+//! registers it as `AsyncFd<std::fs::File>` on the same Tokio reactor that
+//! performs relay I/O. Reads/writes are cancellation-safe and rely on the
+//! broker opening the physical hidraw node with `O_NONBLOCK`.
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -410,13 +410,33 @@ impl SecurityKeyState {
 /// no raw fd reconstruction is used anywhere in this module.
 #[derive(Debug)]
 pub struct HidrawDevice {
-    file: AsyncFd<File>,
+    file: File,
 }
 
 impl HidrawDevice {
-    pub fn from_owned_fd(fd: OwnedFd) -> std::io::Result<Self> {
+    pub fn from_owned_fd(fd: OwnedFd) -> Self {
+        Self {
+            file: File::from(fd),
+        }
+    }
+
+    fn into_async_fd(self) -> std::io::Result<AsyncHidrawDevice> {
+        Ok(AsyncHidrawDevice {
+            file: AsyncFd::new(self.file)?,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct AsyncHidrawDevice {
+    file: AsyncFd<File>,
+}
+
+impl AsyncHidrawDevice {
+    #[cfg(test)]
+    fn from_file(file: File) -> std::io::Result<Self> {
         Ok(Self {
-            file: AsyncFd::new(File::from(fd))?,
+            file: AsyncFd::new(file)?,
         })
     }
 
@@ -477,7 +497,9 @@ fn track_response_cid(report: &CtaphidReport, cids: &parking_lot::Mutex<HashSet<
     }
 }
 
-async fn read_hidraw_report_polling(hidraw: Arc<HidrawDevice>) -> std::io::Result<CtaphidReport> {
+async fn read_hidraw_report_polling(
+    hidraw: Arc<AsyncHidrawDevice>,
+) -> std::io::Result<CtaphidReport> {
     loop {
         match hidraw.read_report().await {
             Ok(report) => return Ok(report),
@@ -679,7 +701,7 @@ pub fn spawn_accept_loop(
     expected_uid: u32,
     expected_gid: u32,
     state: Arc<parking_lot::Mutex<SecurityKeyState>>,
-    hidraw: Arc<HidrawDevice>,
+    hidraw: HidrawDevice,
 ) -> std::io::Result<SkAcceptAbort> {
     listener.set_nonblocking(true)?;
     let (abort, mut stop_rx) = SkAcceptAbort::new();
@@ -698,6 +720,13 @@ pub fn spawn_accept_loop(
                 }
             };
             runtime.block_on(async move {
+                let hidraw = match hidraw.into_async_fd() {
+                    Ok(hidraw) => Arc::new(hidraw),
+                    Err(error) => {
+                        info!(vm = %thread_vm_id, error = %error, "security-key: hidraw async fd init failed");
+                        return;
+                    }
+                };
                 let listener = match tokio::net::UnixListener::from_std(listener) {
                     Ok(listener) => listener,
                     Err(error) => {
@@ -750,7 +779,7 @@ pub(crate) async fn run_connection(
     expected_uid: u32,
     expected_gid: u32,
     state: Arc<parking_lot::Mutex<SecurityKeyState>>,
-    hidraw: Arc<HidrawDevice>,
+    hidraw: Arc<AsyncHidrawDevice>,
 ) {
     if let Err(error) = authenticate_peer(&stream, expected_uid, expected_gid) {
         info!(
@@ -910,10 +939,12 @@ mod tests {
         )
     }
 
-    fn dev_null_hidraw() -> Arc<HidrawDevice> {
+    fn test_hidraw() -> Arc<AsyncHidrawDevice> {
         let (left, _right) = std::os::unix::net::UnixStream::pair().expect("socket pair");
         left.set_nonblocking(true).expect("left nonblocking");
-        Arc::new(HidrawDevice::from_owned_fd(left.into()).expect("wrap socket fd"))
+        Arc::new(
+            AsyncHidrawDevice::from_file(File::from(OwnedFd::from(left))).expect("wrap socket fd"),
+        )
     }
 
     fn current_peer_ids() -> (u32, u32) {
@@ -1204,7 +1235,7 @@ mod tests {
         left.set_nonblocking(true).expect("left nonblocking");
         drop(right);
         let fd: OwnedFd = left.into();
-        let device = HidrawDevice::from_owned_fd(fd).expect("wrap socket fd");
+        let device = AsyncHidrawDevice::from_file(File::from(fd)).expect("wrap socket fd");
         let err = device.read_report().await.unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
     }
@@ -1214,7 +1245,7 @@ mod tests {
         let (left, mut right) = std::os::unix::net::UnixStream::pair().expect("socket pair");
         left.set_nonblocking(true).expect("left nonblocking");
         let fd: OwnedFd = left.into();
-        let device = HidrawDevice::from_owned_fd(fd).expect("wrap socket fd");
+        let device = AsyncHidrawDevice::from_file(File::from(fd)).expect("wrap socket fd");
         let report = build_error_report(1, CTAPHID_ERR_INVALID_CMD);
         device.write_report(&report).await.expect("write report");
 
@@ -1231,7 +1262,7 @@ mod tests {
         let (left, mut right) = std::os::unix::net::UnixStream::pair().expect("socket pair");
         left.set_nonblocking(true).expect("left nonblocking");
         let fd: OwnedFd = left.into();
-        let device = HidrawDevice::from_owned_fd(fd).expect("wrap socket fd");
+        let device = AsyncHidrawDevice::from_file(File::from(fd)).expect("wrap socket fd");
         let report = build_init_packet(CTAPHID_BROADCAST_CID, CTAPHID_INIT, 8, &[1, 2, 3, 4]);
 
         device.write_report(&report).await.expect("write report");
@@ -1292,7 +1323,7 @@ mod tests {
         let (stream, _peer) = tokio_socket_pair();
         let state = Arc::new(parking_lot::Mutex::new(SecurityKeyState::new("selector")));
         state.lock().enabled_vms.insert("vm-a".to_owned());
-        let hidraw = dev_null_hidraw();
+        let hidraw = test_hidraw();
         let (wrong_uid, wrong_gid) = mismatched_ids();
 
         tokio::time::timeout(
@@ -1314,7 +1345,7 @@ mod tests {
     async fn run_connection_rejects_disabled_vm() {
         let (stream, _peer) = tokio_socket_pair();
         let state = Arc::new(parking_lot::Mutex::new(SecurityKeyState::new("selector")));
-        let hidraw = dev_null_hidraw();
+        let hidraw = test_hidraw();
         let (uid, gid) = current_peer_ids();
 
         tokio::time::timeout(
@@ -1331,7 +1362,7 @@ mod tests {
         let mut inner = SecurityKeyState::new("selector");
         inner.enabled_vms.insert("vm-a".to_owned());
         let state = Arc::new(parking_lot::Mutex::new(inner));
-        let hidraw = dev_null_hidraw();
+        let hidraw = test_hidraw();
         let (uid, gid) = current_peer_ids();
 
         drop(peer);

--- a/packages/d2bd/src/security_key.rs
+++ b/packages/d2bd/src/security_key.rs
@@ -451,9 +451,13 @@ fn track_response_cid(report: &CtaphidReport, cids: &parking_lot::Mutex<HashSet<
     }
 }
 
-async fn read_hidraw_report_polling(hidraw: &HidrawDevice) -> std::io::Result<CtaphidReport> {
+async fn read_hidraw_report_polling(hidraw: Arc<HidrawDevice>) -> std::io::Result<CtaphidReport> {
     loop {
-        match hidraw.read_report() {
+        let hidraw = Arc::clone(&hidraw);
+        match tokio::task::spawn_blocking(move || hidraw.read_report())
+            .await
+            .map_err(relay_join_error)?
+        {
             Ok(report) => return Ok(report),
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 tokio::time::sleep(Duration::from_millis(10)).await;
@@ -804,7 +808,7 @@ pub(crate) async fn run_connection(
         let hidraw = Arc::clone(&hidraw);
         async move {
             loop {
-                let report = match read_hidraw_report_polling(&hidraw).await {
+                let report = match read_hidraw_report_polling(Arc::clone(&hidraw)).await {
                     Ok(report) => {
                         track_response_cid(&report, &active_cids);
                         report

--- a/packages/d2bd/src/security_key.rs
+++ b/packages/d2bd/src/security_key.rs
@@ -40,12 +40,11 @@
 //!
 //! ## Blocking I/O
 //!
-//! [`HidrawDevice`] wraps the fd handed off by the broker in a plain
-//! `std::fs::File` (a safe `OwnedFd -> File` conversion — this crate's
-//! workspace lints `forbid(unsafe_code)`, so no raw fd reconstruction
-//! is used). Reads/writes against it should be dispatched via
-//! `tokio::task::spawn_blocking` so the async executor is never
-//! stalled waiting for user touch.
+//! [`HidrawDevice`] wraps the fd handed off by the broker in
+//! `AsyncFd<std::fs::File>` (a safe `OwnedFd -> File` conversion — this
+//! crate's workspace lints `forbid(unsafe_code)`, so no raw fd reconstruction
+//! is used). Reads/writes are cancellation-safe and rely on the broker opening
+//! the physical hidraw node with `O_NONBLOCK`.
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -58,7 +57,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, unix::AsyncFd};
 use tracing::{debug, info};
 
 // ---------------------------------------------------------------------------
@@ -411,30 +410,57 @@ impl SecurityKeyState {
 /// no raw fd reconstruction is used anywhere in this module.
 #[derive(Debug)]
 pub struct HidrawDevice {
-    file: File,
+    file: AsyncFd<File>,
 }
 
 impl HidrawDevice {
-    pub fn from_owned_fd(fd: OwnedFd) -> Self {
-        Self {
-            file: File::from(fd),
+    pub fn from_owned_fd(fd: OwnedFd) -> std::io::Result<Self> {
+        Ok(Self {
+            file: AsyncFd::new(File::from(fd))?,
+        })
+    }
+
+    /// Read a single 64-byte CTAPHID report from the physical token.
+    pub async fn read_report(&self) -> std::io::Result<CtaphidReport> {
+        loop {
+            let mut guard = self.file.readable().await?;
+            match guard.try_io(|inner| {
+                let mut file = inner.get_ref();
+                let mut report = [0u8; CTAPHID_REPORT_SIZE];
+                match file.read(&mut report) {
+                    Ok(CTAPHID_REPORT_SIZE) => Ok(report),
+                    Ok(0) => Err(std::io::ErrorKind::UnexpectedEof.into()),
+                    Ok(n) => Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        format!("short hidraw report: {n} bytes"),
+                    )),
+                    Err(error) => Err(error),
+                }
+            }) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
         }
     }
 
-    /// Blocking read of a single 64-byte CTAPHID report from the
-    /// physical token. Call from `tokio::task::spawn_blocking`.
-    pub fn read_report(&self) -> std::io::Result<CtaphidReport> {
-        let mut report = [0u8; CTAPHID_REPORT_SIZE];
-        (&self.file).read_exact(&mut report)?;
-        Ok(report)
-    }
-
-    /// Blocking write of a single 64-byte CTAPHID report to the
-    /// physical token. Call from `tokio::task::spawn_blocking`.
-    pub fn write_report(&self, report: &CtaphidReport) -> std::io::Result<()> {
+    /// Write a single 64-byte CTAPHID report to the physical token.
+    pub async fn write_report(&self, report: &CtaphidReport) -> std::io::Result<()> {
         let mut hidraw_report = [0u8; CTAPHID_REPORT_SIZE + 1];
         hidraw_report[1..].copy_from_slice(report);
-        (&self.file).write_all(&hidraw_report)
+        let mut buf = hidraw_report.as_slice();
+        while !buf.is_empty() {
+            let mut guard = self.file.writable().await?;
+            match guard.try_io(|inner| {
+                let mut file = inner.get_ref();
+                file.write(buf)
+            }) {
+                Ok(Ok(0)) => return Err(std::io::ErrorKind::WriteZero.into()),
+                Ok(Ok(n)) => buf = &buf[n..],
+                Ok(Err(error)) => return Err(error),
+                Err(_would_block) => continue,
+            }
+        }
+        Ok(())
     }
 }
 
@@ -453,11 +479,7 @@ fn track_response_cid(report: &CtaphidReport, cids: &parking_lot::Mutex<HashSet<
 
 async fn read_hidraw_report_polling(hidraw: Arc<HidrawDevice>) -> std::io::Result<CtaphidReport> {
     loop {
-        let hidraw = Arc::clone(&hidraw);
-        match tokio::task::spawn_blocking(move || hidraw.read_report())
-            .await
-            .map_err(relay_join_error)?
-        {
+        match hidraw.read_report().await {
             Ok(report) => return Ok(report),
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 tokio::time::sleep(Duration::from_millis(10)).await;
@@ -713,10 +735,6 @@ pub fn spawn_accept_loop(
     Ok(abort)
 }
 
-fn relay_join_error(error: tokio::task::JoinError) -> std::io::Error {
-    std::io::Error::other(format!("relay task join error: {error}"))
-}
-
 fn relay_eof(error: &std::io::Error) -> bool {
     matches!(
         error.kind(),
@@ -793,10 +811,7 @@ pub(crate) async fn run_connection(
                     _ => {}
                 }
 
-                let hidraw = Arc::clone(&hidraw);
-                tokio::task::spawn_blocking(move || hidraw.write_report(&report))
-                    .await
-                    .map_err(relay_join_error)??;
+                hidraw.write_report(&report).await?;
             }
             #[allow(unreachable_code)]
             Ok::<(), std::io::Error>(())
@@ -855,7 +870,7 @@ pub(crate) async fn run_connection(
     for cid in cancel_cids {
         let cancel_packet = build_cancel_packet(cid);
         let hidraw = Arc::clone(&hidraw);
-        let _ = tokio::task::spawn_blocking(move || hidraw.write_report(&cancel_packet)).await;
+        let _ = hidraw.write_report(&cancel_packet).await;
     }
 
     state.lock().release_lease(&vm_id, lease_id);
@@ -896,12 +911,9 @@ mod tests {
     }
 
     fn dev_null_hidraw() -> Arc<HidrawDevice> {
-        let file = File::options()
-            .read(true)
-            .write(true)
-            .open("/dev/null")
-            .expect("open /dev/null");
-        Arc::new(HidrawDevice::from_owned_fd(file.into()))
+        let (left, _right) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        left.set_nonblocking(true).expect("left nonblocking");
+        Arc::new(HidrawDevice::from_owned_fd(left.into()).expect("wrap socket fd"))
     }
 
     fn current_peer_ids() -> (u32, u32) {
@@ -1186,54 +1198,52 @@ mod tests {
     // Hidraw device wrapper (hermetic: uses /dev/null, no unsafe)
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn hidraw_device_from_owned_fd_wraps_without_unsafe() {
-        let file = File::open("/dev/null").expect("open /dev/null");
-        let fd: OwnedFd = file.into();
-        let device = HidrawDevice::from_owned_fd(fd);
-        // /dev/null reads always return EOF (0 bytes); read_exact on a
-        // 64-byte buffer against it must fail with UnexpectedEof, not
-        // panic or hang.
-        let err = device.read_report().unwrap_err();
+    #[tokio::test]
+    async fn hidraw_device_from_owned_fd_wraps_without_unsafe() {
+        let (left, right) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        left.set_nonblocking(true).expect("left nonblocking");
+        drop(right);
+        let fd: OwnedFd = left.into();
+        let device = HidrawDevice::from_owned_fd(fd).expect("wrap socket fd");
+        let err = device.read_report().await.unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
     }
 
-    #[test]
-    fn hidraw_device_write_report_to_dev_null_succeeds() {
-        let file = File::options()
-            .write(true)
-            .open("/dev/null")
-            .expect("open /dev/null for write");
-        let fd: OwnedFd = file.into();
-        let device = HidrawDevice::from_owned_fd(fd);
+    #[tokio::test]
+    async fn hidraw_device_write_report_to_socket_succeeds() {
+        let (left, mut right) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        left.set_nonblocking(true).expect("left nonblocking");
+        let fd: OwnedFd = left.into();
+        let device = HidrawDevice::from_owned_fd(fd).expect("wrap socket fd");
         let report = build_error_report(1, CTAPHID_ERR_INVALID_CMD);
-        device.write_report(&report).expect("write to /dev/null");
+        device.write_report(&report).await.expect("write report");
+
+        let mut written = [0u8; CTAPHID_REPORT_SIZE + 1];
+        right
+            .read_exact(&mut written)
+            .expect("read report from peer socket");
+        assert_eq!(written[0], 0);
+        assert_eq!(&written[1..], &report);
     }
 
-    #[test]
-    fn hidraw_device_write_report_prefixes_report_id() {
-        let dir = test_scratch_dir("hidraw-write-prefix");
-        let path = dir.join("hidraw.out");
-        let file = File::options()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(&path)
-            .expect("scratch file writable");
-        let fd: OwnedFd = file.into();
-        let device = HidrawDevice::from_owned_fd(fd);
+    #[tokio::test]
+    async fn hidraw_device_write_report_prefixes_report_id() {
+        let (left, mut right) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        left.set_nonblocking(true).expect("left nonblocking");
+        let fd: OwnedFd = left.into();
+        let device = HidrawDevice::from_owned_fd(fd).expect("wrap socket fd");
         let report = build_init_packet(CTAPHID_BROADCAST_CID, CTAPHID_INIT, 8, &[1, 2, 3, 4]);
 
-        device.write_report(&report).expect("write report");
+        device.write_report(&report).await.expect("write report");
         drop(device);
 
-        let written = fs::read(&path).expect("read scratch file");
+        let mut written = [0u8; CTAPHID_REPORT_SIZE + 1];
+        right
+            .read_exact(&mut written)
+            .expect("read report from peer socket");
         assert_eq!(written.len(), CTAPHID_REPORT_SIZE + 1);
         assert_eq!(written[0], 0, "hidraw write must include report ID prefix");
         assert_eq!(&written[1..], &report);
-
-        let _ = fs::remove_file(&path);
-        let _ = fs::remove_dir_all(&dir);
     }
 
     // -----------------------------------------------------------------------

--- a/tests/unit/nix/cases/index.nix
+++ b/tests/unit/nix/cases/index.nix
@@ -205,6 +205,15 @@ in
     };
   };
 
+  "index/guest-journal-bounded" = {
+    expr = cfg.d2b._computed.zed.config.services.journald.extraConfig;
+    expected = ''
+      SystemMaxUse=512M
+      SystemKeepFree=512M
+      RuntimeMaxUse=128M
+    '';
+  };
+
   "index/home-lan-metadata" = {
     expr = {
       envNames = index.externalNetwork.envNames;

--- a/tests/unit/nix/cases/security-key-gating.nix
+++ b/tests/unit/nix/cases/security-key-gating.nix
@@ -60,6 +60,7 @@ let
   # manifest helpers: parse vms.json text (the manifest per-VM entry)
   manifestData = cfg: builtins.fromJSON cfg.config.d2b._manifestPkg.text;
   vmManifest = cfg: vm: (manifestData cfg).${vm};
+  guestConfig = cfg: vm: cfg.config.d2b._computed.${vm}.config;
 
   # assertion helper: tryEval + check failing assertion message
   mkEvalCfg = overrides: (evalWith overrides).config;
@@ -107,6 +108,20 @@ in
       in
       skNode.role;
     expected = "security-key-frontend";
+  };
+
+  "security-key-gating/guest-udev-uses-plugdev" = {
+    expr =
+      let rules = (guestConfig enabledEval "corp-vm").services.udev.extraRules;
+      in
+      lib.hasInfix ''KERNELS=="0003:1050:0407.*"'' rules
+      && lib.hasInfix ''GROUP="plugdev"'' rules;
+    expected = true;
+  };
+
+  "security-key-gating/guest-declares-plugdev-group" = {
+    expr = (guestConfig enabledEval "corp-vm").users.groups ? plugdev;
+    expected = true;
   };
 
   # --- assertion: usbip.yubikey + security-key conflict ---

--- a/tests/unit/nix/cases/security-key-gating.nix
+++ b/tests/unit/nix/cases/security-key-gating.nix
@@ -124,6 +124,20 @@ in
     expected = true;
   };
 
+  "security-key-gating/guest-activation-creates-etc-before-users" = {
+    expr =
+      let
+        script = (guestConfig enabledEval "corp-vm").system.activationScripts.script;
+        ensureNeedle = "Activation script snippet d2bEnsureEtcForUsers";
+        usersNeedle = "Activation script snippet users";
+        ensureMatch = builtins.match ".*${ensureNeedle}.*" script;
+        usersMatch = builtins.match ".*${usersNeedle}.*" script;
+        beforeMatch = builtins.match ".*${ensureNeedle}.*${usersNeedle}.*" script;
+      in
+      ensureMatch != null && usersMatch != null && beforeMatch != null;
+    expected = true;
+  };
+
   # --- assertion: usbip.yubikey + security-key conflict ---
 
   "security-key-gating/yubikey-conflict-fires" = {

--- a/tests/unit/nix/cases/security-key-gating.nix
+++ b/tests/unit/nix/cases/security-key-gating.nix
@@ -124,7 +124,7 @@ in
     expected = true;
   };
 
-  "security-key-gating/guest-activation-users-after-etc" = {
+  "security-key-gating/guest-activation-refreshes-users-after-etc" = {
     expr =
       let
         activation = (guestConfig enabledEval "corp-vm").system.activationScripts;
@@ -135,7 +135,10 @@ in
       in
       activation ? d2bEnsureEtcForUsers
       && ensureText != ""
-      && builtins.elem "etc" activation.users.deps;
+      && activation ? d2bRefreshUsersAfterEtc
+      && builtins.elem "d2bEnsureEtcForUsers" activation.users.deps
+      && builtins.elem "etc" activation.d2bRefreshUsersAfterEtc.deps
+      && builtins.match ".*update-users-groups\\.pl.*" activation.d2bRefreshUsersAfterEtc.text != null;
     expected = true;
   };
 

--- a/tests/unit/nix/cases/security-key-gating.nix
+++ b/tests/unit/nix/cases/security-key-gating.nix
@@ -124,17 +124,18 @@ in
     expected = true;
   };
 
-  "security-key-gating/guest-activation-creates-etc-before-users" = {
+  "security-key-gating/guest-activation-users-after-etc" = {
     expr =
       let
-        script = (guestConfig enabledEval "corp-vm").system.activationScripts.script;
-        ensureNeedle = "Activation script snippet d2bEnsureEtcForUsers";
-        usersNeedle = "Activation script snippet users";
-        ensureMatch = builtins.match ".*${ensureNeedle}.*" script;
-        usersMatch = builtins.match ".*${usersNeedle}.*" script;
-        beforeMatch = builtins.match ".*${ensureNeedle}.*${usersNeedle}.*" script;
+        activation = (guestConfig enabledEval "corp-vm").system.activationScripts;
+        ensureText =
+          if builtins.isAttrs activation.d2bEnsureEtcForUsers
+          then activation.d2bEnsureEtcForUsers.text or ""
+          else activation.d2bEnsureEtcForUsers;
       in
-      ensureMatch != null && usersMatch != null && beforeMatch != null;
+      activation ? d2bEnsureEtcForUsers
+      && ensureText != ""
+      && builtins.elem "etc" activation.users.deps;
     expected = true;
   };
 

--- a/tests/unit/nix/cases/security-key-gating.nix
+++ b/tests/unit/nix/cases/security-key-gating.nix
@@ -124,28 +124,6 @@ in
     expected = true;
   };
 
-  "security-key-gating/guest-refreshes-users-after-switch-root" = {
-    expr =
-      let
-        guest = guestConfig enabledEval "corp-vm";
-        activation = guest.system.activationScripts;
-        service = guest.systemd.services.d2b-refresh-users-after-switch-root;
-        ensureText =
-          if builtins.isAttrs activation.d2bEnsureEtcForUsers
-          then activation.d2bEnsureEtcForUsers.text or ""
-          else activation.d2bEnsureEtcForUsers;
-      in
-      activation ? d2bEnsureEtcForUsers
-      && ensureText != ""
-      && builtins.elem "d2bEnsureEtcForUsers" activation.users.deps
-      && builtins.elem "sysinit.target" service.wantedBy
-      && builtins.elem "sockets.target" service.before
-      && service.unitConfig.DefaultDependencies == false
-      && service.serviceConfig.Type == "oneshot"
-      && builtins.match ".*update-users-groups\\.pl.*" activation.users.text != null;
-    expected = true;
-  };
-
   # --- assertion: usbip.yubikey + security-key conflict ---
 
   "security-key-gating/yubikey-conflict-fires" = {

--- a/tests/unit/nix/cases/security-key-gating.nix
+++ b/tests/unit/nix/cases/security-key-gating.nix
@@ -124,10 +124,12 @@ in
     expected = true;
   };
 
-  "security-key-gating/guest-activation-refreshes-users-after-etc" = {
+  "security-key-gating/guest-refreshes-users-after-switch-root" = {
     expr =
       let
-        activation = (guestConfig enabledEval "corp-vm").system.activationScripts;
+        guest = guestConfig enabledEval "corp-vm";
+        activation = guest.system.activationScripts;
+        service = guest.systemd.services.d2b-refresh-users-after-switch-root;
         ensureText =
           if builtins.isAttrs activation.d2bEnsureEtcForUsers
           then activation.d2bEnsureEtcForUsers.text or ""
@@ -135,10 +137,12 @@ in
       in
       activation ? d2bEnsureEtcForUsers
       && ensureText != ""
-      && activation ? d2bRefreshUsersAfterEtc
       && builtins.elem "d2bEnsureEtcForUsers" activation.users.deps
-      && builtins.elem "etc" activation.d2bRefreshUsersAfterEtc.deps
-      && builtins.match ".*update-users-groups\\.pl.*" activation.d2bRefreshUsersAfterEtc.text != null;
+      && builtins.elem "sysinit.target" service.wantedBy
+      && builtins.elem "sockets.target" service.before
+      && service.unitConfig.DefaultDependencies == false
+      && service.serviceConfig.Type == "oneshot"
+      && builtins.match ".*update-users-groups\\.pl.*" activation.users.text != null;
     expected = true;
   };
 


### PR DESCRIPTION
## Summary
- match the virtual UHID FIDO hidraw device by HID parent identity instead of a missing `phys` attribute
- update the security-key guest module comments and changelog

## Validation
- `nix-instantiate --parse nixos-modules/components/security-key-guest.nix`
- `make test-nix-unit`

## Live context
On the d2b workstation, the virtual device enumerated in `personal-dev` as `/dev/hidraw0` but udev left it `root:root 0600`; `fido2-token` failed to open it as the user. `udevadm info -a -n /dev/hidraw0` showed the UHID parent as `KERNELS=="0003:1050:0407.0001"` with no `phys` attribute, so the previous `ATTRS{phys}=="d2b-sk*"` rule never matched.