### PR TITLE
Fix host terminal Wayland proxy environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,10 @@ deprecations ship one minor release before removal.
 - `d2b-wayland-proxy` now presents proxy-drawn VM identity rails through a
   proxy-owned wrapper toplevel, so host compositor borders and focus rings wrap
   the VM rail and guest content together without copying guest buffers.
+- `d2b-wayland-proxy --host-terminal` now launches child terminals with a
+  private runtime directory and relative `WAYLAND_DISPLAY`, while accepting
+  ACL-protected user runtime directories, so host terminals connect to the
+  intended single-use proxy socket.
 - `d2b-wayland-proxy` treats `ENOTCONN` during nonblocking clipboard bridge
   handoff as retryable backpressure, preserving pending FDs until the bridge
   socket finishes connecting.

--- a/packages/d2b-wayland-proxy/src/terminal.rs
+++ b/packages/d2b-wayland-proxy/src/terminal.rs
@@ -53,8 +53,15 @@ impl TerminalRuntime {
         &self.mux_socket
     }
 
+    pub fn runtime_dir(&self) -> &Path {
+        &self.root
+    }
+
     pub fn wayland_display_value(&self) -> OsString {
-        self.listen_socket.as_os_str().to_owned()
+        self.listen_socket
+            .file_name()
+            .expect("listen socket has a file name")
+            .to_owned()
     }
 
     fn prepare_in_with_token(runtime_dir: &Path, vm_name: &str, token: &str) -> io::Result<Self> {
@@ -154,6 +161,7 @@ pub fn terminal_command(program: &OsStr, args: &[OsString], runtime: &TerminalRu
     let mut command = Command::new(program);
     command
         .args(args)
+        .env("XDG_RUNTIME_DIR", runtime.runtime_dir())
         .env("WAYLAND_DISPLAY", runtime.wayland_display_value())
         .env("WEZTERM_UNIX_SOCKET", runtime.mux_socket())
         .stdin(Stdio::inherit())
@@ -170,10 +178,10 @@ fn ensure_runtime_parent(runtime_dir: &Path) -> io::Result<()> {
             "XDG_RUNTIME_DIR must be a real directory",
         ));
     }
-    if metadata.permissions().mode() & 0o077 != 0 {
+    if metadata.permissions().mode() & 0o007 != 0 {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
-            "XDG_RUNTIME_DIR must not be group/world accessible",
+            "XDG_RUNTIME_DIR must not be world accessible",
         ));
     }
     Ok(())
@@ -352,8 +360,12 @@ mod tests {
         let env = command.get_envs().collect::<Vec<_>>();
 
         assert!(env.iter().any(|(key, value)| {
+            *key == OsStr::new("XDG_RUNTIME_DIR")
+                && value == &Some(runtime.runtime_dir().as_os_str())
+        }));
+        assert!(env.iter().any(|(key, value)| {
             *key == OsStr::new("WAYLAND_DISPLAY")
-                && value == &Some(runtime.listen_socket().as_os_str())
+                && value == &Some(OsStr::new("wayland-abc123.sock"))
         }));
         assert!(env.iter().any(|(key, value)| {
             *key == OsStr::new("WEZTERM_UNIX_SOCKET")


### PR DESCRIPTION
## Summary

Fix the host-terminal proxy environment for VM-bound terminal windows:

- allow ACL-protected `XDG_RUNTIME_DIR` parents like `/run/user/1000` with mode `0750`
- keep the proxy-owned per-VM runtime directory private (`0700`)
- pass terminal children that private directory as `XDG_RUNTIME_DIR`
- pass a relative `WAYLAND_DISPLAY` socket name inside that private runtime dir

This points host-launched terminals at the intended single-use d2b Wayland proxy socket instead of relying on absolute socket paths or rejecting ACL-protected runtime dirs.

## Validation

- `cargo fmt --manifest-path packages/Cargo.toml -p d2b-wayland-proxy`
- `cargo clippy --manifest-path packages/Cargo.toml -p d2b-wayland-proxy --all-targets -- -D warnings`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-wayland-proxy --quiet`
- `nix build --no-link --impure --no-warn-dirty '.#vmChecks.x86_64-linux."wayland-proxy"'`
- private proxy launch reached WeezTerm over the generated proxy socket
