### PR TITLE
Add d2b terminal integration support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,9 +331,27 @@ flake and is composed per-VM:
 - [`vicondoa/entrablau.nix`][entrablau] — Microsoft Entra ID
   joins (Himmelblau + TPM-bound machine credential).
 
-The composition pattern is intentionally one-way: sibling flakes
-know nothing about d2b, and d2b knows nothing about them.
-Consumers compose them on a specific workload VM:
+Optional **desktop companion** pieces also live in sibling flakes:
+
+- `vicondoa/d2b-toolkit` — shared Rust/Nix client DTOs, public-socket
+  framing, redaction wrappers, Wayland color parsing, and Waybar helpers for
+  desktop integrations.
+- `vicondoa/d2b-wlterm` — Home Manager module and user-session launcher for
+  persistent guest shells.
+- `vicondoa/weezterm` — WeezTerm package/provider integration used by the
+  terminal launcher when a d2b-aware terminal build is desired.
+
+Consumer flakes that combine these pieces keep a single nixpkgs and toolkit
+revision by using `inputs.d2b.inputs.nixpkgs.follows = "nixpkgs"`,
+`inputs.d2b-toolkit.inputs.nixpkgs.follows = "nixpkgs"`, and
+`inputs.d2b-wlterm.inputs.d2b-toolkit.follows = "d2b-toolkit"` (same for
+WeezTerm). The exact copy-paste boilerplate lives in
+[`docs/how-to/configure-desktop-terminal-integration.md`](./docs/how-to/configure-desktop-terminal-integration.md).
+
+The composition pattern is intentionally one-way: d2b core does not import
+identity, workload, or desktop companion flakes. Identity/workload flakes can
+stay d2b-agnostic; desktop companions consume only d2b's public CLI/socket
+contracts. Consumers compose workload modules on a specific VM:
 
 ```nix
 d2b.vms.work.config.imports = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ deprecations ship one minor release before removal.
 - Documented the stable public-socket discovery contract for persistent shells
   so desktop clients such as `d2b-wlterm` can use `List`/`Status` plus
   `ShellOp::List` without scraping human CLI output or leaking terminal state.
+- Added typed deserialization support for public daemon response envelopes so
+  downstream clients can parse `PublicResponse` DTOs without falling back to
+  untyped JSON.
 - Added CTAP/WebAuthn security-key proxy: `d2b.host.usb.securityKey.*` and
   `d2b.vms.<vm>.usb.securityKey.enable`. The host broker (`d2bd`) serializes
   CTAP HID traffic from opted-in VMs to a host-attached FIDO2 device (YubiKey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,11 @@ deprecations ship one minor release before removal.
 - `d2b-wayland-proxy` now presents proxy-drawn VM identity rails through a
   proxy-owned wrapper toplevel, so host compositor borders and focus rings wrap
   the VM rail and guest content together without copying guest buffers.
+- `d2b-wayland-proxy` treats `ENOTCONN` during nonblocking clipboard bridge
+  handoff as retryable backpressure, preserving pending FDs until the bridge
+  socket finishes connecting.
+- Added host-integration coverage for the live `d2b-wayland-proxy`
+  AF_UNIX client-to-upstream relay path.
 - Updated the Windows notification transitive dependency to remove the runtime
   `quick-xml` advisory path, and documented a temporary build-time
   `wayland-scanner` advisory exception until that code generator publishes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ deprecations ship one minor release before removal.
 - Added typed deserialization support for public daemon response envelopes so
   downstream clients can parse `PublicResponse` DTOs without falling back to
   untyped JSON.
+- Exported `packages.<system>.d2b-wayland-proxy` and added a supported
+  `--host-terminal` launch path for VM-bound host terminals. The launcher creates
+  randomized single-use Wayland and WezTerm mux sockets under a private
+  `$XDG_RUNTIME_DIR` directory, waits for proxy readiness before launching the
+  foreground child, preserves d2b clipboard mediation, and keeps privileged
+  Wayland globals hidden.
 - Added CTAP/WebAuthn security-key proxy: `d2b.host.usb.securityKey.*` and
   `d2b.vms.<vm>.usb.securityKey.enable`. The host broker (`d2bd`) serializes
   CTAP HID traffic from opted-in VMs to a host-attached FIDO2 device (YubiKey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ deprecations ship one minor release before removal.
   `$XDG_RUNTIME_DIR` directory, waits for proxy readiness before launching the
   foreground child, preserves d2b clipboard mediation, and keeps privileged
   Wayland globals hidden.
+- Documented the optional desktop terminal integration stack (`d2b-toolkit`,
+  `d2b-wlterm`, and WeezTerm) with exact flake-input follow boilerplate,
+  Home Manager wiring, Waybar setup, and validation commands.
 - Added CTAP/WebAuthn security-key proxy: `d2b.host.usb.securityKey.*` and
   `d2b.vms.<vm>.usb.securityKey.enable`. The host broker (`d2bd`) serializes
   CTAP HID traffic from opted-in VMs to a host-attached FIDO2 device (YubiKey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Documented the stable public-socket discovery contract for persistent shells
+  so desktop clients such as `d2b-wlterm` can use `List`/`Status` plus
+  `ShellOp::List` without scraping human CLI output or leaking terminal state.
 - Added CTAP/WebAuthn security-key proxy: `d2b.host.usb.securityKey.*` and
   `d2b.vms.<vm>.usb.securityKey.enable`. The host broker (`d2bd`) serializes
   CTAP HID traffic from opted-in VMs to a host-attached FIDO2 device (YubiKey

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ table of the doc-friendly example aliases (`personal-dev`,
 `graphics-workstation`, `multi-env`) plus the manual integration path.
 For reconnectable interactive shells, see
 [Use persistent guest shells](./docs/how-to/use-persistent-shells.md).
+For Waybar/terminal launcher integration around those shells, see
+[Configure desktop terminal integration](./docs/how-to/configure-desktop-terminal-integration.md).
 For browser WebAuthn with a host-attached YubiKey/security key, see
 [Use the USB security-key proxy](./docs/how-to/use-usb-security-key.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -166,6 +166,9 @@ Task-oriented recipes. Prescriptive, copy-and-adapt.
   configure, enter, and recover realm gateway guests.
 - [`how-to/use-persistent-shells.md`](./how-to/use-persistent-shells.md) —
   enable, attach, detach, reattach, list, and kill persistent named guest shells.
+- [`how-to/configure-desktop-terminal-integration.md`](./how-to/configure-desktop-terminal-integration.md) —
+  wire the sibling toolkit, launcher, and terminal flakes to d2b's public shell
+  surface with aligned flake inputs.
 - [`how-to/migrate-d2b-v1-2-to-v2.md`](./how-to/migrate-d2b-v1-2-to-v2.md) —
   migrate from local-only or implicit realm metadata to explicit gateway-backed
   realm policy.

--- a/docs/explanation/clipboard-architecture.md
+++ b/docs/explanation/clipboard-architecture.md
@@ -53,6 +53,11 @@ sufficient for per-VM `d2b-<vm>-wlproxy` ACLs or lifecycle cleanup.
 
 The bridge is local-only, validates peer credentials, and may use `SCM_RIGHTS`
 between d2b components. Transfer FDs never go to the picker.
+The Wayland proxy keeps transfer FDs as owned descriptors while they are queued;
+short `sendmsg` results or `EAGAIN` keep the metadata frame and ancillary FD
+coupled until an atomic retry succeeds, and any truncated control-message
+receive is treated as fail-closed by d2b receivers. Clipboard logs identify only
+bounded metadata such as VM, MIME label, transfer kind, and reason code.
 
 ## Guest Wayland clipboard virtualization
 

--- a/docs/how-to/configure-desktop-terminal-integration.md
+++ b/docs/how-to/configure-desktop-terminal-integration.md
@@ -1,0 +1,139 @@
+# Configure desktop terminal integration
+
+> Diataxis: how-to. Install the sibling desktop terminal flakes that consume
+> d2b's public shell surface.
+
+This recipe wires the optional desktop companions around persistent guest
+shells:
+
+- `d2b-toolkit` provides shared public-socket DTOs, client framing,
+  redaction helpers, Wayland color parsing, and Waybar JSON helpers.
+- `d2b-wlterm` is a Home Manager module and launcher for persistent d2b
+  shell sessions.
+- WeezTerm can be built from the `weezterm` flake when you want the terminal
+  binary name and native d2b provider integration used by the launcher command.
+
+The core d2b module does not import these flakes automatically. Keeping them
+as sibling inputs preserves the one-way composition rule: desktop clients know
+about d2b's public socket, while d2b does not depend on any particular bar,
+launcher, or terminal emulator.
+
+## Prerequisites
+
+Enable persistent shells on every VM that should appear in the launcher:
+
+```nix
+d2b.vms.work = {
+  ssh.user = "alice";
+
+  guest.control.enable = true;
+  guest.exec.enable = true;
+  guest.shell.enable = true;
+};
+```
+
+For the shell lifecycle model and CLI fallback commands, see
+[Use persistent guest shells](./use-persistent-shells.md).
+
+## Add aligned flake inputs
+
+Use one `nixpkgs` input for the host and make every sibling follow it. Make the
+desktop companions share the same `d2b-toolkit` input:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    d2b = {
+      url = "github:vicondoa/d2b";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    d2b-toolkit = {
+      url = "github:vicondoa/d2b-toolkit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    d2b-wlterm = {
+      url = "github:vicondoa/d2b-wlterm";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.d2b-toolkit.follows = "d2b-toolkit";
+    };
+
+    weezterm = {
+      url = "github:vicondoa/weezterm";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.d2b-toolkit.follows = "d2b-toolkit";
+    };
+  };
+}
+```
+
+When iterating locally, replace the `url` values with `path:/...` but keep the
+same `inputs.<name>.follows` lines. That keeps package builds, Home Manager
+evaluation, and toolkit path-dependency rewrites on one nixpkgs and toolkit
+revision.
+
+## Import the Home Manager module
+
+```nix
+{ inputs, pkgs, ... }:
+{
+  imports = [ inputs.d2b-wlterm.homeManagerModules.default ];
+
+  programs.d2b-wlterm = {
+    enable = true;
+    weztermCommand = [
+      "${inputs.weezterm.packages.${pkgs.stdenv.hostPlatform.system}.default}/bin/weezterm"
+      "start"
+      "--"
+    ];
+    waybar.enable = true;
+    waybar.injectHomeManager = true;
+  };
+}
+```
+
+The module renders `~/.config/d2b-wlterm/config.toml` and, when enabled,
+injects the custom module into `programs.waybar.settings` when Home Manager also
+manages Waybar. It also writes `~/.config/d2b-wlterm/waybar-module.json` for
+operators who manage Waybar outside Home Manager. The upstream `d2b-wlterm`
+flake has a `checks.<system>.home-manager-module` evaluation check that exercises
+this rendered shape.
+
+## Configure Waybar
+
+When Waybar is managed by Home Manager, enable native injection instead of
+copy-pasting JSON:
+
+```nix
+{
+  programs.waybar.enable = true;
+  programs.d2b-wlterm.waybar = {
+    enable = true;
+    injectHomeManager = true;
+    barName = "mainBar";
+    modulesList = "modules-right";
+  };
+}
+```
+
+If Waybar is managed elsewhere, import the generated
+`~/.config/d2b-wlterm/waybar-module.json` manually and include
+`custom/d2b-wlterm` in the desired module list.
+
+## Validate
+
+Run these checks from the consumer host flake:
+
+```bash
+nix flake check
+home-manager build --flake .#alice
+d2b shell work list
+d2b-wlterm list work
+```
+
+If `d2b-wlterm list` reports a typed shell capability error, confirm that the
+VM has `guest.control.enable`, `guest.exec.enable`, and `guest.shell.enable`
+set and that the VM was restarted after switching the host configuration.

--- a/docs/reference/components-graphics.md
+++ b/docs/reference/components-graphics.md
@@ -62,6 +62,37 @@ protocol features remain disabled until the proxy can validate seat-bound
 requests safely, avoiding guest application crashes from invalid forwarded
 text-input requests under Niri-backed cross-domain Wayland.
 
+## Host-app terminal proxy mode
+
+The flake exports `packages.<system>.d2b-wayland-proxy` for host tools such as
+`d2b-wlterm` that must resolve the supported proxy binary without relying on an
+internal package path or the operator's `PATH`. The binary also has a
+foreground host-terminal launch path:
+
+```bash
+d2b-wayland-proxy --host-terminal --vm-name work --border-enable -- wezterm start
+```
+
+In this mode the proxy derives the upstream compositor from `--connect` or
+`$WAYLAND_DISPLAY`, creates a randomized single-use listen socket below
+`$XDG_RUNTIME_DIR/d2b-wayland-proxy/<vm>/`, forces that directory to `0700`,
+removes only stale socket files at the selected paths, and chmods the listen
+socket to `0600` before launching the child. `WAYLAND_DISPLAY` is set to the
+single-use proxy socket and `WEZTERM_UNIX_SOCKET` is set to a randomized
+per-VM mux socket, so the terminal does not reuse the operator's global WezTerm
+daemon. The proxy opens a close-on-exec pidfd for the child, waits in the
+foreground, and removes the single-use socket paths when the process exits.
+
+The same Wayland security policy applies to the terminal child: ordinary
+application globals needed by WezTerm remain available, privileged globals such
+as layer-shell, screencopy, virtual input, session-lock, and compositor control
+stay hidden, and the host compositor's raw `wl_data_device_manager` is never
+forwarded. Clipboard traffic stays on the d2b virtual clipboard path and must
+cross the `d2b-clipd` bridge/picker policy rather than granting unmediated host
+clipboard access. Proxy diagnostics remain bounded metadata only; they do not
+log Wayland payload bytes, clipboard contents, raw fd handles, shell names, or
+unbounded titles.
+
 Site-level dependency:
 
 | Option | Type | Required when | Description |

--- a/docs/reference/daemon-api.md
+++ b/docs/reference/daemon-api.md
@@ -200,10 +200,10 @@ host reboot.
 | `HostDestroyRequest` | struct | [`HostDestroyRequest`](../../packages/d2b-contracts/src/public_wire.rs#L1928) | struct { `flags`: `MutationFlags` } |
 | `HostInstallRequest` | struct | [`HostInstallRequest`](../../packages/d2b-contracts/src/public_wire.rs#L1935) | struct { `flags`: `MutationFlags`; `enable`: `bool`; `start`: `bool`; `no_start`: `bool` } |
 | `HostReconcileRequest` | struct | [`HostReconcileRequest`](../../packages/d2b-contracts/src/public_wire.rs#L1953) | struct { `flags`: `MutationFlags`; `network`: `bool` } |
-| `UsbSecurityKeyStatusRequest` | struct | [`UsbSecurityKeyStatusRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3459) | empty struct |
-| `UsbSecurityKeySessionsRequest` | struct | [`UsbSecurityKeySessionsRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3545) | empty struct |
-| `UsbSecurityKeyCancelRequest` | struct | [`UsbSecurityKeyCancelRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3599) | struct { `session_id`: `Option<String>`; `current`: `bool` } |
-| `UsbSecurityKeyTestRequest` | struct | [`UsbSecurityKeyTestRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3624) | struct { `vm`: `String` } |
+| `UsbSecurityKeyStatusRequest` | struct | [`UsbSecurityKeyStatusRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3552) | empty struct |
+| `UsbSecurityKeySessionsRequest` | struct | [`UsbSecurityKeySessionsRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3638) | empty struct |
+| `UsbSecurityKeyCancelRequest` | struct | [`UsbSecurityKeyCancelRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3692) | struct { `session_id`: `Option<String>`; `current`: `bool` } |
+| `UsbSecurityKeyTestRequest` | struct | [`UsbSecurityKeyTestRequest`](../../packages/d2b-contracts/src/public_wire.rs#L3717) | struct { `vm`: `String` } |
 
 ### Broker socket request types
 
@@ -322,10 +322,10 @@ see the auto-generated tables above for the committed Rust variants.
 | `KeysListResponse` | struct | [`KeysListResponse`](../../packages/d2b-contracts/src/public_wire.rs#L2083) | struct { `entries`: `Vec<KeyEntry>` } |
 | `KeysShowResponse` | struct | [`KeysShowResponse`](../../packages/d2b-contracts/src/public_wire.rs#L2089) | struct { `vm`: `String`; `env`: `Option<String>`; `managed_key_path`: `String`; `public_key`: `String`; `fingerprint`: `String`; `known_hosts_entry`: `Option<String>` } |
 | `UsbipProbeResponse` | struct | [`UsbipProbeResponse`](../../packages/d2b-contracts/src/public_wire.rs#L2330) | struct { `entries`: `Vec<UsbipProbeEntry>` } |
-| `UsbSecurityKeyStatusResponse` | struct | [`UsbSecurityKeyStatusResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3530) | struct { `host_proxy_enabled`: `bool`; `physical_keys`: `Vec<UsbSkPhysicalKeyStatus>`; `vm_devices`: `Vec<UsbSkVirtualDeviceStatus>`; `lease`: `UsbSkLeaseStatus` } |
-| `UsbSecurityKeySessionsResponse` | struct | [`UsbSecurityKeySessionsResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3592) | struct { `sessions`: `Vec<UsbSkSession>` } |
-| `UsbSecurityKeyCancelResponse` | struct | [`UsbSecurityKeyCancelResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3610) | struct { `cancelled_session_id`: `Option<String>`; `already_idle`: `bool` } |
-| `UsbSecurityKeyTestResponse` | struct | [`UsbSecurityKeyTestResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3647) | struct { `vm`: `String`; `ok`: `bool`; `checks`: `Vec<UsbSkTestCheck>` } |
+| `UsbSecurityKeyStatusResponse` | struct | [`UsbSecurityKeyStatusResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3623) | struct { `host_proxy_enabled`: `bool`; `physical_keys`: `Vec<UsbSkPhysicalKeyStatus>`; `vm_devices`: `Vec<UsbSkVirtualDeviceStatus>`; `lease`: `UsbSkLeaseStatus` } |
+| `UsbSecurityKeySessionsResponse` | struct | [`UsbSecurityKeySessionsResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3685) | struct { `sessions`: `Vec<UsbSkSession>` } |
+| `UsbSecurityKeyCancelResponse` | struct | [`UsbSecurityKeyCancelResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3703) | struct { `cancelled_session_id`: `Option<String>`; `already_idle`: `bool` } |
+| `UsbSecurityKeyTestResponse` | struct | [`UsbSecurityKeyTestResponse`](../../packages/d2b-contracts/src/public_wire.rs#L3740) | struct { `vm`: `String`; `ok`: `bool`; `checks`: `Vec<UsbSkTestCheck>` } |
 
 ### Broker socket response types
 
@@ -511,8 +511,8 @@ running live guest activation.
 | `AuditFormat` | enum | [`AuditFormat`](../../packages/d2b-contracts/src/public_wire.rs#L2344) | `Human`; `Json` |
 | `AuthRole` | enum | [`AuthRole`](../../packages/d2b-contracts/src/public_wire.rs#L2352) | `None`; `Launcher`; `Admin` |
 | `HostFindingSeverity` | enum | [`HostFindingSeverity`](../../packages/d2b-contracts/src/public_wire.rs#L2561) | `Pass`; `Warn`; `Fail` |
-| `UsbSkLeaseState` | enum | [`UsbSkLeaseState`](../../packages/d2b-contracts/src/public_wire.rs#L3497) | `Idle`; `Active`; `Queued`; `Unknown` |
-| `UsbSkSessionOutcome` | enum | [`UsbSkSessionOutcome`](../../packages/d2b-contracts/src/public_wire.rs#L3552) | `Success`; `Timeout`; `Cancelled`; `DeviceUnavailable`; `Active`; `Unknown` |
+| `UsbSkLeaseState` | enum | [`UsbSkLeaseState`](../../packages/d2b-contracts/src/public_wire.rs#L3590) | `Idle`; `Active`; `Queued`; `Unknown` |
+| `UsbSkSessionOutcome` | enum | [`UsbSkSessionOutcome`](../../packages/d2b-contracts/src/public_wire.rs#L3645) | `Success`; `Timeout`; `Cancelled`; `DeviceUnavailable`; `Active`; `Unknown` |
 | `SecurityKeyVmSessionState` | enum | [`SecurityKeyVmSessionState`](../../packages/d2b-contracts/src/security_key.rs#L165) | `Idle`; `AwaitingLease`; `Active`; `Completed`; `Cancelled` |
 | `SecurityKeySessionResult` | enum | [`SecurityKeySessionResult`](../../packages/d2b-contracts/src/security_key.rs#L230) | `InProgress`; `Success`; `CtapError`; `Timeout`; `Cancelled`; `InternalError` |
 | `SecurityKeyEvent` | enum | [`SecurityKeyEvent`](../../packages/d2b-contracts/src/security_key.rs#L290) | `SessionStarted` — struct { `session_id`: `SecurityKeySessionId`; `vm`: `String`; `device_label`: `SecurityKeyDeviceLabel`; `started_at`: `String` }; `SessionSucceeded` — struct { `session_id`: `SecurityKeySessionId`; `vm`: `String`; `device_label`: `SecurityKeyDeviceLabel`; `ended_at`: `String` }; `SessionFailed` — struct { `session_id`: `SecurityKeySessionId`; `vm`: `String`; `device_label`: `SecurityKeyDeviceLabel`; `result`: `SecurityKeySessionResult`; `ended_at`: `String` }; `SessionCancelled` — struct { `session_id`: `SecurityKeySessionId`; `vm`: `String`; `device_label`: `SecurityKeyDeviceLabel`; `ended_at`: `String` }; `DeviceRemoved` — struct { `device_label`: `SecurityKeyDeviceLabel`; `interrupted_session_id`: `Option<SecurityKeySessionId>` }; `DeviceReinserted` — struct { `device_label`: `SecurityKeyDeviceLabel` }; `SessionQueued` — struct { `session_id`: `SecurityKeySessionId`; `vm`: `String`; `device_label`: `SecurityKeyDeviceLabel`; `queued_at`: `String`; `blocking_vm`: `String` } |

--- a/docs/reference/guest-control-persistent-shell.md
+++ b/docs/reference/guest-control-persistent-shell.md
@@ -47,6 +47,37 @@ The public daemon wire exposes `PublicRequest::Shell(ShellOp)` and
 `Kill` requires a name. `Attach` and `Detach` may omit the name so the VM's
 configured default can be resolved by the daemon/guest.
 
+## Local discovery contract
+
+Local desktop clients such as `d2b-wlterm` do not need to scrape human CLI
+output. They discover candidate local VMs through the public `List` or `Status`
+response, preferring `runtime.operationCapabilities.guest.shell == true` when
+present and otherwise the legacy `runtimeCapabilities[]` entry `shell`. They
+then issue `ShellOp::List { vm }` over the same public socket for each candidate
+VM.
+
+The current stable list payload is intentionally minimal:
+
+- `defaultName`;
+- `sessions[].name`;
+- `sessions[].state`;
+- `sessions[].attached`;
+- `sessions[].isDefault`.
+
+That is sufficient for local VM/session discovery and for rendering an
+open/stop control surface. The contract does not currently expose attached
+owner identity, session handles, last activity timestamps, terminal titles, or
+cwd. Those fields are reserved until they can be proven non-leaky and useful;
+clients should treat their absence as intentional rather than falling back to
+logs, metrics, audit records, or terminal output scraping.
+
+If `ShellOp::List` returns a typed shell error, clients should surface the
+closed wire `kind` (`guest-control-shell-capability-unavailable`,
+`guest-control-shell-transport-unavailable`, and so on) and avoid retry loops
+that would attach to or create a shell. Older daemons that do not understand the
+`shell` public-socket frame fail closed; the CLI maps that class to exit code
+`70`.
+
 ## States and close causes
 
 Shell session states are closed enum values:

--- a/flake.nix
+++ b/flake.nix
@@ -256,6 +256,7 @@
           pname = "d2b-wayland-proxy";
           cargoBuildFlags = [ "--package" "d2b-wayland-proxy" "--bin" "d2b-wayland-proxy" ];
           doCheck = false;
+          meta.mainProgram = "d2b-wayland-proxy";
         };
 
         signoz = import ./pkgs/signoz { inherit pkgs; };

--- a/flake.nix
+++ b/flake.nix
@@ -252,6 +252,11 @@
           cargoBuildFlags = [ "--package" "d2b-clipd" "--bin" "d2b-clipd" ];
           doCheck = false;
         };
+        d2b-wayland-proxy = rustWorkspace {
+          pname = "d2b-wayland-proxy";
+          cargoBuildFlags = [ "--package" "d2b-wayland-proxy" "--bin" "d2b-wayland-proxy" ];
+          doCheck = false;
+        };
 
         signoz = import ./pkgs/signoz { inherit pkgs; };
         signozOtelCollector = import ./pkgs/signoz-otel-collector { inherit pkgs; };

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1151,6 +1151,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "getrandom 0.2.17",
  "libc",
  "log",
  "nix 0.29.0",

--- a/packages/d2b-contract-tests/tests/usb_sk_contract.rs
+++ b/packages/d2b-contract-tests/tests/usb_sk_contract.rs
@@ -252,13 +252,8 @@ fn public_response_usb_security_key_status_round_trips() {
         vm_states: vec![],
     });
     let json = serde_json::to_string(&resp).expect("serialize");
-    // PublicResponse is Serialize only (no Deserialize), so assert tag is present
-    let value: serde_json::Value = serde_json::from_str(&json).expect("parse");
-    assert_eq!(
-        value.get("kind").and_then(|v| v.as_str()),
-        Some("usb security-key status"),
-        "unexpected kind tag in: {json}"
-    );
+    let decoded: PublicResponse = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(resp, decoded);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/d2b-contracts/src/public_wire.rs
+++ b/packages/d2b-contracts/src/public_wire.rs
@@ -132,7 +132,7 @@ pub enum PublicRequest {
     UsbSecurityKeyCancel(crate::security_key::SecurityKeyCancelRequest),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", content = "payload")]
 pub enum PublicResponse {
     #[serde(rename = "capabilities")]
@@ -2007,7 +2007,7 @@ pub enum MutatingVerbOutcome {
     InvalidRequest,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CapabilitiesResponse {
     pub broker_socket: String,
@@ -2017,7 +2017,7 @@ pub struct CapabilitiesResponse {
     pub selected_version: Version,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AuthStatusResponse {
     pub allowed_subcommands: Vec<String>,
@@ -2026,7 +2026,7 @@ pub struct AuthStatusResponse {
     pub sockets: Vec<SocketReachability>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ListResponse {
     pub vms: Vec<ListEntry>,
@@ -2034,7 +2034,7 @@ pub struct ListResponse {
     pub read_model: Option<PublicReadModelMetadata>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StatusResponse {
     pub entries: Vec<VmStatus>,
@@ -2054,13 +2054,13 @@ pub struct PublicReadModelMetadata {
     pub deep_refresh: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AuditResponse {
     pub entries: Vec<AuditEntry>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct HostCheckResponse {
     pub exit_code: u8,
@@ -2571,10 +2571,11 @@ fn default_true() -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        LevelPercent, MutationFlags, PublicRequest, RuntimeSummary, VmLifecycleRequest,
-        VmLifecycleState,
+        LevelPercent, MutationFlags, PublicRequest, PublicResponse, RuntimeSummary,
+        VmLifecycleRequest, VmLifecycleState,
     };
-    use crate::{decode_frame, encode_frame};
+    use crate::{FeatureFlag, Version, decode_frame, encode_frame};
+    use d2b_core::error::Error;
     use d2b_core::{
         processes::ProcessRole,
         runtime::{RuntimeOperationCapabilities, RuntimeServiceRole, RuntimeServiceSummary},
@@ -2584,6 +2585,98 @@ mod tests {
     fn vm_lifecycle_keeps_booted_variant() {
         let encoded = serde_json::to_string(&VmLifecycleState::Booted).expect("serializes");
         assert_eq!(encoded, "\"Booted\"");
+    }
+
+    #[test]
+    fn public_response_deserializes_success_envelopes() {
+        let capability_value = serde_json::json!({
+            "kind": "capabilities",
+            "payload": {
+                "brokerSocket": "/run/d2b/priv.sock",
+                "capabilities": ["typed-errors"],
+                "publicSocket": "/run/d2b/public.sock",
+                "serverVersion": "1.2.3",
+                "selectedVersion": "1.2.0"
+            }
+        });
+        let decoded: PublicResponse =
+            serde_json::from_value(capability_value.clone()).expect("capabilities decodes");
+        match decoded {
+            PublicResponse::Capabilities(response) => {
+                assert_eq!(response.broker_socket, "/run/d2b/priv.sock");
+                assert_eq!(
+                    response.capabilities,
+                    vec![FeatureFlag::new("typed-errors").expect("valid feature")]
+                );
+                assert_eq!(
+                    response.server_version,
+                    Version::new("1.2.3").expect("valid version")
+                );
+            }
+            other => panic!("unexpected response variant: {other:?}"),
+        }
+
+        for value in [
+            serde_json::json!({
+                "kind": "auth status",
+                "payload": {
+                    "allowedSubcommands": ["list"],
+                    "deniedSubcommands": [{"command": "audit", "reason": "admin only"}],
+                    "role": "launcher",
+                    "sockets": [{"reachable": true, "socket": "/run/d2b/public.sock"}]
+                }
+            }),
+            serde_json::json!({"kind": "list", "payload": {"vms": []}}),
+            serde_json::json!({"kind": "status", "payload": {"entries": []}}),
+            serde_json::json!({
+                "kind": "audit",
+                "payload": {
+                    "entries": [{
+                        "action": "vm-start",
+                        "result": "ok",
+                        "scope": "vm:corp-vm",
+                        "timestamp": "2026-07-05T18:00:00Z"
+                    }]
+                }
+            }),
+            serde_json::json!({
+                "kind": "host check",
+                "payload": {
+                    "exitCode": 0,
+                    "findings": [{
+                        "check": "bridge",
+                        "message": "ok",
+                        "remediation": "none",
+                        "severity": "Pass"
+                    }]
+                }
+            }),
+        ] {
+            serde_json::from_value::<PublicResponse>(value).expect("public response decodes");
+        }
+    }
+
+    #[test]
+    fn public_response_deserializes_error_envelope_losslessly() {
+        let response = PublicResponse::Error(Error::broker_validation_failed("opaque target"));
+        let value = serde_json::to_value(&response).expect("error response serializes");
+
+        let decoded: PublicResponse =
+            serde_json::from_value(value.clone()).expect("error response decodes");
+        let PublicResponse::Error(error) = decoded else {
+            panic!("expected error response");
+        };
+
+        assert_eq!(error.kind(), Error::broker_validation_failed("x").kind());
+        assert_eq!(error.code(), 31);
+        assert_eq!(
+            error.message(),
+            "broker validation failed for opaque target opaque target"
+        );
+        assert_eq!(
+            serde_json::to_value(PublicResponse::Error(error)).unwrap(),
+            value
+        );
     }
 
     #[test]

--- a/packages/d2b-core/src/error.rs
+++ b/packages/d2b-core/src/error.rs
@@ -274,6 +274,7 @@ pub enum Error {
     Internal(InternalError),
     Bundle(BundleError),
     Audio(AudioError),
+    PublicEnvelope(ErrorEnvelope),
 }
 
 impl Error {
@@ -373,7 +374,7 @@ impl Error {
         &ERROR_KIND_RECORDS
     }
 
-    pub const fn kind(&self) -> Kind {
+    pub fn kind(&self) -> Kind {
         match self {
             Self::Authz(error) => error.kind(),
             Self::Wire(error) => error.kind(),
@@ -382,11 +383,15 @@ impl Error {
             Self::Internal(error) => error.kind(),
             Self::Bundle(error) => error.kind(),
             Self::Audio(error) => error.kind(),
+            Self::PublicEnvelope(envelope) => envelope.kind,
         }
     }
 
-    pub const fn code(&self) -> u8 {
-        self.kind().exit_code()
+    pub fn code(&self) -> u8 {
+        match self {
+            Self::PublicEnvelope(envelope) => envelope.code,
+            _ => self.kind().exit_code(),
+        }
     }
 
     pub fn message(&self) -> String {
@@ -398,23 +403,33 @@ impl Error {
             Self::Internal(error) => error.message(),
             Self::Bundle(error) => error.message(),
             Self::Audio(error) => error.message(),
+            Self::PublicEnvelope(envelope) => envelope.message.clone(),
         }
     }
 
-    pub const fn message_template(&self) -> &'static str {
+    pub fn message_template(&self) -> &'static str {
         self.kind().message_template()
     }
 
-    pub const fn remediation(&self) -> &'static str {
-        self.kind().remediation()
+    pub fn remediation(&self) -> &str {
+        match self {
+            Self::PublicEnvelope(envelope) => envelope.remediation.as_str(),
+            _ => self.kind().remediation(),
+        }
     }
 
     pub fn docs_anchor(&self) -> String {
-        format!("docs/reference/error-codes.md{}", self.kind().docs_anchor())
+        match self {
+            Self::PublicEnvelope(envelope) => envelope.docs_anchor.clone(),
+            _ => format!("docs/reference/error-codes.md{}", self.kind().docs_anchor()),
+        }
     }
 
-    pub const fn owning_command(&self) -> &'static str {
-        self.kind().owning_command()
+    pub fn owning_command(&self) -> &str {
+        match self {
+            Self::PublicEnvelope(envelope) => envelope.owning_command.as_str(),
+            _ => self.kind().owning_command(),
+        }
     }
 }
 
@@ -914,9 +929,9 @@ impl JsonSchema for SemverRange {
     }
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-struct ErrorEnvelope {
+pub struct ErrorEnvelope {
     kind: Kind,
     code: u8,
     message: String,
@@ -939,6 +954,22 @@ impl Serialize for Error {
             owning_command: self.owning_command().to_owned(),
         }
         .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Error {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let envelope = ErrorEnvelope::deserialize(deserializer)?;
+        if envelope.code != envelope.kind.exit_code() {
+            return Err(serde::de::Error::custom(format!(
+                "error envelope code {} does not match kind {}",
+                envelope.code, envelope.kind
+            )));
+        }
+        Ok(Self::PublicEnvelope(envelope))
     }
 }
 

--- a/packages/d2b-wayland-proxy/Cargo.toml
+++ b/packages/d2b-wayland-proxy/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4", features = ["derive"] }
 libc = "0.2"
 log = "0.4"
 env_logger = "0.11"
+getrandom = "0.2"
 nix = { version = "0.29", default-features = false, features = ["fs", "socket", "uio"] }
 rustix = { workspace = true, features = ["event"] }
 smallvec = "1"

--- a/packages/d2b-wayland-proxy/src/bridge.rs
+++ b/packages/d2b-wayland-proxy/src/bridge.rs
@@ -542,7 +542,7 @@ mod tests {
         let mut frame = [0_u8; 256];
         let mut iov = [IoSliceMut::new(&mut frame)];
         let mut cmsg_space = vec![0_u8; SCM_RIGHTS_MIN_CONTROL_BYTES];
-        assert!(SCM_RIGHTS_CONTROL_FD_SLOTS >= SCM_RIGHTS_MIN_FDS);
+        const { assert!(SCM_RIGHTS_CONTROL_FD_SLOTS >= SCM_RIGHTS_MIN_FDS) };
         assert!(cmsg_space.len() >= SCM_RIGHTS_MIN_CONTROL_BYTES);
         let msg = nix::sys::socket::recvmsg::<()>(
             peer.as_raw_fd(),

--- a/packages/d2b-wayland-proxy/src/bridge.rs
+++ b/packages/d2b-wayland-proxy/src/bridge.rs
@@ -320,7 +320,10 @@ fn handoff_status_from_sendmsg_result(
 }
 
 fn is_would_block_errno(error: nix::errno::Errno) -> bool {
-    error == nix::errno::Errno::EAGAIN
+    matches!(
+        error,
+        nix::errno::Errno::EAGAIN | nix::errno::Errno::ENOTCONN
+    )
 }
 
 pub fn recv_flags_are_fail_closed(flags: nix::sys::socket::MsgFlags) -> bool {
@@ -502,6 +505,10 @@ mod tests {
     fn sendmsg_backpressure_is_not_fatal_handoff_failure() {
         assert_eq!(
             handoff_status_from_sendmsg_result(Err(nix::errno::Errno::EAGAIN), 128),
+            HandoffStatus::Backpressure
+        );
+        assert_eq!(
+            handoff_status_from_sendmsg_result(Err(nix::errno::Errno::ENOTCONN), 128),
             HandoffStatus::Backpressure
         );
         assert_eq!(

--- a/packages/d2b-wayland-proxy/src/bridge.rs
+++ b/packages/d2b-wayland-proxy/src/bridge.rs
@@ -15,6 +15,9 @@ use std::{
 };
 
 const LINUX_SUN_PATH_BYTES: usize = 108;
+pub const SCM_RIGHTS_MIN_FDS: usize = 28;
+pub const SCM_RIGHTS_MIN_CONTROL_BYTES: usize = 256;
+pub const SCM_RIGHTS_CONTROL_FD_SLOTS: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BridgeConfig {
@@ -225,7 +228,11 @@ pub enum HandoffStatus {
 }
 
 /// Owns a local transfer FD until the bridge handoff attempt reaches a terminal
-/// result. Dropping the wrapper closes the proxy's local copy on every path.
+/// result. Dropping the wrapper closes the proxy's local copy on every path,
+/// acting as the CloseAttach barrier for clipboard transfers: callers may only
+/// release their local copy after the bridge reports delivered/deferred/failed,
+/// never while payload bytes and ancillary FDs can still be separated by
+/// backpressure.
 pub struct LocalTransferFd {
     fd: Option<OwnedFd>,
 }
@@ -301,6 +308,10 @@ fn handoff_status_from_sendmsg_result(
 
 fn is_would_block_errno(error: nix::errno::Errno) -> bool {
     error == nix::errno::Errno::EAGAIN
+}
+
+pub fn recv_flags_are_fail_closed(flags: nix::sys::socket::MsgFlags) -> bool {
+    !flags.contains(nix::sys::socket::MsgFlags::MSG_CTRUNC)
 }
 
 fn bridge_frame(metadata: &BridgeTransferMetadata) -> String {
@@ -510,14 +521,17 @@ mod tests {
 
         let mut frame = [0_u8; 256];
         let mut iov = [IoSliceMut::new(&mut frame)];
-        let mut cmsg_space = nix::cmsg_space!([i32; 1]);
+        let mut cmsg_space = vec![0_u8; SCM_RIGHTS_MIN_CONTROL_BYTES];
+        assert!(SCM_RIGHTS_CONTROL_FD_SLOTS >= SCM_RIGHTS_MIN_FDS);
+        assert!(cmsg_space.len() >= SCM_RIGHTS_MIN_CONTROL_BYTES);
         let msg = nix::sys::socket::recvmsg::<()>(
             peer.as_raw_fd(),
             &mut iov,
             Some(&mut cmsg_space),
-            nix::sys::socket::MsgFlags::empty(),
+            nix::sys::socket::MsgFlags::MSG_CMSG_CLOEXEC,
         )
         .expect("recvmsg");
+        assert!(recv_flags_are_fail_closed(msg.flags));
         let bytes = msg.bytes;
         let mut saw_fd = false;
         for cmsg in msg.cmsgs().expect("cmsgs") {
@@ -535,6 +549,16 @@ mod tests {
         assert!(frame.contains("\"vm_name\":\"work\""));
         let mut buf = [0_u8; 1];
         assert_eq!(local_peer.read(&mut buf).expect("local peer EOF"), 0);
+    }
+
+    #[test]
+    fn ctruncated_scm_rights_receive_is_fail_closed() {
+        assert!(!recv_flags_are_fail_closed(
+            nix::sys::socket::MsgFlags::MSG_CTRUNC
+        ));
+        assert!(recv_flags_are_fail_closed(
+            nix::sys::socket::MsgFlags::empty()
+        ));
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/bridge.rs
+++ b/packages/d2b-wayland-proxy/src/bridge.rs
@@ -233,8 +233,15 @@ pub enum HandoffStatus {
 /// release their local copy after the bridge reports delivered/deferred/failed,
 /// never while payload bytes and ancillary FDs can still be separated by
 /// backpressure.
+#[derive(Debug)]
 pub struct LocalTransferFd {
     fd: Option<OwnedFd>,
+}
+
+impl From<UnixStream> for LocalTransferFd {
+    fn from(value: UnixStream) -> Self {
+        Self::new(value.into())
+    }
 }
 
 impl LocalTransferFd {
@@ -246,12 +253,18 @@ impl LocalTransferFd {
         drop(self.fd.take());
         status
     }
+
+    fn as_owned_fd(&self) -> &OwnedFd {
+        self.fd
+            .as_ref()
+            .expect("fd present until close_after_handoff")
+    }
 }
 
 pub trait BridgeHandoff {
     fn handoff_transfer_fd(
         &mut self,
-        fd: &OwnedFd,
+        fd: &LocalTransferFd,
         metadata: &BridgeTransferMetadata,
     ) -> HandoffStatus;
 }
@@ -273,10 +286,10 @@ pub enum BridgeTransferKind {
 impl BridgeHandoff for UnixStream {
     fn handoff_transfer_fd(
         &mut self,
-        local_fd: &OwnedFd,
+        local_fd: &LocalTransferFd,
         metadata: &BridgeTransferMetadata,
     ) -> HandoffStatus {
-        let raw_fd = local_fd.as_raw_fd();
+        let raw_fd = local_fd.as_owned_fd().as_raw_fd();
         let frame = bridge_frame(metadata);
         let iov = [IoSlice::new(frame.as_bytes())];
         let fds = [raw_fd];
@@ -505,7 +518,7 @@ mod tests {
     fn bridge_handoff_sends_fd_with_scm_rights() {
         let (mut bridge, peer) = UnixStream::pair().expect("bridge socket pair");
         let (local, mut local_peer) = UnixStream::pair().expect("transfer socket pair");
-        let local: OwnedFd = local.into();
+        let local = LocalTransferFd::new(local.into());
         let metadata = BridgeTransferMetadata {
             vm_name: "work".to_owned(),
             mime_type: "text/plain".to_owned(),
@@ -517,7 +530,7 @@ mod tests {
             bridge.handoff_transfer_fd(&local, &metadata),
             HandoffStatus::Delivered
         );
-        drop(local);
+        let _ = local.close_after_handoff(HandoffStatus::Delivered);
 
         let mut frame = [0_u8; 256];
         let mut iov = [IoSliceMut::new(&mut frame)];

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -78,7 +78,7 @@ use wl_proxy::{
 use crate::{
     bridge::{
         BridgeConfig, BridgeConnectionState, BridgeHandoff, BridgeReconnectMachine,
-        BridgeTransferKind, BridgeTransferMetadata,
+        BridgeTransferKind, BridgeTransferMetadata, LocalTransferFd,
     },
     clipboard::{
         ClipboardGlobalDisposition, ClipboardMimePolicy, ClipboardRoute, MimeDecision,
@@ -227,7 +227,7 @@ struct VirtualOffer {
 
 #[derive(Debug)]
 struct PendingBridgeHandoff {
-    fd: OwnedFd,
+    fd: LocalTransferFd,
     metadata: BridgeTransferMetadata,
 }
 
@@ -569,17 +569,33 @@ impl VirtualClipboardState {
 
     fn handoff_via_bridge(&mut self, fd: &OwnedFd, metadata: &BridgeTransferMetadata) {
         self.flush_pending_bridge_handoffs();
+        let local_fd = match rustix::io::fcntl_dupfd_cloexec(fd, 0) {
+            Ok(fd) => LocalTransferFd::new(fd),
+            Err(error) => {
+                let vm = self.vm_name.clone();
+                let error = bounded_error_detail(error.to_string());
+                self.diag
+                    .borrow_mut()
+                    .warn("clipboard-bridge", "handoff-fd-dup-failed", || {
+                        format!(
+                            "[d2b-wlproxy] vm={vm} event=clipboard-bridge reason=handoff-fd-dup-failed error={error}"
+                        )
+                    });
+                return;
+            }
+        };
         if !self.pending_bridge_handoffs.is_empty() {
-            self.enqueue_bridge_handoff(fd, metadata);
+            self.enqueue_bridge_handoff(local_fd, metadata);
             self.ensure_bridge_connected();
             return;
         }
         let Some(bridge) = self.ensure_bridge_connected() else {
-            self.enqueue_bridge_handoff(fd, metadata);
+            self.enqueue_bridge_handoff(local_fd, metadata);
             return;
         };
-        match bridge.handoff_transfer_fd(fd, metadata) {
+        match bridge.handoff_transfer_fd(&local_fd, metadata) {
             crate::bridge::HandoffStatus::Delivered => {
+                let _ = local_fd.close_after_handoff(crate::bridge::HandoffStatus::Delivered);
                 log::debug!(
                     "[d2b-wlproxy] vm={} event=clipboard-bridge reason=handoff-delivered kind={:?} mime={}",
                     self.vm_name,
@@ -588,11 +604,16 @@ impl VirtualClipboardState {
                 );
             }
             crate::bridge::HandoffStatus::Backpressure => {
-                self.enqueue_bridge_handoff(fd, metadata);
+                self.enqueue_bridge_handoff(local_fd, metadata);
             }
             crate::bridge::HandoffStatus::Failed(error) => {
+                let status = crate::bridge::HandoffStatus::Failed(error);
+                let error = match status {
+                    crate::bridge::HandoffStatus::Failed(error) => error,
+                    _ => unreachable!(),
+                };
+                let _ = local_fd.close_after_handoff(crate::bridge::HandoffStatus::Failed(error));
                 self.mark_bridge_disconnected();
-                self.enqueue_bridge_handoff(fd, metadata);
                 self.ensure_bridge_connected();
                 let vm = self.vm_name.clone();
                 let kind = metadata.kind;
@@ -609,7 +630,7 @@ impl VirtualClipboardState {
         }
     }
 
-    fn enqueue_bridge_handoff(&mut self, fd: &OwnedFd, metadata: &BridgeTransferMetadata) {
+    fn enqueue_bridge_handoff(&mut self, fd: LocalTransferFd, metadata: &BridgeTransferMetadata) {
         if self.pending_bridge_handoffs.len() >= MAX_PENDING_BRIDGE_HANDOFFS {
             let vm = self.vm_name.clone();
             let kind = metadata.kind;
@@ -623,24 +644,9 @@ impl VirtualClipboardState {
                 });
             return;
         }
-        let dup_fd = match rustix::io::fcntl_dupfd_cloexec(fd, 0) {
-            Ok(fd) => fd,
-            Err(error) => {
-                let vm = self.vm_name.clone();
-                let error = bounded_error_detail(error.to_string());
-                self.diag
-                    .borrow_mut()
-                    .warn("clipboard-bridge", "handoff-fd-dup-failed", || {
-                        format!(
-                            "[d2b-wlproxy] vm={vm} event=clipboard-bridge reason=handoff-fd-dup-failed error={error}"
-                        )
-                    });
-                return;
-            }
-        };
         self.pending_bridge_handoffs
             .push_back(PendingBridgeHandoff {
-                fd: dup_fd,
+                fd,
                 metadata: metadata.clone(),
             });
     }
@@ -668,6 +674,9 @@ impl VirtualClipboardState {
     ) -> PendingHandoffStep {
         match status {
             crate::bridge::HandoffStatus::Delivered => {
+                let _ = pending
+                    .fd
+                    .close_after_handoff(crate::bridge::HandoffStatus::Delivered);
                 log::debug!(
                     "[d2b-wlproxy] vm={} event=clipboard-bridge reason=queued-handoff-delivered kind={:?} mime={}",
                     self.vm_name,
@@ -1509,6 +1518,7 @@ impl WlSeatHandler for FilterSeatHandler {
         id.set_handler(FilterPointerHandler {
             decoration: self.decoration.clone(),
             focus: PointerFocus::None,
+            target_surface: None,
             pending_forwarded_frame: false,
         });
         slf.send_get_pointer(id);
@@ -1526,6 +1536,7 @@ impl WlSeatHandler for FilterSeatHandler {
             decoration: self.decoration.clone(),
             suppressed_ids: HashSet::new(),
             forwarded_ids: HashSet::new(),
+            wrapper_forwarded_ids: HashSet::new(),
             pending_forwarded_frame: false,
         });
         slf.send_get_touch(id);
@@ -1612,6 +1623,7 @@ impl WlKeyboardHandler for FilterKeyboardHandler {
 struct FilterPointerHandler {
     decoration: SharedDecorationManager,
     focus: PointerFocus,
+    target_surface: Option<Rc<WlSurface>>,
     pending_forwarded_frame: bool,
 }
 
@@ -1650,6 +1662,7 @@ impl WlPointerHandler for FilterPointerHandler {
     ) {
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
             if surface_belongs_to_receiver(&target, slf.client()) {
+                self.target_surface = Some(target.clone());
                 if let Some(x) = wrapper_content_pointer_x(surface_x) {
                     self.focus = PointerFocus::WrapperContent;
                     self.pending_forwarded_frame = true;
@@ -1659,14 +1672,17 @@ impl WlPointerHandler for FilterPointerHandler {
                 }
             } else {
                 self.focus = PointerFocus::None;
+                self.target_surface = None;
             }
             return;
         }
         if !surface_belongs_to_receiver(surface, slf.client()) {
             self.focus = PointerFocus::None;
+            self.target_surface = None;
             return;
         }
         self.focus = PointerFocus::Direct;
+        self.target_surface = Some(surface.clone());
         self.pending_forwarded_frame = true;
         slf.send_enter(serial, surface, surface_x, surface_y);
     }
@@ -1680,13 +1696,16 @@ impl WlPointerHandler for FilterPointerHandler {
                 slf.send_leave(serial, &target);
             }
             self.focus = PointerFocus::None;
+            self.target_surface = None;
             return;
         }
         if !surface_belongs_to_receiver(surface, slf.client()) {
             self.focus = PointerFocus::None;
+            self.target_surface = None;
             return;
         }
         self.focus = PointerFocus::None;
+        self.target_surface = None;
         self.pending_forwarded_frame = true;
         slf.send_leave(serial, surface);
     }
@@ -1700,7 +1719,28 @@ impl WlPointerHandler for FilterPointerHandler {
     ) {
         if !receiver_has_client(slf.client()) {
             self.focus = PointerFocus::None;
+            self.target_surface = None;
             self.pending_forwarded_frame = false;
+            return;
+        }
+        if self.focus == PointerFocus::WrapperContent
+            && wrapper_content_pointer_x(surface_x).is_none()
+        {
+            self.focus = PointerFocus::Rail;
+            self.pending_forwarded_frame = true;
+            if let Some(target) = &self.target_surface {
+                slf.send_leave(0, target);
+            }
+            return;
+        }
+        if self.focus == PointerFocus::Rail {
+            if let Some(x) = wrapper_content_pointer_x(surface_x) {
+                self.focus = PointerFocus::WrapperContent;
+                self.pending_forwarded_frame = true;
+                if let Some(target) = &self.target_surface {
+                    slf.send_enter(0, target, x, surface_y);
+                }
+            }
             return;
         }
         let Some(x) = pointer_motion_x_for_focus(self.focus, surface_x) else {
@@ -1831,6 +1871,7 @@ struct FilterTouchHandler {
     decoration: SharedDecorationManager,
     suppressed_ids: HashSet<i32>,
     forwarded_ids: HashSet<i32>,
+    wrapper_forwarded_ids: HashSet<i32>,
     pending_forwarded_frame: bool,
 }
 
@@ -1848,12 +1889,20 @@ impl WlTouchHandler for FilterTouchHandler {
         if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
+            self.wrapper_forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
         if let Some(target) = self.decoration.borrow().wrapper_input_target(surface) {
             if surface_belongs_to_receiver(&target, slf.client()) {
-                self.suppressed_ids.insert(id);
+                if let Some(adjusted_x) = wrapper_content_pointer_x(x) {
+                    self.forwarded_ids.insert(id);
+                    self.wrapper_forwarded_ids.insert(id);
+                    self.pending_forwarded_frame = true;
+                    slf.send_down(serial, time, &target, id, adjusted_x, y);
+                } else {
+                    self.suppressed_ids.insert(id);
+                }
             }
             return;
         }
@@ -1869,6 +1918,7 @@ impl WlTouchHandler for FilterTouchHandler {
         if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
+            self.wrapper_forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
@@ -1876,6 +1926,7 @@ impl WlTouchHandler for FilterTouchHandler {
             return;
         }
         self.forwarded_ids.remove(&id);
+        self.wrapper_forwarded_ids.remove(&id);
         self.pending_forwarded_frame = true;
         slf.send_up(serial, time, id);
     }
@@ -1884,6 +1935,7 @@ impl WlTouchHandler for FilterTouchHandler {
         if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
+            self.wrapper_forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
@@ -1891,13 +1943,19 @@ impl WlTouchHandler for FilterTouchHandler {
             return;
         }
         self.pending_forwarded_frame = true;
-        slf.send_motion(time, id, x, y);
+        let adjusted_x = if self.wrapper_forwarded_ids.contains(&id) {
+            wrapper_content_pointer_x(x).unwrap_or(Fixed::ZERO)
+        } else {
+            x
+        };
+        slf.send_motion(time, id, adjusted_x, y);
     }
 
     fn handle_shape(&mut self, slf: &Rc<WlTouch>, id: i32, major: Fixed, minor: Fixed) {
         if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
+            self.wrapper_forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
@@ -1912,6 +1970,7 @@ impl WlTouchHandler for FilterTouchHandler {
         if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
+            self.wrapper_forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
@@ -1931,11 +1990,13 @@ impl WlTouchHandler for FilterTouchHandler {
         }
         if self.forwarded_ids.is_empty() {
             self.suppressed_ids.clear();
+            self.wrapper_forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
         self.forwarded_ids.clear();
         self.suppressed_ids.clear();
+        self.wrapper_forwarded_ids.clear();
         self.pending_forwarded_frame = false;
         slf.send_cancel();
     }
@@ -1944,6 +2005,7 @@ impl WlTouchHandler for FilterTouchHandler {
         if !receiver_has_client(slf.client()) {
             self.suppressed_ids.clear();
             self.forwarded_ids.clear();
+            self.wrapper_forwarded_ids.clear();
             self.pending_forwarded_frame = false;
             return;
         }
@@ -2755,9 +2817,12 @@ fn connect_bridge_nonblocking(path: &PathBuf) -> std::io::Result<UnixStream> {
     )
     .map_err(errno_to_io)?;
     let addr = UnixAddr::new(path).map_err(errno_to_io)?;
-    connect(fd.as_raw_fd(), &addr)
-        .map(|()| UnixStream::from(fd))
-        .map_err(errno_to_io)
+    match connect(fd.as_raw_fd(), &addr) {
+        Ok(()) | Err(nix::errno::Errno::EINPROGRESS | nix::errno::Errno::EAGAIN) => {
+            Ok(UnixStream::from(fd))
+        }
+        Err(error) => Err(errno_to_io(error)),
+    }
 }
 
 fn errno_to_io(error: nix::errno::Errno) -> std::io::Error {

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -3000,14 +3000,16 @@ mod tests {
         assert_eq!(clipboard.pending_handoff_count_for_tests(), 0);
         let mut frame = [0_u8; 256];
         let mut iov = [IoSliceMut::new(&mut frame)];
-        let mut cmsg_space = nix::cmsg_space!([i32; 1]);
+        let mut cmsg_space = vec![0_u8; crate::bridge::SCM_RIGHTS_MIN_CONTROL_BYTES];
+        assert!(crate::bridge::SCM_RIGHTS_CONTROL_FD_SLOTS >= crate::bridge::SCM_RIGHTS_MIN_FDS);
         let msg = nix::sys::socket::recvmsg::<()>(
             peer.as_raw_fd(),
             &mut iov,
             Some(&mut cmsg_space),
-            nix::sys::socket::MsgFlags::empty(),
+            nix::sys::socket::MsgFlags::MSG_CMSG_CLOEXEC,
         )
         .expect("recvmsg");
+        assert!(crate::bridge::recv_flags_are_fail_closed(msg.flags));
         assert!(msg.bytes > 0);
         for cmsg in msg.cmsgs().expect("cmsgs") {
             if let nix::sys::socket::ControlMessageOwned::ScmRights(fds) = cmsg {

--- a/packages/d2b-wayland-proxy/src/filter.rs
+++ b/packages/d2b-wayland-proxy/src/filter.rs
@@ -3066,7 +3066,9 @@ mod tests {
         let mut frame = [0_u8; 256];
         let mut iov = [IoSliceMut::new(&mut frame)];
         let mut cmsg_space = vec![0_u8; crate::bridge::SCM_RIGHTS_MIN_CONTROL_BYTES];
-        assert!(crate::bridge::SCM_RIGHTS_CONTROL_FD_SLOTS >= crate::bridge::SCM_RIGHTS_MIN_FDS);
+        const {
+            assert!(crate::bridge::SCM_RIGHTS_CONTROL_FD_SLOTS >= crate::bridge::SCM_RIGHTS_MIN_FDS)
+        };
         let msg = nix::sys::socket::recvmsg::<()>(
             peer.as_raw_fd(),
             &mut iov,

--- a/packages/d2b-wayland-proxy/src/lib.rs
+++ b/packages/d2b-wayland-proxy/src/lib.rs
@@ -11,5 +11,6 @@ pub mod diag;
 pub mod dmabuf;
 pub mod filter;
 pub mod policy;
+pub mod terminal;
 
 pub use policy::{FilterPolicy, GlobalAction, PolicyInput, PolicyWarning};

--- a/packages/d2b-wayland-proxy/src/main.rs
+++ b/packages/d2b-wayland-proxy/src/main.rs
@@ -349,14 +349,14 @@ fn main() {
             std::process::exit(1);
         }
     };
-    if terminal_runtime.is_some() {
-        if let Err(e) = chmod_socket_strict(&listen_path) {
-            eprintln!(
-                "d2b-wayland-proxy: failed to secure listen socket `{}`: {e}",
-                listen_path.display()
-            );
-            std::process::exit(1);
-        }
+    if terminal_runtime.is_some()
+        && let Err(e) = chmod_socket_strict(&listen_path)
+    {
+        eprintln!(
+            "d2b-wayland-proxy: failed to secure listen socket `{}`: {e}",
+            listen_path.display()
+        );
+        std::process::exit(1);
     }
 
     log::info!(

--- a/packages/d2b-wayland-proxy/src/main.rs
+++ b/packages/d2b-wayland-proxy/src/main.rs
@@ -13,6 +13,7 @@
 
 use std::{
     cell::RefCell,
+    ffi::OsString,
     io,
     os::unix::net::UnixListener,
     path::PathBuf,
@@ -30,6 +31,10 @@ use d2b_wayland_proxy::{
     diag::{DiagRateLimiter, bounded_error_detail},
     dmabuf::{DmabufFilter, parse_filter as parse_dmabuf_filter},
     policy::{FilterPolicy, PolicyInput},
+    terminal::{
+        TerminalChild, TerminalRuntime, child_exit_code, chmod_socket_strict,
+        unlink_stale_socket_path,
+    },
 };
 use env_logger::Env;
 use rustix::event::{PollFd, PollFlags, poll};
@@ -43,11 +48,11 @@ const ACCEPT_RESOURCE_BACKOFF: Duration = Duration::from_millis(50);
 struct Args {
     /// Path of the Unix socket to create and accept client connections on.
     #[arg(long)]
-    listen: PathBuf,
+    listen: Option<PathBuf>,
 
     /// Path of the upstream host compositor socket to connect to.
     #[arg(long)]
-    connect: String,
+    connect: Option<String>,
 
     /// VM name, e.g. `work`. Used in app-id prefix, title prefix, and logs.
     #[arg(long, value_name = "VM")]
@@ -152,6 +157,18 @@ struct Args {
         default_value = "top-left"
     )]
     border_label_position: LabelPosition,
+
+    /// Launch a foreground WezTerm child through a randomized single-use proxy socket.
+    #[arg(long = "host-terminal")]
+    host_terminal: bool,
+
+    /// Terminal program to launch in --host-terminal mode.
+    #[arg(long = "terminal-program", default_value = "wezterm")]
+    terminal_program: OsString,
+
+    /// Arguments passed to the terminal program after `--` in --host-terminal mode.
+    #[arg(last = true, allow_hyphen_values = true)]
+    terminal_args: Vec<OsString>,
 }
 
 fn parse_max_version(s: &str) -> Result<(String, u32), String> {
@@ -274,34 +291,55 @@ fn main() {
         );
     }
 
+    let upstream = resolve_upstream(&args).unwrap_or_else(|e| {
+        eprintln!("d2b-wayland-proxy: {e}");
+        std::process::exit(1);
+    });
+
+    let terminal_runtime = if args.host_terminal {
+        Some(TerminalRuntime::prepare(&args.vm_name).unwrap_or_else(|e| {
+            eprintln!("d2b-wayland-proxy: failed to prepare host-terminal runtime: {e}");
+            std::process::exit(1);
+        }))
+    } else {
+        None
+    };
+    let listen_path = resolve_listen_path(&args, terminal_runtime.as_ref()).unwrap_or_else(|e| {
+        eprintln!("d2b-wayland-proxy: {e}");
+        std::process::exit(1);
+    });
+
     // Step 3: prove the upstream compositor is reachable before exposing a
     // listen socket. Each accepted client gets its own upstream connection below.
-    match build_state(&args.connect) {
+    match build_state(&upstream) {
         Ok(_) => {}
         Err(e) => {
             eprintln!(
                 "d2b-wayland-proxy: failed to connect to upstream compositor `{}`: {e}",
-                args.connect
+                upstream
             );
             std::process::exit(1);
         }
     }
 
     // Step 4: create the listen socket AFTER successful upstream connect.
-    let listen_path = &args.listen;
-
     // Remove a stale socket if present so restart cycles are idempotent.
-    if listen_path.exists()
-        && let Err(e) = std::fs::remove_file(listen_path)
-    {
-        eprintln!(
-            "d2b-wayland-proxy: failed to remove stale socket `{}`: {e}",
-            listen_path.display()
-        );
-        std::process::exit(1);
+    if listen_path.exists() {
+        let stale_result = if terminal_runtime.is_some() {
+            unlink_stale_socket_path(&listen_path)
+        } else {
+            std::fs::remove_file(&listen_path)
+        };
+        if let Err(e) = stale_result {
+            eprintln!(
+                "d2b-wayland-proxy: failed to remove stale socket `{}`: {e}",
+                listen_path.display()
+            );
+            std::process::exit(1);
+        }
     }
 
-    let listener = match UnixListener::bind(listen_path) {
+    let listener = match UnixListener::bind(&listen_path) {
         Ok(l) => l,
         Err(e) => {
             eprintln!(
@@ -311,16 +349,78 @@ fn main() {
             std::process::exit(1);
         }
     };
+    if terminal_runtime.is_some() {
+        if let Err(e) = chmod_socket_strict(&listen_path) {
+            eprintln!(
+                "d2b-wayland-proxy: failed to secure listen socket `{}`: {e}",
+                listen_path.display()
+            );
+            std::process::exit(1);
+        }
+    }
 
     log::info!(
         "[d2b-wlproxy] vm={} listening on {} upstream={}",
         args.vm_name,
         listen_path.display(),
-        args.connect
+        upstream
     );
 
+    let mut terminal_child = terminal_runtime.as_ref().map(|runtime| {
+        TerminalChild::spawn(&args.terminal_program, &args.terminal_args, runtime).unwrap_or_else(
+            |e| {
+                eprintln!("d2b-wayland-proxy: failed to launch host terminal child: {e}");
+                std::process::exit(1);
+            },
+        )
+    });
+    if terminal_child.is_some() {
+        log::info!(
+            "[d2b-wlproxy] vm={} event=host-terminal-launched mux=per-vm",
+            args.vm_name
+        );
+    }
+
     // Step 5: dispatch loop.
-    accept_loop(listener, args.connect, policy, bridge_config, border_config);
+    let exit_code = accept_loop(
+        listener,
+        upstream,
+        policy,
+        bridge_config,
+        border_config,
+        terminal_child.as_mut(),
+    );
+    if let Some(child) = terminal_child.as_mut()
+        && exit_code != 0
+    {
+        child.terminate();
+    }
+    drop(terminal_runtime);
+    std::process::exit(exit_code);
+}
+
+fn resolve_upstream(args: &Args) -> Result<String, String> {
+    if let Some(connect) = &args.connect {
+        return Ok(connect.clone());
+    }
+    if args.host_terminal {
+        return Ok(std::env::var("WAYLAND_DISPLAY").unwrap_or_else(|_| "wayland-0".to_owned()));
+    }
+    Err("--connect is required unless --host-terminal is used".to_owned())
+}
+
+fn resolve_listen_path(
+    args: &Args,
+    terminal_runtime: Option<&TerminalRuntime>,
+) -> Result<PathBuf, String> {
+    match (&args.listen, terminal_runtime) {
+        (Some(path), None) => Ok(path.clone()),
+        (Some(_), Some(_)) => {
+            Err("--listen cannot be combined with randomized --host-terminal mode".to_owned())
+        }
+        (None, Some(runtime)) => Ok(runtime.listen_socket().to_owned()),
+        (None, None) => Err("--listen is required unless --host-terminal is used".to_owned()),
+    }
 }
 
 fn accept_loop(
@@ -329,7 +429,8 @@ fn accept_loop(
     policy: FilterPolicy,
     bridge_config: BridgeConfig,
     border_config: BorderConfig,
-) {
+    mut terminal_child: Option<&mut TerminalChild>,
+) -> i32 {
     if let Err(e) = listener.set_nonblocking(true) {
         eprintln!("d2b-wayland-proxy: failed to set listen socket nonblocking: {e}");
         std::process::exit(1);
@@ -370,6 +471,20 @@ fn accept_loop(
     let mut last_diag_flush = Instant::now();
     let mut listener_backoff_until: Option<Instant> = None;
     while state.is_not_destroyed() {
+        if let Some(child) = terminal_child.as_mut() {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    state.destroy();
+                    diag.borrow_mut().flush_suppressed();
+                    return child_exit_code(status);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    log::warn!("[d2b-wlproxy] vm={vm} event=host-terminal-wait error={error}");
+                    break;
+                }
+            }
+        }
         let (listener_ready, _state_ready, bridge_ready) = {
             let now = Instant::now();
             let listener_in_backoff = accept_backoff_active(listener_backoff_until, now);
@@ -383,6 +498,7 @@ fn accept_loop(
                 listener_backoff_until,
                 clipboard_ref.bridge_retry_deadline(),
                 now,
+                terminal_child.is_some(),
             );
             let mut poll_fds: SmallVec<[PollFd<'_>; 3]> = smallvec![
                 PollFd::new(&listener, listener_accept_poll_flags(listener_in_backoff)),
@@ -500,6 +616,7 @@ fn accept_loop(
     }
     state.destroy();
     diag.borrow_mut().flush_suppressed();
+    0
 }
 
 fn is_recoverable_accept_error(error: &io::Error) -> bool {
@@ -535,6 +652,7 @@ fn accept_poll_timeout_ms(
     listener_backoff_until: Option<Instant>,
     bridge_retry_until: Option<Instant>,
     now: Instant,
+    watching_child: bool,
 ) -> i32 {
     let backoff_timeout = listener_backoff_until
         .map(|until| until.saturating_duration_since(now))
@@ -542,9 +660,15 @@ fn accept_poll_timeout_ms(
     let bridge_timeout = bridge_retry_until
         .map(|until| until.saturating_duration_since(now))
         .unwrap_or(diag_timeout);
+    let child_timeout = if watching_child {
+        Duration::from_millis(100)
+    } else {
+        diag_timeout
+    };
     diag_timeout
         .min(backoff_timeout)
         .min(bridge_timeout)
+        .min(child_timeout)
         .as_millis()
         .min(i32::MAX as u128) as i32
 }
@@ -625,6 +749,40 @@ mod tests {
     }
 
     #[test]
+    fn host_terminal_cli_does_not_require_static_listen_or_connect() {
+        let args = Args::try_parse_from([
+            "d2b-wayland-proxy",
+            "--host-terminal",
+            "--vm-name",
+            "work",
+            "--",
+            "start",
+            "--always-new-process",
+        ])
+        .expect("parse args");
+
+        assert!(args.host_terminal);
+        assert!(args.listen.is_none());
+        assert!(args.connect.is_none());
+        assert_eq!(
+            args.terminal_args,
+            vec![
+                OsString::from("start"),
+                OsString::from("--always-new-process")
+            ]
+        );
+    }
+
+    #[test]
+    fn regular_proxy_still_requires_explicit_listen_and_connect() {
+        let args = Args::try_parse_from(["d2b-wayland-proxy", "--vm-name", "work"])
+            .expect("deferred validation keeps clap errors friendly");
+
+        assert!(resolve_listen_path(&args, None).is_err());
+        assert!(resolve_upstream(&args).is_err());
+    }
+
+    #[test]
     fn interrupted_accept_is_recoverable() {
         let err = io::Error::from_raw_os_error(libc::EINTR);
         assert!(is_recoverable_accept_error(&err));
@@ -656,7 +814,13 @@ mod tests {
             PollFlags::IN | PollFlags::ERR | PollFlags::HUP
         );
         assert_eq!(
-            accept_poll_timeout_ms(Duration::from_secs(60), Some(backoff_until), None, now),
+            accept_poll_timeout_ms(
+                Duration::from_secs(60),
+                Some(backoff_until),
+                None,
+                now,
+                false,
+            ),
             50
         );
         assert_eq!(
@@ -665,6 +829,7 @@ mod tests {
                 Some(now + Duration::from_secs(5)),
                 Some(now + Duration::from_millis(25)),
                 now,
+                false,
             ),
             25
         );
@@ -678,8 +843,17 @@ mod tests {
             now
         ));
         assert_eq!(
-            accept_poll_timeout_ms(Duration::from_millis(25), Some(now), None, now),
+            accept_poll_timeout_ms(Duration::from_millis(25), Some(now), None, now, false),
             0
+        );
+    }
+
+    #[test]
+    fn child_watch_bounds_accept_poll_timeout() {
+        let now = Instant::now();
+        assert_eq!(
+            accept_poll_timeout_ms(Duration::from_secs(60), None, None, now, true),
+            100
         );
     }
 

--- a/packages/d2b-wayland-proxy/src/policy.rs
+++ b/packages/d2b-wayland-proxy/src/policy.rs
@@ -12,6 +12,8 @@
 
 use std::collections::HashMap;
 
+const MAX_REWRITTEN_LABEL_CHARS: usize = 256;
+
 /// The action to apply for a Wayland global interface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GlobalAction {
@@ -333,12 +335,13 @@ impl FilterPolicy {
     ///   `d2b.<this>.d2b.<other>....` — spoof prevention.
     /// - Otherwise prepend our prefix unconditionally.
     pub fn rewrite_app_id(&self, guest_value: &str) -> String {
+        let guest_value = sanitize_rewritten_label(guest_value);
         if self.app_id_prefix.is_empty() {
-            return guest_value.to_owned();
+            return guest_value;
         }
         // Already has our exact prefix — pass through.
         if guest_value.starts_with(&self.app_id_prefix) {
-            return guest_value.to_owned();
+            return guest_value;
         }
         // Prepend our prefix (covers both plain values and cross-VM spoofs).
         format!("{}{}", self.app_id_prefix, guest_value)
@@ -348,13 +351,42 @@ impl FilterPolicy {
     ///
     /// Prepends `title_prefix` unless already present (idempotent).
     pub fn rewrite_title(&self, guest_value: &str) -> String {
+        let guest_value = sanitize_rewritten_label(guest_value);
         if self.title_prefix.is_empty() {
-            return guest_value.to_owned();
+            return guest_value;
         }
         if guest_value.starts_with(&self.title_prefix) {
-            return guest_value.to_owned();
+            return guest_value;
         }
         format!("{}{}", self.title_prefix, guest_value)
+    }
+}
+
+fn sanitize_rewritten_label(value: &str) -> String {
+    let mut sanitized = String::new();
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            while let Some(next) = chars.peek().copied() {
+                chars.next();
+                if next.is_ascii_alphabetic() || next == 'm' {
+                    break;
+                }
+            }
+            continue;
+        }
+        if ch.is_control() {
+            continue;
+        }
+        sanitized.push(ch);
+        if sanitized.chars().count() >= MAX_REWRITTEN_LABEL_CHARS {
+            break;
+        }
+    }
+    if sanitized.is_empty() {
+        "unnamed".to_owned()
+    } else {
+        sanitized
     }
 }
 
@@ -816,6 +848,13 @@ mod tests {
         assert_eq!(p.rewrite_app_id("org.example.app"), "org.example.app");
     }
 
+    #[test]
+    fn app_id_rewrite_sanitizes_control_sequences() {
+        let p = policy_for("work");
+        let rewritten = p.rewrite_app_id("org.example.\u{1b}[31mevil\napp");
+        assert_eq!(rewritten, "d2b.work.org.example.evilapp");
+    }
+
     // --- title prefix tests ---
 
     #[test]
@@ -839,6 +878,17 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(p.rewrite_title("Firefox"), "Firefox");
+    }
+
+    #[test]
+    fn title_rewrite_sanitizes_and_truncates_guest_value() {
+        let p = policy_for("work");
+        let input = format!("{}\u{1b}[31m\n{}", "A".repeat(300), "tail");
+        let rewritten = p.rewrite_title(&input);
+        assert!(rewritten.starts_with("[work] "));
+        assert!(!rewritten.contains('\u{1b}'));
+        assert!(!rewritten.contains('\n'));
+        assert!(rewritten.chars().count() <= "[work] ".chars().count() + MAX_REWRITTEN_LABEL_CHARS);
     }
 
     // --- version cap tests ---

--- a/packages/d2b-wayland-proxy/src/terminal.rs
+++ b/packages/d2b-wayland-proxy/src/terminal.rs
@@ -1,0 +1,369 @@
+//! Host-app terminal launch helpers.
+//!
+//! This path is intentionally per-invocation: it creates a randomized
+//! Wayland socket under a VM-scoped 0700 directory and points the foreground
+//! WezTerm child at a randomized mux socket so a VM-bound terminal never
+//! reuses the operator's global WezTerm daemon.
+
+use std::{
+    ffi::{OsStr, OsString},
+    fs, io,
+    os::unix::fs::{FileTypeExt, PermissionsExt},
+    path::{Path, PathBuf},
+    process::{Child, Command, ExitStatus, Stdio},
+};
+
+use rustix::{
+    fd::OwnedFd,
+    process::{Pid, PidfdFlags, pidfd_open},
+};
+
+const TERMINAL_RUNTIME_DIR: &str = "d2b-wayland-proxy";
+const SOCKET_MODE: u32 = 0o600;
+const DIR_MODE: u32 = 0o700;
+
+#[derive(Debug)]
+pub struct TerminalRuntime {
+    root: PathBuf,
+    listen_socket: PathBuf,
+    mux_socket: PathBuf,
+}
+
+impl TerminalRuntime {
+    pub fn prepare(vm_name: &str) -> io::Result<Self> {
+        let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR").ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "XDG_RUNTIME_DIR is required for host-terminal proxy mode",
+            )
+        })?;
+        Self::prepare_in(Path::new(&runtime_dir), vm_name)
+    }
+
+    pub fn prepare_in(runtime_dir: &Path, vm_name: &str) -> io::Result<Self> {
+        let token = random_token()?;
+        Self::prepare_in_with_token(runtime_dir, vm_name, &token)
+    }
+
+    pub fn listen_socket(&self) -> &Path {
+        &self.listen_socket
+    }
+
+    pub fn mux_socket(&self) -> &Path {
+        &self.mux_socket
+    }
+
+    pub fn wayland_display_value(&self) -> OsString {
+        self.listen_socket.as_os_str().to_owned()
+    }
+
+    fn prepare_in_with_token(runtime_dir: &Path, vm_name: &str, token: &str) -> io::Result<Self> {
+        validate_vm_component(vm_name)?;
+        validate_token(token)?;
+        ensure_runtime_parent(runtime_dir)?;
+        let root = runtime_dir.join(TERMINAL_RUNTIME_DIR).join(vm_name);
+        ensure_private_dir(&root)?;
+
+        let listen_socket = root.join(format!("wayland-{token}.sock"));
+        let mux_socket = root.join(format!("wezterm-mux-{token}.sock"));
+        unlink_stale_socket(&listen_socket)?;
+        unlink_stale_socket(&mux_socket)?;
+
+        Ok(Self {
+            root,
+            listen_socket,
+            mux_socket,
+        })
+    }
+}
+
+impl Drop for TerminalRuntime {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.listen_socket);
+        let _ = fs::remove_file(&self.mux_socket);
+        let _ = fs::remove_dir(&self.root);
+    }
+}
+
+pub fn chmod_socket_strict(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_socket() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "proxy listen path is not a Unix socket",
+        ));
+    }
+
+    fs::set_permissions(path, fs::Permissions::from_mode(SOCKET_MODE))?;
+    let mode = fs::symlink_metadata(path)?.permissions().mode() & 0o777;
+    if mode != SOCKET_MODE {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("proxy listen socket mode must be 0600, got {mode:o}"),
+        ));
+    }
+    Ok(())
+}
+
+pub fn unlink_stale_socket_path(path: &Path) -> io::Result<()> {
+    unlink_stale_socket(path)
+}
+
+#[derive(Debug)]
+pub struct TerminalChild {
+    child: Child,
+    _pidfd: OwnedFd,
+}
+
+impl TerminalChild {
+    pub fn spawn(
+        program: &OsStr,
+        args: &[OsString],
+        runtime: &TerminalRuntime,
+    ) -> io::Result<Self> {
+        let mut command = terminal_command(program, args, runtime);
+        let mut child = command.spawn()?;
+        let pidfd = pidfd_open(Pid::from_child(&child), PidfdFlags::empty()).map_err(|err| {
+            let _ = child.kill();
+            let _ = child.wait();
+            io::Error::other(format!("pidfd_open failed: {err}"))
+        })?;
+        Ok(Self {
+            child,
+            _pidfd: pidfd,
+        })
+    }
+
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.child.try_wait()
+    }
+
+    pub fn terminate(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+pub fn child_exit_code(status: ExitStatus) -> i32 {
+    status.code().unwrap_or(128)
+}
+
+pub fn terminal_command(program: &OsStr, args: &[OsString], runtime: &TerminalRuntime) -> Command {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .env("WAYLAND_DISPLAY", runtime.wayland_display_value())
+        .env("WEZTERM_UNIX_SOCKET", runtime.mux_socket())
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    command
+}
+
+fn ensure_runtime_parent(runtime_dir: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(runtime_dir)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "XDG_RUNTIME_DIR must be a real directory",
+        ));
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "XDG_RUNTIME_DIR must not be group/world accessible",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_private_dir(path: &Path) -> io::Result<()> {
+    if let Ok(metadata) = fs::symlink_metadata(path)
+        && (!metadata.is_dir() || metadata.file_type().is_symlink())
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "terminal runtime path exists but is not a directory",
+        ));
+    }
+    fs::create_dir_all(path)?;
+    fs::set_permissions(path, fs::Permissions::from_mode(DIR_MODE))?;
+    let mode = fs::symlink_metadata(path)?.permissions().mode() & 0o777;
+    if mode != DIR_MODE {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("terminal runtime directory mode must be 0700, got {mode:o}"),
+        ));
+    }
+    Ok(())
+}
+
+fn unlink_stale_socket(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_socket() => fs::remove_file(path),
+        Ok(_) => Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "refusing to replace non-socket terminal runtime path",
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn validate_vm_component(vm_name: &str) -> io::Result<()> {
+    if vm_name.is_empty()
+        || vm_name == "."
+        || vm_name == ".."
+        || vm_name.contains('/')
+        || vm_name.contains('\0')
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid VM name for terminal runtime path",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_token(token: &str) -> io::Result<()> {
+    if token.is_empty()
+        || !token
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid terminal runtime token",
+        ));
+    }
+    Ok(())
+}
+
+fn random_token() -> io::Result<String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::getrandom(&mut bytes).map_err(|err| io::Error::other(err.to_string()))?;
+    let mut out = String::with_capacity(32);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+
+    fn test_root(name: &str) -> PathBuf {
+        let root = PathBuf::from("target")
+            .join("d2b-wayland-proxy-terminal-tests")
+            .join(format!("{}-{}", name, std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("create root");
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).expect("chmod root");
+        root
+    }
+
+    #[test]
+    fn terminal_runtime_creates_private_vm_dir_and_random_socket_paths() {
+        let root = test_root("private-dir");
+        let runtime =
+            TerminalRuntime::prepare_in_with_token(&root, "work", "abc123").expect("runtime");
+
+        assert_eq!(
+            fs::symlink_metadata(root.join(TERMINAL_RUNTIME_DIR).join("work"))
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            runtime.listen_socket(),
+            root.join(TERMINAL_RUNTIME_DIR)
+                .join("work")
+                .join("wayland-abc123.sock")
+        );
+        assert_eq!(
+            runtime.mux_socket(),
+            root.join(TERMINAL_RUNTIME_DIR)
+                .join("work")
+                .join("wezterm-mux-abc123.sock")
+        );
+        drop(runtime);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn terminal_runtime_unlinks_stale_socket_but_not_regular_file() {
+        let root = test_root("stale");
+        let first =
+            TerminalRuntime::prepare_in_with_token(&root, "work", "abc123").expect("runtime");
+        let stale_path = first.listen_socket().to_owned();
+        UnixListener::bind(&stale_path).expect("bind stale socket");
+        std::mem::forget(first);
+
+        let second =
+            TerminalRuntime::prepare_in_with_token(&root, "work", "abc123").expect("reprepare");
+        assert!(!second.listen_socket().exists());
+        fs::write(second.mux_socket(), b"not a socket").expect("regular file");
+        let err = TerminalRuntime::prepare_in_with_token(&root, "work", "abc123")
+            .expect_err("regular file refused");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        drop(second);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn chmod_socket_strict_enforces_0600_socket_mode() {
+        let root = test_root("socket-mode");
+        let path = root.join("wayland.sock");
+        let _listener = UnixListener::bind(&path).expect("bind socket");
+
+        chmod_socket_strict(&path).expect("chmod socket");
+
+        assert_eq!(
+            fs::symlink_metadata(path)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn terminal_child_env_points_to_proxy_and_per_launch_mux() {
+        let root = test_root("env");
+        let runtime =
+            TerminalRuntime::prepare_in_with_token(&root, "work", "abc123").expect("runtime");
+        let command = terminal_command(
+            OsStr::new("wezterm"),
+            &[
+                OsString::from("start"),
+                OsString::from("--always-new-process"),
+            ],
+            &runtime,
+        );
+        let env = command.get_envs().collect::<Vec<_>>();
+
+        assert!(env.iter().any(|(key, value)| {
+            *key == OsStr::new("WAYLAND_DISPLAY")
+                && value == &Some(runtime.listen_socket().as_os_str())
+        }));
+        assert!(env.iter().any(|(key, value)| {
+            *key == OsStr::new("WEZTERM_UNIX_SOCKET")
+                && value == &Some(runtime.mux_socket().as_os_str())
+        }));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("start"), OsStr::new("--always-new-process")]
+        );
+        drop(runtime);
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/tests/host-integration/wayland-proxy.nix
+++ b/tests/host-integration/wayland-proxy.nix
@@ -1,0 +1,122 @@
+# Type-G runNixOSTest: live Wayland proxy AF_UNIX relay.
+#
+# Boots a minimal NixOS node and runs d2b-wayland-proxy against a fake Wayland
+# compositor socket. This covers the live client-to-upstream relay path and
+# socket posture that unit tests cannot exercise; rendered d2b DAG wiring remains
+# covered by the graphics smoke/eval cases.
+{ pkgs, self }:
+
+let
+  proxyPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.d2b-wayland-proxy;
+in
+pkgs.testers.runNixOSTest {
+  name = "d2b-wayland-proxy";
+
+  nodes.machine = {
+    users.users.alice = {
+      isNormalUser = true;
+      uid = 1000;
+    };
+
+    environment.systemPackages = [
+      pkgs.python3
+      proxyPackage
+    ];
+
+    system.stateVersion = "25.11";
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("install -d -m 0700 -o alice -g users /run/d2b-wayland-proxy-test")
+    machine.succeed(
+        "cat > /run/d2b-wayland-proxy-test/fake-upstream.py <<'PY'\n"
+        "import os, select, socket, time\n"
+        "path = '/run/d2b-wayland-proxy-test/upstream.sock'\n"
+        "ready = '/run/d2b-wayland-proxy-test/upstream.ready'\n"
+        "seen = '/run/d2b-wayland-proxy-test/upstream.seen'\n"
+        "for p in (path, ready, seen):\n"
+        "    try:\n"
+        "        os.unlink(p)\n"
+        "    except FileNotFoundError:\n"
+        "        pass\n"
+        "srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+        "srv.bind(path)\n"
+        "os.chmod(path, 0o600)\n"
+        "srv.setblocking(False)\n"
+        "srv.listen(8)\n"
+        "open(ready, 'w').write('ready')\n"
+        "connections = []\n"
+        "deadline = time.monotonic() + 60\n"
+        "while time.monotonic() < deadline:\n"
+        "    readable = [srv] + connections\n"
+        "    ready, _, _ = select.select(readable, [], [], 0.2)\n"
+        "    for sock in ready:\n"
+        "        if sock is srv:\n"
+        "            conn, _ = srv.accept()\n"
+        "            conn.setblocking(False)\n"
+        "            connections.append(conn)\n"
+        "        else:\n"
+        "            data = sock.recv(12)\n"
+        "            if data:\n"
+        "                open(seen, 'wb').write(data)\n"
+        "                deadline = 0\n"
+        "                break\n"
+        "            connections.remove(sock)\n"
+        "            sock.close()\n"
+        "for conn in connections:\n"
+        "    conn.close()\n"
+        "srv.close()\n"
+        "PY\n"
+        "chown alice:users /run/d2b-wayland-proxy-test/fake-upstream.py"
+    )
+    machine.succeed(
+        "runuser -u alice -- python3 /run/d2b-wayland-proxy-test/fake-upstream.py "
+        ">/run/d2b-wayland-proxy-test/upstream.log 2>&1 & "
+        "echo $! > /run/d2b-wayland-proxy-test/upstream.pid"
+    )
+    machine.wait_for_file("/run/d2b-wayland-proxy-test/upstream.ready")
+
+    machine.succeed(
+        "runuser -u alice -- env XDG_RUNTIME_DIR=/run/d2b-wayland-proxy-test "
+        "d2b-wayland-proxy "
+        "--listen /run/d2b-wayland-proxy-test/proxy.sock "
+        "--connect /run/d2b-wayland-proxy-test/upstream.sock "
+        "--vm-name corp-vm "
+        ">/run/d2b-wayland-proxy-test/proxy.log 2>&1 & "
+        "echo $! > /run/d2b-wayland-proxy-test/proxy.pid"
+    )
+    machine.wait_for_file("/run/d2b-wayland-proxy-test/proxy.sock")
+    machine.succeed("test -S /run/d2b-wayland-proxy-test/proxy.sock")
+    machine.succeed("test \"$(stat -c %a /run/d2b-wayland-proxy-test)\" = 700")
+
+    # Send a minimal wl_display.get_registry request through the proxy. The fake
+    # compositor must observe the same 12-byte Wayland request on its upstream
+    # socket, proving the live proxy accepted a client and relayed protocol
+    # traffic rather than only binding a socket.
+    machine.succeed(
+        "python3 - <<'PY'\n"
+        "import socket, struct\n"
+        "import time\n"
+        "sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+        "sock.connect('/run/d2b-wayland-proxy-test/proxy.sock')\n"
+        "sock.sendall(struct.pack('<III', 1, (12 << 16) | 1, 2))\n"
+        "time.sleep(1)\n"
+        "sock.close()\n"
+        "PY"
+    )
+    machine.wait_for_file("/run/d2b-wayland-proxy-test/upstream.seen")
+    machine.succeed(
+        "python3 - <<'PY'\n"
+        "import pathlib, struct\n"
+        "data = pathlib.Path('/run/d2b-wayland-proxy-test/upstream.seen').read_bytes()\n"
+        "assert data == struct.pack('<III', 1, (12 << 16) | 1, 2), data\n"
+        "PY"
+    )
+
+    machine.succeed("kill $(cat /run/d2b-wayland-proxy-test/proxy.pid) || true")
+    machine.succeed("kill $(cat /run/d2b-wayland-proxy-test/upstream.pid) || true")
+  '';
+}


### PR DESCRIPTION
## Summary

Add the d2b-side support for desktop terminal integration:

- documents the stable persistent-shell discovery contract
- adds typed public response deserialization for downstream clients
- exports `d2b-wayland-proxy` with `meta.mainProgram`
- adds `--host-terminal` mode with randomized per-user Wayland and WeezTerm mux sockets
- hardens proxy title/app-id sanitization, pointer/touch translation, and bridge fd retry behavior
- adds a host-integration VM check for the live AF_UNIX proxy relay
- documents desktop terminal integration setup with sibling flakes and Home Manager

## Validation

- `cargo fmt --manifest-path packages/Cargo.toml -p d2b-wayland-proxy`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-wayland-proxy --quiet`
- `nix eval --impure --no-warn-dirty .#packages.x86_64-linux.d2b-wayland-proxy.meta.mainProgram`
- `nix build --no-link --impure --no-warn-dirty '.#vmChecks.x86_64-linux."wayland-proxy"'`
- `make check-tier0`
- `git diff --check`
