### PR TITLE
realms: add ADR 0043 Nix option foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ deprecations ship one minor release before removal.
 ### Added
 
 - Added the public `d2b.realms.<realm>` Nix option schema foundation for
-  ADR 0043 without changing existing `d2b.envs` runtime behavior.
+  ADR 0043 without changing existing `d2b.envs` runtime behavior, with
+  reference documentation for placement, user access, provider/relay/policy/key
+  references, and the transitional env/network bridge.
 - Added the ADR 0043 `RealmTarget` parser with canonical realm-qualified
   rendering, bare-alias ambiguity diagnostics, and old node-qualified target
   migration errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ deprecations ship one minor release before removal.
   ADR 0043 without changing existing `d2b.envs` runtime behavior, with
   reference documentation for placement, user access, provider/relay/policy/key
   references, and the transitional env/network bridge.
+- Added normalized internal realm index metadata plus eval-time assertions for
+  realm identity, parent graph, and derived path uniqueness.
 - Added the ADR 0043 `RealmTarget` parser with canonical realm-qualified
   rendering, bare-alias ambiguity diagnostics, and old node-qualified target
   migration errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ deprecations ship one minor release before removal.
 - Added Layer-1 nix-unit coverage for the ADR 0043 realm option schema,
   normalized realm index, parent/path collision assertions, legacy gateway/ACA
   migration guidance, and minimal/multi-env eval compatibility.
+- Added realm `placementProvider` metadata and AF_UNIX socket path length
+  assertions for future realm public and broker socket declarations.
 - Added the ADR 0043 `RealmTarget` parser with canonical realm-qualified
   rendering, bare-alias ambiguity diagnostics, and old node-qualified target
   migration errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,10 @@ deprecations ship one minor release before removal.
   `d2b-constellation-*` to `d2b-realm-*` without changing runtime behavior,
   establishing realm-native package/import names for follow-up parser and DTO
   work.
+- Added ADR 0043 eval-time migration errors for legacy `d2b.gateways` and
+  nested gateway/ACA sandbox configuration, pointing operators to
+  `d2b.realms` while preserving current `d2b.envs` behavior when no legacy
+  gateway surface is declared.
 - Aligned current realm-core reference pages and generated schema companions
   with `d2b-realm-core` naming and the ADR 0043 realm-qualified target
   grammar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Added the public `d2b.realms.<realm>` Nix option schema foundation for
+  ADR 0043 without changing existing `d2b.envs` runtime behavior.
 - Added the ADR 0043 `RealmTarget` parser with canonical realm-qualified
   rendering, bare-alias ambiguity diagnostics, and old node-qualified target
   migration errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ deprecations ship one minor release before removal.
   references, and the transitional env/network bridge.
 - Added normalized internal realm index metadata plus eval-time assertions for
   realm identity, parent graph, and derived path uniqueness.
+- Added Layer-1 nix-unit coverage for the ADR 0043 realm option schema,
+  normalized realm index, parent/path collision assertions, legacy gateway/ACA
+  migration guidance, and minimal/multi-env eval compatibility.
 - Added the ADR 0043 `RealmTarget` parser with canonical realm-qualified
   rendering, bare-alias ambiguity diagnostics, and old node-qualified target
   migration errors.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,10 @@ The contracts. Stable interfaces a consumer can depend on.
 - [`reference/realm-policy.md`](./reference/realm-policy.md) —
   host-resident vs gateway-backed realm policy, default-deny cross-realm
   behavior, authorization, audit, and network isolation boundaries.
+- [`reference/realm-options.md`](./reference/realm-options.md) —
+  current `d2b.realms.<realm>` Nix option shape and transition boundary:
+  schema-only realm declarations while `d2b.envs` remains the active
+  runtime substrate.
 - [`reference/constellation-observability.md`](./reference/constellation-observability.md) —
   bounded `d2b op inspect`, TraceContext propagation, degraded partial
   results, and telemetry redaction/cardinality constraints.

--- a/docs/how-to/realm-gateway.md
+++ b/docs/how-to/realm-gateway.md
@@ -7,6 +7,13 @@ host starts and enters the gateway VM as a normal d2b workload, while
 realm relay credentials, provider configuration, remote registries, and
 realm audit live inside the gateway guest.
 
+The current `d2b.realms.<realm>` Nix namespace is a schema foundation for
+the realm-native model. It does not replace this gateway workflow yet and
+does not spawn per-realm daemons, brokers, sockets, or network substrate
+by itself. Continue using the documented `d2b.gateways`, `d2b.envs`, and
+`d2b.vms.<vm>.env` surfaces for the implemented gateway path until future
+runtime support consumes realm declarations.
+
 ## Declare a gateway-backed realm
 
 Add one gateway per trust-boundary realm and keep each gateway in a

--- a/docs/reference/naming-conventions.md
+++ b/docs/reference/naming-conventions.md
@@ -88,6 +88,14 @@ without spaces. See
 [`realm-core.md`](./realm-core.md) for the complete realm-core model
 contract.
 
+`d2b.realms.<realm>` uses the same lowercase label shape for the realm
+attribute name and default `id`. The realm option schema also exposes a
+`path` field for most-specific-first realm paths and an `env` /
+`network.envs` bridge to existing `d2b.envs` names. That bridge is
+transition metadata only in the current implementation; bridge and TAP
+names below are still generated from `d2b.envs` and `d2b.vms.<vm>.env`.
+See [Realm option schema](./realm-options.md).
+
 Gateway-backed realms use a local gateway VM entrypoint. The default
 gateway VM name is `sys-<realm-path-with-dashes>-gateway`, but
 operators may override `d2b.gateways.<name>.vmName`; consumers
@@ -194,6 +202,7 @@ unambiguously.
 
 - [AGENTS.md](../../AGENTS.md)
 - [Design explanation](../explanation/design.md)
+- [Realm option schema](./realm-options.md)
 - [Realm core model reference](./realm-core.md)
 - [USB/IP component reference](./components-usbip.md)
 - [tests/README.md](../../tests/README.md)

--- a/docs/reference/realm-core.md
+++ b/docs/reference/realm-core.md
@@ -8,6 +8,12 @@ names, identifiers, capability checks, redacted audit metadata, typed
 errors, realm-controller metadata, route/enrollment DTOs, and semantic
 frame schema roots.
 
+For the current Nix option surface, see
+[Realm option schema](./realm-options.md). The `d2b.realms.<realm>`
+namespace validates realm declaration shape only in the current release;
+it does not yet instantiate the per-realm runtime described by the DTO
+model below.
+
 The crate is intentionally codec-neutral. Protocol codecs map bytes to
 and from `ConstellationFrame`; routing, authorization, audit, and
 provider code reason over the Rust model below rather than over a
@@ -252,4 +258,5 @@ the structured capability.
 - [Constellation peer protocol reference](./constellation-protocol.md)
 - [Daemon API reference](./daemon-api.md)
 - [Naming conventions](./naming-conventions.md)
+- [Realm option schema](./realm-options.md)
 - [Manifest bundle reference](./manifest-bundle.md)

--- a/docs/reference/realm-options.md
+++ b/docs/reference/realm-options.md
@@ -62,13 +62,15 @@ identifier families.
 | `host-local` | Realm controller as an isolated host-local service. |
 | `gateway-vm` | Realm controller inside a dedicated local gateway VM. |
 | `cloud-full-host` | Realm controller on a cloud VM running full d2b. |
-| `provider-controller` | Provider-supported controller environment. |
-| `provider-agent` | Agent inside or adjacent to a managed provider sandbox. |
-| `provider-specific` | Adapter-defined placement named by `providerSpecificPlacement`. |
+| `provider-controller` | Provider-supported controller environment named by `placementProvider`. |
+| `provider-agent` | Agent inside or adjacent to a managed provider sandbox named by `placementProvider`. |
+| `provider-specific` | Adapter-defined placement named by `placementProvider` plus `providerSpecificPlacement`. |
 
-`providerSpecificPlacement` is meaningful only with
-`placement = "provider-specific"`. The value is inert metadata in the
-current schema.
+`placementProvider` is required for `provider-controller`,
+`provider-agent`, and `provider-specific`, and must be null for
+`host-local`, `gateway-vm`, and `cloud-full-host`. `providerSpecificPlacement`
+is meaningful only with `placement = "provider-specific"`. Both values are
+inert metadata in the current schema.
 
 ## Local access metadata
 
@@ -88,7 +90,10 @@ The derived `paths.*` fields reserve future path shapes:
 | `paths.publicSocket` | `paths.runDir + "/public.sock"` |
 | `paths.brokerSocket` | `paths.runDir + "/broker.sock"` |
 
-These paths are not created or bound by the schema-only declaration.
+These paths are not created or bound by the schema-only declaration. Socket
+paths are still checked against Linux AF_UNIX pathname sockets and must fit in
+107 bytes, leaving the final `sockaddr_un.sun_path` byte for the terminating
+NUL.
 
 ## Env and network substrate bridge
 

--- a/docs/reference/realm-options.md
+++ b/docs/reference/realm-options.md
@@ -1,0 +1,153 @@
+# Realm option schema
+
+**Diataxis category:** reference.
+
+`d2b.realms.<realm>` is the public Nix option namespace for the
+realm-native control-plane model. In the current release it is a schema
+foundation only: defining a realm records intent and validates option
+shape, but it does not spawn per-realm daemons or brokers, bind realm
+sockets, allocate network resources, create users or groups, migrate VMs,
+or change the active `d2b.envs` / `d2b.vms.<vm>.env` runtime model.
+
+Existing `d2b.envs` declarations remain the implemented network substrate.
+Workload VMs still join that substrate with `d2b.vms.<vm>.env = "<env>"`.
+Realm declarations may point at existing envs as transition metadata so
+future runtime support can map realm policy to the current bridge, net-VM,
+NAT, DHCP, and firewall substrate without changing today's behavior.
+
+## Minimal declaration
+
+```nix
+d2b.realms.work = {
+  placement = "host-local";
+  allowedUsers = [ "alice" ];
+  env = "work";
+  network.envs = [ "work" ];
+};
+
+d2b.envs.work = {
+  lanSubnet = "10.44.0.0/24";
+  uplinkSubnet = "192.0.2.0/30";
+};
+
+d2b.vms.laptop.env = "work";
+```
+
+The realm above does not move `laptop` into a new runtime namespace. The
+active VM placement remains `d2b.vms.laptop.env = "work"` until future
+runtime support consumes the realm declaration.
+
+## Identifier and path fields
+
+| Option | Type / values | Default | Meaning |
+| --- | --- | --- | --- |
+| `enable` | boolean | `true` | Includes the realm declaration in future realm-native planning. It has no runtime side effect today. |
+| `id` | lowercase label matching `^[a-z][a-z0-9-]*$` | attribute name | Stable realm id used for derived paths. |
+| `name` | string | attribute name | Human-readable realm name. |
+| `parent` | realm path or `null` | `null` | Optional parent realm path. Parent/child validation and routing are future runtime work. |
+| `path` | realm path | `id`, or derived from `parent` | Canonical realm path, written most-specific first for targets such as `builder.dev.d2b`. |
+| `defaultWorkloadNamespace` | realm path | `id` | Namespace future target resolution will use for unqualified workload declarations. Current VM names are unchanged. |
+
+Realm path labels use the same lowercase label shape as other
+realm-core identifiers. See [Naming conventions](./naming-conventions.md)
+and [Realm core model reference](./realm-core.md) for target grammar and
+identifier families.
+
+## Placement
+
+`placement` selects the intended controller placement:
+
+| Value | Intended placement |
+| --- | --- |
+| `host-local` | Realm controller as an isolated host-local service. |
+| `gateway-vm` | Realm controller inside a dedicated local gateway VM. |
+| `cloud-full-host` | Realm controller on a cloud VM running full d2b. |
+| `provider-controller` | Provider-supported controller environment. |
+| `provider-agent` | Agent inside or adjacent to a managed provider sandbox. |
+| `provider-specific` | Adapter-defined placement named by `providerSpecificPlacement`. |
+
+`providerSpecificPlacement` is meaningful only with
+`placement = "provider-specific"`. The value is inert metadata in the
+current schema.
+
+## Local access metadata
+
+`allowedUsers` lists host user names intended to receive direct access to
+the realm's future local public socket. The option does not create those
+users, groups, socket ACLs, or systemd units today. Local lifecycle
+authorization for the current implementation remains the existing
+`SO_PEERCRED` plus `d2b` group check on `/run/d2b/public.sock`.
+
+The derived `paths.*` fields reserve future path shapes:
+
+| Option | Default |
+| --- | --- |
+| `paths.stateDir` | `config.d2b.site.stateDir + "/realms/<realm>"` |
+| `paths.auditDir` | `paths.stateDir + "/audit"` |
+| `paths.runDir` | `/run/d2b/realms/<realm>` |
+| `paths.publicSocket` | `paths.runDir + "/public.sock"` |
+| `paths.brokerSocket` | `paths.runDir + "/broker.sock"` |
+
+These paths are not created or bound by the schema-only declaration.
+
+## Env and network substrate bridge
+
+| Option | Type / values | Default | Current effect |
+| --- | --- | --- | --- |
+| `env` | existing env name or `null` | `null` | Records the primary existing `d2b.envs.<env>` association for the realm. |
+| `network.envs` | list of env names | `[]` | Records additional existing envs associated with the realm. |
+| `network.mode` | `none`, `inherit-env`, `declared`, `external` | `none` | Placeholder for the future realm network model. |
+| `network.cidrRefs` | list of strings | `[]` | Opaque references to future realm-owned address allocation records. |
+
+The safe default is `network.mode = "none"`: declaring a realm claims no
+network resources. Even when `env` or `network.envs` is set, `network.nix`
+continues to materialize bridges, net VMs, NAT/DHCP, and workload taps from
+`d2b.envs` and `d2b.vms.<vm>.env`.
+
+## Provider declarations
+
+`providers.<provider>` entries describe provider metadata owned by the
+realm:
+
+| Option | Type / values | Default | Meaning |
+| --- | --- | --- | --- |
+| `enable` | boolean | `true` | Whether this provider declaration is active for future planning. |
+| `id` | string | provider attribute name | Stable provider identifier within the realm. |
+| `kind` | string or `null` | `null` | Provider family or adapter name, such as `aca`. |
+| `placement` | placement enum or `null` | `null` | Optional provider placement override; `null` inherits the realm placement. |
+| `capabilityRefs` | list of strings | `[]` | Opaque references to capability bundles or advertisements. |
+| `configRef` | string or `null` | `null` | Opaque reference to non-secret provider configuration. |
+
+Provider declarations do not start provider adapters or daemons yet. Keep
+credentials out of `configRef`; use external enrollment and key references
+instead.
+
+## Relay, discovery, policy, and keys
+
+Realm declarations use opaque references for material that must not be
+stored directly in Nix:
+
+| Namespace | Options | Notes |
+| --- | --- | --- |
+| `relay` | `enable`, `mode`, `endpoints`, `credentialRef` | `mode` is `disabled`, `static`, or `discovery`. The default opens no listeners and connects no relays. `credentialRef` must point outside the host Nix store. |
+| `discovery` | `enable`, `domain`, `configRef` | Non-secret discovery metadata. |
+| `policy` | `bundleRef`, `bundlePath`, `defaultDeny` | Policy starts from `defaultDeny = true`. `bundlePath` must be an absolute path when set. |
+| `keys` | `controllerKeyRef`, `trustBundleRef`, `enrollmentRef`, `rotationPolicyRef` | Opaque references to controller, trust, enrollment, and rotation material held outside Nix expressions. |
+
+Relay identity is transport metadata, not local authorization. Future
+cross-realm operations still require realm identity, capability checks,
+policy, idempotency, and bounded audit.
+
+## Broker placeholder
+
+`broker.enable` and `broker.hostMutation` are deliberately default-off
+placeholders for future realm-local privileged broker work. Setting them in
+the current schema records intent only; it does not start a broker, bind
+`paths.brokerSocket`, or grant host mutation authority.
+
+## Related references
+
+- [ADR 0043 — Realm-native control plane](../adr/0043-realm-native-control-plane.md)
+- [Realm core model reference](./realm-core.md)
+- [Realm policy](./realm-policy.md)
+- [Naming conventions](./naming-conventions.md)

--- a/docs/reference/realm-policy.md
+++ b/docs/reference/realm-policy.md
@@ -7,6 +7,14 @@ fast path for bare VM names and the reserved `local` realm. Gateway-backed
 realms are fronted by a dedicated gateway guest in a separate d2b env/L2
 segment.
 
+Current Nix support for `d2b.realms.<realm>` is schema-only. Defining a
+realm can record intended placement, users, provider/relay/policy/key
+references, and associated existing envs, but it does not yet create the
+per-realm policy evaluator, daemon, broker, socket, audit domain, or
+network partition described by future runtime support. Existing
+`d2b.envs` and `d2b.vms.<vm>.env` declarations remain the implemented
+substrate.
+
 ## Policy modes
 
 | Mode | Authority | Credential boundary | Cross-realm default |
@@ -47,3 +55,8 @@ audit events. Audit and error surfaces carry only low-cardinality realm,
 operation or stream kind, decision, and reason labels. They must not contain
 payload bytes, argv, stdout/stderr, credentials, tokens, provider headers, full
 endpoints, host paths, or PII.
+
+## Related references
+
+- [Realm option schema](./realm-options.md)
+- [Realm core model reference](./realm-core.md)

--- a/flake.nix
+++ b/flake.nix
@@ -752,6 +752,7 @@
             "index.nix"
             "multi-env-daemon-backed.nix"
             "net-vm-network.nix"
+            "realms.nix"
             "usbip-gating.nix"
           ];
           nix-unit-runtime = [

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -187,16 +187,6 @@ let
   realmParentCycles = lib.unique
     (lib.filter (cycle: cycle != null)
       (map realmParentCycleFor enabledRealmRows));
-  realmLocalUnitOrderingRows = lib.filter
-    (realm: realm.localUnitOrdering != null)
-    enabledRealmRows;
-  invalidRealmLocalUnitOrderingRows = lib.filter
-    (realm:
-      realm.parentPath == null
-      || realm.placement != "host-local"
-      || !(builtins.isAttrs realm.localUnitOrdering))
-    realmLocalUnitOrderingRows;
-
   realmAssertions = [
     {
       assertion = duplicateRealmIds == [ ];
@@ -232,16 +222,6 @@ let
           lib.concatStringsSep "; " (map
             (cycle: lib.concatStringsSep " -> " cycle)
             realmParentCycles)
-        }.
-      '';
-    }
-    {
-      assertion = invalidRealmLocalUnitOrderingRows == [ ];
-      message = ''
-        child local unit ordering metadata, when present, is valid only on
-        enabled host-local child realms and must be an attrset. Invalid realm
-        path(s): ${
-          lib.concatStringsSep ", " (map (realm: realm.path) invalidRealmLocalUnitOrderingRows)
         }.
       '';
     }

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -139,6 +139,20 @@ let
     "publicSocket"
     "brokerSocket"
   ];
+  realmUnixSocketFields = [
+    "publicSocket"
+    "brokerSocket"
+  ];
+  providerBackedRealmPlacements = [
+    "provider-controller"
+    "provider-agent"
+    "provider-specific"
+  ];
+  localRealmPlacements = [
+    "host-local"
+    "gateway-vm"
+    "cloud-full-host"
+  ];
 
   missingRealmParents = lib.filter
     (realm:
@@ -187,6 +201,21 @@ let
   realmParentCycles = lib.unique
     (lib.filter (cycle: cycle != null)
       (map realmParentCycleFor enabledRealmRows));
+  realmSocketPathTooLongRows = field:
+    lib.filter
+      (realm: builtins.stringLength realm.paths.${field} > 107)
+      enabledRealmRows;
+  realmMissingPlacementProviderRows = lib.filter
+    (realm:
+      builtins.elem realm.placement providerBackedRealmPlacements
+      && realm.placementProvider == null)
+    enabledRealmRows;
+  realmUnexpectedPlacementProviderRows = lib.filter
+    (realm:
+      builtins.elem realm.placement localRealmPlacements
+      && realm.placementProvider != null)
+    enabledRealmRows;
+
   realmAssertions = [
     {
       assertion = duplicateRealmIds == [ ];
@@ -225,7 +254,44 @@ let
         }.
       '';
     }
+    {
+      assertion = realmMissingPlacementProviderRows == [ ];
+      message = ''
+        provider-backed d2b.realms placements require
+        `placementProvider` so the realm can map to
+        RealmControllerPlacement.provider. Set
+        d2b.realms.<realm>.placementProvider for provider-controller,
+        provider-agent, and provider-specific realm(s): ${
+          lib.concatStringsSep ", " (map (realm: "${realm.path} (${realm.placement})") realmMissingPlacementProviderRows)
+        }.
+      '';
+    }
+    {
+      assertion = realmUnexpectedPlacementProviderRows == [ ];
+      message = ''
+        d2b.realms.<realm>.placementProvider is valid only for provider-backed
+        placements (provider-controller, provider-agent, provider-specific).
+        Leave it null for host-local, gateway-vm, and cloud-full-host realm(s): ${
+          lib.concatStringsSep ", " (map (realm: "${realm.path} (${realm.placement})") realmUnexpectedPlacementProviderRows)
+        }.
+      '';
+    }
   ] ++ map
+    (field:
+      let overlong = realmSocketPathTooLongRows field;
+      in {
+        assertion = overlong == [ ];
+        message = ''
+          d2b.realms.<realm>.paths.${field} must fit Linux AF_UNIX pathname
+          sockets: at most 107 bytes including path characters, leaving one
+          byte for the terminating NUL in sockaddr_un.sun_path. Overlong
+          realm socket path(s): ${
+            lib.concatStringsSep ", " (map (realm: "${realm.path} (${toString (builtins.stringLength realm.paths.${field})} bytes)") overlong)
+          }.
+        '';
+      })
+    realmUnixSocketFields
+  ++ map
     (field:
       let duplicates = duplicateEnabledRealmPathValues field;
       in {

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -125,6 +125,139 @@ let
   duplicateGatewayEnvs = duplicateValues enabledGatewayEnvs;
   duplicateGatewayVmNames = duplicateValues enabledGatewayVmNames;
 
+  realmIndex = cfg._index.realms;
+  realmRows = realmIndex.list;
+  enabledRealmRows = realmIndex.enabledList;
+  duplicateRealmIds = duplicateValues (map (realm: realm.id) realmRows);
+  duplicateRealmPaths = duplicateValues (map (realm: realm.path) realmRows);
+  duplicateEnabledRealmPathValues = field:
+    duplicateValues (map (realm: realm.paths.${field}) enabledRealmRows);
+  realmPathCollisionFields = [
+    "stateDir"
+    "auditDir"
+    "runDir"
+    "publicSocket"
+    "brokerSocket"
+  ];
+
+  missingRealmParents = lib.filter
+    (realm:
+      realm.enabled
+      && realm.parentPath != null
+      && !(builtins.hasAttr realm.parentPath realmIndex.enabledByPath))
+    enabledRealmRows;
+
+  realmParentCycleFor = realm:
+    let
+      maxDepth = (lib.length enabledRealmRows) + 1;
+      step = state: _:
+        if state.done then
+          state
+        else
+          let
+            currentRow = realmIndex.enabledByPath.${state.current};
+            parent = currentRow.parentPath;
+          in
+          if parent == null || !(builtins.hasAttr parent realmIndex.enabledByPath) then
+            state // { done = true; }
+          else if builtins.elem parent state.seen then
+            {
+              done = true;
+              current = parent;
+              seen = state.seen ++ [ parent ];
+              cycle = state.seen ++ [ parent ];
+            }
+          else
+            {
+              done = false;
+              current = parent;
+              seen = state.seen ++ [ parent ];
+              cycle = null;
+            };
+      final = lib.foldl' step
+        {
+          done = false;
+          current = realm.path;
+          seen = [ realm.path ];
+          cycle = null;
+        }
+        (lib.genList (i: i) maxDepth);
+    in
+    final.cycle;
+  realmParentCycles = lib.unique
+    (lib.filter (cycle: cycle != null)
+      (map realmParentCycleFor enabledRealmRows));
+  realmLocalUnitOrderingRows = lib.filter
+    (realm: realm.localUnitOrdering != null)
+    enabledRealmRows;
+  invalidRealmLocalUnitOrderingRows = lib.filter
+    (realm:
+      realm.parentPath == null
+      || realm.placement != "host-local"
+      || !(builtins.isAttrs realm.localUnitOrdering))
+    realmLocalUnitOrderingRows;
+
+  realmAssertions = [
+    {
+      assertion = duplicateRealmIds == [ ];
+      message = ''
+        d2b.realms must use unique stable realm ids. Duplicate id(s): ${
+          lib.concatStringsSep ", " duplicateRealmIds
+        }.
+      '';
+    }
+    {
+      assertion = duplicateRealmPaths == [ ];
+      message = ''
+        d2b.realms must use unique canonical realm paths. Duplicate path(s): ${
+          lib.concatStringsSep ", " duplicateRealmPaths
+        }.
+      '';
+    }
+    {
+      assertion = missingRealmParents == [ ];
+      message = ''
+        enabled child realms must name an enabled parent realm by canonical
+        path. Missing or disabled parent reference(s): ${
+          lib.concatStringsSep ", " (map
+            (realm: "${realm.path} -> ${realm.parentPath}")
+            missingRealmParents)
+        }.
+      '';
+    }
+    {
+      assertion = realmParentCycles == [ ];
+      message = ''
+        enabled d2b.realms parent links must form an acyclic tree. Cycle(s): ${
+          lib.concatStringsSep "; " (map
+            (cycle: lib.concatStringsSep " -> " cycle)
+            realmParentCycles)
+        }.
+      '';
+    }
+    {
+      assertion = invalidRealmLocalUnitOrderingRows == [ ];
+      message = ''
+        child local unit ordering metadata, when present, is valid only on
+        enabled host-local child realms and must be an attrset. Invalid realm
+        path(s): ${
+          lib.concatStringsSep ", " (map (realm: realm.path) invalidRealmLocalUnitOrderingRows)
+        }.
+      '';
+    }
+  ] ++ map
+    (field:
+      let duplicates = duplicateEnabledRealmPathValues field;
+      in {
+        assertion = duplicates == [ ];
+        message = ''
+          enabled d2b.realms must not share ${field} paths. Duplicate path(s): ${
+            lib.concatStringsSep ", " duplicates
+          }.
+        '';
+      })
+    realmPathCollisionFields;
+
   autoSysVmNames =
     (lib.mapAttrsToList
       (envName: env: env.netName or "sys-${envName}-net")
@@ -1456,6 +1589,7 @@ in
     ++ legacyGatewayMigrationAssertions
     ++ gatewayEntrypointAssertions
     ++ gatewayDaemonAssertions
+    ++ realmAssertions
     ++ securityKeyHostRequiredAssertions
     ++ securityKeyUsbipMutualExclusionAssertions
     ++ securityKeyDeviceAssertions

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -303,6 +303,40 @@ let
     '';
   };
 
+  legacyGatewayMigrationAssertions = lib.optional (cfg.gateways != { }) {
+    assertion = false;
+    message = ''
+      d2b migration-required (legacy-surface-detected: d2b.gateways):
+      `d2b.gateways` and its old gateway/ACA sandbox fields were removed as a
+      public configuration surface by ADR 0043.
+
+      Move non-secret coordinates into the realm-native schema, for example:
+
+        d2b.realms.work = {
+          placement = "gateway-vm";        # or provider-agent/provider-controller
+          env = "work";                    # transitional link to existing d2b.envs
+          providers.aca = {
+            kind = "aca";
+            placement = "provider-agent";
+            configRef = "aca-work-non-secret-coordinates";
+          };
+          relay.mode = "static";
+          relay.endpoints = [ "relns-example.servicebus.windows.net" ];
+          relay.credentialRef = "work-relay-credential";
+        };
+
+      Do not put Relay SAS tokens, Entra tokens, sealed credential bytes, or
+      ACA provider secrets in Nix. Use enrollment/import tooling when the
+      realm-native runtime lands.
+
+      This is a guarded tombstone for the transition: declaring no
+      `d2b.gateways` entries keeps today's local VM behavior unchanged.
+      `d2b.envs` remains the current substrate/configuration key for bridges,
+      net VMs, address allocation, and workload `d2b.vms.<vm>.env`
+      membership until a later realm migration explicitly replaces it.
+    '';
+  };
+
   # Systemd-escape identity regex (lower-case alnum and `-`, must
   # start with a LETTER). `^[a-z][a-z0-9-]*$` deliberately excludes
   #   * `.` (dots — systemd-escape would turn them into `\x2e`)
@@ -1419,6 +1453,7 @@ in
     ++ gatewayHostRelayCredentialAssertions
     ++ gatewayStateBoundaryAssertions
     ++ gatewayCoordinateAssertions
+    ++ legacyGatewayMigrationAssertions
     ++ gatewayEntrypointAssertions
     ++ gatewayDaemonAssertions
     ++ securityKeyHostRequiredAssertions

--- a/nixos-modules/index.nix
+++ b/nixos-modules/index.nix
@@ -154,6 +154,7 @@ let
         then null
         else builtins.head (lib.splitString "." realm.parent);
       placement = realm.placement;
+      placementProvider = realm.placementProvider;
       providerSpecificPlacement = realm.providerSpecificPlacement;
       allowedUsers = sortNames (lib.unique realm.allowedUsers);
       defaultWorkloadNamespace = realm.defaultWorkloadNamespace;

--- a/nixos-modules/index.nix
+++ b/nixos-modules/index.nix
@@ -131,10 +131,6 @@ let
             else realm.placement;
           capabilityRefs = sortNames (lib.unique provider.capabilityRefs);
           configRef = provider.configRef;
-          localUnitOrdering =
-            if provider ? localUnitOrdering
-            then provider.localUnitOrdering
-            else null;
         };
       })
       realm.providers);
@@ -161,10 +157,6 @@ let
       providerSpecificPlacement = realm.providerSpecificPlacement;
       allowedUsers = sortNames (lib.unique realm.allowedUsers);
       defaultWorkloadNamespace = realm.defaultWorkloadNamespace;
-      localUnitOrdering =
-        if realm ? localUnitOrdering
-        then realm.localUnitOrdering
-        else null;
       network = {
         env = realm.env;
         envNames = envNames;

--- a/nixos-modules/index.nix
+++ b/nixos-modules/index.nix
@@ -15,6 +15,8 @@ let
 
   enabledEnvs = sortedAttrs (lib.filterAttrs (_: env: env.enable) cfg.envs);
   enabledVms = sortedAttrs (lib.filterAttrs (_: vm: vm.enable) cfg.vms);
+  declaredRealms = sortedAttrs cfg.realms;
+  enabledRealms = sortedAttrs (lib.filterAttrs (_: realm: realm.enable) cfg.realms);
   normalNixosVms = sortedAttrs (d2bLib.normalNixosVms cfg.vms);
   qemuMediaVms = sortedAttrs (d2bLib.qemuMediaVms cfg.vms);
 
@@ -107,6 +109,106 @@ let
 
   envMeta = lib.mapAttrs netMeta enabledEnvs;
   externalNetworkEnvs = sortedAttrs (lib.filterAttrs (_: env: externalNetworkConfigured env) enabledEnvs);
+
+  realmEnvNames = realm:
+    sortNames (lib.unique (
+      lib.optionals (realm.env != null) [ realm.env ]
+      ++ realm.network.envs
+    ));
+
+  realmProviderRows = realmName: realm:
+    lib.listToAttrs (sortedMapAttrsToList
+      (providerName: provider: {
+        name = providerName;
+        value = {
+          inherit providerName;
+          id = provider.id;
+          enabled = provider.enable;
+          kind = provider.kind;
+          placement =
+            if provider.placement != null
+            then provider.placement
+            else realm.placement;
+          capabilityRefs = sortNames (lib.unique provider.capabilityRefs);
+          configRef = provider.configRef;
+          localUnitOrdering =
+            if provider ? localUnitOrdering
+            then provider.localUnitOrdering
+            else null;
+        };
+      })
+      realm.providers);
+
+  realmRow = realmName: realm:
+    let
+      envNames = realmEnvNames realm;
+      providerRows = realmProviderRows realmName realm;
+      enabledProviderRows = lib.filterAttrs (_: provider: provider.enabled) providerRows;
+    in
+    {
+      inherit realmName;
+      id = realm.id;
+      name = realm.name;
+      path = realm.path;
+      pathParts = lib.splitString "." realm.path;
+      enabled = realm.enable;
+      parentPath = realm.parent;
+      parentId =
+        if realm.parent == null
+        then null
+        else builtins.head (lib.splitString "." realm.parent);
+      placement = realm.placement;
+      providerSpecificPlacement = realm.providerSpecificPlacement;
+      allowedUsers = sortNames (lib.unique realm.allowedUsers);
+      defaultWorkloadNamespace = realm.defaultWorkloadNamespace;
+      localUnitOrdering =
+        if realm ? localUnitOrdering
+        then realm.localUnitOrdering
+        else null;
+      network = {
+        env = realm.env;
+        envNames = envNames;
+        declaredEnvNames = lib.filter (envName: builtins.hasAttr envName cfg.envs) envNames;
+        enabledEnvNames = lib.filter (envName: builtins.hasAttr envName enabledEnvs) envNames;
+        missingEnvNames = lib.filter (envName: !(builtins.hasAttr envName cfg.envs)) envNames;
+        mode = realm.network.mode;
+        cidrRefs = sortNames (lib.unique realm.network.cidrRefs);
+      };
+      providers = providerRows;
+      providerKeys = sortedAttrNames providerRows;
+      enabledProviderKeys = sortedAttrNames enabledProviderRows;
+      relay = {
+        inherit (realm.relay) enable mode credentialRef;
+        endpoints = sortNames (lib.unique realm.relay.endpoints);
+      };
+      discovery = realm.discovery;
+      policy = realm.policy;
+      keys = realm.keys;
+      paths = realm.paths;
+      broker = realm.broker;
+    };
+
+  realmRows = sortedMapAttrsToList realmRow declaredRealms;
+  enabledRealmRows = lib.filter (realm: realm.enabled) realmRows;
+  realmAttrsBy = field: rows:
+    lib.listToAttrs (map (row: {
+      name = row.${field};
+      value = row;
+    }) rows);
+  realmNamesByEnv = rows:
+    lib.listToAttrs (map
+      (envName: {
+        name = envName;
+        value = {
+          realmNames = sortNames (map (row: row.realmName)
+            (lib.filter (row: builtins.elem envName row.network.envNames) rows));
+          realmIds = sortNames (map (row: row.id)
+            (lib.filter (row: builtins.elem envName row.network.envNames) rows));
+          realmPaths = sortNames (map (row: row.path)
+            (lib.filter (row: builtins.elem envName row.network.envNames) rows));
+        };
+      })
+      (sortedAttrNames cfg.envs));
 
   subset = pred: sortedAttrs (lib.filterAttrs pred enabledVms);
   subsetNames = pred: sortedAttrNames (subset pred);
@@ -334,6 +436,20 @@ let
       byVm = runtimeRows;
       providers = runtimeProviders;
       kinds = sortNames (lib.unique (map (name: runtimeRows.${name}.kind) (sortedAttrNames runtimeRows)));
+    };
+
+    realms = {
+      declared = declaredRealms;
+      enabled = enabledRealms;
+      names = sortedAttrNames declaredRealms;
+      enabledNames = sortedAttrNames enabledRealms;
+      list = realmRows;
+      enabledList = enabledRealmRows;
+      byId = realmAttrsBy "id" realmRows;
+      byPath = realmAttrsBy "path" realmRows;
+      enabledById = realmAttrsBy "id" enabledRealmRows;
+      enabledByPath = realmAttrsBy "path" enabledRealmRows;
+      byEnv = realmNamesByEnv enabledRealmRows;
     };
   };
 in

--- a/nixos-modules/options-gateway.nix
+++ b/nixos-modules/options-gateway.nix
@@ -1,4 +1,9 @@
-# Realm gateway declarations.
+# ADR 0043 legacy gateway tombstone declarations.
+#
+# Keep the old schema in place long enough for the top-level assertion in
+# assertions.nix to emit a migration error instead of a generic
+# "option does not exist" failure. Non-empty d2b.gateways declarations are not
+# a supported runtime surface.
 { lib, ... }:
 
 let
@@ -31,11 +36,14 @@ in
 
   options.d2b.gateways = lib.mkOption {
     description = ''
-      Realm gateway guests. Each enabled entry auto-declares a dedicated
-      d2b VM that holds realm provider/relay credentials inside the guest
-      boundary. The host declaration carries only non-secret coordinates and
-      state-directory paths; plaintext credentials are never represented in the
-      host Nix store.
+      Removed ADR 0043 gateway/ACA compatibility surface.
+
+      This option remains as an eval-time tombstone so configurations that
+      still declare `d2b.gateways.<name>` or nested old ACA sandbox fields get
+      a typed migration error pointing at `d2b.realms.<realm>` instead of a
+      generic unknown-option failure. Leave it unset and declare realm-native
+      metadata under `d2b.realms`; existing `d2b.envs` remains the active
+      network substrate during the transition.
     '';
     default = { };
     type = lib.types.attrsOf (lib.types.submodule ({ name, ... }: {

--- a/nixos-modules/options-realms.nix
+++ b/nixos-modules/options-realms.nix
@@ -151,6 +151,18 @@ in
             '';
           };
 
+          placementProvider = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "aca";
+            description = ''
+              Provider identifier that owns provider-backed controller
+              placements. Required when `placement` is `provider-controller`,
+              `provider-agent`, or `provider-specific`; must be null for local
+              placements.
+            '';
+          };
+
           providerSpecificPlacement = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default = null;

--- a/nixos-modules/options-realms.nix
+++ b/nixos-modules/options-realms.nix
@@ -1,0 +1,390 @@
+# d2b.realms.<realm>.* — realm-native control-plane option foundation.
+#
+# This file declares the public Nix schema selected by ADR 0043 without
+# materialising per-realm daemons, brokers, networks, allocators, or VM/env
+# migrations. Existing `d2b.envs` and `d2b.vms.<vm>.env` behaviour remains the
+# runtime source of truth until later migration scopes wire these declarations
+# into the index, assertions, and runtime.
+{ lib, config, ... }:
+
+let
+  outerConfig = config;
+
+  label = "^[a-z][a-z0-9-]*$";
+  realmPath = "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)*$";
+  absolutePath = "^/.*$";
+
+  placementKinds = [
+    "host-local"
+    "gateway-vm"
+    "cloud-full-host"
+    "provider-controller"
+    "provider-agent"
+    "provider-specific"
+  ];
+
+  providerType = lib.types.submodule ({ name, ... }: {
+    freeformType = lib.types.attrsOf lib.types.unspecified;
+    options = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether this provider declaration is active for the realm.";
+      };
+
+      id = lib.mkOption {
+        type = lib.types.str;
+        default = name;
+        description = "Stable provider identifier within the realm.";
+      };
+
+      kind = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "aca";
+        description = ''
+          Provider family or adapter name. This is descriptive schema
+          foundation only; no provider adapter is instantiated from this
+          option in the current scope.
+        '';
+      };
+
+      placement = lib.mkOption {
+        type = lib.types.nullOr (lib.types.enum placementKinds);
+        default = null;
+        description = ''
+          Optional provider-specific placement override. When null, the
+          provider inherits `d2b.realms.<realm>.placement`.
+        '';
+      };
+
+      capabilityRefs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Opaque references to provider capability bundles or advertisements.";
+      };
+
+      configRef = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Opaque reference to non-secret provider configuration material. Do not
+          put credentials directly in Nix; use enrollment/key refs below.
+        '';
+      };
+    };
+  });
+in
+{
+  options.d2b.realms = lib.mkOption {
+    description = ''
+      Realm-native control-plane declarations. A realm is the future unit of
+      daemon, broker, state, audit, provider, relay, policy, and workload
+      namespace ownership selected by ADR 0043.
+
+      This release exposes the option schema only. Declaring a realm does not
+      spawn per-realm daemons or brokers, allocate network resources, or alter
+      current `d2b.envs` / `d2b.vms.<vm>.env` behaviour.
+    '';
+    default = { };
+    type = lib.types.attrsOf (lib.types.submodule ({ name, config, ... }:
+      let
+        realmConfig = config;
+        realmStateDir = "${toString outerConfig.d2b.site.stateDir}/realms/${realmConfig.id}";
+        realmRunDir = "/run/d2b/realms/${realmConfig.id}";
+      in
+      {
+        freeformType = null;
+        options = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether this realm declaration participates in future realm-native planning.";
+          };
+
+          id = lib.mkOption {
+            type = lib.types.strMatching label;
+            default = name;
+            description = ''
+              Stable realm id. Defaults to the attribute name and is used to
+              derive local paths until explicitly overridden.
+            '';
+          };
+
+          name = lib.mkOption {
+            type = lib.types.str;
+            default = name;
+            description = "Human-readable realm name; defaults to the attribute name.";
+          };
+
+          parent = lib.mkOption {
+            type = lib.types.nullOr (lib.types.strMatching realmPath);
+            default = null;
+            example = "work";
+            description = ''
+              Optional parent realm path. Parent/child validation and routing
+              are intentionally left to later ADR 0043 implementation scopes.
+            '';
+          };
+
+          path = lib.mkOption {
+            type = lib.types.strMatching realmPath;
+            default =
+              if realmConfig.parent == null
+              then realmConfig.id
+              else "${realmConfig.id}.${realmConfig.parent}";
+            defaultText = lib.literalExpression "if parent == null then id else id + \".\" + parent";
+            example = "payments.work";
+            description = ''
+              Canonical realm path, written most-specific first for target
+              addresses such as `<workload>.<realm>[.<ancestor>].d2b`.
+            '';
+          };
+
+          placement = lib.mkOption {
+            type = lib.types.enum placementKinds;
+            default = "host-local";
+            description = ''
+              Controller placement for this realm. `provider-specific` is an
+              escape hatch for adapters that need a named placement before the
+              shared enum grows.
+            '';
+          };
+
+          providerSpecificPlacement = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "aca-managed-sandbox";
+            description = ''
+              Provider-defined placement name used only when `placement =
+              "provider-specific"`. It is inert schema metadata in this scope.
+            '';
+          };
+
+          allowedUsers = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            example = [ "alice" ];
+            description = ''
+              Host users intended to receive direct access to this realm's
+              future local public socket. This option does not create users,
+              groups, ACLs, or socket units in the current scope.
+            '';
+          };
+
+          defaultWorkloadNamespace = lib.mkOption {
+            type = lib.types.strMatching realmPath;
+            default = realmConfig.id;
+            defaultText = lib.literalExpression "id";
+            description = ''
+              Default workload namespace for unqualified workload declarations
+              inside this realm. Later scopes will use it for realm-qualified
+              target resolution; current `d2b.vms` names are unchanged.
+            '';
+          };
+
+          env = lib.mkOption {
+            type = lib.types.nullOr (lib.types.strMatching label);
+            default = null;
+            example = "work";
+            description = ''
+              Transitional bridge to an existing `d2b.envs.<env>` network. It
+              records intended membership only; it does not create, rename, or
+              migrate envs, net VMs, or workload VM `env` assignments.
+            '';
+          };
+
+          network = {
+            envs = lib.mkOption {
+              type = lib.types.listOf (lib.types.strMatching label);
+              default = [ ];
+              example = [ "work" ];
+              description = ''
+                Additional existing `d2b.envs` names associated with this realm
+                during the transition from env groups to realms. Runtime network
+                behaviour remains driven by `d2b.envs` until later scopes.
+              '';
+            };
+
+            mode = lib.mkOption {
+              type = lib.types.enum [ "none" "inherit-env" "declared" "external" ];
+              default = "none";
+              description = ''
+                Placeholder for the future realm network model. `none` is the
+                behaviour-safe default: no network resources are claimed by
+                declaring a realm.
+              '';
+            };
+
+            cidrRefs = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "Opaque references to realm-owned CIDR/address allocation records.";
+            };
+          };
+
+          providers = lib.mkOption {
+            type = lib.types.attrsOf providerType;
+            default = { };
+            description = ''
+              Provider declarations owned by this realm. Entries are inert
+              configuration records in this scope; provider daemons/adapters are
+              not started from them yet.
+            '';
+          };
+
+          relay = {
+            enable = lib.mkEnableOption "realm relay reachability metadata";
+
+            mode = lib.mkOption {
+              type = lib.types.enum [ "disabled" "static" "discovery" ];
+              default = "disabled";
+              description = ''
+                Relay configuration mode. The default is non-claiming and does
+                not open listeners, connect relays, or alter routing.
+              '';
+            };
+
+            endpoints = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "Non-secret relay endpoint names or refs for static relay mode.";
+            };
+
+            credentialRef = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Opaque reference to relay credential material held outside the
+                host Nix store. Plaintext credentials do not belong in this option.
+              '';
+            };
+          };
+
+          discovery = {
+            enable = lib.mkEnableOption "dynamic realm discovery metadata";
+
+            domain = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              example = "work.example.invalid";
+              description = "Optional discovery domain or namespace for this realm.";
+            };
+
+            configRef = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Opaque reference to discovery configuration material.";
+            };
+          };
+
+          policy = {
+            bundleRef = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Opaque reference to the realm policy bundle.";
+            };
+
+            bundlePath = lib.mkOption {
+              type = lib.types.nullOr (lib.types.strMatching absolutePath);
+              default = null;
+              description = "Optional absolute runtime path to a realm policy bundle artifact.";
+            };
+
+            defaultDeny = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Future realm policy starts from default-deny unless a later policy bundle says otherwise.";
+            };
+          };
+
+          keys = {
+            controllerKeyRef = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Opaque reference to this realm controller's signing/encryption key material.";
+            };
+
+            trustBundleRef = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Opaque reference to trusted parent/peer realm key material.";
+            };
+
+            enrollmentRef = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Opaque reference to realm enrollment material stored outside the Nix store.";
+            };
+
+            rotationPolicyRef = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Opaque reference to future key-rotation policy metadata.";
+            };
+          };
+
+          paths = {
+            stateDir = lib.mkOption {
+              type = lib.types.strMatching absolutePath;
+              default = realmStateDir;
+              defaultText = lib.literalExpression "config.d2b.site.stateDir + \"/realms/<realm>\"";
+              description = ''
+                Derived realm state directory. It is not created or managed by
+                this schema-only scope.
+              '';
+            };
+
+            auditDir = lib.mkOption {
+              type = lib.types.strMatching absolutePath;
+              default = "${realmStateDir}/audit";
+              defaultText = lib.literalExpression "paths.stateDir + \"/audit\"";
+              description = "Derived per-realm audit directory placeholder.";
+            };
+
+            runDir = lib.mkOption {
+              type = lib.types.strMatching absolutePath;
+              default = realmRunDir;
+              defaultText = lib.literalExpression "\"/run/d2b/realms/<realm>\"";
+              description = "Derived per-realm runtime directory placeholder.";
+            };
+
+            publicSocket = lib.mkOption {
+              type = lib.types.strMatching absolutePath;
+              default = "${realmRunDir}/public.sock";
+              defaultText = lib.literalExpression "paths.runDir + \"/public.sock\"";
+              description = "Future realm public socket path. No socket is bound in this scope.";
+            };
+
+            brokerSocket = lib.mkOption {
+              type = lib.types.strMatching absolutePath;
+              default = "${realmRunDir}/broker.sock";
+              defaultText = lib.literalExpression "paths.runDir + \"/broker.sock\"";
+              description = "Future realm broker socket path. No broker is started in this scope.";
+            };
+          };
+
+          broker = {
+            enable = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Future opt-in for a realm-local privileged broker. It is
+                deliberately false and unused in this schema-only scope.
+              '';
+            };
+
+            hostMutation = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Whether this realm is intended to request host-mutation leases
+                from the future local-root allocator. No allocator exists in
+                this scope.
+              '';
+            };
+          };
+        };
+      }));
+  };
+}

--- a/nixos-modules/options-realms.nix
+++ b/nixos-modules/options-realms.nix
@@ -3,8 +3,8 @@
 # This file declares the public Nix schema selected by ADR 0043 without
 # materialising per-realm daemons, brokers, networks, allocators, or VM/env
 # migrations. Existing `d2b.envs` and `d2b.vms.<vm>.env` behaviour remains the
-# runtime source of truth until later migration scopes wire these declarations
-# into the index, assertions, and runtime.
+# runtime source of truth; the realm index and assertions only normalize and
+# validate inert planning metadata.
 { lib, config, ... }:
 
 let
@@ -122,8 +122,8 @@ in
             default = null;
             example = "work";
             description = ''
-              Optional parent realm path. Parent/child validation and routing
-              are intentionally left to later ADR 0043 implementation scopes.
+              Optional parent realm path. Enabled child realms must point at an
+              enabled parent path, and the parent graph must remain acyclic.
             '';
           };
 

--- a/nixos-modules/options.nix
+++ b/nixos-modules/options.nix
@@ -7,6 +7,10 @@
 # under `nixos-modules/components/` is conditionally imported by
 # host.nix.
 #
+# Realm-native declarations live under `d2b.realms.<realm>` as schema
+# foundation only during the ADR 0043 transition; they do not yet alter
+# env or VM runtime behaviour.
+#
 # Isolated environments live under `d2b.envs.<env>`. Each env
 # is materialised by network.nix into two host bridges (`br-<env>-up`
 # point-to-point host↔net-VM, `br-<env>-lan` net-VM↔workload-VMs),
@@ -21,6 +25,7 @@
     ./options-site.nix
     ./options-host.nix
     ./options-envs.nix
+    ./options-realms.nix
     ./options-vms.nix
     ./options-daemon.nix
     ./options-gateway.nix

--- a/tests/unit/nix/cases/gateway-vm.nix
+++ b/tests/unit/nix/cases/gateway-vm.nix
@@ -135,6 +135,8 @@ let
     };
   gatewayProc = lib.findFirst (vm: vm.vm == "sys-work-gateway") null
     goodCfg.d2b._bundle.processesJson.data.vms;
+  legacyGatewayMigrationMessages = failureMessages goodCfg;
+  noGatewayMessages = failureMessages noGatewayCfg;
   badCfg = (mkEval [
     (lib.recursiveUpdate base {
       d2b.gateways.work.credentialPath = "SharedAccessKey=bad";
@@ -271,6 +273,32 @@ in
     expr = lib.any (m: lib.hasInfix "prefixes are reserved" m)
       (map (a: a.message) (lib.filter (a: !a.assertion) goodCfg.assertions));
     expected = false;
+  };
+
+  "gateway-vm/rejects-legacy-gateway-surface-with-realm-migration-error" = {
+    expr = lib.any
+      (m:
+        lib.hasInfix "legacy-surface-detected: d2b.gateways" m
+        && lib.hasInfix "old gateway/ACA sandbox fields" m
+        && lib.hasInfix "d2b.realms.work" m
+        && lib.hasInfix "`d2b.envs` remains the current substrate" m)
+      legacyGatewayMigrationMessages;
+    expected = true;
+  };
+
+  "gateway-vm/leaves-current-envs-valid-when-legacy-gateway-unset" = {
+    expr = {
+      envs = builtins.attrNames noGatewayCfg.d2b.envs;
+      workNet = noGatewayCfg.d2b.envs.work.netName;
+      noLegacyGatewayError = !(lib.any
+        (m: lib.hasInfix "legacy-surface-detected: d2b.gateways" m)
+        noGatewayMessages);
+    };
+    expected = {
+      envs = [ "work" ];
+      workNet = "sys-work-net";
+      noLegacyGatewayError = true;
+    };
   };
 
   "gateway-vm/rejects-secret-shaped-credential-path" = {

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -1,0 +1,376 @@
+# nix-unit coverage for ADR 0043 realm option/schema foundations.
+{ mkEval, lib, flakeRoot, ... }:
+
+let
+  hostBase = {
+    boot.loader.grub.enable = false;
+    boot.loader.systemd-boot.enable = false;
+    boot.initrd.includeDefaultModules = false;
+    fileSystems."/" = { device = "tmpfs"; fsType = "tmpfs"; };
+    environment.etc."machine-id".text = "00000000000000000000000000000000";
+    system.stateVersion = "25.11";
+    users.users.alice = { isNormalUser = true; uid = 1000; };
+
+    d2b.site = {
+      stateDir = "/var/lib/d2b";
+      waylandUser = "alice";
+      launcherUsers = [ "alice" ];
+    };
+
+    d2b.envs.home = {
+      lanSubnet = "10.10.0.0/24";
+      uplinkSubnet = "192.0.2.0/30";
+    };
+    d2b.envs.dev = {
+      lanSubnet = "10.20.0.0/24";
+      uplinkSubnet = "198.51.100.0/30";
+    };
+    d2b.envs.work = {
+      lanSubnet = "10.30.0.0/24";
+      uplinkSubnet = "203.0.113.0/30";
+    };
+
+    d2b.vms.homebox = {
+      env = "home";
+      index = 10;
+      ssh.user = "alice";
+      config.users.users.alice = { isNormalUser = true; uid = 1000; };
+    };
+    d2b.vms.devbox = {
+      env = "dev";
+      index = 10;
+      ssh.user = "alice";
+      config.users.users.alice = { isNormalUser = true; uid = 1000; };
+    };
+    d2b.vms.corp = {
+      env = "work";
+      index = 10;
+      ssh.user = "alice";
+      config.users.users.alice = { isNormalUser = true; uid = 1000; };
+    };
+  };
+
+  realmFixture = lib.recursiveUpdate hostBase {
+    d2b.realms.home = {
+      name = "Home";
+      env = "home";
+      network.envs = [ "home" ];
+      allowedUsers = [ "alice" "alice" ];
+    };
+
+    d2b.realms.dev = {
+      parent = "home";
+      path = "dev.home";
+      env = "dev";
+      network = {
+        envs = [ "work" "dev" ];
+        mode = "inherit-env";
+        cidrRefs = [ "lab" "dev" "lab" ];
+      };
+    };
+
+    d2b.realms.work = {
+      parent = "home";
+      path = "work.home";
+      placement = "gateway-vm";
+      env = "work";
+      network.envs = [ "work" ];
+      providers.aca = {
+        kind = "aca";
+        placement = "provider-agent";
+        capabilityRefs = [ "relay" "aca" "relay" ];
+        configRef = "work-aca-non-secret";
+      };
+      relay = {
+        enable = true;
+        mode = "static";
+        endpoints = [ "relns-b.example.invalid" "relns-a.example.invalid" ];
+        credentialRef = "work-relay-credential";
+      };
+      policy.bundleRef = "work-policy";
+      keys.enrollmentRef = "work-enrollment";
+    };
+
+    d2b.realms.archive = {
+      enable = false;
+      placement = "provider-specific";
+      providerSpecificPlacement = "archived-off-host";
+    };
+  };
+
+  cfg = (mkEval [ realmFixture ]).config;
+  realms = cfg.d2b._index.realms;
+
+  failureMessages = modules:
+    map (a: a.message)
+      (lib.filter (a: !a.assertion) (mkEval modules).config.assertions);
+
+  hasMessage = needles: messages:
+    lib.any
+      (message: lib.all (needle: lib.hasInfix needle message) needles)
+      messages;
+
+  missingParentMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.child = {
+        parent = "missing";
+        path = "child.missing";
+      };
+    })
+  ];
+
+  parentCycleMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.alpha = {
+        path = "alpha";
+        parent = "beta";
+      };
+      d2b.realms.beta = {
+        path = "beta";
+        parent = "alpha";
+      };
+    })
+  ];
+
+  duplicateIdPathMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.alpha = {
+        id = "same";
+        path = "same-path";
+      };
+      d2b.realms.beta = {
+        id = "same";
+        path = "same-path";
+      };
+    })
+  ];
+
+  duplicateRuntimePathMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.alpha = { };
+      d2b.realms.beta.paths = {
+        stateDir = "/var/lib/d2b/realms/alpha";
+        auditDir = "/var/lib/d2b/realms/alpha/audit";
+        runDir = "/run/d2b/realms/alpha";
+        publicSocket = "/run/d2b/realms/alpha/public.sock";
+        brokerSocket = "/run/d2b/realms/alpha/broker.sock";
+      };
+    })
+  ];
+
+  legacyGatewayMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.gateways.work = {
+        env = "work";
+        aca.endpoint = "https://example.azurecontainerapps.invalid";
+        aca.resourceGroup = "rg-example";
+      };
+    })
+  ];
+
+  minimalCfg = (mkEval [ (import (flakeRoot + "/examples/minimal/configuration.nix")) ]).config;
+  multiEnvCfg = (mkEval [ (import (flakeRoot + "/examples/multi-env/configuration.nix")) ]).config;
+in
+{
+  "realms/valid-home-dev-work-keeps-env-substrate-active" = {
+    expr = {
+      assertionsPass = lib.all (a: a.assertion) cfg.assertions;
+      enabledEnvNames = cfg.d2b._index.enabledEnvNames;
+      netVmByEnv = cfg.d2b._index.netVmByEnv;
+      workloadNamesByEnv = cfg.d2b._index.workloadNamesByEnv;
+    };
+    expected = {
+      assertionsPass = true;
+      enabledEnvNames = [ "dev" "home" "work" ];
+      netVmByEnv = {
+        dev = "sys-dev-net";
+        home = "sys-home-net";
+        work = "sys-work-net";
+      };
+      workloadNamesByEnv = {
+        dev = [ "devbox" ];
+        home = [ "homebox" ];
+        work = [ "corp" ];
+      };
+    };
+  };
+
+  "realms/index-normalizes-enabled-disabled-and-derived-paths" = {
+    expr = {
+      names = realms.names;
+      enabledNames = realms.enabledNames;
+      archiveInDeclared = realms.byId.archive.enabled;
+      archiveInEnabled = builtins.hasAttr "archive" realms.enabledById;
+      dev = {
+        inherit (realms.byPath."dev.home") realmName id path pathParts parentPath parentId placement enabled;
+        network = realms.byPath."dev.home".network;
+      };
+      home = {
+        allowedUsers = realms.byPath.home.allowedUsers;
+        paths = realms.byPath.home.paths;
+      };
+      work = {
+        inherit (realms.byPath."work.home") placement;
+        providerKeys = realms.byPath."work.home".providerKeys;
+        enabledProviderKeys = realms.byPath."work.home".enabledProviderKeys;
+        provider = realms.byPath."work.home".providers.aca;
+        relay = realms.byPath."work.home".relay;
+      };
+      byEnv = realms.byEnv;
+      bridges = {
+        dev = cfg.d2b._index.envMeta.dev.lanBridge;
+        home = cfg.d2b._index.envMeta.home.lanBridge;
+        work = cfg.d2b._index.envMeta.work.lanBridge;
+      };
+    };
+    expected = {
+      names = [ "archive" "dev" "home" "work" ];
+      enabledNames = [ "dev" "home" "work" ];
+      archiveInDeclared = false;
+      archiveInEnabled = false;
+      dev = {
+        realmName = "dev";
+        id = "dev";
+        path = "dev.home";
+        pathParts = [ "dev" "home" ];
+        parentPath = "home";
+        parentId = "home";
+        placement = "host-local";
+        enabled = true;
+        network = {
+          env = "dev";
+          envNames = [ "dev" "work" ];
+          declaredEnvNames = [ "dev" "work" ];
+          enabledEnvNames = [ "dev" "work" ];
+          missingEnvNames = [ ];
+          mode = "inherit-env";
+          cidrRefs = [ "dev" "lab" ];
+        };
+      };
+      home = {
+        allowedUsers = [ "alice" ];
+        paths = {
+          stateDir = "/var/lib/d2b/realms/home";
+          auditDir = "/var/lib/d2b/realms/home/audit";
+          runDir = "/run/d2b/realms/home";
+          publicSocket = "/run/d2b/realms/home/public.sock";
+          brokerSocket = "/run/d2b/realms/home/broker.sock";
+        };
+      };
+      work = {
+        placement = "gateway-vm";
+        providerKeys = [ "aca" ];
+        enabledProviderKeys = [ "aca" ];
+        provider = {
+          providerName = "aca";
+          id = "aca";
+          enabled = true;
+          kind = "aca";
+          placement = "provider-agent";
+          capabilityRefs = [ "aca" "relay" ];
+          configRef = "work-aca-non-secret";
+          localUnitOrdering = null;
+        };
+        relay = {
+          enable = true;
+          mode = "static";
+          endpoints = [ "relns-a.example.invalid" "relns-b.example.invalid" ];
+          credentialRef = "work-relay-credential";
+        };
+      };
+      byEnv = {
+        dev = {
+          realmNames = [ "dev" ];
+          realmIds = [ "dev" ];
+          realmPaths = [ "dev.home" ];
+        };
+        home = {
+          realmNames = [ "home" ];
+          realmIds = [ "home" ];
+          realmPaths = [ "home" ];
+        };
+        work = {
+          realmNames = [ "dev" "work" ];
+          realmIds = [ "dev" "work" ];
+          realmPaths = [ "dev.home" "work.home" ];
+        };
+      };
+      bridges = {
+        dev = "br-dev-lan";
+        home = "br-home-lan";
+        work = "br-work-lan";
+      };
+    };
+  };
+
+  "realms/rejects-missing-parent" = {
+    expr = hasMessage [
+      "enabled child realms must name an enabled parent realm"
+      "child.missing -> missing"
+    ] missingParentMessages;
+    expected = true;
+  };
+
+  "realms/rejects-parent-cycle" = {
+    expr = hasMessage [
+      "enabled d2b.realms parent links must form an acyclic tree"
+      "alpha -> beta -> alpha"
+    ] parentCycleMessages;
+    expected = true;
+  };
+
+  "realms/rejects-duplicate-id-and-path" = {
+    expr = {
+      duplicateId = hasMessage [
+        "d2b.realms must use unique stable realm ids"
+        "same"
+      ] duplicateIdPathMessages;
+      duplicatePath = hasMessage [
+        "d2b.realms must use unique canonical realm paths"
+        "same-path"
+      ] duplicateIdPathMessages;
+    };
+    expected = {
+      duplicateId = true;
+      duplicatePath = true;
+    };
+  };
+
+  "realms/rejects-duplicate-runtime-paths" = {
+    expr = {
+      stateDir = hasMessage [ "must not share stateDir paths" "/var/lib/d2b/realms/alpha" ] duplicateRuntimePathMessages;
+      auditDir = hasMessage [ "must not share auditDir paths" "/var/lib/d2b/realms/alpha/audit" ] duplicateRuntimePathMessages;
+      runDir = hasMessage [ "must not share runDir paths" "/run/d2b/realms/alpha" ] duplicateRuntimePathMessages;
+      publicSocket = hasMessage [ "must not share publicSocket paths" "/run/d2b/realms/alpha/public.sock" ] duplicateRuntimePathMessages;
+      brokerSocket = hasMessage [ "must not share brokerSocket paths" "/run/d2b/realms/alpha/broker.sock" ] duplicateRuntimePathMessages;
+    };
+    expected = {
+      stateDir = true;
+      auditDir = true;
+      runDir = true;
+      publicSocket = true;
+      brokerSocket = true;
+    };
+  };
+
+  "realms/rejects-legacy-gateway-aca-surface-with-migration-guidance" = {
+    expr = hasMessage [
+      "legacy-surface-detected: d2b.gateways"
+      "old gateway/ACA sandbox fields"
+      "d2b.realms.work"
+      "`d2b.envs` remains the current substrate"
+    ] legacyGatewayMessages;
+    expected = true;
+  };
+
+  "realms/examples-minimal-and-multi-env-still-eval" = {
+    expr = {
+      minimal = lib.all (a: a.assertion) minimalCfg.assertions;
+      multiEnv = lib.all (a: a.assertion) multiEnvCfg.assertions;
+    };
+    expected = {
+      minimal = true;
+      multiEnv = true;
+    };
+  };
+}

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -269,7 +269,6 @@ in
           placement = "provider-agent";
           capabilityRefs = [ "aca" "relay" ];
           configRef = "work-aca-non-secret";
-          localUnitOrdering = null;
         };
         relay = {
           enable = true;

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -158,6 +158,59 @@ let
     })
   ];
 
+  longSocketPath = "/run/d2b/realms/${lib.concatStrings (lib.genList (_: "a") 96)}/public.sock";
+
+  overlongPublicSocketMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.work.paths.publicSocket = longSocketPath;
+    })
+  ];
+
+  overlongBrokerSocketMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.work.paths.brokerSocket = longSocketPath;
+    })
+  ];
+
+  missingPlacementProviderMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.work = {
+        placement = "provider-controller";
+        providers.aca.kind = "aca";
+      };
+    })
+  ];
+
+  missingProviderSpecificPlacementProviderMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.work = {
+        placement = "provider-specific";
+        providerSpecificPlacement = "aca-managed-sandbox";
+        providers.aca.kind = "aca";
+      };
+    })
+  ];
+
+  unexpectedPlacementProviderMessages = failureMessages [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.work = {
+        placement = "gateway-vm";
+        placementProvider = "aca";
+        providers.aca.kind = "aca";
+      };
+    })
+  ];
+
+  validProviderPlacementCfg = (mkEval [
+    (lib.recursiveUpdate hostBase {
+      d2b.realms.work = {
+        placement = "provider-agent";
+        placementProvider = "aca";
+        providers.aca.kind = "aca";
+      };
+    })
+  ]).config;
+
   legacyGatewayMessages = failureMessages [
     (lib.recursiveUpdate hostBase {
       d2b.gateways.work = {
@@ -210,7 +263,7 @@ in
         paths = realms.byPath.home.paths;
       };
       work = {
-        inherit (realms.byPath."work.home") placement;
+        inherit (realms.byPath."work.home") placement placementProvider;
         providerKeys = realms.byPath."work.home".providerKeys;
         enabledProviderKeys = realms.byPath."work.home".enabledProviderKeys;
         provider = realms.byPath."work.home".providers.aca;
@@ -259,6 +312,7 @@ in
       };
       work = {
         placement = "gateway-vm";
+        placementProvider = null;
         providerKeys = [ "aca" ];
         enabledProviderKeys = [ "aca" ];
         provider = {
@@ -349,6 +403,53 @@ in
       runDir = true;
       publicSocket = true;
       brokerSocket = true;
+    };
+  };
+
+  "realms/rejects-overlong-unix-socket-paths" = {
+    expr = {
+      publicSocket = hasMessage [
+        "paths.publicSocket must fit Linux AF_UNIX pathname"
+        "at most 107 bytes"
+        "work"
+      ] overlongPublicSocketMessages;
+      brokerSocket = hasMessage [
+        "paths.brokerSocket must fit Linux AF_UNIX pathname"
+        "at most 107 bytes"
+        "work"
+      ] overlongBrokerSocketMessages;
+    };
+    expected = {
+      publicSocket = true;
+      brokerSocket = true;
+    };
+  };
+
+  "realms/requires-provider-for-provider-backed-placement" = {
+    expr = {
+      missingProvider = hasMessage [
+        "provider-backed d2b.realms placements require"
+        "placementProvider"
+        "work (provider-controller)"
+      ] missingPlacementProviderMessages;
+      missingProviderSpecificProvider = hasMessage [
+        "provider-backed d2b.realms placements require"
+        "placementProvider"
+        "work (provider-specific)"
+      ] missingProviderSpecificPlacementProviderMessages;
+      rejectsLocal = hasMessage [
+        "placementProvider is valid only for provider-backed"
+        "work (gateway-vm)"
+      ] unexpectedPlacementProviderMessages;
+      validProvider = lib.all (a: a.assertion) validProviderPlacementCfg.assertions;
+      indexedProvider = validProviderPlacementCfg.d2b._index.realms.byPath.work.placementProvider;
+    };
+    expected = {
+      missingProvider = true;
+      missingProviderSpecificProvider = true;
+      rejectsLocal = true;
+      validProvider = true;
+      indexedProvider = "aca";
     };
   };
 

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -1,3 +1,5 @@
+# nix-unit case-presence pins (common — present on every system).
+# Regenerate with: make nix-unit-pin
 activation-runtime-tmpfiles/activation-preserves-run-parent-daemon-mask
 activation-runtime-tmpfiles/audio-acls-in-tmpfiles-not-activation
 activation-runtime-tmpfiles/audio-lock-in-locks-dir
@@ -57,6 +59,8 @@ assertions/platform-gate-audio-aarch64
 assertions/platform-gate-graphics-aarch64
 assertions/principal-uid-collision
 assertions/private-key-in-authorized-keys
+assertions/security-key-qemu-media-conflict
+assertions/security-key-yubikey-conflict
 assertions/state-dir-override-rejected
 assertions/static-ip-and-env-mutually-exclusive
 assertions/store-state-dir-override-rejected
@@ -297,12 +301,14 @@ gateway-vm/host-realm-entrypoints-exclude-realm-provider-material
 gateway-vm/host-realm-entrypoint-table-defaults-local-and-gateway
 gateway-vm/host-realm-relay-egress-policy-is-redacted-and-gateway-scoped
 gateway-vm/host-system-packages-exclude-realm-provider-material
+gateway-vm/leaves-current-envs-valid-when-legacy-gateway-unset
 gateway-vm/local-fast-path-auth-socket-does-not-require-gateway-relay
 gateway-vm/realm-entrypoint-table-uses-custom-gateway-vm-name
 gateway-vm/rejects-credential-path-outside-gateway-state
 gateway-vm/rejects-duplicate-gateway-realm-entrypoints
 gateway-vm/rejects-gateway-entrypoint-for-local-realm
 gateway-vm/rejects-gateway-realms-sharing-env-l2
+gateway-vm/rejects-legacy-gateway-surface-with-realm-migration-error
 gateway-vm/rejects-parent-traversal-in-state-paths
 gateway-vm/rejects-per-vm-state-root-for-gateway-secrets
 gateway-vm/rejects-retired-host-relay-credential-escape-hatch
@@ -367,6 +373,7 @@ index/allow-east-west-metadata
 index/component-and-usbip-subsets
 index/computed-net-vms-remain-reachable
 index/env-meta-compat-alias
+index/guest-journal-bounded
 index/home-lan-metadata
 index/observability-and-shell-subsets
 index/qemu-media-and-runtime-subsets
@@ -485,7 +492,6 @@ net-vm-network/work-nft-safe-uplink-drop-before-egress-accept
 net-vm-network/work-nft-safe-uplink-drop-present
 net-vm-network/work-uplink-address
 net-vm-network/work-uplink-mtu
-# nix-unit case-presence pins (common — present on every system).
 observability/obs-alerting-surface
 observability/obs-audit-surface
 observability/obs-cid-cross-env-noncollision
@@ -581,7 +587,14 @@ readiness-waves/has-p6
 readiness-waves/has-p7
 readiness-waves/p0-implemented-default
 readiness-waves/p0-validated-default
-# Regenerate with: make nix-unit-pin
+realms/examples-minimal-and-multi-env-still-eval
+realms/index-normalizes-enabled-disabled-and-derived-paths
+realms/rejects-duplicate-id-and-path
+realms/rejects-duplicate-runtime-paths
+realms/rejects-legacy-gateway-aca-surface-with-migration-guidance
+realms/rejects-missing-parent
+realms/rejects-parent-cycle
+realms/valid-home-dev-work-keeps-env-substrate-active
 requested-vm-config/boot-selector-and-hotplug-source-coexist
 requested-vm-config/dark-env-declared
 requested-vm-config/dark-live-manual-qemu-media
@@ -606,6 +619,15 @@ restart-policy/otel-relay-template
 restart-policy/snd
 restart-policy/swtpm
 restart-policy/video
+security-key-gating/default-dag-node-absent
+security-key-gating/default-manifest-false
+security-key-gating/enabled-dag-node-present
+security-key-gating/enabled-dag-node-role
+security-key-gating/enabled-manifest-true
+security-key-gating/guest-declares-plugdev-group
+security-key-gating/guest-udev-uses-plugdev
+security-key-gating/qemu-media-conflict-fires
+security-key-gating/yubikey-conflict-fires
 store-overlay-emit/disabled-no-planops
 store-overlay-emit/first-op-if-absent
 store-overlay-emit/first-op-kind

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -593,7 +593,9 @@ realms/rejects-duplicate-id-and-path
 realms/rejects-duplicate-runtime-paths
 realms/rejects-legacy-gateway-aca-surface-with-migration-guidance
 realms/rejects-missing-parent
+realms/rejects-overlong-unix-socket-paths
 realms/rejects-parent-cycle
+realms/requires-provider-for-provider-backed-placement
 realms/valid-home-dev-work-keeps-env-substrate-active
 requested-vm-config/boot-selector-and-hotplug-source-coexist
 requested-vm-config/dark-env-declared


### PR DESCRIPTION
## Summary
- add the public `d2b.realms.<realm>` option schema without changing existing `d2b.envs` runtime behavior
- add normalized realm index metadata and eval-time assertions for realm identity, parent graph, derived path uniqueness, socket length bounds, and provider-backed placement metadata
- tombstone legacy `d2b.gateways` with a typed migration error
- add nix-unit coverage for realm schema/index/assertions and migration errors
- document the schema-only realm option foundation and transitional env/network bridge

## Validation
- nix build --extra-experimental-features "nix-command flakes" --no-write-lock-file --no-warn-dirty .#checks.x86_64-linux.nix-unit-network .#checks.x86_64-linux.nix-unit .#checks.x86_64-linux.eval-minimal .#checks.x86_64-linux.eval-multi-env --no-link
- git diff --exit-code
- full Gemini 3.1 Pro Wave 2 panel: unanimous signoff after follow-up round

Depends on #241.