### PR TITLE
allocator: add ADR 0043 local-root allocator contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Documented the ADR 0043 local-root allocator contract for typed host-resource
+  leases, opaque resource ids, deterministic acquisition order, reconciliation,
+  quarantine/reclaim, immutable host-file boundaries, and the current
+  contract-only implementation status.
+- Added `d2b-realm-core` local-root allocator DTOs for ADR 0043 host-resource
+  leases, opaque resource ids, allocation/reconciliation responses, bounded
+  allocator audit/metric metadata, and generated JSON schema coverage.
+- Added a pure `d2b-realm-core` local-root allocator engine over fake ledger,
+  observation, and liveness backends for deterministic lease allocation,
+  idempotency replay, reconciliation decisions, and bounded low-cardinality
+  audit/metric metadata.
+- Added private `allocator.json` bundle metadata rooted in `d2b.realms`, covering
+  enabled realms, metadata-only local-root allocator resource requests,
+  path/socket partitions, provider placement, and the transitional env bridge
+  without starting an allocator runtime service.
+- Added Layer-1 allocator coverage for rendered `allocator.json` bundle wiring,
+  realm allocator metadata, fake-engine conflict/replay/reconcile paths, and
+  bounded reconciliation reports.
 - Added the public `d2b.realms.<realm>` Nix option schema foundation for
   ADR 0043 without changing existing `d2b.envs` runtime behavior, with
   reference documentation for placement, user access, provider/relay/policy/key
@@ -238,9 +256,20 @@ deprecations ship one minor release before removal.
 - Aligned current realm-core reference pages and generated schema companions
   with `d2b-realm-core` naming and the ADR 0043 realm-qualified target
   grammar.
+- Kept ADR 0043 operator-troubleshooting identifiers visible in Rust `Debug`
+  output while preserving redaction for credential-, key-, and principal-like
+  identifiers.
+- Tightened `allocator.json` config typing so realm paths, provider kinds,
+  and transitional env-bridge modes carry bounded schema/runtime validation.
 
 ### Fixed
 
+- ADR 0043 allocator metric bounding now aggregates repeated low-cardinality
+  label sets before applying the event cap, preserving counts instead of
+  dropping later samples.
+- ADR 0043 allocator metadata now emits one namespace-boundary resource
+  request per networked realm, avoiding duplicate resource ids for realms
+  spanning multiple enabled environments.
 - ADR 0043 realm audit, operation, and typed-error envelopes now carry the
   cross-realm correlation id needed to reconstruct rejected routes.
 - ADR 0043 operation responses now carry the same required correlation id as
@@ -254,6 +283,9 @@ deprecations ship one minor release before removal.
 - Aligned ADR 0043 realm-core schema generation and identifier validation:
   `xtask gen-schemas` now emits `d2b-realm-core.json`, and realm reference
   tokens reject leading punctuation consistently with their JSON schemas.
+- Aligned ADR 0043 allocator reference docs with the generated realm-core
+  schema roots and documented the future repair-path shape for fail-closed
+  allocator reconciliation states.
 - `d2b-wayland-proxy --host-terminal` now waits until the proxy-owned wrapper
   toplevel has acked its initial configure before attaching the VM identity rail,
   preventing Wayland compositors from rejecting proxied WeezTerm windows during

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,9 @@ The contracts. Stable interfaces a consumer can depend on.
   current `d2b.realms.<realm>` Nix option shape and transition boundary:
   schema-only realm declarations while `d2b.envs` remains the active
   runtime substrate.
+- [`reference/local-root-allocator.md`](./reference/local-root-allocator.md) —
+  typed host-resource lease contract for future local-root allocation,
+  reconciliation, quarantine, reclaim, and realm-broker boundaries.
 - [`reference/constellation-observability.md`](./reference/constellation-observability.md) —
   bounded `d2b op inspect`, TraceContext propagation, degraded partial
   results, and telemetry redaction/cardinality constraints.

--- a/docs/explanation/host-realm-isolation.md
+++ b/docs/explanation/host-realm-isolation.md
@@ -20,3 +20,21 @@ host-side realm relay exception.
 The host is not a global realm-policy singleton. Gateway guests own
 remote/provider realm policy evaluation, while local host authorization remains
 `SO_PEERCRED` plus the canonical `d2b` lifecycle group.
+
+## Local host-resource arbitration
+
+The host remains the only place that can arbitrate local kernel and
+filesystem resources shared by multiple local realm controllers. The
+local-root allocator contract defines how future realm brokers request
+typed leases for bridges, taps, nftables partitions, cgroup subtrees,
+host-file partitions, and namespace boundaries without becoming
+independent host mutators. See
+[Local-root allocator contract](../reference/local-root-allocator.md)
+for the reference shape.
+
+That contract is a foundation, not a live allocator service in the
+current implementation. Today it does not change runtime host mutation.
+The important design boundary is already fixed: realm brokers must not
+work around the allocator with ad-hoc locks, host-file edits, or
+realm-specific repair paths. Ambiguous or foreign host state is
+quarantined or denied until an explicit owner reconciles or reclaims it.

--- a/docs/reference/local-root-allocator.md
+++ b/docs/reference/local-root-allocator.md
@@ -1,0 +1,165 @@
+# Local-root allocator contract
+
+**Diataxis category:** reference.
+
+This page documents the committed `d2b-realm-core` contract for
+arbitrating host resources that are shared by local realm controllers. It
+is a contract and schema foundation only: the current implementation does
+not yet provide a runtime allocator service, live host mutation, or
+realm-broker dispatch for these DTOs.
+
+## Purpose
+
+The local-root allocator is the future local authority for host resources
+that cannot safely be created independently by each realm broker. Realm
+brokers request typed leases from the allocator instead of inventing
+interface names, writing host files, or creating their own lock files.
+The allocator decides whether the requested resource set can be granted,
+denied, quarantined, or reclaimed while preserving a single
+fail-closed ownership ledger.
+
+The contract is intentionally host-local. It does not grant relay
+identity, remote-provider credentials, cross-realm policy authority, or
+permission to bypass `SO_PEERCRED`-based local authorization. Gateway
+realms may ask for local host resources only through this contract once a
+runtime allocator exists.
+
+## Contract terms
+
+| Term | Meaning |
+| --- | --- |
+| Local-root allocator | The planned local authority that owns host-resource allocation decisions and the persisted allocation ledger. |
+| Typed lease | A `LeaseAllocationRequest` / `LeaseAllocationResponse` pair for closed `HostResourceKind` values rather than free-form shell or path mutations. |
+| Resource id | An opaque `HostResourceId` used for matching, conflict reporting, and delegation. It is not a raw interface name, filesystem path, nftables expression, cgroup path, or credential. |
+| Lease owner | The realm path, controller generation, and optional node identity that requested and owns a lease. |
+| Delegation | The allocator's opaque handoff shape for a grant: opaque name, file-descriptor placeholder, partition id, or namespace handle. |
+| Reconciliation | Comparing persisted lease state with observed kernel/host state and producing explicit decisions. |
+| Quarantine | A fail-closed state that prevents automatic reuse until a later repair path resolves ambiguity. |
+| Reclaim | A terminal cleanup decision for resources that can be safely retired from the ledger. |
+
+## Resource kinds
+
+The allocator contract only covers the closed `HostResourceKind` enum:
+
+- bridge
+- tap
+- veth-pair
+- nftables-table
+- nftables-partition
+- cgroup-subtree
+- host-file-partition
+- namespace-boundary
+
+Adding a new kind is a schema change. It must carry clear ownership,
+reconciliation, metric-cardinality, and security semantics before any
+runtime implementation grants it.
+
+## Typed leases
+
+A mutating allocation request carries an operation id, correlation id,
+mandatory idempotency key, lease owner, and one to thirty-two requested
+resources. Each requested resource declares:
+
+- an opaque `resource_id`;
+- a closed `kind`;
+- `exclusive` or `shared-partition` sharing semantics;
+- explicit acquisition-order metadata.
+
+The response is either `granted`, with an `AllocatorLease`, or `denied`,
+with a low-cardinality `AllocatorReasonCode` and bounded conflict list.
+Conflicts expose only resource ids, kinds, closed reasons, and optional
+lease ids. They do not expose host paths, command output, credentials,
+provider endpoints, or raw interface names.
+
+Lease states are `granted`, `reconciled`, `quarantined`, `reclaimed`, and
+`denied`. `denied` and `reclaimed` are terminal. Active states may move
+through reconciliation, quarantine, or reclamation only along the state
+transitions encoded in `AllocatorLeaseState::can_transition_to`.
+
+## Total acquisition order
+
+Every multi-resource request carries a deterministic total acquisition
+order. Callers provide a coarse `phase` and `ordinal`; ties are broken by
+closed resource kind and opaque resource id. All participants must sort
+by the resulting `ResourceAcquisitionKey` before acquiring or releasing
+resources. This prevents two realm brokers from deadlocking by acquiring
+the same resource set in different orders.
+
+A request that cannot be expressed in this total order must be denied
+rather than partially applied. Future runtime code must not acquire a
+resource out of order and then rely on cleanup to recover correctness.
+
+## Immutable host-file boundary
+
+`host-file-partition` is a typed resource kind, not permission for a
+realm broker to edit arbitrary host files. A grant delegates only an
+opaque partition id or handle that the allocator recognizes. Realm
+brokers must not create ad-hoc ownership markers, take independent lock
+files, chmod/chown paths, or mutate host files outside a granted
+partition.
+
+This boundary keeps host-file mutation auditable and reconciliable. If a
+future allocator cannot prove that a partition is owned by the expected
+lease, it must deny, quarantine, or report a storage-contract violation
+instead of repairing by guesswork.
+
+## Reconciliation, quarantine, and reclaim
+
+Reconciliation reports compare two facts for each resource id:
+
+1. the persisted lease metadata from the allocator ledger;
+2. the observed host state from a bounded source such as kernel netlink,
+   the nftables API, cgroupfs, host filesystem inspection, a namespace
+   registry, or the allocator ledger itself.
+
+Observed states are `present`, `missing`, `foreign-owner`, `ambiguous`,
+and `inaccessible`. Decisions are `reconciled`, `quarantine`, `reclaim`,
+and `deny`. Non-reconciled decisions require a closed reason code.
+Quarantine, reclaim, and deny are fail-closed decisions: they prevent
+reuse until a later, explicit owner resolves or retires the resource.
+
+The current crate defines these reports and bounds them to keep audit and
+metric metadata small. It does not yet observe the live kernel, mutate
+nftables, create cgroups, or repair host files.
+
+Future operator repair should be explicit and evidence-driven rather than
+automatic cleanup. A future CLI or daemon repair path for states such as
+`DriftDetected`, `ReconcileMismatch`, or quarantine should inspect the
+bounded `correlation_id`, `operation_id`, `resource_id`, and `lease_id`
+metadata from allocator events and reconciliation reports, compare the
+ledger entry with the observed host resource, then either reconcile the
+lease, retire the stale record, or clear a quarantine only when ownership is
+unambiguous. This document does not define a live repair command yet; until
+such a command exists, these fail-closed states are contract signals for
+future operator tooling, not permission for realm brokers to guess, delete,
+or recreate host resources directly.
+
+## No realm-broker ad-hoc locks
+
+Realm brokers must use typed allocator leases and the generated
+storage/synchronization contracts for coordination. They must not add
+realm-specific lock files, hidden state directories, broad `/run/d2b`
+sweeps, or direct host-resource mutation paths to work around the
+allocator. If the allocator contract cannot represent a resource or lock
+ordering, the correct next step is to extend the contract and schema, not
+to bypass it in a broker.
+
+## Redaction and observability
+
+Allocator events are low-cardinality metadata: grant, denial, conflict,
+reconciliation, reclamation, and quarantine. Event records carry operation
+and correlation ids, the lease owner, optional resource kind, optional
+reason, and optional trace context. They intentionally omit paths, raw
+interface names, command output, credentials, provider endpoints, and
+opaque resource values that would expand label cardinality or leak host
+state.
+
+## Current implementation status
+
+The committed foundation consists of Rust DTOs, validation helpers, tests,
+and generated schema coverage in `d2b-realm-core`. It does not install a
+local-root allocator daemon, expose a public or broker socket operation,
+or change the live behavior of existing `d2b.envs` networking, cgroup,
+nftables, host-file, or namespace management. Runtime allocation, live
+mutation, and migration from today's local host-resource paths are future
+implementation work.

--- a/docs/reference/manifest-bundle.md
+++ b/docs/reference/manifest-bundle.md
@@ -18,6 +18,7 @@ world-readable system profile.
 | `processes.json` | private supervisor intent | root:`d2bd` `0640` | Per-VM process DAG, readiness predicates, cgroup placement, and minijail profile IDs. |
 | `storage.json` | private storage lifecycle contract | root:`d2bd` `0640` | Managed path inventory, restart/adoption policy, degraded-state taxonomy, cleanup/repair policy, and remediation IDs. |
 | `sync.json` | private synchronization contract | root:`d2bd` `0640` | Lock inventory, OFD/fd-transfer policy, acquisition order, stale-owner policy, and lock degraded-state handling. |
+| `allocator.json` | private allocator metadata | root:`d2bd` `0640` | Metadata-only local-root allocator plan rooted in `d2b.realms`: enabled realms, resource requests, path/socket partitions, provider placement, and env bridges. |
 | `privileges.json` | private authorization policy | root:`d2bd` `0640` | Public API/CLI authorization matrix and private broker operation matrix. |
 | `closures/<vm>.json` | private closure metadata | root:`d2bd` `0640` | Per-VM toplevel, closure paths, declared-runner parity data, and generation metadata. |
 | `minijail-profile.json` | private sandbox profile catalog | root:`d2bd` `0640` | Typed minijail profile fields, mount policy, and bounded start-as-root exceptions. |
@@ -39,8 +40,8 @@ The policy is defined by
 schema directory is `docs/reference/schemas/v2/`; the bundle and
 per-artifact schemas were bumped from `v1` to `v2` to land the
 host-prepare additions; the current emitted
-bundle keeps `schemaVersion = "v2"` and bumps `bundleVersion = 6`
-for the storage/restart/synchronization contract additions (ADR 0034).
+bundle keeps `schemaVersion = "v2"` and bumps `bundleVersion = 7`
+for the metadata-only local-root allocator artifact (ADR 0043).
 Each artifact now carries a
 matching v2 markdown companion beside the committed JSON schema.
 `cargo xtask gen-schemas` regenerates the JSON files under
@@ -91,6 +92,7 @@ references below.
 | `processes.json` | [`schemas/v2/processes.md`](./schemas/v2/processes.md) | `schemas/v2/processes.json` |
 | `storage.json` | [`schemas/v2/storage.md`](./schemas/v2/storage.md) | `schemas/v2/storage.json` |
 | `sync.json` | [`schemas/v2/sync.md`](./schemas/v2/sync.md) | `schemas/v2/sync.json` |
+| `allocator.json` | [`schemas/v2/allocator.md`](./schemas/v2/allocator.md) | `schemas/v2/allocator.json` |
 | `privileges.json` | [`schemas/v2/privileges.md`](./schemas/v2/privileges.md) | `schemas/v2/privileges.json` |
 | `closures/<vm>.json` | [`schemas/v2/closures.md`](./schemas/v2/closures.md) | `schemas/v2/closures.json` |
 | `minijail-profile.json` | [`schemas/v2/minijail-profile.md`](./schemas/v2/minijail-profile.md) | `schemas/v2/minijail-profile.json` |

--- a/docs/reference/realm-core.md
+++ b/docs/reference/realm-core.md
@@ -5,8 +5,10 @@
 This page documents the committed `d2b-realm-core` DTO and parser
 contract. It is a contributor-facing reference for ADR 0043 realm target
 names, identifiers, capability checks, redacted audit metadata, typed
-errors, realm-controller metadata, route/enrollment DTOs, and semantic
-frame schema roots.
+errors, realm-controller metadata, route/enrollment DTOs, host-resource
+allocator DTOs, and semantic frame schema roots. See
+[Local-root allocator contract](./local-root-allocator.md) for the
+allocator-specific invariants and current implementation boundary.
 
 For the current Nix option surface, see
 [Realm option schema](./realm-options.md). The `d2b.realms.<realm>`
@@ -42,6 +44,7 @@ Regenerate that file; do not edit generated JSON by hand.
 | `RealmControllerPlacement`, `RealmAccessBinding`, `RealmTransportBinding`, `AccessBindingRef`, `UnixSocketPath` | `src/realm.rs`, `src/access.rs` | ADR 0043 controller placement and access-binding DTOs for future realm access discovery. |
 | `ProviderRegistryEntry`, `WorkloadPlacement`, `WorkloadPlacementSummary`, `RealmTreeEdge`, `DescendantRoute`, `RouteAdvertisement` | `src/registry.rs`, `src/routing.rs` | Provider/workload placement and tree-route metadata. |
 | `EnrollmentRecord`, `RevocationRecord`, `KeyPin`, `SignatureRef`, migration DTOs | `src/enrollment.rs`, `src/routing.rs`, `src/migration.rs` | Realm identity lifecycle, signed-route metadata, and typed migration-error envelopes. |
+| `LeaseAllocationRequest` / `LeaseAllocationResponse`, `AllocatorLease`, `ReconciliationReport`, allocator event DTOs | `src/allocator.rs` | Contract-only local-root host-resource leases, total acquisition order, reconciliation/quarantine/reclaim decisions, and bounded allocator observability metadata. |
 | `NodeSummary` / `WorkloadSelector` / `WorkloadSummary` / `ExecutionSummary` / `ShellSummary` | `src/node.rs`, `src/workload.rs`, `src/execution.rs`, `src/shell.rs` | Bounded status summaries and selectors for nodes, workloads, durable executions, and persistent shells. |
 | `ExecStartRequest` / `ExecAttachRequest` / `ExecLogsRequest` / `ExecCancelRequest` | `src/execution.rs` | Bounded durable-execution metadata for start, reconnect, retained logs, and retry-safe cancel. |
 | `ShellListRequest` / `ShellAttachRequest` / `ShellDetachRequest` / `ShellKillRequest` / `ShellListResponse` / `ShellAttachSummary` | `src/shell.rs` | Bounded persistent-shell metadata for list, attach, detach, kill, list responses, and shell-authorized PTY attachment. |

--- a/docs/reference/schemas/v2/allocator.json
+++ b/docs/reference/schemas/v2/allocator.json
@@ -1,0 +1,483 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AllocatorJson",
+  "type": "object",
+  "required": [
+    "allocator",
+    "invariants",
+    "realms",
+    "schemaVersion"
+  ],
+  "properties": {
+    "allocator": {
+      "$ref": "#/definitions/AllocatorRoot"
+    },
+    "envBridge": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AllocatorEnvBridge"
+      }
+    },
+    "invariants": {
+      "$ref": "#/definitions/AllocatorInvariants"
+    },
+    "pathPartitions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AllocatorPathPartition"
+      }
+    },
+    "providerPlacements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AllocatorProviderPlacement"
+      }
+    },
+    "realms": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AllocatorRealm"
+      }
+    },
+    "resourceRequests": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AllocatorResourceRequest"
+      }
+    },
+    "schemaVersion": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "AllocatorAcquisitionOrder": {
+      "type": "object",
+      "required": [
+        "ordinal",
+        "phase"
+      ],
+      "properties": {
+        "ordinal": {
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "phase": {
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorEnvBridge": {
+      "type": "object",
+      "required": [
+        "declared",
+        "enabled",
+        "envName",
+        "realmPath"
+      ],
+      "properties": {
+        "declared": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "envName": {
+          "type": "string"
+        },
+        "lanBridge": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllocatorEnvBridgeMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "netVm": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "realmPath": {
+          "$ref": "#/definitions/AllocatorRealmPath"
+        },
+        "uplinkBridge": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorEnvBridgeMode": {
+      "type": "string",
+      "enum": [
+        "none",
+        "inherit-env",
+        "declared",
+        "external"
+      ]
+    },
+    "AllocatorHostResourceKind": {
+      "type": "string",
+      "enum": [
+        "bridge",
+        "tap",
+        "veth-pair",
+        "nftables-table",
+        "nftables-partition",
+        "cgroup-subtree",
+        "host-file-partition",
+        "namespace-boundary"
+      ]
+    },
+    "AllocatorInvariants": {
+      "type": "object",
+      "required": [
+        "noRuntimeAllocatorService",
+        "preservesEnvRuntimeSourceOfTruth",
+        "privateMetadataOnly"
+      ],
+      "properties": {
+        "noRuntimeAllocatorService": {
+          "type": "boolean"
+        },
+        "preservesEnvRuntimeSourceOfTruth": {
+          "type": "boolean"
+        },
+        "privateMetadataOnly": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorPathPartition": {
+      "type": "object",
+      "required": [
+        "auditDir",
+        "brokerSocket",
+        "publicSocket",
+        "realmPath",
+        "runDir",
+        "stateDir"
+      ],
+      "properties": {
+        "auditDir": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "brokerSocket": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "publicSocket": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "realmPath": {
+          "$ref": "#/definitions/AllocatorRealmPath"
+        },
+        "runDir": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "stateDir": {
+          "$ref": "#/definitions/PathTemplate"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorProviderKind": {
+      "description": "Opaque provider adapter kind slug, bounded for schema-only allocator metadata.",
+      "type": "string",
+      "maxLength": 64,
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "AllocatorProviderPlacement": {
+      "type": "object",
+      "required": [
+        "enabled",
+        "placement",
+        "providerId",
+        "providerName",
+        "realmPath"
+      ],
+      "properties": {
+        "capabilityRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "configRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllocatorProviderKind"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "placement": {
+          "$ref": "#/definitions/RealmPlacement"
+        },
+        "providerId": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "providerName": {
+          "type": "string"
+        },
+        "realmPath": {
+          "$ref": "#/definitions/AllocatorRealmPath"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorRealm": {
+      "type": "object",
+      "required": [
+        "enabled",
+        "hostMutation",
+        "placement",
+        "realmId",
+        "realmName",
+        "realmPath"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "envNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostMutation": {
+          "type": "boolean"
+        },
+        "placement": {
+          "$ref": "#/definitions/RealmPlacement"
+        },
+        "placementProvider": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContractId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "providerKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "providerSpecificPlacement": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "realmId": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "realmName": {
+          "type": "string"
+        },
+        "realmPath": {
+          "$ref": "#/definitions/AllocatorRealmPath"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorRealmPath": {
+      "description": "Realm path copied from d2b.realms, most-specific first, with 1-16 DNS-style labels and a 255-byte cap.",
+      "type": "string",
+      "maxLength": 255,
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){0,15}$"
+    },
+    "AllocatorResourceRequest": {
+      "type": "object",
+      "required": [
+        "acquisitionOrder",
+        "kind",
+        "realmPath",
+        "resourceId",
+        "share",
+        "source"
+      ],
+      "properties": {
+        "acquisitionOrder": {
+          "$ref": "#/definitions/AllocatorAcquisitionOrder"
+        },
+        "kind": {
+          "$ref": "#/definitions/AllocatorHostResourceKind"
+        },
+        "realmPath": {
+          "$ref": "#/definitions/AllocatorRealmPath"
+        },
+        "resourceId": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "share": {
+          "$ref": "#/definitions/AllocatorResourceShare"
+        },
+        "source": {
+          "$ref": "#/definitions/AllocatorResourceSource"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorResourceShare": {
+      "type": "string",
+      "enum": [
+        "exclusive",
+        "shared-partition"
+      ]
+    },
+    "AllocatorResourceSource": {
+      "type": "object",
+      "required": [
+        "kind",
+        "refName"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/AllocatorResourceSourceKind"
+        },
+        "refName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorResourceSourceKind": {
+      "type": "string",
+      "enum": [
+        "realm-path",
+        "realm-socket",
+        "realm-state-dir",
+        "realm-run-dir",
+        "realm-audit-dir",
+        "realm-network",
+        "realm-broker",
+        "env-bridge",
+        "env-net-vm"
+      ]
+    },
+    "AllocatorRoot": {
+      "type": "object",
+      "required": [
+        "auditDir",
+        "enabled",
+        "leaseLedger",
+        "rootSocket",
+        "runtime",
+        "runtimeState",
+        "stateDir"
+      ],
+      "properties": {
+        "auditDir": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "leaseLedger": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "rootSocket": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "runtime": {
+          "$ref": "#/definitions/AllocatorRuntime"
+        },
+        "runtimeState": {
+          "$ref": "#/definitions/AllocatorRuntimeState"
+        },
+        "stateDir": {
+          "$ref": "#/definitions/PathTemplate"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorRuntime": {
+      "type": "object",
+      "required": [
+        "socketActivated",
+        "spawnsService"
+      ],
+      "properties": {
+        "serviceName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "socketActivated": {
+          "type": "boolean"
+        },
+        "spawnsService": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorRuntimeState": {
+      "type": "string",
+      "enum": [
+        "metadata-only"
+      ]
+    },
+    "ContractId": {
+      "description": "Bounded storage/synchronization contract identifier.",
+      "type": "string",
+      "maxLength": 160,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$"
+    },
+    "PathTemplate": {
+      "description": "Absolute path template with typed variables expanded by the broker.",
+      "type": "string",
+      "maxLength": 1024,
+      "minLength": 1,
+      "pattern": "^/[^\\u0000]*$"
+    },
+    "RealmPlacement": {
+      "type": "string",
+      "enum": [
+        "host-local",
+        "gateway-vm",
+        "cloud-full-host",
+        "provider-controller",
+        "provider-agent",
+        "provider-specific"
+      ]
+    }
+  }
+}

--- a/docs/reference/schemas/v2/allocator.md
+++ b/docs/reference/schemas/v2/allocator.md
@@ -1,0 +1,37 @@
+# `allocator.json` schema (`v2`)
+
+Schema: [`allocator.json`](./allocator.json)
+
+`allocator.json` is private, metadata-only local-root allocator configuration.
+It is rooted in the normalized `d2b.realms` index and does not start a service,
+bind a socket, mutate host state, or change current `d2b.envs` behavior.
+
+## Top-level fields
+
+- `schemaVersion` — schema version for this artifact.
+- `allocator` — future allocator root socket/state/audit paths plus explicit
+  `metadata-only` runtime state.
+- `realms` — enabled realm rows selected from `d2b._index.realms`.
+- `resourceRequests` — schema-friendly host-resource request metadata for
+  path/socket partitions, network namespaces, shared env bridges, and optional
+  host-mutation partitions.
+- `pathPartitions` — per-realm state/run/audit/public-socket/broker-socket
+  paths.
+- `providerPlacements` — provider placement metadata copied from enabled realm
+  provider rows. Optional provider `kind` values are bounded lowercase slugs.
+- `envBridge` — transitional mapping from realm paths to existing env bridges and
+  net VMs. `mode` is the closed realm network mode enum:
+  `none`, `inherit-env`, `declared`, or `external`.
+- `invariants` — booleans asserting this artifact is private metadata only and
+  preserves the existing env runtime source of truth.
+
+## Contract notes
+
+- `runtimeState` is `metadata-only`; there is no allocator service/socket unit in
+  this scope.
+- Resource identifiers are opaque metadata. They are not host paths, interface
+  names, nftables object names, file descriptors, or credentials.
+- Every `realmPath` is a bounded DNS-style realm path: 1-16 lowercase
+  dot-separated labels, maximum 255 bytes.
+- Existing `d2b.envs` and `d2b.vms.<vm>.env` remain the runtime source of truth
+  until a later allocator implementation lands.

--- a/docs/reference/schemas/v2/bundle.json
+++ b/docs/reference/schemas/v2/bundle.json
@@ -15,8 +15,15 @@
     "schemaVersion"
   ],
   "properties": {
+    "allocatorPath": {
+      "description": "Private local-root allocator metadata artifact path.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "artifactHashes": {
-      "description": "Per-artifact SHA-256 hashes for tamper detection of every private bundle artifact loaded by the resolver.\n\nKeys match the path strings stored in the bundle path fields: absolute paths for `host_path`, `processes_path`, `privileges_path`, `storage_path`, and `sync_path`; bundle-relative paths for `closures[*].path` and `minijail_profiles[*].path`. Values are `\"sha256:<hex64>\"` strings.\n\nWhen `None`, per-artifact hash verification is skipped (backwards compatibility with bundles that pre-date this field).",
+      "description": "Per-artifact SHA-256 hashes for tamper detection of every private bundle artifact loaded by the resolver.\n\nKeys match the path strings stored in the bundle path fields: absolute paths for `host_path`, `processes_path`, `privileges_path`, `storage_path`, `sync_path`, and `allocator_path`; bundle-relative paths for `closures[*].path` and `minijail_profiles[*].path`. Values are `\"sha256:<hex64>\"` strings.\n\nWhen `None`, per-artifact hash verification is skipped (backwards compatibility with bundles that pre-date this field).",
       "type": [
         "object",
         "null"
@@ -33,7 +40,7 @@
       ]
     },
     "bundleVersion": {
-      "description": "Version of the bundle format; bundleVersion 6 adds the private storage lifecycle and synchronization artifacts while artifact schemaVersion stays v2.",
+      "description": "Version of the bundle format; bundleVersion 7 adds allocator metadata while artifact schemaVersion stays v2.",
       "type": "integer",
       "format": "uint32",
       "minimum": 0.0

--- a/docs/reference/schemas/v2/bundle.md
+++ b/docs/reference/schemas/v2/bundle.md
@@ -5,18 +5,19 @@ Schema: [`bundle.json`](./bundle.json)
 `bundle.json` is the private bundle index installed beside the public
 `vms.json` manifest. It gives the daemon and broker one stable place to
 find the current `host.json`, `processes.json`, `privileges.json`,
-`closures/*.json`, `storage.json`, `sync.json`, and
+`closures/*.json`, `storage.json`, `sync.json`, `allocator.json`, and
 `minijail-profile.json` artifacts.
 
 ## Top-level fields
 
 - `schemaVersion` — schema directory/version for every referenced artifact.
-- `bundleVersion` — additive bundle contract rev (`6` in the current tree).
+- `bundleVersion` — additive bundle contract rev (`7` in the current tree).
 - `publicManifestPath` — path to the public `vms.json` manifest.
 - `hostPath` — path to the private `host.json` artifact.
 - `processesPath` — path to the private `processes.json` artifact.
 - `storagePath` — path to the private `storage.json` artifact.
 - `syncPath` — path to the private `sync.json` artifact.
+- `allocatorPath` — path to the private `allocator.json` artifact.
 - `privilegesPath` — path to the private `privileges.json` artifact.
 - `closures` — per-VM closure artifact paths.
 - `minijailProfiles` — shipped minijail profile metadata paths.

--- a/docs/reference/schemas/v2/d2b-realm-core.json
+++ b/docs/reference/schemas/v2/d2b-realm-core.json
@@ -54,6 +54,12 @@
       "$ref": "#/definitions/ControllerGenerationId"
     },
     {
+      "$ref": "#/definitions/AllocatorLeaseId"
+    },
+    {
+      "$ref": "#/definitions/HostResourceId"
+    },
+    {
       "$ref": "#/definitions/EnrollmentId"
     },
     {
@@ -279,6 +285,78 @@
       "$ref": "#/definitions/AuditSinkHealth"
     },
     {
+      "$ref": "#/definitions/HostResourceKind"
+    },
+    {
+      "$ref": "#/definitions/LeaseOwner"
+    },
+    {
+      "$ref": "#/definitions/ResourceShareMode"
+    },
+    {
+      "$ref": "#/definitions/ResourceAcquisitionOrder"
+    },
+    {
+      "$ref": "#/definitions/LeaseResourceRequest"
+    },
+    {
+      "$ref": "#/definitions/ResourceAcquisitionKey"
+    },
+    {
+      "$ref": "#/definitions/ResourceDelegation"
+    },
+    {
+      "$ref": "#/definitions/GrantedHostResource"
+    },
+    {
+      "$ref": "#/definitions/AllocatorLeaseState"
+    },
+    {
+      "$ref": "#/definitions/AllocatorLease"
+    },
+    {
+      "$ref": "#/definitions/AllocatorReasonCode"
+    },
+    {
+      "$ref": "#/definitions/AllocatorConflict"
+    },
+    {
+      "$ref": "#/definitions/LeaseAllocationResponse"
+    },
+    {
+      "$ref": "#/definitions/LeaseAllocationRequest"
+    },
+    {
+      "$ref": "#/definitions/LeaseAllocationResult"
+    },
+    {
+      "$ref": "#/definitions/AllocatorEventKind"
+    },
+    {
+      "$ref": "#/definitions/AllocatorEventMetadata"
+    },
+    {
+      "$ref": "#/definitions/PersistedResourceLease"
+    },
+    {
+      "$ref": "#/definitions/ResourceObservationSource"
+    },
+    {
+      "$ref": "#/definitions/ObservedResourceState"
+    },
+    {
+      "$ref": "#/definitions/ObservedHostResource"
+    },
+    {
+      "$ref": "#/definitions/ReconciliationDecision"
+    },
+    {
+      "$ref": "#/definitions/ReconciliationRecord"
+    },
+    {
+      "$ref": "#/definitions/ReconciliationReport"
+    },
+    {
       "$ref": "#/definitions/ConstellationError"
     },
     {
@@ -384,6 +462,169 @@
         }
       },
       "additionalProperties": false
+    },
+    "AllocatorConflict": {
+      "description": "Conflict metadata returned on denial. Only opaque ids and closed reasons.",
+      "type": "object",
+      "required": [
+        "kind",
+        "reason",
+        "resource_id"
+      ],
+      "properties": {
+        "existing_lease": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllocatorLeaseId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "kind": {
+          "$ref": "#/definitions/HostResourceKind"
+        },
+        "reason": {
+          "$ref": "#/definitions/AllocatorReasonCode"
+        },
+        "resource_id": {
+          "$ref": "#/definitions/HostResourceId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorEventKind": {
+      "description": "Bounded allocator audit/metric event kind.",
+      "type": "string",
+      "enum": [
+        "grant",
+        "denial",
+        "conflict",
+        "reconciliation",
+        "reclamation",
+        "quarantine"
+      ]
+    },
+    "AllocatorEventMetadata": {
+      "description": "Bounded allocator event metadata. Carries no paths, interface names, command output, or credentials.",
+      "type": "object",
+      "required": [
+        "correlation_id",
+        "event",
+        "operation_id",
+        "owner"
+      ],
+      "properties": {
+        "correlation_id": {
+          "$ref": "#/definitions/CorrelationId"
+        },
+        "event": {
+          "$ref": "#/definitions/AllocatorEventKind"
+        },
+        "operation_id": {
+          "$ref": "#/definitions/OperationId"
+        },
+        "owner": {
+          "$ref": "#/definitions/LeaseOwner"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllocatorReasonCode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resource_kind": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HostResourceKind"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trace": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceContext"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorLease": {
+      "description": "Persisted allocator lease record.",
+      "type": "object",
+      "required": [
+        "lease_id",
+        "owner",
+        "resources",
+        "state"
+      ],
+      "properties": {
+        "lease_id": {
+          "$ref": "#/definitions/AllocatorLeaseId"
+        },
+        "owner": {
+          "$ref": "#/definitions/LeaseOwner"
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GrantedHostResource"
+          },
+          "maxItems": 32,
+          "minItems": 1
+        },
+        "state": {
+          "$ref": "#/definitions/AllocatorLeaseState"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AllocatorLeaseId": {
+      "type": "string",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "AllocatorLeaseState": {
+      "description": "Allocator lease lifecycle state.",
+      "type": "string",
+      "enum": [
+        "granted",
+        "reconciled",
+        "quarantined",
+        "reclaimed",
+        "denied"
+      ]
+    },
+    "AllocatorReasonCode": {
+      "description": "Closed, low-cardinality allocator denial/conflict/quarantine reasons.",
+      "type": "string",
+      "enum": [
+        "resource-conflict",
+        "ownership-conflict",
+        "acquisition-order-violation",
+        "invalid-request",
+        "capacity-exhausted",
+        "drift-detected",
+        "reconcile-mismatch",
+        "owner-not-live",
+        "policy-denied",
+        "unsupported-kind",
+        "storage-contract-violation",
+        "kernel-state-unknown"
+      ]
     },
     "AuditChainCheckFailure": {
       "description": "Closed audit-chain verification failure.",
@@ -2368,6 +2609,35 @@
       "minLength": 1,
       "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
     },
+    "GrantedHostResource": {
+      "description": "One resource granted under a lease.",
+      "type": "object",
+      "required": [
+        "acquisition_order",
+        "delegation",
+        "kind",
+        "resource_id",
+        "share"
+      ],
+      "properties": {
+        "acquisition_order": {
+          "$ref": "#/definitions/ResourceAcquisitionOrder"
+        },
+        "delegation": {
+          "$ref": "#/definitions/ResourceDelegation"
+        },
+        "kind": {
+          "$ref": "#/definitions/HostResourceKind"
+        },
+        "resource_id": {
+          "$ref": "#/definitions/HostResourceId"
+        },
+        "share": {
+          "$ref": "#/definitions/ResourceShareMode"
+        }
+      },
+      "additionalProperties": false
+    },
     "Handshake": {
       "description": "Negotiated wire/codec version and capability advertisement exchanged at the start of a peer session.",
       "type": "object",
@@ -2470,6 +2740,26 @@
         "malformed-handshake"
       ]
     },
+    "HostResourceId": {
+      "type": "string",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "HostResourceKind": {
+      "description": "Closed host-resource kinds the local root allocator can arbitrate.",
+      "type": "string",
+      "enum": [
+        "bridge",
+        "tap",
+        "veth-pair",
+        "nftables-table",
+        "nftables-partition",
+        "cgroup-subtree",
+        "host-file-partition",
+        "namespace-boundary"
+      ]
+    },
     "IdempotencyKey": {
       "type": "string",
       "maxLength": 128,
@@ -2536,6 +2826,226 @@
           "allOf": [
             {
               "$ref": "#/definitions/RealmKeyRole"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LeaseAllocationRequest": {
+      "description": "Mutating lease allocation request. Idempotency is mandatory.",
+      "type": "object",
+      "required": [
+        "correlation_id",
+        "idempotency_key",
+        "operation_id",
+        "owner",
+        "resources"
+      ],
+      "properties": {
+        "correlation_id": {
+          "description": "Cross-realm correlation id.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CorrelationId"
+            }
+          ]
+        },
+        "idempotency_key": {
+          "description": "Caller-generated dedup key for at-least-once delivery.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IdempotencyKey"
+            }
+          ]
+        },
+        "operation_id": {
+          "description": "Per-attempt operation id.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OperationId"
+            }
+          ]
+        },
+        "owner": {
+          "description": "Lease owner realm/controller generation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LeaseOwner"
+            }
+          ]
+        },
+        "resources": {
+          "description": "Requested host resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LeaseResourceRequest"
+          },
+          "maxItems": 32,
+          "minItems": 1
+        },
+        "trace": {
+          "description": "Optional bounded trace metadata.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TraceContext"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LeaseAllocationResponse": {
+      "description": "Allocator response to a typed lease request.",
+      "type": "object",
+      "required": [
+        "correlation_id",
+        "operation_id",
+        "result"
+      ],
+      "properties": {
+        "correlation_id": {
+          "$ref": "#/definitions/CorrelationId"
+        },
+        "operation_id": {
+          "$ref": "#/definitions/OperationId"
+        },
+        "result": {
+          "$ref": "#/definitions/LeaseAllocationResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LeaseAllocationResult": {
+      "description": "Granted or fail-closed denied allocation result.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "lease",
+            "status"
+          ],
+          "properties": {
+            "lease": {
+              "$ref": "#/definitions/AllocatorLease"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "granted"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "conflicts",
+            "reason",
+            "status"
+          ],
+          "properties": {
+            "conflicts": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AllocatorConflict"
+              },
+              "maxItems": 16
+            },
+            "reason": {
+              "$ref": "#/definitions/AllocatorReasonCode"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "denied"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "LeaseOwner": {
+      "description": "The realm-controller generation that owns a lease.",
+      "type": "object",
+      "required": [
+        "controller_generation",
+        "realm"
+      ],
+      "properties": {
+        "controller_generation": {
+          "description": "Active controller generation that requested the lease.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ControllerGenerationId"
+            }
+          ]
+        },
+        "node": {
+          "description": "Realm node/broker identity, when the caller has one bound.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NodeId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "realm": {
+          "description": "Owning realm path.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RealmId"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "LeaseResourceRequest": {
+      "description": "One resource requested from the local-root allocator.",
+      "type": "object",
+      "required": [
+        "acquisition_order",
+        "kind",
+        "resource_id",
+        "share"
+      ],
+      "properties": {
+        "acquisition_order": {
+          "description": "Total acquisition order metadata.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ResourceAcquisitionOrder"
+            }
+          ]
+        },
+        "kind": {
+          "description": "Resource kind.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HostResourceKind"
+            }
+          ]
+        },
+        "resource_id": {
+          "description": "Opaque requested resource/partition id.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HostResourceId"
+            }
+          ]
+        },
+        "share": {
+          "description": "Sharing contract.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ResourceShareMode"
             }
           ]
         }
@@ -2704,6 +3214,42 @@
         }
       },
       "additionalProperties": false
+    },
+    "ObservedHostResource": {
+      "description": "Host-resource observation from the live system side of reconciliation.",
+      "type": "object",
+      "required": [
+        "kind",
+        "resource_id",
+        "source",
+        "state"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/HostResourceKind"
+        },
+        "resource_id": {
+          "$ref": "#/definitions/HostResourceId"
+        },
+        "source": {
+          "$ref": "#/definitions/ResourceObservationSource"
+        },
+        "state": {
+          "$ref": "#/definitions/ObservedResourceState"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ObservedResourceState": {
+      "description": "Kernel/host-observed state for one resource id.",
+      "type": "string",
+      "enum": [
+        "present",
+        "missing",
+        "foreign-owner",
+        "ambiguous",
+        "inaccessible"
+      ]
     },
     "OpaquePayload": {
       "type": "array",
@@ -2920,6 +3466,27 @@
               "type": "null"
             }
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistedResourceLease": {
+      "description": "Persisted resource lease metadata from the allocator ledger.",
+      "type": "object",
+      "required": [
+        "lease_id",
+        "owner",
+        "state"
+      ],
+      "properties": {
+        "lease_id": {
+          "$ref": "#/definitions/AllocatorLeaseId"
+        },
+        "owner": {
+          "$ref": "#/definitions/LeaseOwner"
+        },
+        "state": {
+          "$ref": "#/definitions/AllocatorLeaseState"
         }
       },
       "additionalProperties": false
@@ -3352,6 +3919,311 @@
         }
       },
       "additionalProperties": false
+    },
+    "ReconciliationDecision": {
+      "description": "Reconciliation decision for a persisted/live observation pair.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "decision"
+          ],
+          "properties": {
+            "decision": {
+              "type": "string",
+              "enum": [
+                "reconciled"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "decision",
+            "reason"
+          ],
+          "properties": {
+            "decision": {
+              "type": "string",
+              "enum": [
+                "quarantine"
+              ]
+            },
+            "reason": {
+              "$ref": "#/definitions/AllocatorReasonCode"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "decision",
+            "reason"
+          ],
+          "properties": {
+            "decision": {
+              "type": "string",
+              "enum": [
+                "reclaim"
+              ]
+            },
+            "reason": {
+              "$ref": "#/definitions/AllocatorReasonCode"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "decision",
+            "reason"
+          ],
+          "properties": {
+            "decision": {
+              "type": "string",
+              "enum": [
+                "deny"
+              ]
+            },
+            "reason": {
+              "$ref": "#/definitions/AllocatorReasonCode"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ReconciliationRecord": {
+      "description": "One reconciliation record distinguishes persisted lease state from live kernel/host-observed state.",
+      "type": "object",
+      "required": [
+        "decision",
+        "kind",
+        "observed",
+        "resource_id"
+      ],
+      "properties": {
+        "decision": {
+          "$ref": "#/definitions/ReconciliationDecision"
+        },
+        "kind": {
+          "$ref": "#/definitions/HostResourceKind"
+        },
+        "observed": {
+          "$ref": "#/definitions/ObservedHostResource"
+        },
+        "persisted": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PersistedResourceLease"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resource_id": {
+          "$ref": "#/definitions/HostResourceId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReconciliationReport": {
+      "description": "Bounded reconciliation report.",
+      "type": "object",
+      "required": [
+        "correlation_id",
+        "events",
+        "operation_id",
+        "records"
+      ],
+      "properties": {
+        "correlation_id": {
+          "$ref": "#/definitions/CorrelationId"
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AllocatorEventMetadata"
+          },
+          "maxItems": 128
+        },
+        "operation_id": {
+          "$ref": "#/definitions/OperationId"
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReconciliationRecord"
+          },
+          "maxItems": 128
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResourceAcquisitionKey": {
+      "description": "Deterministic total-order key for resource acquisition.",
+      "type": "object",
+      "required": [
+        "kind",
+        "order",
+        "resource_id"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/HostResourceKind"
+        },
+        "order": {
+          "$ref": "#/definitions/ResourceAcquisitionOrder"
+        },
+        "resource_id": {
+          "$ref": "#/definitions/HostResourceId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResourceAcquisitionOrder": {
+      "description": "Explicit acquisition order used for multi-resource requests.",
+      "type": "object",
+      "required": [
+        "ordinal",
+        "phase"
+      ],
+      "properties": {
+        "ordinal": {
+          "description": "Order within the phase. Lower ordinals are acquired first.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "phase": {
+          "description": "Coarse phase. Lower phases are acquired first.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResourceDelegation": {
+      "description": "How a granted resource is delegated to a realm broker.",
+      "oneOf": [
+        {
+          "description": "Delegated opaque name/handle. It is not a raw interface/path name.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/HostResourceId"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "opaque-name"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "FD handoff placeholder id used only for correlation before SCM_RIGHTS.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/HostResourceId"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "file-descriptor"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Shared-resource partition id.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/HostResourceId"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "partition-id"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Namespace-boundary handle id.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/HostResourceId"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "namespace-handle"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ResourceObservationSource": {
+      "description": "Contract-only source for observed host state. These values describe which subsystem produced an observation; they do not imply an implementation here.",
+      "type": "string",
+      "enum": [
+        "kernel-netlink",
+        "nftables-api",
+        "cgroup-fs",
+        "host-filesystem",
+        "namespace-registry",
+        "allocator-ledger"
+      ]
+    },
+    "ResourceShareMode": {
+      "description": "Shared-vs-exclusive resource semantics.",
+      "oneOf": [
+        {
+          "description": "No other owner may hold the same resource id.",
+          "type": "string",
+          "enum": [
+            "exclusive"
+          ]
+        },
+        {
+          "description": "The allocator grants a partition inside a shared resource.",
+          "type": "string",
+          "enum": [
+            "shared-partition"
+          ]
+        }
+      ]
     },
     "RevocationId": {
       "type": "string",

--- a/docs/reference/schemas/v2/d2b-realm-core.md
+++ b/docs/reference/schemas/v2/d2b-realm-core.md
@@ -23,8 +23,8 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
 - `NodeId`, `WorkloadId`, `ProviderId`, `GatewayId`;
 - `ExecutionId`, `StreamId`, `StreamCursor`, `PrincipalId`,
   `OperationId`, `IdempotencyKey`;
-- `RouteId`, `CorrelationId`, `ControllerGenerationId`, `EnrollmentId`,
-  `RevocationId`;
+- `RouteId`, `CorrelationId`, `ControllerGenerationId`,
+  `AllocatorLeaseId`, `HostResourceId`, `EnrollmentId`, `RevocationId`;
 - `Capability`, `CapabilitySet`, `CapabilityNegotiation`;
 - `RealmControllerPlacement`, `UnixSocketPath`, `AccessBindingRef`,
   `RealmTransportBinding`, `RealmAccessBinding`;
@@ -55,6 +55,17 @@ The generated top-level schema is an `anyOf` wrapper over these roots:
   `AuditChainCheckFailure`, `AuditStreamKind`,
   `AuditRetentionFloorReason`, `AuditRetentionFloorStatus`,
   `AuditSinkHealthReason`, `AuditSinkHealth`;
+- `HostResourceKind`, `LeaseOwner`, `ResourceShareMode`,
+  `ResourceAcquisitionOrder`, `LeaseResourceRequest`,
+  `ResourceAcquisitionKey`, `ResourceDelegation`,
+  `GrantedHostResource`, `AllocatorLeaseState`, `AllocatorLease`,
+  `AllocatorReasonCode`, `AllocatorConflict`,
+  `LeaseAllocationResponse`, `LeaseAllocationRequest`,
+  `LeaseAllocationResult`, `AllocatorEventKind`,
+  `AllocatorEventMetadata`, `PersistedResourceLease`,
+  `ResourceObservationSource`, `ObservedResourceState`,
+  `ObservedHostResource`, `ReconciliationDecision`,
+  `ReconciliationRecord`, `ReconciliationReport`;
 - `ConstellationError`, `ConstellationFrame`.
 
 ## Contract notes

--- a/flake.nix
+++ b/flake.nix
@@ -450,6 +450,7 @@
           cp ${bundle.processesJson.path} $out/processes.json
           cp ${bundle.storageJson.path} $out/storage.json
           cp ${bundle.syncJson.path} $out/sync.json
+          cp ${bundle.allocatorJson.path} $out/allocator.json
           cp ${bundle.bundle.path} $out/bundle.json
           cp ${manifestPkg}/share/d2b/vms.json $out/manifest.json
           ${nixpkgs.lib.concatStringsSep "\n" (nixpkgs.lib.mapAttrsToList
@@ -534,6 +535,7 @@
           cp ${bundle.processesJson.path} $out/processes.json
           cp ${bundle.storageJson.path} $out/storage.json
           cp ${bundle.syncJson.path} $out/sync.json
+          cp ${bundle.allocatorJson.path} $out/allocator.json
           cp ${bundle.bundle.path} $out/bundle.json
           cp ${manifestPkg}/share/d2b/vms.json $out/manifest.json
           ${nixpkgs.lib.concatStringsSep "\n" (nixpkgs.lib.mapAttrsToList

--- a/nixos-modules/allocator-json.nix
+++ b/nixos-modules/allocator-json.nix
@@ -1,0 +1,159 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.d2b;
+
+  sortNames = names: lib.sort lib.lessThan names;
+  sortedAttrNames = attrs: sortNames (lib.attrNames attrs);
+  sortedMapAttrsToList = f: attrs:
+    map (name: f name attrs.${name}) (sortedAttrNames attrs);
+
+  realmRows = cfg._index.realms.enabledList;
+  envMeta = cfg._index.envMeta;
+
+  allocatorStateDir = "${toString cfg.site.stateDir}/allocator";
+  allocatorRunDir = "/run/d2b/allocator";
+  allocatorRootSocket = "${allocatorRunDir}/local-root.sock";
+
+  providerPlacement = realm: providerName: provider: {
+    realmPath = realm.path;
+    inherit providerName;
+    providerId = provider.id;
+    enabled = provider.enabled;
+    kind = provider.kind;
+    placement = provider.placement;
+    capabilityRefs = sortNames (lib.unique provider.capabilityRefs);
+    configRef = provider.configRef;
+  };
+
+  providerPlacements = lib.flatten (map
+    (realm: sortedMapAttrsToList (providerPlacement realm) realm.providers)
+    realmRows);
+
+  pathPartition = realm: {
+    realmPath = realm.path;
+    inherit (realm.paths) stateDir runDir auditDir publicSocket brokerSocket;
+  };
+
+  envBridge = realm: envName:
+    let
+      declared = builtins.hasAttr envName cfg.envs;
+      enabled = builtins.hasAttr envName cfg._index.enabledEnvs;
+      meta = if builtins.hasAttr envName envMeta then envMeta.${envName} else null;
+    in
+    {
+      realmPath = realm.path;
+      inherit envName declared enabled;
+      mode = realm.network.mode;
+      netVm = if declared then cfg.envs.${envName}.netName else null;
+      lanBridge = if meta != null then meta.lanBridge else null;
+      uplinkBridge = if meta != null then meta.uplinkBridge else null;
+    };
+
+  envBridgeRows = lib.flatten (map
+    (realm: map (envBridge realm) realm.network.envNames)
+    realmRows);
+
+  acquisition = phase: ordinal: { inherit phase ordinal; };
+  source = kind: refName: { inherit kind; refName = refName; };
+  request = realm: resourceId: kind: share: phase: ordinal: sourceKind: refName: {
+    realmPath = realm.path;
+    inherit resourceId kind share;
+    acquisitionOrder = acquisition phase ordinal;
+    source = source sourceKind refName;
+  };
+
+  baseRealmRequests = realm:
+    let
+      id = realm.id;
+    in
+    [
+      (request realm "realm-${id}-state" "host-file-partition" "exclusive" 10 0 "realm-state-dir" realm.paths.stateDir)
+      (request realm "realm-${id}-run" "host-file-partition" "exclusive" 10 1 "realm-run-dir" realm.paths.runDir)
+      (request realm "realm-${id}-audit" "host-file-partition" "exclusive" 10 2 "realm-audit-dir" realm.paths.auditDir)
+      (request realm "realm-${id}-public-socket" "host-file-partition" "exclusive" 10 3 "realm-socket" realm.paths.publicSocket)
+      (request realm "realm-${id}-broker-socket" "host-file-partition" "exclusive" 10 4 "realm-socket" realm.paths.brokerSocket)
+    ];
+
+  hostMutationRequests = realm:
+    lib.optionals realm.broker.hostMutation [
+      (request realm "realm-${realm.id}-cgroup" "cgroup-subtree" "exclusive" 20 0 "realm-broker" realm.id)
+      (request realm "realm-${realm.id}-nft" "nftables-partition" "shared-partition" 20 1 "realm-broker" realm.id)
+    ];
+
+  networkRequests = realm:
+    (lib.imap0
+      (i: envName:
+        (request realm "env-${envName}-bridge" "bridge" "shared-partition" 30 i "env-bridge" envName))
+      realm.network.enabledEnvNames)
+    ++ lib.optional (realm.network.mode != "none")
+      (request realm "realm-${realm.id}-netns" "namespace-boundary" "exclusive" 31 0 "realm-network" realm.id);
+
+  resourceRequests = lib.flatten (map
+    (realm: baseRealmRequests realm ++ hostMutationRequests realm ++ networkRequests realm)
+    realmRows);
+
+  realmMetadata = realm: {
+    inherit (realm)
+      realmName
+      enabled
+      placement
+      placementProvider
+      providerSpecificPlacement
+      ;
+    realmId = realm.id;
+    realmPath = realm.path;
+    hostMutation = realm.broker.hostMutation;
+    envNames = realm.network.envNames;
+    providerKeys = realm.providerKeys;
+  };
+
+  data = {
+    schemaVersion = "v2";
+    allocator = {
+      enabled = realmRows != [ ];
+      runtimeState = "metadata-only";
+      rootSocket = allocatorRootSocket;
+      stateDir = allocatorStateDir;
+      leaseLedger = "${allocatorStateDir}/leases.jsonl";
+      auditDir = "${allocatorStateDir}/audit";
+      runtime = {
+        spawnsService = false;
+        socketActivated = false;
+        serviceName = null;
+      };
+    };
+    realms = map realmMetadata realmRows;
+    resourceRequests = resourceRequests;
+    pathPartitions = map pathPartition realmRows;
+    providerPlacements = providerPlacements;
+    envBridge = envBridgeRows;
+    invariants = {
+      noRuntimeAllocatorService = true;
+      preservesEnvRuntimeSourceOfTruth = true;
+      privateMetadataOnly = true;
+    };
+  };
+
+in
+{
+  config = {
+    assertions = [
+      {
+        assertion = builtins.substring 0 9 allocatorRootSocket == "/run/d2b/";
+        message = "d2b allocator.json rootSocket must remain under /run/d2b while runtime is metadata-only.";
+      }
+      {
+        assertion = builtins.stringLength allocatorRootSocket <= 107;
+        message = "d2b allocator.json rootSocket must fit Linux AF_UNIX sockaddr_un.sun_path.";
+      }
+    ];
+
+    d2b._bundle.allocatorJson = {
+      inherit data;
+      installFileName = "allocator.json";
+      classification = "contractPrivateNonSecret";
+      sensitivity = "nonSecret";
+    };
+  };
+}

--- a/nixos-modules/bundle-artifacts.nix
+++ b/nixos-modules/bundle-artifacts.nix
@@ -136,6 +136,7 @@ let
     "privilegesJson"
     "storageJson"
     "syncJson"
+    "allocatorJson"
   ];
 
   shouldInstall = artifact:
@@ -203,6 +204,14 @@ in
       internal = true;
       visible = false;
       description = "Internal typed sync.json artifact metadata.";
+    };
+
+    allocatorJson = lib.mkOption {
+      type = artifactModule;
+      default = { };
+      internal = true;
+      visible = false;
+      description = "Internal typed allocator.json artifact metadata.";
     };
 
     extraArtifacts = lib.mkOption {

--- a/nixos-modules/bundle.nix
+++ b/nixos-modules/bundle.nix
@@ -51,6 +51,10 @@ let
         key = "/etc/d2b/sync.json";
         path = config.d2b._bundle.syncJson.path;
       }
+      {
+        key = "/etc/d2b/allocator.json";
+        path = config.d2b._bundle.allocatorJson.path;
+      }
     ]
     ++ map (ref: {
       key = ref.path;
@@ -69,7 +73,7 @@ let
   # presence of this field; the resolver nullifies it before comparing.
   dataWithoutHash = {
     artifactHashes = null;
-    bundleVersion = 6;
+    bundleVersion = 7;
     schemaVersion = "v2";
     publicManifestPath = "/run/current-system/sw/share/d2b/vms.json";
     hostPath = "/etc/d2b/host.json";
@@ -77,6 +81,7 @@ let
     privilegesPath = "/etc/d2b/privileges.json";
     storagePath = "/etc/d2b/storage.json";
     syncPath = "/etc/d2b/sync.json";
+    allocatorPath = "/etc/d2b/allocator.json";
     closures = closureRefs;
     minijailProfiles = profileRefs;
     managedKeys = {

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -60,6 +60,7 @@
     ./processes-json.nix
     ./storage-json.nix
     ./sync-json.nix
+    ./allocator-json.nix
     ./privileges-json.nix
     ./closures-json.nix
     ./minijail-profiles.nix

--- a/nixos-modules/options-realms.nix
+++ b/nixos-modules/options-realms.nix
@@ -12,6 +12,7 @@ let
 
   label = "^[a-z][a-z0-9-]*$";
   realmPath = "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)*$";
+  providerKind = "^[a-z][a-z0-9-]*$";
   absolutePath = "^/.*$";
 
   placementKinds = [
@@ -39,7 +40,7 @@ let
       };
 
       kind = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
+        type = lib.types.nullOr (lib.types.strMatching providerKind);
         default = null;
         example = "aca";
         description = ''

--- a/nixos-modules/storage-json.nix
+++ b/nixos-modules/storage-json.nix
@@ -87,6 +87,7 @@ let
     "/etc/d2b/privileges.json"
     "/etc/d2b/storage.json"
     "/etc/d2b/sync.json"
+    "/etc/d2b/allocator.json"
   ];
 
   daemonStateReports = [

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -6,8 +6,10 @@ use std::{
 
 use d2b_contract_tests::{read_repo_file, repo_root};
 use d2b_core::{
+    allocator_config::{AllocatorJson, AllocatorRuntimeState},
+    bundle::Bundle,
     processes::ProcessesJson,
-    storage::{StorageJson, StoragePathKind},
+    storage::{SensitivityClass, StorageJson, StoragePathKind},
     sync::{LockKind, SyncJson},
 };
 use regex::Regex;
@@ -36,19 +38,113 @@ fn storage_and_sync_emitters_are_wired_into_private_bundle() {
             "bundle.nix missing storage/sync wiring: {needle}"
         );
     }
-
     let bundle_doc = read_repo_file("docs/reference/manifest-bundle.md");
     assert!(bundle_doc.contains("`storage.json`"));
     assert!(bundle_doc.contains("`sync.json`"));
 }
 
 #[test]
+fn allocator_artifact_is_wired_into_private_bundle() {
+    let default_nix = read_repo_file("nixos-modules/default.nix");
+    assert!(
+        default_nix.contains("./allocator-json.nix"),
+        "default.nix must import allocator-json.nix"
+    );
+
+    let bundle_artifacts = read_repo_file("nixos-modules/bundle-artifacts.nix");
+    assert!(
+        bundle_artifacts.contains("allocatorJson"),
+        "bundle-artifacts.nix must declare allocatorJson metadata"
+    );
+
+    let bundle_nix = read_repo_file("nixos-modules/bundle.nix");
+    for needle in [
+        "allocatorPath = \"/etc/d2b/allocator.json\";",
+        "key = \"/etc/d2b/allocator.json\";",
+    ] {
+        assert!(
+            bundle_nix.contains(needle),
+            "bundle.nix missing allocator wiring: {needle}"
+        );
+    }
+
+    let allocator_nix = read_repo_file("nixos-modules/allocator-json.nix");
+    assert!(allocator_nix.contains("runtimeState = \"metadata-only\";"));
+    assert!(allocator_nix.contains("spawnsService = false;"));
+    assert!(allocator_nix.contains("classification = \"contractPrivateNonSecret\";"));
+    assert!(allocator_nix.contains("sensitivity = \"nonSecret\";"));
+
+    let bundle_doc = read_repo_file("docs/reference/manifest-bundle.md");
+    assert!(bundle_doc.contains("`allocator.json`"));
+}
+
+#[test]
+fn rendered_allocator_contract_shape_and_private_bundle_path_when_fixture_available() {
+    let Some(dir) = env::var_os("D2B_FIXTURES").map(PathBuf::from) else {
+        eprintln!("  (skipping rendered allocator contract check; D2B_FIXTURES unset)");
+        return;
+    };
+
+    let allocator: AllocatorJson = read_json(&dir, "allocator.json");
+    let bundle: Bundle = read_json(&dir, "bundle.json");
+    let storage: StorageJson = read_json(&dir, "storage.json");
+
+    assert_eq!(allocator.schema_version, "v2");
+    assert_eq!(
+        allocator.allocator.runtime_state,
+        AllocatorRuntimeState::MetadataOnly
+    );
+    assert!(!allocator.allocator.runtime.spawns_service);
+    assert!(!allocator.allocator.runtime.socket_activated);
+    assert!(allocator.allocator.runtime.service_name.is_none());
+    assert_eq!(
+        allocator.allocator.root_socket.as_str(),
+        "/run/d2b/allocator/local-root.sock"
+    );
+    assert_eq!(
+        allocator.allocator.lease_ledger.as_str(),
+        "/var/lib/d2b/allocator/leases.jsonl"
+    );
+    assert!(allocator.invariants.no_runtime_allocator_service);
+    assert!(allocator.invariants.preserves_env_runtime_source_of_truth);
+    assert!(allocator.invariants.private_metadata_only);
+
+    let mut resource_ids = BTreeSet::new();
+    for request in &allocator.resource_requests {
+        assert!(
+            resource_ids.insert(request.resource_id.as_str()),
+            "allocator resource id rendered more than once: {}",
+            request.resource_id
+        );
+        assert!(
+            !request.realm_path.is_empty(),
+            "allocator resource requests must remain rooted in a realm path"
+        );
+    }
+
+    assert_eq!(
+        bundle.allocator_path.as_deref(),
+        Some("/etc/d2b/allocator.json")
+    );
+    let allocator_path = storage
+        .paths
+        .iter()
+        .find(|path| path.path_template.as_str() == "/etc/d2b/allocator.json")
+        .expect("storage.json covers allocator.json as a private bundle artifact");
+    assert_eq!(allocator_path.kind, StoragePathKind::RegularFile);
+    assert_eq!(allocator_path.sensitivity, SensitivityClass::Private);
+    assert_eq!(allocator_path.mode, "0640");
+}
+
+#[test]
 fn storage_and_sync_schemas_are_committed_and_closed() {
     let storage_schema = read_repo_file("docs/reference/schemas/v2/storage.json");
     let sync_schema = read_repo_file("docs/reference/schemas/v2/sync.json");
+    let allocator_schema = read_repo_file("docs/reference/schemas/v2/allocator.json");
     for (name, schema) in [
         ("storage.json", storage_schema.as_str()),
         ("sync.json", sync_schema.as_str()),
+        ("allocator.json", allocator_schema.as_str()),
     ] {
         assert!(
             schema.contains("\"additionalProperties\": false"),
@@ -60,6 +156,8 @@ fn storage_and_sync_schemas_are_committed_and_closed() {
     assert!(sync_schema.contains("\"ofd\""));
     assert!(sync_schema.contains("\"scm-rights\""));
     assert!(sync_schema.contains("\"explicit-fd-mapping\""));
+    assert!(allocator_schema.contains("\"metadata-only\""));
+    assert!(allocator_schema.contains("\"namespace-boundary\""));
 }
 
 #[test]
@@ -166,6 +264,13 @@ fn rendered_storage_contract_covers_process_writable_paths_when_fixture_availabl
             .iter()
             .any(|path| path.path_template.as_str() == "/etc/d2b/sync.json"),
         "storage.json must describe sync.json as a private bundle artifact"
+    );
+    assert!(
+        storage
+            .paths
+            .iter()
+            .any(|path| path.path_template.as_str() == "/etc/d2b/allocator.json"),
+        "storage.json must describe allocator.json as a private bundle artifact"
     );
     assert!(
         storage

--- a/packages/d2b-core/fuzz/src/bin/core.rs
+++ b/packages/d2b-core/fuzz/src/bin/core.rs
@@ -317,6 +317,7 @@ fn build_synthetic_resolver() -> BundleResolver {
         privileges_path: "/etc/d2b/privileges.json".to_owned(),
         storage_path: None,
         sync_path: None,
+        allocator_path: None,
         closures: Vec::new(),
         minijail_profiles: Vec::new(),
         managed_keys: BundleManagedKeys::default(),

--- a/packages/d2b-core/src/allocator_config.rs
+++ b/packages/d2b-core/src/allocator_config.rs
@@ -1,0 +1,331 @@
+use schemars::{
+    JsonSchema,
+    r#gen::SchemaGenerator,
+    schema::{InstanceType, Schema, SchemaObject, SingleOrVec, StringValidation},
+};
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::contract_id::{ContractId, ContractStringError, PathTemplate};
+
+pub const MAX_ALLOCATOR_REALM_PATH_BYTES: usize = 255;
+pub const MAX_ALLOCATOR_REALM_PATH_LABELS: usize = 16;
+pub const MAX_ALLOCATOR_PROVIDER_KIND_BYTES: usize = 64;
+
+const ALLOCATOR_REALM_PATH_PATTERN: &str = "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){0,15}$";
+const ALLOCATOR_PROVIDER_KIND_PATTERN: &str = "^[a-z][a-z0-9-]*$";
+
+fn validate_realm_path(raw: String) -> Result<String, ContractStringError> {
+    if raw.is_empty() {
+        return Err(ContractStringError::Empty);
+    }
+    if raw.len() > MAX_ALLOCATOR_REALM_PATH_BYTES {
+        return Err(ContractStringError::TooLong {
+            max: MAX_ALLOCATOR_REALM_PATH_BYTES,
+        });
+    }
+
+    let labels = raw.split('.').collect::<Vec<_>>();
+    if labels.is_empty() || labels.len() > MAX_ALLOCATOR_REALM_PATH_LABELS {
+        return Err(ContractStringError::BadShape);
+    }
+    if labels.iter().all(|label| {
+        let mut chars = label.chars();
+        matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+            && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    }) {
+        Ok(raw)
+    } else {
+        Err(ContractStringError::BadShape)
+    }
+}
+
+fn validate_provider_kind(raw: String) -> Result<String, ContractStringError> {
+    if raw.is_empty() {
+        return Err(ContractStringError::Empty);
+    }
+    if raw.len() > MAX_ALLOCATOR_PROVIDER_KIND_BYTES {
+        return Err(ContractStringError::TooLong {
+            max: MAX_ALLOCATOR_PROVIDER_KIND_BYTES,
+        });
+    }
+
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return Err(ContractStringError::BadShape),
+    }
+    if chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+        Ok(raw)
+    } else {
+        Err(ContractStringError::BadShape)
+    }
+}
+
+macro_rules! allocator_string {
+    ($name:ident, $parse_fn:ident, $max:expr, $pattern:expr, $description:expr) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn parse(raw: impl Into<String>) -> Result<Self, ContractStringError> {
+                $parse_fn(raw.into()).map(Self)
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn is_empty(&self) -> bool {
+                self.0.is_empty()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Self::parse(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+            }
+        }
+
+        impl JsonSchema for $name {
+            fn schema_name() -> String {
+                stringify!($name).to_owned()
+            }
+
+            fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+                Schema::Object(SchemaObject {
+                    instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
+                    string: Some(Box::new(StringValidation {
+                        max_length: Some($max as u32),
+                        min_length: Some(1),
+                        pattern: Some($pattern.to_owned()),
+                    })),
+                    metadata: Some(Box::new(schemars::schema::Metadata {
+                        description: Some($description.to_owned()),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })
+            }
+        }
+    };
+}
+
+allocator_string!(
+    AllocatorRealmPath,
+    validate_realm_path,
+    MAX_ALLOCATOR_REALM_PATH_BYTES,
+    ALLOCATOR_REALM_PATH_PATTERN,
+    "Realm path copied from d2b.realms, most-specific first, with 1-16 DNS-style labels and a 255-byte cap."
+);
+
+allocator_string!(
+    AllocatorProviderKind,
+    validate_provider_kind,
+    MAX_ALLOCATOR_PROVIDER_KIND_BYTES,
+    ALLOCATOR_PROVIDER_KIND_PATTERN,
+    "Opaque provider adapter kind slug, bounded for schema-only allocator metadata."
+);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorJson {
+    pub schema_version: String,
+    pub allocator: AllocatorRoot,
+    pub realms: Vec<AllocatorRealm>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resource_requests: Vec<AllocatorResourceRequest>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_partitions: Vec<AllocatorPathPartition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_placements: Vec<AllocatorProviderPlacement>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_bridge: Vec<AllocatorEnvBridge>,
+    pub invariants: AllocatorInvariants,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorRoot {
+    pub enabled: bool,
+    pub runtime_state: AllocatorRuntimeState,
+    pub root_socket: PathTemplate,
+    pub state_dir: PathTemplate,
+    pub lease_ledger: PathTemplate,
+    pub audit_dir: PathTemplate,
+    pub runtime: AllocatorRuntime,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorRuntimeState {
+    MetadataOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorRuntime {
+    pub spawns_service: bool,
+    pub socket_activated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorRealm {
+    pub realm_name: String,
+    pub realm_id: ContractId,
+    pub realm_path: AllocatorRealmPath,
+    pub enabled: bool,
+    pub placement: RealmPlacement,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_provider: Option<ContractId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_specific_placement: Option<String>,
+    pub host_mutation: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealmPlacement {
+    HostLocal,
+    GatewayVm,
+    CloudFullHost,
+    ProviderController,
+    ProviderAgent,
+    ProviderSpecific,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorResourceRequest {
+    pub realm_path: AllocatorRealmPath,
+    pub resource_id: ContractId,
+    pub kind: AllocatorHostResourceKind,
+    pub share: AllocatorResourceShare,
+    pub acquisition_order: AllocatorAcquisitionOrder,
+    pub source: AllocatorResourceSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorHostResourceKind {
+    Bridge,
+    Tap,
+    VethPair,
+    NftablesTable,
+    NftablesPartition,
+    CgroupSubtree,
+    HostFilePartition,
+    NamespaceBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorResourceShare {
+    Exclusive,
+    SharedPartition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorAcquisitionOrder {
+    pub phase: u16,
+    pub ordinal: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorResourceSource {
+    pub kind: AllocatorResourceSourceKind,
+    pub ref_name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorResourceSourceKind {
+    RealmPath,
+    RealmSocket,
+    RealmStateDir,
+    RealmRunDir,
+    RealmAuditDir,
+    RealmNetwork,
+    RealmBroker,
+    EnvBridge,
+    EnvNetVm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorPathPartition {
+    pub realm_path: AllocatorRealmPath,
+    pub state_dir: PathTemplate,
+    pub run_dir: PathTemplate,
+    pub audit_dir: PathTemplate,
+    pub public_socket: PathTemplate,
+    pub broker_socket: PathTemplate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorProviderPlacement {
+    pub realm_path: AllocatorRealmPath,
+    pub provider_name: String,
+    pub provider_id: ContractId,
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<AllocatorProviderKind>,
+    pub placement: RealmPlacement,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capability_refs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorEnvBridge {
+    pub realm_path: AllocatorRealmPath,
+    pub env_name: String,
+    pub declared: bool,
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<AllocatorEnvBridgeMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub net_vm: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lan_bridge: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uplink_bridge: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllocatorInvariants {
+    pub no_runtime_allocator_service: bool,
+    pub preserves_env_runtime_source_of_truth: bool,
+    pub private_metadata_only: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorEnvBridgeMode {
+    None,
+    InheritEnv,
+    Declared,
+    External,
+}

--- a/packages/d2b-core/src/bundle.rs
+++ b/packages/d2b-core/src/bundle.rs
@@ -8,9 +8,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Bundle {
-    /// Version of the bundle format; bundleVersion 6 adds the private
-    /// storage lifecycle and synchronization artifacts while artifact
-    /// schemaVersion stays v2.
+    /// Version of the bundle format; bundleVersion 7 adds allocator metadata
+    /// while artifact schemaVersion stays v2.
     pub bundle_version: u32,
     /// Schema version directory used to validate all artifacts in this bundle.
     pub schema_version: String,
@@ -28,6 +27,9 @@ pub struct Bundle {
     /// Private synchronization/lock contract artifact path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sync_path: Option<String>,
+    /// Private local-root allocator metadata artifact path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allocator_path: Option<String>,
     /// Per-VM closure artifact paths keyed by VM name.
     pub closures: Vec<BundleClosureRef>,
     /// Minijail profile metadata paths shipped with the bundle.
@@ -51,10 +53,10 @@ pub struct Bundle {
     /// Per-artifact SHA-256 hashes for tamper detection of every private
     /// bundle artifact loaded by the resolver.
     ///
-    /// Keys match the path strings stored in the bundle path fields:
-    /// absolute paths for `host_path`, `processes_path`, `privileges_path`,
-    /// `storage_path`, and `sync_path`; bundle-relative paths for
-    /// `closures[*].path` and `minijail_profiles[*].path`. Values are
+    /// Keys match the path strings stored in the bundle path fields: absolute
+    /// paths for `host_path`, `processes_path`, `privileges_path`,
+    /// `storage_path`, `sync_path`, and `allocator_path`; bundle-relative paths
+    /// for `closures[*].path` and `minijail_profiles[*].path`. Values are
     /// `"sha256:<hex64>"` strings.
     ///
     /// When `None`, per-artifact hash verification is skipped (backwards

--- a/packages/d2b-core/src/bundle_resolver.rs
+++ b/packages/d2b-core/src/bundle_resolver.rs
@@ -2959,6 +2959,7 @@ mod tests {
                 privileges_path: "privileges.json".to_owned(),
                 storage_path: None,
                 sync_path: None,
+                allocator_path: None,
                 closures: Vec::new(),
                 minijail_profiles: Vec::new(),
                 managed_keys: Default::default(),
@@ -3299,6 +3300,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: None,
             sync_path: None,
+            allocator_path: None,
             closures: vec![BundleClosureRef {
                 vm: "personal-dev".to_owned(),
                 path: "closures/personal-dev.json".to_owned(),

--- a/packages/d2b-core/src/lib.rs
+++ b/packages/d2b-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = "Canonical data transfer objects for d2b bundle artifacts."]
 
+pub mod allocator_config;
 pub mod audio_policy;
 pub mod base64_codec;
 pub mod bundle;

--- a/packages/d2b-core/tests/allocator_config.rs
+++ b/packages/d2b-core/tests/allocator_config.rs
@@ -1,0 +1,76 @@
+use d2b_core::allocator_config::{
+    AllocatorEnvBridgeMode, AllocatorJson, AllocatorProviderKind, AllocatorRealmPath,
+    MAX_ALLOCATOR_PROVIDER_KIND_BYTES, MAX_ALLOCATOR_REALM_PATH_LABELS,
+};
+
+#[test]
+fn allocator_realm_path_bounds_are_enforced() {
+    assert!(AllocatorRealmPath::parse("payments.work").is_ok());
+    assert!(AllocatorRealmPath::parse("").is_err());
+    assert!(AllocatorRealmPath::parse("Work").is_err());
+    assert!(AllocatorRealmPath::parse("work..payments").is_err());
+
+    let too_many = std::iter::repeat("a")
+        .take(MAX_ALLOCATOR_REALM_PATH_LABELS + 1)
+        .collect::<Vec<_>>()
+        .join(".");
+    assert!(AllocatorRealmPath::parse(too_many).is_err());
+}
+
+#[test]
+fn allocator_provider_kind_is_bounded_slug() {
+    assert!(AllocatorProviderKind::parse("aca").is_ok());
+    assert!(AllocatorProviderKind::parse("azure-container-apps").is_ok());
+    assert!(AllocatorProviderKind::parse("Azure").is_err());
+    assert!(AllocatorProviderKind::parse("aca/provider").is_err());
+    assert!(
+        AllocatorProviderKind::parse("a".repeat(MAX_ALLOCATOR_PROVIDER_KIND_BYTES + 1)).is_err()
+    );
+}
+
+#[test]
+fn allocator_env_bridge_mode_is_closed_on_decode() {
+    let json = r#"{
+      "schemaVersion": "v2",
+      "allocator": {
+        "enabled": true,
+        "runtimeState": "metadata-only",
+        "rootSocket": "/run/d2b/allocator/local-root.sock",
+        "stateDir": "/var/lib/d2b/allocator",
+        "leaseLedger": "/var/lib/d2b/allocator/leases.jsonl",
+        "auditDir": "/var/lib/d2b/allocator/audit",
+        "runtime": {
+          "spawnsService": false,
+          "socketActivated": false
+        }
+      },
+      "realms": [{
+        "realmName": "work",
+        "realmId": "work",
+        "realmPath": "work",
+        "enabled": true,
+        "placement": "host-local",
+        "hostMutation": false
+      }],
+      "envBridge": [{
+        "realmPath": "work",
+        "envName": "work",
+        "declared": true,
+        "enabled": true,
+        "mode": "inherit-env"
+      }],
+      "invariants": {
+        "noRuntimeAllocatorService": true,
+        "preservesEnvRuntimeSourceOfTruth": true,
+        "privateMetadataOnly": true
+      }
+    }"#;
+    let parsed: AllocatorJson = serde_json::from_str(json).expect("closed mode parses");
+    assert_eq!(
+        parsed.env_bridge[0].mode,
+        Some(AllocatorEnvBridgeMode::InheritEnv)
+    );
+
+    let bad = json.replace("\"inherit-env\"", "\"surprise\"");
+    assert!(serde_json::from_str::<AllocatorJson>(&bad).is_err());
+}

--- a/packages/d2b-core/tests/allocator_config.rs
+++ b/packages/d2b-core/tests/allocator_config.rs
@@ -10,8 +10,7 @@ fn allocator_realm_path_bounds_are_enforced() {
     assert!(AllocatorRealmPath::parse("Work").is_err());
     assert!(AllocatorRealmPath::parse("work..payments").is_err());
 
-    let too_many = std::iter::repeat("a")
-        .take(MAX_ALLOCATOR_REALM_PATH_LABELS + 1)
+    let too_many = std::iter::repeat_n("a", MAX_ALLOCATOR_REALM_PATH_LABELS + 1)
         .collect::<Vec<_>>()
         .join(".");
     assert!(AllocatorRealmPath::parse(too_many).is_err());

--- a/packages/d2b-core/tests/bundle_resolver_runner_intent_parity.rs
+++ b/packages/d2b-core/tests/bundle_resolver_runner_intent_parity.rs
@@ -84,6 +84,7 @@ fn bundle() -> Bundle {
         privileges_path: "privileges.json".to_owned(),
         storage_path: None,
         sync_path: None,
+        allocator_path: None,
         closures: Vec::new(),
         minijail_profiles: Vec::new(),
         managed_keys: Default::default(),

--- a/packages/d2b-priv-broker/src/ops/storage_contract.rs
+++ b/packages/d2b-priv-broker/src/ops/storage_contract.rs
@@ -636,6 +636,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: Some("storage.json".to_owned()),
             sync_path: Some("sync.json".to_owned()),
+            allocator_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/d2b-priv-broker/src/ops/tap.rs
+++ b/packages/d2b-priv-broker/src/ops/tap.rs
@@ -918,6 +918,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: None,
             sync_path: None,
+            allocator_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/d2b-priv-broker/src/runtime.rs
+++ b/packages/d2b-priv-broker/src/runtime.rs
@@ -9750,6 +9750,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: None,
             sync_path: None,
+            allocator_path: None,
             closures: vec![BundleClosureRef {
                 vm: "corp-vm".to_owned(),
                 path: "closures/corp-vm.json".to_owned(),

--- a/packages/d2b-priv-broker/tests/w15_install_migrate.rs
+++ b/packages/d2b-priv-broker/tests/w15_install_migrate.rs
@@ -60,6 +60,7 @@ fn installer_bundle_resolver(public_manifest_path: &str) -> BundleResolver {
         privileges_path: "/ignored/privileges.json".to_owned(),
         storage_path: None,
         sync_path: None,
+            allocator_path: None,
         closures: Vec::new(),
         minijail_profiles: Vec::new(),
         managed_keys: BundleManagedKeys::default(),

--- a/packages/d2b-realm-core/src/allocator.rs
+++ b/packages/d2b-realm-core/src/allocator.rs
@@ -1,0 +1,1152 @@
+//! Pure local-root host-resource allocator DTOs (ADR 0043).
+//!
+//! This module defines the shared contract for typed host-resource leases,
+//! reconciliation observations, and bounded allocator audit/metric metadata. It
+//! intentionally contains no netlink, nftables, filesystem, broker, daemon, or
+//! provider implementation code.
+
+use crate::ids::{
+    AllocatorLeaseId, ControllerGenerationId, CorrelationId, HostResourceId, IdempotencyKey,
+    NodeId, OperationId,
+};
+use crate::realm::RealmPath;
+use crate::trace_context::TraceContext;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeSet;
+
+/// Maximum resources in a single allocator lease request.
+pub const MAX_ALLOCATOR_REQUEST_RESOURCES: usize = 32;
+/// Maximum conflicts carried in a denial response.
+pub const MAX_ALLOCATOR_CONFLICTS: usize = 16;
+/// Maximum records in one reconciliation report.
+pub const MAX_RECONCILIATION_RECORDS: usize = 128;
+/// Maximum allocator events in one bounded metadata batch.
+pub const MAX_ALLOCATOR_EVENTS: usize = 128;
+
+/// Closed host-resource kinds the local root allocator can arbitrate.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum HostResourceKind {
+    Bridge,
+    Tap,
+    VethPair,
+    NftablesTable,
+    NftablesPartition,
+    CgroupSubtree,
+    HostFilePartition,
+    NamespaceBoundary,
+}
+
+impl HostResourceKind {
+    /// Stable low-cardinality metric label for this resource kind.
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::Bridge => "bridge",
+            Self::Tap => "tap",
+            Self::VethPair => "veth-pair",
+            Self::NftablesTable => "nftables-table",
+            Self::NftablesPartition => "nftables-partition",
+            Self::CgroupSubtree => "cgroup-subtree",
+            Self::HostFilePartition => "host-file-partition",
+            Self::NamespaceBoundary => "namespace-boundary",
+        }
+    }
+}
+
+/// The realm-controller generation that owns a lease.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LeaseOwner {
+    /// Owning realm path.
+    pub realm: RealmPath,
+    /// Active controller generation that requested the lease.
+    pub controller_generation: ControllerGenerationId,
+    /// Realm node/broker identity, when the caller has one bound.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub node: Option<NodeId>,
+}
+
+/// Shared-vs-exclusive resource semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ResourceShareMode {
+    /// No other owner may hold the same resource id.
+    Exclusive,
+    /// The allocator grants a partition inside a shared resource.
+    SharedPartition,
+}
+
+/// Explicit acquisition order used for multi-resource requests.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceAcquisitionOrder {
+    /// Coarse phase. Lower phases are acquired first.
+    pub phase: u16,
+    /// Order within the phase. Lower ordinals are acquired first.
+    pub ordinal: u16,
+}
+
+/// One resource requested from the local-root allocator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LeaseResourceRequest {
+    /// Opaque requested resource/partition id.
+    pub resource_id: HostResourceId,
+    /// Resource kind.
+    pub kind: HostResourceKind,
+    /// Sharing contract.
+    pub share: ResourceShareMode,
+    /// Total acquisition order metadata.
+    pub acquisition_order: ResourceAcquisitionOrder,
+}
+
+impl LeaseResourceRequest {
+    fn acquisition_key(&self) -> ResourceAcquisitionKey {
+        ResourceAcquisitionKey {
+            order: self.acquisition_order,
+            kind: self.kind,
+            resource_id: self.resource_id.clone(),
+        }
+    }
+}
+
+/// Deterministic total-order key for resource acquisition.
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceAcquisitionKey {
+    pub order: ResourceAcquisitionOrder,
+    pub kind: HostResourceKind,
+    pub resource_id: HostResourceId,
+}
+
+/// Mutating lease allocation request. Idempotency is mandatory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LeaseAllocationRequest {
+    /// Per-attempt operation id.
+    pub operation_id: OperationId,
+    /// Cross-realm correlation id.
+    pub correlation_id: CorrelationId,
+    /// Caller-generated dedup key for at-least-once delivery.
+    pub idempotency_key: IdempotencyKey,
+    /// Lease owner realm/controller generation.
+    pub owner: LeaseOwner,
+    /// Requested host resources.
+    #[schemars(length(min = 1, max = 32))]
+    pub resources: Vec<LeaseResourceRequest>,
+    /// Optional bounded trace metadata.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub trace: Option<TraceContext>,
+}
+
+impl<'de> Deserialize<'de> for LeaseAllocationRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Raw {
+            operation_id: OperationId,
+            correlation_id: CorrelationId,
+            idempotency_key: IdempotencyKey,
+            owner: LeaseOwner,
+            resources: Vec<LeaseResourceRequest>,
+            #[serde(default)]
+            trace: Option<TraceContext>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        validate_resource_requests(&raw.resources).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            operation_id: raw.operation_id,
+            correlation_id: raw.correlation_id,
+            idempotency_key: raw.idempotency_key,
+            owner: raw.owner,
+            resources: raw.resources,
+            trace: raw.trace,
+        })
+    }
+}
+
+impl LeaseAllocationRequest {
+    /// Resource acquisition keys in deterministic total order. Ties in the
+    /// caller-supplied phase/ordinal are broken by closed resource kind and
+    /// opaque resource id so every participant can sort identically.
+    pub fn acquisition_order(&self) -> Vec<ResourceAcquisitionKey> {
+        let mut ordered = self
+            .resources
+            .iter()
+            .map(LeaseResourceRequest::acquisition_key)
+            .collect::<Vec<_>>();
+        ordered.sort();
+        ordered
+    }
+}
+
+/// How a granted resource is delegated to a realm broker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum ResourceDelegation {
+    /// Delegated opaque name/handle. It is not a raw interface/path name.
+    OpaqueName { id: HostResourceId },
+    /// FD handoff placeholder id used only for correlation before SCM_RIGHTS.
+    FileDescriptor { id: HostResourceId },
+    /// Shared-resource partition id.
+    PartitionId { id: HostResourceId },
+    /// Namespace-boundary handle id.
+    NamespaceHandle { id: HostResourceId },
+}
+
+/// One resource granted under a lease.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GrantedHostResource {
+    pub resource_id: HostResourceId,
+    pub kind: HostResourceKind,
+    pub share: ResourceShareMode,
+    pub delegation: ResourceDelegation,
+    pub acquisition_order: ResourceAcquisitionOrder,
+}
+
+/// Allocator lease lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorLeaseState {
+    Granted,
+    Reconciled,
+    Quarantined,
+    Reclaimed,
+    Denied,
+}
+
+impl AllocatorLeaseState {
+    /// Terminal states cannot transition to an active lease.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Reclaimed | Self::Denied)
+    }
+
+    /// Pure DTO helper for fail-closed state-machine checks.
+    pub fn can_transition_to(self, next: Self) -> bool {
+        use AllocatorLeaseState as S;
+        matches!(
+            (self, next),
+            (S::Granted, S::Reconciled)
+                | (S::Granted, S::Quarantined)
+                | (S::Granted, S::Reclaimed)
+                | (S::Reconciled, S::Quarantined)
+                | (S::Reconciled, S::Reclaimed)
+                | (S::Quarantined, S::Reconciled)
+                | (S::Quarantined, S::Reclaimed)
+        )
+    }
+}
+
+/// Persisted allocator lease record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AllocatorLease {
+    pub lease_id: AllocatorLeaseId,
+    pub owner: LeaseOwner,
+    pub state: AllocatorLeaseState,
+    #[schemars(length(min = 1, max = 32))]
+    pub resources: Vec<GrantedHostResource>,
+}
+
+impl<'de> Deserialize<'de> for AllocatorLease {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Raw {
+            lease_id: AllocatorLeaseId,
+            owner: LeaseOwner,
+            state: AllocatorLeaseState,
+            resources: Vec<GrantedHostResource>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        validate_granted_resources(&raw.resources).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            lease_id: raw.lease_id,
+            owner: raw.owner,
+            state: raw.state,
+            resources: raw.resources,
+        })
+    }
+}
+
+/// Closed, low-cardinality allocator denial/conflict/quarantine reasons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorReasonCode {
+    ResourceConflict,
+    OwnershipConflict,
+    AcquisitionOrderViolation,
+    InvalidRequest,
+    CapacityExhausted,
+    DriftDetected,
+    ReconcileMismatch,
+    OwnerNotLive,
+    PolicyDenied,
+    UnsupportedKind,
+    StorageContractViolation,
+    KernelStateUnknown,
+}
+
+impl AllocatorReasonCode {
+    /// Stable low-cardinality metric label.
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::ResourceConflict => "resource-conflict",
+            Self::OwnershipConflict => "ownership-conflict",
+            Self::AcquisitionOrderViolation => "acquisition-order-violation",
+            Self::InvalidRequest => "invalid-request",
+            Self::CapacityExhausted => "capacity-exhausted",
+            Self::DriftDetected => "drift-detected",
+            Self::ReconcileMismatch => "reconcile-mismatch",
+            Self::OwnerNotLive => "owner-not-live",
+            Self::PolicyDenied => "policy-denied",
+            Self::UnsupportedKind => "unsupported-kind",
+            Self::StorageContractViolation => "storage-contract-violation",
+            Self::KernelStateUnknown => "kernel-state-unknown",
+        }
+    }
+}
+
+/// Low-cardinality reason count; keep this small before adding new labels.
+pub const ALLOCATOR_REASON_CODE_COUNT: usize = 12;
+
+/// Conflict metadata returned on denial. Only opaque ids and closed reasons.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AllocatorConflict {
+    pub resource_id: HostResourceId,
+    pub kind: HostResourceKind,
+    pub reason: AllocatorReasonCode,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub existing_lease: Option<AllocatorLeaseId>,
+}
+
+/// Allocator response to a typed lease request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LeaseAllocationResponse {
+    pub operation_id: OperationId,
+    pub correlation_id: CorrelationId,
+    pub result: LeaseAllocationResult,
+}
+
+/// Granted or fail-closed denied allocation result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case", tag = "status", deny_unknown_fields)]
+pub enum LeaseAllocationResult {
+    Granted {
+        lease: AllocatorLease,
+    },
+    Denied {
+        reason: AllocatorReasonCode,
+        #[schemars(length(max = 16))]
+        conflicts: Vec<AllocatorConflict>,
+    },
+}
+
+impl<'de> Deserialize<'de> for LeaseAllocationResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["status", "lease", "reason", "conflicts"];
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        enum Status {
+            Granted,
+            Denied,
+        }
+
+        struct ResultVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for ResultVisitor {
+            type Value = LeaseAllocationResult;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("lease allocation result")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut status = None;
+                let mut lease_present = false;
+                let mut lease = None;
+                let mut reason_present = false;
+                let mut reason = None;
+                let mut conflicts_present = false;
+                let mut conflicts = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "status" => {
+                            if status.is_some() {
+                                return Err(serde::de::Error::duplicate_field("status"));
+                            }
+                            status = Some(map.next_value::<Status>()?);
+                        }
+                        "lease" => {
+                            if lease_present {
+                                return Err(serde::de::Error::duplicate_field("lease"));
+                            }
+                            lease_present = true;
+                            lease = map.next_value::<Option<AllocatorLease>>()?;
+                        }
+                        "reason" => {
+                            if reason_present {
+                                return Err(serde::de::Error::duplicate_field("reason"));
+                            }
+                            reason_present = true;
+                            reason = map.next_value::<Option<AllocatorReasonCode>>()?;
+                        }
+                        "conflicts" => {
+                            if conflicts_present {
+                                return Err(serde::de::Error::duplicate_field("conflicts"));
+                            }
+                            conflicts_present = true;
+                            conflicts = map.next_value::<Option<Vec<AllocatorConflict>>>()?;
+                        }
+                        other => return Err(serde::de::Error::unknown_field(other, FIELDS)),
+                    }
+                }
+
+                let status = status.ok_or_else(|| serde::de::Error::missing_field("status"))?;
+                match status {
+                    Status::Granted => {
+                        if reason_present || conflicts_present {
+                            return Err(serde::de::Error::custom(
+                                "granted allocation result must not carry denial fields",
+                            ));
+                        }
+                        if !lease_present {
+                            return Err(serde::de::Error::missing_field("lease"));
+                        }
+                        lease
+                            .map(|lease| LeaseAllocationResult::Granted { lease })
+                            .ok_or_else(|| {
+                                serde::de::Error::custom(
+                                    "granted allocation result requires non-null lease",
+                                )
+                            })
+                    }
+                    Status::Denied => {
+                        if lease_present {
+                            return Err(serde::de::Error::custom(
+                                "denied allocation result must not carry lease",
+                            ));
+                        }
+                        if !reason_present {
+                            return Err(serde::de::Error::missing_field("reason"));
+                        }
+                        let reason = reason.ok_or_else(|| {
+                            serde::de::Error::custom(
+                                "denied allocation result requires non-null reason",
+                            )
+                        })?;
+                        if !conflicts_present {
+                            return Err(serde::de::Error::missing_field("conflicts"));
+                        }
+                        let conflicts = conflicts.ok_or_else(|| {
+                            serde::de::Error::custom(
+                                "denied allocation result requires non-null conflicts",
+                            )
+                        })?;
+                        validate_len(&conflicts, MAX_ALLOCATOR_CONFLICTS, "conflicts")
+                            .map_err(serde::de::Error::custom)?;
+                        Ok(LeaseAllocationResult::Denied { reason, conflicts })
+                    }
+                }
+            }
+        }
+
+        deserializer.deserialize_map(ResultVisitor)
+    }
+}
+
+/// Bounded allocator audit/metric event kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AllocatorEventKind {
+    Grant,
+    Denial,
+    Conflict,
+    Reconciliation,
+    Reclamation,
+    Quarantine,
+}
+
+impl AllocatorEventKind {
+    /// Stable low-cardinality metric label.
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::Grant => "grant",
+            Self::Denial => "denial",
+            Self::Conflict => "conflict",
+            Self::Reconciliation => "reconciliation",
+            Self::Reclamation => "reclamation",
+            Self::Quarantine => "quarantine",
+        }
+    }
+}
+
+/// Bounded allocator event metadata. Carries no paths, interface names,
+/// command output, or credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AllocatorEventMetadata {
+    pub operation_id: OperationId,
+    pub correlation_id: CorrelationId,
+    pub owner: LeaseOwner,
+    pub event: AllocatorEventKind,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub resource_kind: Option<HostResourceKind>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reason: Option<AllocatorReasonCode>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub trace: Option<TraceContext>,
+}
+
+/// Persisted resource lease metadata from the allocator ledger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PersistedResourceLease {
+    pub lease_id: AllocatorLeaseId,
+    pub owner: LeaseOwner,
+    pub state: AllocatorLeaseState,
+}
+
+/// Contract-only source for observed host state. These values describe which
+/// subsystem produced an observation; they do not imply an implementation here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ResourceObservationSource {
+    KernelNetlink,
+    NftablesApi,
+    CgroupFs,
+    HostFilesystem,
+    NamespaceRegistry,
+    AllocatorLedger,
+}
+
+/// Kernel/host-observed state for one resource id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ObservedResourceState {
+    Present,
+    Missing,
+    ForeignOwner,
+    Ambiguous,
+    Inaccessible,
+}
+
+/// Host-resource observation from the live system side of reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ObservedHostResource {
+    pub resource_id: HostResourceId,
+    pub kind: HostResourceKind,
+    pub source: ResourceObservationSource,
+    pub state: ObservedResourceState,
+}
+
+/// Reconciliation decision for a persisted/live observation pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case", tag = "decision", deny_unknown_fields)]
+pub enum ReconciliationDecision {
+    Reconciled,
+    Quarantine { reason: AllocatorReasonCode },
+    Reclaim { reason: AllocatorReasonCode },
+    Deny { reason: AllocatorReasonCode },
+}
+
+impl ReconciliationDecision {
+    /// True when this decision prevents reuse until remediation.
+    pub fn is_fail_closed(&self) -> bool {
+        matches!(
+            self,
+            Self::Quarantine { .. } | Self::Deny { .. } | Self::Reclaim { .. }
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for ReconciliationDecision {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["decision", "reason"];
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        enum Decision {
+            Reconciled,
+            Quarantine,
+            Reclaim,
+            Deny,
+        }
+
+        struct DecisionVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for DecisionVisitor {
+            type Value = ReconciliationDecision;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("reconciliation decision")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut decision = None;
+                let mut reason_present = false;
+                let mut reason = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "decision" => {
+                            if decision.is_some() {
+                                return Err(serde::de::Error::duplicate_field("decision"));
+                            }
+                            decision = Some(map.next_value::<Decision>()?);
+                        }
+                        "reason" => {
+                            if reason_present {
+                                return Err(serde::de::Error::duplicate_field("reason"));
+                            }
+                            reason_present = true;
+                            reason = map.next_value::<Option<AllocatorReasonCode>>()?;
+                        }
+                        other => return Err(serde::de::Error::unknown_field(other, FIELDS)),
+                    }
+                }
+
+                let decision =
+                    decision.ok_or_else(|| serde::de::Error::missing_field("decision"))?;
+                match decision {
+                    Decision::Reconciled => {
+                        if reason_present {
+                            Err(serde::de::Error::custom(
+                                "reconciled decision must not carry reason",
+                            ))
+                        } else {
+                            Ok(ReconciliationDecision::Reconciled)
+                        }
+                    }
+                    Decision::Quarantine => reason
+                        .map(|reason| ReconciliationDecision::Quarantine { reason })
+                        .ok_or_else(|| {
+                            serde::de::Error::custom("quarantine decision requires non-null reason")
+                        }),
+                    Decision::Reclaim => reason
+                        .map(|reason| ReconciliationDecision::Reclaim { reason })
+                        .ok_or_else(|| {
+                            serde::de::Error::custom("reclaim decision requires non-null reason")
+                        }),
+                    Decision::Deny => reason
+                        .map(|reason| ReconciliationDecision::Deny { reason })
+                        .ok_or_else(|| {
+                            serde::de::Error::custom("deny decision requires non-null reason")
+                        }),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(DecisionVisitor)
+    }
+}
+
+/// One reconciliation record distinguishes persisted lease state from
+/// live kernel/host-observed state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReconciliationRecord {
+    pub resource_id: HostResourceId,
+    pub kind: HostResourceKind,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub persisted: Option<PersistedResourceLease>,
+    pub observed: ObservedHostResource,
+    pub decision: ReconciliationDecision,
+}
+
+/// Bounded reconciliation report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReconciliationReport {
+    pub operation_id: OperationId,
+    pub correlation_id: CorrelationId,
+    #[schemars(length(max = 128))]
+    pub records: Vec<ReconciliationRecord>,
+    #[schemars(length(max = 128))]
+    pub events: Vec<AllocatorEventMetadata>,
+}
+
+impl<'de> Deserialize<'de> for ReconciliationReport {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Raw {
+            operation_id: OperationId,
+            correlation_id: CorrelationId,
+            records: Vec<ReconciliationRecord>,
+            events: Vec<AllocatorEventMetadata>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        validate_len(&raw.records, MAX_RECONCILIATION_RECORDS, "records")
+            .map_err(serde::de::Error::custom)?;
+        validate_len(&raw.events, MAX_ALLOCATOR_EVENTS, "events")
+            .map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            operation_id: raw.operation_id,
+            correlation_id: raw.correlation_id,
+            records: raw.records,
+            events: raw.events,
+        })
+    }
+}
+
+fn validate_resource_requests(resources: &[LeaseResourceRequest]) -> Result<(), &'static str> {
+    validate_len_non_empty(
+        resources,
+        MAX_ALLOCATOR_REQUEST_RESOURCES,
+        "allocator resource requests",
+    )?;
+    let mut ids = BTreeSet::new();
+    for resource in resources {
+        if !ids.insert(resource.resource_id.clone()) {
+            return Err("duplicate resource id in allocator request");
+        }
+    }
+    Ok(())
+}
+
+fn validate_granted_resources(resources: &[GrantedHostResource]) -> Result<(), &'static str> {
+    validate_len_non_empty(
+        resources,
+        MAX_ALLOCATOR_REQUEST_RESOURCES,
+        "granted allocator resources",
+    )?;
+    let mut ids = BTreeSet::new();
+    for resource in resources {
+        if !ids.insert(resource.resource_id.clone()) {
+            return Err("duplicate granted resource id in allocator lease");
+        }
+    }
+    Ok(())
+}
+
+fn validate_len<T>(items: &[T], max: usize, label: &'static str) -> Result<(), &'static str> {
+    if items.len() > max {
+        Err(match label {
+            "conflicts" => "too many allocator conflicts",
+            "records" => "too many reconciliation records",
+            "events" => "too many allocator events",
+            _ => "too many allocator items",
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_len_non_empty<T>(
+    items: &[T],
+    max: usize,
+    label: &'static str,
+) -> Result<(), &'static str> {
+    if items.is_empty() {
+        Err(match label {
+            "allocator resource requests" => "allocator request must include at least one resource",
+            "granted allocator resources" => "allocator lease must include at least one resource",
+            _ => "allocator list must not be empty",
+        })
+    } else {
+        validate_len(items, max, label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::RealmId;
+    use serde_json::json;
+    use std::collections::BTreeSet;
+
+    fn id(raw: &str) -> HostResourceId {
+        HostResourceId::parse(raw).unwrap()
+    }
+
+    fn lease_id(raw: &str) -> AllocatorLeaseId {
+        AllocatorLeaseId::parse(raw).unwrap()
+    }
+
+    fn op(raw: &str) -> OperationId {
+        OperationId::parse(raw).unwrap()
+    }
+
+    fn corr(raw: &str) -> CorrelationId {
+        CorrelationId::parse(raw).unwrap()
+    }
+
+    fn owner() -> LeaseOwner {
+        LeaseOwner {
+            realm: RealmPath::new(vec![RealmId::parse("work").unwrap()]).unwrap(),
+            controller_generation: ControllerGenerationId::parse("gen-1").unwrap(),
+            node: Some(NodeId::parse("realm-node").unwrap()),
+        }
+    }
+
+    fn request_resource(raw: &str, kind: HostResourceKind, phase: u16) -> LeaseResourceRequest {
+        LeaseResourceRequest {
+            resource_id: id(raw),
+            kind,
+            share: ResourceShareMode::Exclusive,
+            acquisition_order: ResourceAcquisitionOrder { phase, ordinal: 0 },
+        }
+    }
+
+    fn granted_resource(raw: &str, kind: HostResourceKind) -> GrantedHostResource {
+        GrantedHostResource {
+            resource_id: id(raw),
+            kind,
+            share: ResourceShareMode::Exclusive,
+            delegation: ResourceDelegation::OpaqueName { id: id(raw) },
+            acquisition_order: ResourceAcquisitionOrder {
+                phase: 1,
+                ordinal: 0,
+            },
+        }
+    }
+
+    fn allocation_request_value(resources: Vec<serde_json::Value>) -> serde_json::Value {
+        json!({
+            "operation_id": "op-1",
+            "correlation_id": "corr-1",
+            "idempotency_key": "idem-1",
+            "owner": {
+                "realm": ["work"],
+                "controller_generation": "gen-1",
+                "node": "realm-node"
+            },
+            "resources": resources
+        })
+    }
+
+    fn resource_value(raw: &str) -> serde_json::Value {
+        json!({
+            "resource_id": raw,
+            "kind": "bridge",
+            "share": "exclusive",
+            "acquisition_order": { "phase": 1, "ordinal": 0 }
+        })
+    }
+
+    #[test]
+    fn allocation_request_decode_is_strict_and_bounded() {
+        let mut ok = allocation_request_value(vec![resource_value("bridge-1")]);
+        assert!(serde_json::from_value::<LeaseAllocationRequest>(ok.clone()).is_ok());
+
+        ok["unexpected"] = json!(true);
+        assert!(serde_json::from_value::<LeaseAllocationRequest>(ok).is_err());
+
+        let empty = allocation_request_value(Vec::new());
+        assert!(serde_json::from_value::<LeaseAllocationRequest>(empty).is_err());
+
+        let too_many = allocation_request_value(
+            (0..=MAX_ALLOCATOR_REQUEST_RESOURCES)
+                .map(|i| resource_value(&format!("bridge-{i}")))
+                .collect(),
+        );
+        assert!(serde_json::from_value::<LeaseAllocationRequest>(too_many).is_err());
+
+        let duplicate =
+            allocation_request_value(vec![resource_value("bridge-1"), resource_value("bridge-1")]);
+        assert!(serde_json::from_value::<LeaseAllocationRequest>(duplicate).is_err());
+    }
+
+    #[test]
+    fn debug_keeps_resource_and_lease_ids_actionable() {
+        let lease = AllocatorLease {
+            lease_id: lease_id("lease-home-1"),
+            owner: owner(),
+            state: AllocatorLeaseState::Granted,
+            resources: vec![granted_resource("bridge-home-1", HostResourceKind::Bridge)],
+        };
+        let debug = format!("{lease:?}");
+        assert!(debug.contains("AllocatorLeaseId(\"lease-home-1\")"));
+        assert!(debug.contains("HostResourceId(\"bridge-home-1\")"));
+    }
+
+    #[test]
+    fn reason_codes_are_low_cardinality_static_labels() {
+        let reasons = [
+            AllocatorReasonCode::ResourceConflict,
+            AllocatorReasonCode::OwnershipConflict,
+            AllocatorReasonCode::AcquisitionOrderViolation,
+            AllocatorReasonCode::InvalidRequest,
+            AllocatorReasonCode::CapacityExhausted,
+            AllocatorReasonCode::DriftDetected,
+            AllocatorReasonCode::ReconcileMismatch,
+            AllocatorReasonCode::OwnerNotLive,
+            AllocatorReasonCode::PolicyDenied,
+            AllocatorReasonCode::UnsupportedKind,
+            AllocatorReasonCode::StorageContractViolation,
+            AllocatorReasonCode::KernelStateUnknown,
+        ];
+        assert_eq!(reasons.len(), ALLOCATOR_REASON_CODE_COUNT);
+        assert!(ALLOCATOR_REASON_CODE_COUNT <= 16);
+        let labels = reasons
+            .iter()
+            .map(|reason| reason.as_metric_label())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(labels.len(), ALLOCATOR_REASON_CODE_COUNT);
+        assert!(labels.iter().all(|label| !label.is_empty()));
+    }
+
+    #[test]
+    fn total_acquisition_order_is_stable() {
+        let request = LeaseAllocationRequest {
+            operation_id: op("op-1"),
+            correlation_id: corr("corr-1"),
+            idempotency_key: IdempotencyKey::parse("idem-1").unwrap(),
+            owner: owner(),
+            resources: vec![
+                request_resource("tap-1", HostResourceKind::Tap, 2),
+                request_resource("bridge-1", HostResourceKind::Bridge, 1),
+                request_resource("cgroup-1", HostResourceKind::CgroupSubtree, 1),
+            ],
+            trace: None,
+        };
+
+        let ordered = request.acquisition_order();
+        assert_eq!(
+            ordered
+                .iter()
+                .map(|key| key.resource_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["bridge-1", "cgroup-1", "tap-1"]
+        );
+
+        let mut reversed = request.clone();
+        reversed.resources.reverse();
+        assert_eq!(request.acquisition_order(), reversed.acquisition_order());
+    }
+
+    #[test]
+    fn lease_state_transitions_fail_closed() {
+        assert!(AllocatorLeaseState::Granted.can_transition_to(AllocatorLeaseState::Reconciled));
+        assert!(
+            AllocatorLeaseState::Reconciled.can_transition_to(AllocatorLeaseState::Quarantined)
+        );
+        assert!(AllocatorLeaseState::Quarantined.can_transition_to(AllocatorLeaseState::Reclaimed));
+        assert!(!AllocatorLeaseState::Denied.can_transition_to(AllocatorLeaseState::Granted));
+        assert!(!AllocatorLeaseState::Reclaimed.can_transition_to(AllocatorLeaseState::Reconciled));
+        assert!(AllocatorLeaseState::Denied.is_terminal());
+        assert!(AllocatorLeaseState::Reclaimed.is_terminal());
+    }
+
+    #[test]
+    fn denied_result_is_strict_and_conflict_bounded() {
+        let ok = json!({
+            "status": "denied",
+            "reason": "resource-conflict",
+            "conflicts": [{
+                "resource_id": "bridge-1",
+                "kind": "bridge",
+                "reason": "resource-conflict",
+                "existing_lease": "lease-1"
+            }]
+        });
+        assert!(serde_json::from_value::<LeaseAllocationResult>(ok).is_ok());
+
+        let no_reason = json!({"status": "denied", "conflicts": []});
+        assert!(serde_json::from_value::<LeaseAllocationResult>(no_reason).is_err());
+
+        let contradictory = json!({
+            "status": "granted",
+            "lease": {
+                "lease_id": "lease-1",
+                "owner": {
+                    "realm": ["work"],
+                    "controller_generation": "gen-1",
+                    "node": "realm-node"
+                },
+                "state": "granted",
+                "resources": [{
+                    "resource_id": "bridge-1",
+                    "kind": "bridge",
+                    "share": "exclusive",
+                    "delegation": { "kind": "opaque-name", "id": "bridge-1" },
+                    "acquisition_order": { "phase": 1, "ordinal": 0 }
+                }]
+            },
+            "conflicts": []
+        });
+        assert!(serde_json::from_value::<LeaseAllocationResult>(contradictory).is_err());
+
+        let contradictory_null = json!({
+            "status": "granted",
+            "lease": {
+                "lease_id": "lease-1",
+                "owner": {
+                    "realm": ["work"],
+                    "controller_generation": "gen-1",
+                    "node": "realm-node"
+                },
+                "state": "granted",
+                "resources": [{
+                    "resource_id": "bridge-1",
+                    "kind": "bridge",
+                    "share": "exclusive",
+                    "delegation": { "kind": "opaque-name", "id": "bridge-1" },
+                    "acquisition_order": { "phase": 1, "ordinal": 0 }
+                }]
+            },
+            "conflicts": null
+        });
+        assert!(serde_json::from_value::<LeaseAllocationResult>(contradictory_null).is_err());
+
+        let denied_null_conflicts = json!({
+            "status": "denied",
+            "reason": "resource-conflict",
+            "conflicts": null
+        });
+        assert!(serde_json::from_value::<LeaseAllocationResult>(denied_null_conflicts).is_err());
+
+        let denied_missing_conflicts = json!({
+            "status": "denied",
+            "reason": "resource-conflict"
+        });
+        assert!(serde_json::from_value::<LeaseAllocationResult>(denied_missing_conflicts).is_err());
+
+        let conflicts = (0..=MAX_ALLOCATOR_CONFLICTS)
+            .map(|i| {
+                json!({
+                    "resource_id": format!("bridge-{i}"),
+                    "kind": "bridge",
+                    "reason": "resource-conflict"
+                })
+            })
+            .collect::<Vec<_>>();
+        let too_many = json!({
+            "status": "denied",
+            "reason": "resource-conflict",
+            "conflicts": conflicts
+        });
+        assert!(serde_json::from_value::<LeaseAllocationResult>(too_many).is_err());
+    }
+
+    #[test]
+    fn reconciliation_keeps_persisted_and_observed_state_distinct() {
+        let record = ReconciliationRecord {
+            resource_id: id("bridge-1"),
+            kind: HostResourceKind::Bridge,
+            persisted: Some(PersistedResourceLease {
+                lease_id: lease_id("lease-1"),
+                owner: owner(),
+                state: AllocatorLeaseState::Granted,
+            }),
+            observed: ObservedHostResource {
+                resource_id: id("bridge-1"),
+                kind: HostResourceKind::Bridge,
+                source: ResourceObservationSource::KernelNetlink,
+                state: ObservedResourceState::ForeignOwner,
+            },
+            decision: ReconciliationDecision::Quarantine {
+                reason: AllocatorReasonCode::DriftDetected,
+            },
+        };
+
+        assert!(record.decision.is_fail_closed());
+        let encoded = serde_json::to_value(&record).unwrap();
+        assert!(encoded.get("persisted").is_some());
+        assert!(encoded.get("observed").is_some());
+        assert_eq!(encoded["observed"]["source"], "kernel-netlink");
+    }
+
+    #[test]
+    fn reconciliation_decision_rejects_contradictory_fields() {
+        let contradictory = json!({
+            "decision": "reconciled",
+            "reason": "drift-detected"
+        });
+        assert!(serde_json::from_value::<ReconciliationDecision>(contradictory).is_err());
+
+        let null_reason = json!({
+            "decision": "reconciled",
+            "reason": null
+        });
+        assert!(serde_json::from_value::<ReconciliationDecision>(null_reason).is_err());
+
+        let quarantine_missing_reason = json!({"decision": "quarantine"});
+        assert!(
+            serde_json::from_value::<ReconciliationDecision>(quarantine_missing_reason).is_err()
+        );
+    }
+
+    #[test]
+    fn reconciliation_report_is_bounded() {
+        let record = ReconciliationRecord {
+            resource_id: id("bridge-1"),
+            kind: HostResourceKind::Bridge,
+            persisted: None,
+            observed: ObservedHostResource {
+                resource_id: id("bridge-1"),
+                kind: HostResourceKind::Bridge,
+                source: ResourceObservationSource::KernelNetlink,
+                state: ObservedResourceState::Missing,
+            },
+            decision: ReconciliationDecision::Reclaim {
+                reason: AllocatorReasonCode::OwnerNotLive,
+            },
+        };
+        let report = ReconciliationReport {
+            operation_id: op("op-1"),
+            correlation_id: corr("corr-1"),
+            records: vec![record.clone(); MAX_RECONCILIATION_RECORDS + 1],
+            events: Vec::new(),
+        };
+        let encoded = serde_json::to_value(report).unwrap();
+        assert!(serde_json::from_value::<ReconciliationReport>(encoded).is_err());
+    }
+}

--- a/packages/d2b-realm-core/src/allocator.rs
+++ b/packages/d2b-realm-core/src/allocator.rs
@@ -934,7 +934,7 @@ mod tests {
             AllocatorReasonCode::KernelStateUnknown,
         ];
         assert_eq!(reasons.len(), ALLOCATOR_REASON_CODE_COUNT);
-        assert!(ALLOCATOR_REASON_CODE_COUNT <= 16);
+        const { assert!(ALLOCATOR_REASON_CODE_COUNT <= 16) };
         let labels = reasons
             .iter()
             .map(|reason| reason.as_metric_label())

--- a/packages/d2b-realm-core/src/allocator_engine.rs
+++ b/packages/d2b-realm-core/src/allocator_engine.rs
@@ -1,0 +1,1635 @@
+//! Hermetic local-root allocator engine over fake host observations.
+//!
+//! The engine is deliberately pure: it reconciles typed allocator DTOs against
+//! in-memory fake ledger/liveness/observation backends and emits decisions,
+//! audit metadata, and low-cardinality metric samples. It performs no netlink,
+//! nftables, filesystem, systemd, broker, or other live host mutation.
+
+use crate::allocator::{
+    AllocatorConflict, AllocatorEventKind, AllocatorEventMetadata, AllocatorLease,
+    AllocatorLeaseState, AllocatorReasonCode, GrantedHostResource, HostResourceKind,
+    LeaseAllocationRequest, LeaseAllocationResponse, LeaseAllocationResult, LeaseOwner,
+    MAX_ALLOCATOR_CONFLICTS, MAX_ALLOCATOR_EVENTS, MAX_ALLOCATOR_REQUEST_RESOURCES,
+    MAX_RECONCILIATION_RECORDS, ObservedHostResource, ObservedResourceState,
+    PersistedResourceLease, ReconciliationDecision, ReconciliationRecord, ReconciliationReport,
+    ResourceAcquisitionKey, ResourceDelegation, ResourceObservationSource, ResourceShareMode,
+};
+use crate::ids::{AllocatorLeaseId, CorrelationId, HostResourceId, IdempotencyKey, OperationId};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Allocation/reconciliation decision made by the pure engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllocatorEngineDecision {
+    Grant,
+    DenyConflict { reason: AllocatorReasonCode },
+    Reclaim { reason: AllocatorReasonCode },
+    Quarantine { reason: AllocatorReasonCode },
+    Preserve { reason: AllocatorReasonCode },
+    Reconcile,
+}
+
+impl AllocatorEngineDecision {
+    fn reason(&self) -> Option<AllocatorReasonCode> {
+        match self {
+            Self::Grant | Self::Reconcile => None,
+            Self::DenyConflict { reason }
+            | Self::Reclaim { reason }
+            | Self::Quarantine { reason }
+            | Self::Preserve { reason } => Some(*reason),
+        }
+    }
+
+    fn event_kind(&self) -> AllocatorEventKind {
+        match self {
+            Self::Grant => AllocatorEventKind::Grant,
+            Self::DenyConflict { .. } => AllocatorEventKind::Denial,
+            Self::Reclaim { .. } => AllocatorEventKind::Reclamation,
+            Self::Quarantine { .. } => AllocatorEventKind::Quarantine,
+            Self::Preserve { .. } | Self::Reconcile => AllocatorEventKind::Reconciliation,
+        }
+    }
+
+    fn outcome(&self) -> AllocatorEngineOutcome {
+        match self {
+            Self::Grant => AllocatorEngineOutcome::Granted,
+            Self::DenyConflict { .. } => AllocatorEngineOutcome::Denied,
+            Self::Reclaim { .. } => AllocatorEngineOutcome::Reclaimed,
+            Self::Quarantine { .. } => AllocatorEngineOutcome::Quarantined,
+            Self::Preserve { .. } => AllocatorEngineOutcome::Preserved,
+            Self::Reconcile => AllocatorEngineOutcome::Reconciled,
+        }
+    }
+
+    fn reconciliation_decision(&self) -> ReconciliationDecision {
+        match self {
+            Self::Reconcile => ReconciliationDecision::Reconciled,
+            Self::Reclaim { reason } => ReconciliationDecision::Reclaim { reason: *reason },
+            Self::Quarantine { reason } => ReconciliationDecision::Quarantine { reason: *reason },
+            Self::Preserve { reason } | Self::DenyConflict { reason } => {
+                ReconciliationDecision::Deny { reason: *reason }
+            }
+            Self::Grant => ReconciliationDecision::Reconciled,
+        }
+    }
+}
+
+/// Low-cardinality metric outcome label emitted by the engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AllocatorEngineOutcome {
+    Granted,
+    Denied,
+    Reconciled,
+    Reclaimed,
+    Quarantined,
+    Preserved,
+    IdempotentReplay,
+}
+
+impl AllocatorEngineOutcome {
+    /// Stable metric label; never contains resource ids, paths, endpoints, or
+    /// other caller-controlled values.
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::Granted => "granted",
+            Self::Denied => "denied",
+            Self::Reconciled => "reconciled",
+            Self::Reclaimed => "reclaimed",
+            Self::Quarantined => "quarantined",
+            Self::Preserved => "preserved",
+            Self::IdempotentReplay => "idempotent-replay",
+        }
+    }
+}
+
+/// Bounded low-cardinality metric sample. Labels are closed enums only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllocatorMetricEvent {
+    pub event: AllocatorEventKind,
+    pub outcome: AllocatorEngineOutcome,
+    pub resource_kind: Option<HostResourceKind>,
+    pub reason: Option<AllocatorReasonCode>,
+    pub count: u64,
+}
+
+impl AllocatorMetricEvent {
+    fn new(
+        event: AllocatorEventKind,
+        outcome: AllocatorEngineOutcome,
+        resource_kind: Option<HostResourceKind>,
+        reason: Option<AllocatorReasonCode>,
+    ) -> Self {
+        Self {
+            event,
+            outcome,
+            resource_kind,
+            reason,
+            count: 1,
+        }
+    }
+
+    /// Labels suitable for metric export. Values are static enum labels only.
+    pub fn labels(&self) -> AllocatorMetricLabels {
+        AllocatorMetricLabels {
+            event: self.event.as_metric_label(),
+            outcome: self.outcome.as_metric_label(),
+            resource_kind: self.resource_kind.map(HostResourceKind::as_metric_label),
+            reason: self.reason.map(AllocatorReasonCode::as_metric_label),
+        }
+    }
+}
+
+/// Static labels derived from an [`AllocatorMetricEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AllocatorMetricLabels {
+    pub event: &'static str,
+    pub outcome: &'static str,
+    pub resource_kind: Option<&'static str>,
+    pub reason: Option<&'static str>,
+}
+
+/// One resource-level allocation decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllocatorAllocationDecision {
+    pub resource_id: HostResourceId,
+    pub kind: HostResourceKind,
+    pub decision: AllocatorEngineDecision,
+}
+
+/// Result of one allocation request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllocatorEngineAllocation {
+    pub response: LeaseAllocationResponse,
+    pub decisions: Vec<AllocatorAllocationDecision>,
+    pub events: Vec<AllocatorEventMetadata>,
+    pub metrics: Vec<AllocatorMetricEvent>,
+    pub acquired: Vec<ResourceAcquisitionKey>,
+}
+
+/// One resource-level reconciliation decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllocatorReconciliationAction {
+    pub resource_id: HostResourceId,
+    pub kind: HostResourceKind,
+    pub persisted: Option<PersistedResourceLease>,
+    pub observed: ObservedHostResource,
+    pub decision: AllocatorEngineDecision,
+}
+
+/// Result of reconciling fake observed host state against fake persisted leases.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllocatorEngineReconciliation {
+    pub report: ReconciliationReport,
+    pub actions: Vec<AllocatorReconciliationAction>,
+    pub metrics: Vec<AllocatorMetricEvent>,
+}
+
+/// In-memory fake observed host state.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FakeObservedAllocatorState {
+    pub resources: Vec<ObservedHostResource>,
+}
+
+impl FakeObservedAllocatorState {
+    pub fn new(resources: Vec<ObservedHostResource>) -> Self {
+        Self { resources }
+    }
+}
+
+/// In-memory fake owner-liveness backend.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FakeAllocatorLiveness {
+    pub live_owners: Vec<LeaseOwner>,
+}
+
+impl FakeAllocatorLiveness {
+    pub fn new(live_owners: Vec<LeaseOwner>) -> Self {
+        Self { live_owners }
+    }
+
+    fn is_live(&self, owner: &LeaseOwner) -> bool {
+        self.live_owners.iter().any(|candidate| candidate == owner)
+    }
+}
+
+/// In-memory fake allocator ledger, including idempotency replay records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FakeAllocatorLedger {
+    pub leases: Vec<AllocatorLease>,
+    idempotency: Vec<AllocatorIdempotencyRecord>,
+    next_lease_sequence: u64,
+}
+
+impl Default for FakeAllocatorLedger {
+    fn default() -> Self {
+        Self {
+            leases: Vec::new(),
+            idempotency: Vec::new(),
+            next_lease_sequence: 1,
+        }
+    }
+}
+
+impl FakeAllocatorLedger {
+    pub fn new(leases: Vec<AllocatorLease>) -> Self {
+        Self {
+            leases,
+            ..Self::default()
+        }
+    }
+
+    fn remember_idempotency(
+        &mut self,
+        key: IdempotencyKey,
+        signature: AllocationRequestSignature,
+        result: LeaseAllocationResult,
+    ) {
+        self.idempotency.push(AllocatorIdempotencyRecord {
+            key,
+            signature,
+            result,
+        });
+    }
+
+    fn idempotency_record(&self, key: &IdempotencyKey) -> Option<&AllocatorIdempotencyRecord> {
+        self.idempotency.iter().find(|record| &record.key == key)
+    }
+
+    fn next_lease_id(&mut self) -> AllocatorLeaseId {
+        let existing = self
+            .leases
+            .iter()
+            .map(|lease| lease.lease_id.as_str())
+            .collect::<BTreeSet<_>>();
+        loop {
+            let candidate = format!("lease-engine-{}", self.next_lease_sequence);
+            self.next_lease_sequence += 1;
+            if existing.contains(candidate.as_str()) {
+                continue;
+            }
+            return AllocatorLeaseId::parse(candidate).expect("generated lease id is valid");
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AllocatorIdempotencyRecord {
+    key: IdempotencyKey,
+    signature: AllocationRequestSignature,
+    result: LeaseAllocationResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AllocationRequestSignature {
+    owner: LeaseOwner,
+    resources: Vec<RequestedResourceSignature>,
+}
+
+impl AllocationRequestSignature {
+    fn from_request(request: &LeaseAllocationRequest) -> Self {
+        let mut resources = request
+            .resources
+            .iter()
+            .map(|resource| RequestedResourceSignature {
+                key: ResourceAcquisitionKey {
+                    order: resource.acquisition_order,
+                    kind: resource.kind,
+                    resource_id: resource.resource_id.clone(),
+                },
+                share: resource.share,
+            })
+            .collect::<Vec<_>>();
+        resources.sort();
+        Self {
+            owner: request.owner.clone(),
+            resources,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RequestedResourceSignature {
+    key: ResourceAcquisitionKey,
+    share: ResourceShareMode,
+}
+
+impl PartialOrd for RequestedResourceSignature {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RequestedResourceSignature {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key
+            .cmp(&other.key)
+            .then_with(|| share_rank(self.share).cmp(&share_rank(other.share)))
+    }
+}
+
+/// Pure allocator engine using fake ledger, observed-state, and liveness
+/// backends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalRootAllocatorEngine {
+    allocator_owner: LeaseOwner,
+    pub ledger: FakeAllocatorLedger,
+    pub observed: FakeObservedAllocatorState,
+    pub liveness: FakeAllocatorLiveness,
+}
+
+impl LocalRootAllocatorEngine {
+    pub fn new(
+        allocator_owner: LeaseOwner,
+        ledger: FakeAllocatorLedger,
+        observed: FakeObservedAllocatorState,
+        liveness: FakeAllocatorLiveness,
+    ) -> Self {
+        Self {
+            allocator_owner,
+            ledger,
+            observed,
+            liveness,
+        }
+    }
+
+    /// Allocate a typed lease request without touching the live host.
+    pub fn allocate(&mut self, request: LeaseAllocationRequest) -> AllocatorEngineAllocation {
+        let acquired = request.acquisition_order();
+        let signature = AllocationRequestSignature::from_request(&request);
+
+        if let Some(record) = self.ledger.idempotency_record(&request.idempotency_key) {
+            if record.signature == signature {
+                let metric = metric_from_replay_result(&record.result);
+                let response = LeaseAllocationResponse {
+                    operation_id: request.operation_id.clone(),
+                    correlation_id: request.correlation_id.clone(),
+                    result: record.result.clone(),
+                };
+                return AllocatorEngineAllocation {
+                    response,
+                    decisions: Vec::new(),
+                    events: Vec::new(),
+                    metrics: vec![metric],
+                    acquired,
+                };
+            }
+
+            return self.deny_request(
+                &request,
+                acquired,
+                AllocatorReasonCode::InvalidRequest,
+                Vec::new(),
+            );
+        }
+
+        if !self.liveness.is_live(&request.owner) {
+            return self.deny_request(
+                &request,
+                acquired,
+                AllocatorReasonCode::OwnerNotLive,
+                Vec::new(),
+            );
+        }
+
+        if request.resources.is_empty() || request.resources.len() > MAX_ALLOCATOR_REQUEST_RESOURCES
+        {
+            return self.deny_request(
+                &request,
+                acquired,
+                AllocatorReasonCode::InvalidRequest,
+                Vec::new(),
+            );
+        }
+
+        if has_duplicate_requested_resources(&request) {
+            return self.deny_request(
+                &request,
+                acquired,
+                AllocatorReasonCode::InvalidRequest,
+                Vec::new(),
+            );
+        }
+
+        let conflicts = self.allocation_conflicts(&request);
+        if !conflicts.is_empty() {
+            return self.deny_request(
+                &request,
+                acquired,
+                AllocatorReasonCode::ResourceConflict,
+                conflicts,
+            );
+        }
+
+        let lease = AllocatorLease {
+            lease_id: self.ledger.next_lease_id(),
+            owner: request.owner.clone(),
+            state: AllocatorLeaseState::Granted,
+            resources: grant_resources_in_order(&request),
+        };
+        self.ledger.leases.push(lease.clone());
+
+        let result = LeaseAllocationResult::Granted { lease };
+        self.ledger.remember_idempotency(
+            request.idempotency_key.clone(),
+            signature,
+            result.clone(),
+        );
+
+        let decisions = request
+            .resources
+            .iter()
+            .map(|resource| AllocatorAllocationDecision {
+                resource_id: resource.resource_id.clone(),
+                kind: resource.kind,
+                decision: AllocatorEngineDecision::Grant,
+            })
+            .collect::<Vec<_>>();
+        let events = bounded_events(decisions.iter().map(|decision| {
+            event_metadata(
+                request.operation_id.clone(),
+                request.correlation_id.clone(),
+                request.owner.clone(),
+                &decision.decision,
+                Some(decision.kind),
+                request.trace.clone(),
+            )
+        }));
+        let metrics = bounded_metrics(
+            decisions
+                .iter()
+                .map(|decision| metric_from_decision(&decision.decision, Some(decision.kind))),
+        );
+        let response = LeaseAllocationResponse {
+            operation_id: request.operation_id,
+            correlation_id: request.correlation_id,
+            result,
+        };
+
+        AllocatorEngineAllocation {
+            response,
+            decisions,
+            events,
+            metrics,
+            acquired,
+        }
+    }
+
+    /// Reconcile fake observed host state against fake persisted leases.
+    pub fn reconcile(
+        &self,
+        operation_id: OperationId,
+        correlation_id: CorrelationId,
+    ) -> AllocatorEngineReconciliation {
+        let mut resources = BTreeMap::<ResourceKey, ResourcePair>::new();
+
+        for lease in &self.ledger.leases {
+            for resource in &lease.resources {
+                let key = ResourceKey::new(resource.kind, resource.resource_id.clone());
+                resources
+                    .entry(key)
+                    .or_default()
+                    .persisted
+                    .push(PersistedResourceLease {
+                        lease_id: lease.lease_id.clone(),
+                        owner: lease.owner.clone(),
+                        state: lease.state,
+                    });
+            }
+        }
+
+        for observed in &self.observed.resources {
+            let key = ResourceKey::new(observed.kind, observed.resource_id.clone());
+            resources.entry(key).or_default().observed = Some(observed.clone());
+        }
+
+        let mut actions = Vec::new();
+        for (key, pair) in resources {
+            let observed = pair.observed.unwrap_or_else(|| ObservedHostResource {
+                resource_id: key.resource_id.clone(),
+                kind: key.kind,
+                source: ResourceObservationSource::AllocatorLedger,
+                state: ObservedResourceState::Missing,
+            });
+            let persisted = pair.persisted.first().cloned();
+            let decision = self.reconciliation_decision(&pair.persisted, &observed);
+            actions.push(AllocatorReconciliationAction {
+                resource_id: key.resource_id,
+                kind: key.kind,
+                persisted,
+                observed,
+                decision,
+            });
+        }
+
+        let records = actions
+            .iter()
+            .take(MAX_RECONCILIATION_RECORDS)
+            .map(|action| ReconciliationRecord {
+                resource_id: action.resource_id.clone(),
+                kind: action.kind,
+                persisted: action.persisted.clone(),
+                observed: action.observed.clone(),
+                decision: action.decision.reconciliation_decision(),
+            })
+            .collect::<Vec<_>>();
+
+        let events = bounded_events(actions.iter().map(|action| {
+            let owner = action
+                .persisted
+                .as_ref()
+                .map(|persisted| persisted.owner.clone())
+                .unwrap_or_else(|| self.allocator_owner.clone());
+            event_metadata(
+                operation_id.clone(),
+                correlation_id.clone(),
+                owner,
+                &action.decision,
+                Some(action.kind),
+                None,
+            )
+        }));
+        let metrics = bounded_metrics(
+            actions
+                .iter()
+                .map(|action| metric_from_decision(&action.decision, Some(action.kind))),
+        );
+        let report = ReconciliationReport {
+            operation_id,
+            correlation_id,
+            records,
+            events,
+        };
+
+        AllocatorEngineReconciliation {
+            report,
+            actions,
+            metrics,
+        }
+    }
+
+    fn allocation_conflicts(&self, request: &LeaseAllocationRequest) -> Vec<AllocatorConflict> {
+        let mut conflicts = Vec::new();
+        for resource in request.acquisition_order() {
+            if let Some(conflict) = self.persisted_conflict(&request.owner, &resource) {
+                conflicts.push(conflict);
+            }
+            if let Some(conflict) = self.observed_conflict(&resource) {
+                conflicts.push(conflict);
+            }
+            if conflicts.len() >= MAX_ALLOCATOR_CONFLICTS {
+                break;
+            }
+        }
+        conflicts
+    }
+
+    fn persisted_conflict(
+        &self,
+        owner: &LeaseOwner,
+        resource: &ResourceAcquisitionKey,
+    ) -> Option<AllocatorConflict> {
+        self.ledger
+            .leases
+            .iter()
+            .filter(|lease| !lease.state.is_terminal())
+            .find_map(|lease| {
+                lease
+                    .resources
+                    .iter()
+                    .any(|granted| {
+                        granted.kind == resource.kind && granted.resource_id == resource.resource_id
+                    })
+                    .then(|| AllocatorConflict {
+                        resource_id: resource.resource_id.clone(),
+                        kind: resource.kind,
+                        reason: if &lease.owner == owner {
+                            AllocatorReasonCode::OwnershipConflict
+                        } else {
+                            AllocatorReasonCode::ResourceConflict
+                        },
+                        existing_lease: Some(lease.lease_id.clone()),
+                    })
+            })
+    }
+
+    fn observed_conflict(&self, resource: &ResourceAcquisitionKey) -> Option<AllocatorConflict> {
+        self.observed
+            .resources
+            .iter()
+            .find(|observed| {
+                observed.kind == resource.kind && observed.resource_id == resource.resource_id
+            })
+            .and_then(|observed| match observed.state {
+                ObservedResourceState::Missing => None,
+                ObservedResourceState::Present => Some(AllocatorReasonCode::ResourceConflict),
+                ObservedResourceState::ForeignOwner => Some(AllocatorReasonCode::OwnershipConflict),
+                ObservedResourceState::Ambiguous | ObservedResourceState::Inaccessible => {
+                    Some(AllocatorReasonCode::KernelStateUnknown)
+                }
+            })
+            .map(|reason| AllocatorConflict {
+                resource_id: resource.resource_id.clone(),
+                kind: resource.kind,
+                reason,
+                existing_lease: None,
+            })
+    }
+
+    fn reconciliation_decision(
+        &self,
+        persisted: &[PersistedResourceLease],
+        observed: &ObservedHostResource,
+    ) -> AllocatorEngineDecision {
+        if persisted.len() > 1 {
+            return AllocatorEngineDecision::Quarantine {
+                reason: AllocatorReasonCode::StorageContractViolation,
+            };
+        }
+
+        let Some(persisted) = persisted.first() else {
+            return match observed.state {
+                ObservedResourceState::Missing => AllocatorEngineDecision::Reconcile,
+                ObservedResourceState::Present => AllocatorEngineDecision::Preserve {
+                    reason: AllocatorReasonCode::ResourceConflict,
+                },
+                ObservedResourceState::ForeignOwner => AllocatorEngineDecision::Preserve {
+                    reason: AllocatorReasonCode::OwnershipConflict,
+                },
+                ObservedResourceState::Ambiguous | ObservedResourceState::Inaccessible => {
+                    AllocatorEngineDecision::Quarantine {
+                        reason: AllocatorReasonCode::KernelStateUnknown,
+                    }
+                }
+            };
+        };
+
+        if persisted.state.is_terminal() {
+            return match observed.state {
+                ObservedResourceState::Missing => AllocatorEngineDecision::Reconcile,
+                ObservedResourceState::Present | ObservedResourceState::ForeignOwner => {
+                    AllocatorEngineDecision::Preserve {
+                        reason: AllocatorReasonCode::OwnershipConflict,
+                    }
+                }
+                ObservedResourceState::Ambiguous | ObservedResourceState::Inaccessible => {
+                    AllocatorEngineDecision::Quarantine {
+                        reason: AllocatorReasonCode::KernelStateUnknown,
+                    }
+                }
+            };
+        }
+
+        if !self.liveness.is_live(&persisted.owner) {
+            return AllocatorEngineDecision::Reclaim {
+                reason: AllocatorReasonCode::OwnerNotLive,
+            };
+        }
+
+        match observed.state {
+            ObservedResourceState::Present => AllocatorEngineDecision::Reconcile,
+            ObservedResourceState::Missing => AllocatorEngineDecision::Reclaim {
+                reason: AllocatorReasonCode::DriftDetected,
+            },
+            ObservedResourceState::ForeignOwner => AllocatorEngineDecision::Quarantine {
+                reason: AllocatorReasonCode::DriftDetected,
+            },
+            ObservedResourceState::Ambiguous | ObservedResourceState::Inaccessible => {
+                AllocatorEngineDecision::Quarantine {
+                    reason: AllocatorReasonCode::KernelStateUnknown,
+                }
+            }
+        }
+    }
+
+    fn deny_request(
+        &mut self,
+        request: &LeaseAllocationRequest,
+        acquired: Vec<ResourceAcquisitionKey>,
+        reason: AllocatorReasonCode,
+        conflicts: Vec<AllocatorConflict>,
+    ) -> AllocatorEngineAllocation {
+        let conflicts = conflicts
+            .into_iter()
+            .take(MAX_ALLOCATOR_CONFLICTS)
+            .collect::<Vec<_>>();
+        let decisions = if conflicts.is_empty() {
+            request
+                .resources
+                .iter()
+                .map(|resource| AllocatorAllocationDecision {
+                    resource_id: resource.resource_id.clone(),
+                    kind: resource.kind,
+                    decision: AllocatorEngineDecision::DenyConflict { reason },
+                })
+                .collect::<Vec<_>>()
+        } else {
+            conflicts
+                .iter()
+                .map(|conflict| AllocatorAllocationDecision {
+                    resource_id: conflict.resource_id.clone(),
+                    kind: conflict.kind,
+                    decision: AllocatorEngineDecision::DenyConflict {
+                        reason: conflict.reason,
+                    },
+                })
+                .collect::<Vec<_>>()
+        };
+        let events = bounded_events(decisions.iter().map(|decision| {
+            event_metadata(
+                request.operation_id.clone(),
+                request.correlation_id.clone(),
+                request.owner.clone(),
+                &decision.decision,
+                Some(decision.kind),
+                request.trace.clone(),
+            )
+        }));
+        let metrics = bounded_metrics(
+            decisions
+                .iter()
+                .map(|decision| metric_from_decision(&decision.decision, Some(decision.kind))),
+        );
+        let result = LeaseAllocationResult::Denied { reason, conflicts };
+        if self
+            .ledger
+            .idempotency_record(&request.idempotency_key)
+            .is_none()
+        {
+            self.ledger.remember_idempotency(
+                request.idempotency_key.clone(),
+                AllocationRequestSignature::from_request(request),
+                result.clone(),
+            );
+        }
+        let response = LeaseAllocationResponse {
+            operation_id: request.operation_id.clone(),
+            correlation_id: request.correlation_id.clone(),
+            result,
+        };
+        AllocatorEngineAllocation {
+            response,
+            decisions,
+            events,
+            metrics,
+            acquired,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ResourceKey {
+    kind: HostResourceKind,
+    resource_id: HostResourceId,
+}
+
+impl ResourceKey {
+    fn new(kind: HostResourceKind, resource_id: HostResourceId) -> Self {
+        Self { kind, resource_id }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ResourcePair {
+    persisted: Vec<PersistedResourceLease>,
+    observed: Option<ObservedHostResource>,
+}
+
+fn has_duplicate_requested_resources(request: &LeaseAllocationRequest) -> bool {
+    let mut seen = BTreeSet::new();
+    request
+        .resources
+        .iter()
+        .any(|resource| !seen.insert(resource.resource_id.clone()))
+}
+
+fn grant_resources_in_order(request: &LeaseAllocationRequest) -> Vec<GrantedHostResource> {
+    let by_id = request
+        .resources
+        .iter()
+        .map(|resource| (resource.resource_id.clone(), resource))
+        .collect::<BTreeMap<_, _>>();
+    request
+        .acquisition_order()
+        .into_iter()
+        .filter_map(|key| {
+            by_id
+                .get(&key.resource_id)
+                .map(|resource| GrantedHostResource {
+                    resource_id: resource.resource_id.clone(),
+                    kind: resource.kind,
+                    share: resource.share,
+                    delegation: delegation_for(
+                        resource.kind,
+                        resource.share,
+                        &resource.resource_id,
+                    ),
+                    acquisition_order: resource.acquisition_order,
+                })
+        })
+        .collect()
+}
+
+fn delegation_for(
+    kind: HostResourceKind,
+    share: ResourceShareMode,
+    resource_id: &HostResourceId,
+) -> ResourceDelegation {
+    if share == ResourceShareMode::SharedPartition {
+        return ResourceDelegation::PartitionId {
+            id: resource_id.clone(),
+        };
+    }
+    match kind {
+        HostResourceKind::NftablesPartition | HostResourceKind::HostFilePartition => {
+            ResourceDelegation::PartitionId {
+                id: resource_id.clone(),
+            }
+        }
+        HostResourceKind::NamespaceBoundary => ResourceDelegation::NamespaceHandle {
+            id: resource_id.clone(),
+        },
+        HostResourceKind::Bridge
+        | HostResourceKind::Tap
+        | HostResourceKind::VethPair
+        | HostResourceKind::NftablesTable
+        | HostResourceKind::CgroupSubtree => ResourceDelegation::OpaqueName {
+            id: resource_id.clone(),
+        },
+    }
+}
+
+fn share_rank(share: ResourceShareMode) -> u8 {
+    match share {
+        ResourceShareMode::Exclusive => 0,
+        ResourceShareMode::SharedPartition => 1,
+    }
+}
+
+fn event_metadata(
+    operation_id: OperationId,
+    correlation_id: CorrelationId,
+    owner: LeaseOwner,
+    decision: &AllocatorEngineDecision,
+    resource_kind: Option<HostResourceKind>,
+    trace: Option<crate::trace_context::TraceContext>,
+) -> AllocatorEventMetadata {
+    AllocatorEventMetadata {
+        operation_id,
+        correlation_id,
+        owner,
+        event: decision.event_kind(),
+        resource_kind,
+        reason: decision.reason(),
+        trace,
+    }
+}
+
+fn metric_from_decision(
+    decision: &AllocatorEngineDecision,
+    resource_kind: Option<HostResourceKind>,
+) -> AllocatorMetricEvent {
+    AllocatorMetricEvent::new(
+        decision.event_kind(),
+        decision.outcome(),
+        resource_kind,
+        decision.reason(),
+    )
+}
+
+fn metric_from_replay_result(result: &LeaseAllocationResult) -> AllocatorMetricEvent {
+    match result {
+        LeaseAllocationResult::Granted { lease } => AllocatorMetricEvent::new(
+            AllocatorEventKind::Grant,
+            AllocatorEngineOutcome::IdempotentReplay,
+            lease.resources.first().map(|resource| resource.kind),
+            None,
+        ),
+        LeaseAllocationResult::Denied { reason, conflicts } => AllocatorMetricEvent::new(
+            AllocatorEventKind::Denial,
+            AllocatorEngineOutcome::IdempotentReplay,
+            conflicts.first().map(|conflict| conflict.kind),
+            Some(*reason),
+        ),
+    }
+}
+
+fn bounded_events(
+    events: impl IntoIterator<Item = AllocatorEventMetadata>,
+) -> Vec<AllocatorEventMetadata> {
+    events.into_iter().take(MAX_ALLOCATOR_EVENTS).collect()
+}
+
+fn bounded_metrics(
+    metrics: impl IntoIterator<Item = AllocatorMetricEvent>,
+) -> Vec<AllocatorMetricEvent> {
+    let mut aggregated = BTreeMap::<AllocatorMetricLabels, AllocatorMetricEvent>::new();
+    for metric in metrics {
+        aggregated
+            .entry(metric.labels())
+            .and_modify(|existing| {
+                existing.count = existing.count.saturating_add(metric.count);
+            })
+            .or_insert(metric);
+    }
+    aggregated
+        .into_values()
+        .take(MAX_ALLOCATOR_EVENTS)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::allocator::{
+        MAX_ALLOCATOR_REQUEST_RESOURCES, MAX_RECONCILIATION_RECORDS, ResourceAcquisitionOrder,
+        ResourceShareMode,
+    };
+    use crate::ids::{ControllerGenerationId, NodeId, RealmId};
+    use crate::realm::RealmPath;
+
+    fn id(raw: &str) -> HostResourceId {
+        HostResourceId::parse(raw).unwrap()
+    }
+
+    fn lease_id(raw: &str) -> AllocatorLeaseId {
+        AllocatorLeaseId::parse(raw).unwrap()
+    }
+
+    fn op(raw: &str) -> OperationId {
+        OperationId::parse(raw).unwrap()
+    }
+
+    fn corr(raw: &str) -> CorrelationId {
+        CorrelationId::parse(raw).unwrap()
+    }
+
+    fn idem(raw: &str) -> IdempotencyKey {
+        IdempotencyKey::parse(raw).unwrap()
+    }
+
+    fn owner(raw: &str) -> LeaseOwner {
+        LeaseOwner {
+            realm: RealmPath::new(vec![RealmId::parse(raw).unwrap()]).unwrap(),
+            controller_generation: ControllerGenerationId::parse("gen-1").unwrap(),
+            node: Some(NodeId::parse("realm-node").unwrap()),
+        }
+    }
+
+    fn request_resource(
+        raw: &str,
+        kind: HostResourceKind,
+        phase: u16,
+        ordinal: u16,
+    ) -> crate::allocator::LeaseResourceRequest {
+        crate::allocator::LeaseResourceRequest {
+            resource_id: id(raw),
+            kind,
+            share: ResourceShareMode::Exclusive,
+            acquisition_order: ResourceAcquisitionOrder { phase, ordinal },
+        }
+    }
+
+    fn request(
+        operation_id: &str,
+        correlation_id: &str,
+        idempotency_key: &str,
+        owner: LeaseOwner,
+        resources: Vec<crate::allocator::LeaseResourceRequest>,
+    ) -> LeaseAllocationRequest {
+        LeaseAllocationRequest {
+            operation_id: op(operation_id),
+            correlation_id: corr(correlation_id),
+            idempotency_key: idem(idempotency_key),
+            owner,
+            resources,
+            trace: None,
+        }
+    }
+
+    fn granted(raw: &str, kind: HostResourceKind) -> GrantedHostResource {
+        GrantedHostResource {
+            resource_id: id(raw),
+            kind,
+            share: ResourceShareMode::Exclusive,
+            delegation: ResourceDelegation::OpaqueName { id: id(raw) },
+            acquisition_order: ResourceAcquisitionOrder {
+                phase: 1,
+                ordinal: 0,
+            },
+        }
+    }
+
+    fn lease(
+        raw: &str,
+        owner: LeaseOwner,
+        state: AllocatorLeaseState,
+        resources: Vec<GrantedHostResource>,
+    ) -> AllocatorLease {
+        AllocatorLease {
+            lease_id: lease_id(raw),
+            owner,
+            state,
+            resources,
+        }
+    }
+
+    fn observed(
+        raw: &str,
+        kind: HostResourceKind,
+        state: ObservedResourceState,
+    ) -> ObservedHostResource {
+        ObservedHostResource {
+            resource_id: id(raw),
+            kind,
+            source: ResourceObservationSource::KernelNetlink,
+            state,
+        }
+    }
+
+    fn engine(
+        owner: LeaseOwner,
+        leases: Vec<AllocatorLease>,
+        observations: Vec<ObservedHostResource>,
+        live_owners: Vec<LeaseOwner>,
+    ) -> LocalRootAllocatorEngine {
+        LocalRootAllocatorEngine::new(
+            owner,
+            FakeAllocatorLedger::new(leases),
+            FakeObservedAllocatorState::new(observations),
+            FakeAllocatorLiveness::new(live_owners),
+        )
+    }
+
+    #[test]
+    fn grants_resources_in_total_acquisition_order() {
+        let owner = owner("work");
+        let mut engine = engine(owner.clone(), Vec::new(), Vec::new(), vec![owner.clone()]);
+        let allocation = engine.allocate(request(
+            "op-1",
+            "corr-1",
+            "idem-1",
+            owner,
+            vec![
+                request_resource("tap-1", HostResourceKind::Tap, 3, 0),
+                request_resource("bridge-1", HostResourceKind::Bridge, 1, 5),
+                request_resource("cgroup-1", HostResourceKind::CgroupSubtree, 1, 5),
+                request_resource("nft-1", HostResourceKind::NftablesTable, 1, 1),
+            ],
+        ));
+
+        let LeaseAllocationResult::Granted { lease } = allocation.response.result else {
+            panic!("expected grant");
+        };
+        assert_eq!(
+            allocation
+                .acquired
+                .iter()
+                .map(|key| key.resource_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["nft-1", "bridge-1", "cgroup-1", "tap-1"]
+        );
+        assert_eq!(
+            lease
+                .resources
+                .iter()
+                .map(|resource| resource.resource_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["nft-1", "bridge-1", "cgroup-1", "tap-1"]
+        );
+        assert!(
+            allocation
+                .decisions
+                .iter()
+                .all(|decision| decision.decision == AllocatorEngineDecision::Grant)
+        );
+    }
+
+    #[test]
+    fn denies_conflict_with_existing_persisted_lease() {
+        let requester = owner("work");
+        let other = owner("home");
+        let mut engine = engine(
+            requester.clone(),
+            vec![lease(
+                "lease-1",
+                other.clone(),
+                AllocatorLeaseState::Granted,
+                vec![granted("bridge-1", HostResourceKind::Bridge)],
+            )],
+            Vec::new(),
+            vec![requester.clone(), other],
+        );
+
+        let allocation = engine.allocate(request(
+            "op-1",
+            "corr-1",
+            "idem-1",
+            requester,
+            vec![request_resource("bridge-1", HostResourceKind::Bridge, 1, 0)],
+        ));
+
+        let LeaseAllocationResult::Denied { reason, conflicts } = allocation.response.result else {
+            panic!("expected denial");
+        };
+        assert_eq!(reason, AllocatorReasonCode::ResourceConflict);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].existing_lease, Some(lease_id("lease-1")));
+        assert_eq!(
+            allocation.decisions[0].decision,
+            AllocatorEngineDecision::DenyConflict {
+                reason: AllocatorReasonCode::ResourceConflict
+            }
+        );
+    }
+
+    #[test]
+    fn denies_observed_foreign_resource_during_allocation() {
+        let requester = owner("work");
+        let mut engine = engine(
+            requester.clone(),
+            Vec::new(),
+            vec![observed(
+                "bridge-foreign",
+                HostResourceKind::Bridge,
+                ObservedResourceState::ForeignOwner,
+            )],
+            vec![requester.clone()],
+        );
+
+        let allocation = engine.allocate(request(
+            "op-1",
+            "corr-1",
+            "idem-1",
+            requester,
+            vec![request_resource(
+                "bridge-foreign",
+                HostResourceKind::Bridge,
+                1,
+                0,
+            )],
+        ));
+
+        let LeaseAllocationResult::Denied { reason, conflicts } = allocation.response.result else {
+            panic!("expected denial");
+        };
+        assert_eq!(reason, AllocatorReasonCode::ResourceConflict);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].existing_lease, None);
+        assert_eq!(conflicts[0].reason, AllocatorReasonCode::OwnershipConflict);
+        assert_eq!(
+            allocation.decisions[0].decision,
+            AllocatorEngineDecision::DenyConflict {
+                reason: AllocatorReasonCode::OwnershipConflict
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_resources_in_direct_engine_request() {
+        let owner = owner("work");
+        let duplicate = request_resource("bridge-1", HostResourceKind::Bridge, 1, 0);
+        let mut engine = engine(owner.clone(), Vec::new(), Vec::new(), vec![owner.clone()]);
+
+        let allocation = engine.allocate(request(
+            "op-1",
+            "corr-1",
+            "idem-1",
+            owner,
+            vec![duplicate.clone(), duplicate],
+        ));
+
+        let LeaseAllocationResult::Denied { reason, conflicts } = allocation.response.result else {
+            panic!("expected denial");
+        };
+        assert_eq!(reason, AllocatorReasonCode::InvalidRequest);
+        assert!(conflicts.is_empty());
+        assert!(engine.ledger.leases.is_empty());
+    }
+
+    #[test]
+    fn replays_idempotent_denial_with_current_correlation() {
+        let requester = owner("work");
+        let other = owner("home");
+        let mut engine = engine(
+            requester.clone(),
+            vec![lease(
+                "lease-1",
+                other.clone(),
+                AllocatorLeaseState::Granted,
+                vec![granted("bridge-1", HostResourceKind::Bridge)],
+            )],
+            Vec::new(),
+            vec![requester.clone(), other],
+        );
+        let resource = request_resource("bridge-1", HostResourceKind::Bridge, 1, 0);
+
+        let first = engine.allocate(request(
+            "op-1",
+            "corr-1",
+            "idem-denied",
+            requester.clone(),
+            vec![resource.clone()],
+        ));
+        let second = engine.allocate(request(
+            "op-2",
+            "corr-2",
+            "idem-denied",
+            requester,
+            vec![resource],
+        ));
+
+        assert_eq!(second.response.operation_id, op("op-2"));
+        assert_eq!(second.response.correlation_id, corr("corr-2"));
+        assert_eq!(first.response.result, second.response.result);
+        assert_eq!(second.metrics[0].event, AllocatorEventKind::Denial);
+        assert_eq!(
+            second.metrics[0].outcome,
+            AllocatorEngineOutcome::IdempotentReplay
+        );
+    }
+
+    #[test]
+    fn replays_idempotent_duplicate_with_current_correlation() {
+        let owner = owner("work");
+        let resource = request_resource("bridge-1", HostResourceKind::Bridge, 1, 0);
+        let mut engine = engine(owner.clone(), Vec::new(), Vec::new(), vec![owner.clone()]);
+        let first = engine.allocate(request(
+            "op-1",
+            "corr-1",
+            "idem-1",
+            owner.clone(),
+            vec![resource.clone()],
+        ));
+        let second = engine.allocate(request("op-2", "corr-2", "idem-1", owner, vec![resource]));
+
+        assert_eq!(second.response.operation_id, op("op-2"));
+        assert_eq!(second.response.correlation_id, corr("corr-2"));
+        assert_eq!(first.response.result, second.response.result);
+        assert_eq!(
+            second.metrics[0].outcome,
+            AllocatorEngineOutcome::IdempotentReplay
+        );
+        assert_eq!(engine.ledger.leases.len(), 1);
+    }
+
+    #[test]
+    fn rejects_reused_idempotency_key_for_different_request() {
+        let owner = owner("work");
+        let mut engine = engine(owner.clone(), Vec::new(), Vec::new(), vec![owner.clone()]);
+        let _ = engine.allocate(request(
+            "op-1",
+            "corr-1",
+            "idem-1",
+            owner.clone(),
+            vec![request_resource("bridge-1", HostResourceKind::Bridge, 1, 0)],
+        ));
+        let second = engine.allocate(request(
+            "op-2",
+            "corr-2",
+            "idem-1",
+            owner,
+            vec![request_resource("bridge-2", HostResourceKind::Bridge, 1, 0)],
+        ));
+
+        let LeaseAllocationResult::Denied { reason, conflicts } = second.response.result else {
+            panic!("expected denial");
+        };
+        assert_eq!(reason, AllocatorReasonCode::InvalidRequest);
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn reclaims_stale_persisted_lease_when_observed_missing() {
+        let owner = owner("work");
+        let engine = engine(
+            owner.clone(),
+            vec![lease(
+                "lease-1",
+                owner.clone(),
+                AllocatorLeaseState::Granted,
+                vec![granted("bridge-1", HostResourceKind::Bridge)],
+            )],
+            Vec::new(),
+            vec![owner],
+        );
+
+        let reconciliation = engine.reconcile(op("op-1"), corr("corr-1"));
+
+        assert_eq!(
+            reconciliation.actions[0].decision,
+            AllocatorEngineDecision::Reclaim {
+                reason: AllocatorReasonCode::DriftDetected
+            }
+        );
+        assert_eq!(
+            reconciliation.report.records[0].decision,
+            ReconciliationDecision::Reclaim {
+                reason: AllocatorReasonCode::DriftDetected
+            }
+        );
+    }
+
+    #[test]
+    fn reconciles_live_persisted_lease_when_observed_present() {
+        let owner = owner("work");
+        let engine = engine(
+            owner.clone(),
+            vec![lease(
+                "lease-1",
+                owner.clone(),
+                AllocatorLeaseState::Granted,
+                vec![granted("bridge-1", HostResourceKind::Bridge)],
+            )],
+            vec![observed(
+                "bridge-1",
+                HostResourceKind::Bridge,
+                ObservedResourceState::Present,
+            )],
+            vec![owner],
+        );
+
+        let reconciliation = engine.reconcile(op("op-1"), corr("corr-1"));
+
+        assert_eq!(
+            reconciliation.actions[0].decision,
+            AllocatorEngineDecision::Reconcile
+        );
+        assert_eq!(
+            reconciliation.report.records[0].decision,
+            ReconciliationDecision::Reconciled
+        );
+        assert_eq!(
+            reconciliation.metrics[0].outcome,
+            AllocatorEngineOutcome::Reconciled
+        );
+        assert_eq!(reconciliation.metrics[0].labels().event, "reconciliation");
+    }
+
+    #[test]
+    fn preserves_observed_foreign_resource_without_persisted_lease() {
+        let owner = owner("work");
+        let engine = engine(
+            owner.clone(),
+            Vec::new(),
+            vec![observed(
+                "bridge-foreign",
+                HostResourceKind::Bridge,
+                ObservedResourceState::ForeignOwner,
+            )],
+            vec![owner],
+        );
+
+        let reconciliation = engine.reconcile(op("op-1"), corr("corr-1"));
+
+        assert_eq!(
+            reconciliation.actions[0].decision,
+            AllocatorEngineDecision::Preserve {
+                reason: AllocatorReasonCode::OwnershipConflict
+            }
+        );
+        assert_eq!(
+            reconciliation.report.records[0].decision,
+            ReconciliationDecision::Deny {
+                reason: AllocatorReasonCode::OwnershipConflict
+            }
+        );
+    }
+
+    #[test]
+    fn owner_liveness_placeholder_reclaims_after_broker_death() {
+        let owner = owner("work");
+        let engine = engine(
+            owner.clone(),
+            vec![lease(
+                "lease-1",
+                owner,
+                AllocatorLeaseState::Granted,
+                vec![granted("bridge-1", HostResourceKind::Bridge)],
+            )],
+            vec![observed(
+                "bridge-1",
+                HostResourceKind::Bridge,
+                ObservedResourceState::Present,
+            )],
+            Vec::new(),
+        );
+
+        let reconciliation = engine.reconcile(op("op-1"), corr("corr-1"));
+
+        assert_eq!(
+            reconciliation.actions[0].decision,
+            AllocatorEngineDecision::Reclaim {
+                reason: AllocatorReasonCode::OwnerNotLive
+            }
+        );
+    }
+
+    #[test]
+    fn quarantines_foreign_takeover_of_persisted_resource() {
+        let owner = owner("work");
+        let engine = engine(
+            owner.clone(),
+            vec![lease(
+                "lease-1",
+                owner.clone(),
+                AllocatorLeaseState::Granted,
+                vec![granted("bridge-1", HostResourceKind::Bridge)],
+            )],
+            vec![observed(
+                "bridge-1",
+                HostResourceKind::Bridge,
+                ObservedResourceState::ForeignOwner,
+            )],
+            vec![owner],
+        );
+
+        let reconciliation = engine.reconcile(op("op-1"), corr("corr-1"));
+
+        assert_eq!(
+            reconciliation.actions[0].decision,
+            AllocatorEngineDecision::Quarantine {
+                reason: AllocatorReasonCode::DriftDetected
+            }
+        );
+        assert_eq!(
+            reconciliation.metrics[0].outcome,
+            AllocatorEngineOutcome::Quarantined
+        );
+    }
+
+    #[test]
+    fn quarantines_duplicate_persisted_leases_for_same_resource() {
+        let owner = owner("work");
+        let engine = engine(
+            owner.clone(),
+            vec![
+                lease(
+                    "lease-1",
+                    owner.clone(),
+                    AllocatorLeaseState::Granted,
+                    vec![granted("bridge-1", HostResourceKind::Bridge)],
+                ),
+                lease(
+                    "lease-2",
+                    owner.clone(),
+                    AllocatorLeaseState::Granted,
+                    vec![granted("bridge-1", HostResourceKind::Bridge)],
+                ),
+            ],
+            vec![observed(
+                "bridge-1",
+                HostResourceKind::Bridge,
+                ObservedResourceState::Present,
+            )],
+            vec![owner],
+        );
+
+        let reconciliation = engine.reconcile(op("op-1"), corr("corr-1"));
+
+        assert_eq!(
+            reconciliation.actions[0].decision,
+            AllocatorEngineDecision::Quarantine {
+                reason: AllocatorReasonCode::StorageContractViolation
+            }
+        );
+    }
+
+    #[test]
+    fn event_and_metric_batches_are_bounded_and_low_cardinality() {
+        let owner = owner("work");
+        let mut engine = engine(owner.clone(), Vec::new(), Vec::new(), vec![owner.clone()]);
+        let resources = (0..MAX_ALLOCATOR_REQUEST_RESOURCES)
+            .map(|idx| {
+                request_resource(
+                    &format!("bridge-sensitive-{idx}"),
+                    HostResourceKind::Bridge,
+                    1,
+                    idx as u16,
+                )
+            })
+            .collect::<Vec<_>>();
+        let allocation = engine.allocate(request("op-1", "corr-1", "idem-1", owner, resources));
+
+        assert!(allocation.events.len() <= MAX_ALLOCATOR_EVENTS);
+        assert!(allocation.metrics.len() <= MAX_ALLOCATOR_EVENTS);
+        let labels = allocation.metrics[0].labels();
+        let rendered = format!("{labels:?}");
+        assert!(rendered.contains("grant"));
+        assert!(rendered.contains("granted"));
+        assert!(!rendered.contains("bridge-sensitive"));
+        assert!(
+            !allocation
+                .events
+                .iter()
+                .any(|event| format!("{event:?}").contains("bridge-sensitive"))
+        );
+    }
+
+    #[test]
+    fn reconciliation_report_events_and_metrics_are_bounded() {
+        let owner = owner("work");
+        let observations = (0..(MAX_RECONCILIATION_RECORDS + 8))
+            .map(|idx| {
+                observed(
+                    &format!("bridge-sensitive-{idx}"),
+                    HostResourceKind::Bridge,
+                    ObservedResourceState::Present,
+                )
+            })
+            .collect::<Vec<_>>();
+        let engine = engine(owner.clone(), Vec::new(), observations, vec![owner]);
+
+        let reconciliation = engine.reconcile(op("op-1"), corr("corr-1"));
+
+        assert_eq!(
+            reconciliation.report.records.len(),
+            MAX_RECONCILIATION_RECORDS
+        );
+        assert!(reconciliation.report.events.len() <= MAX_ALLOCATOR_EVENTS);
+        assert!(reconciliation.metrics.len() <= MAX_ALLOCATOR_EVENTS);
+        let labels = reconciliation.metrics[0].labels();
+        let rendered = format!("{labels:?}");
+        assert!(rendered.contains("preserved"));
+        assert!(!rendered.contains("bridge-sensitive"));
+        assert!(
+            !reconciliation
+                .report
+                .events
+                .iter()
+                .any(|event| format!("{event:?}").contains("bridge-sensitive"))
+        );
+    }
+
+    #[test]
+    fn bounded_metrics_aggregates_repeated_labels() {
+        let metrics = bounded_metrics(vec![
+            AllocatorMetricEvent::new(
+                AllocatorEventKind::Grant,
+                AllocatorEngineOutcome::Granted,
+                Some(HostResourceKind::Bridge),
+                None,
+            ),
+            AllocatorMetricEvent::new(
+                AllocatorEventKind::Denial,
+                AllocatorEngineOutcome::Denied,
+                Some(HostResourceKind::Tap),
+                Some(AllocatorReasonCode::ResourceConflict),
+            ),
+            AllocatorMetricEvent::new(
+                AllocatorEventKind::Grant,
+                AllocatorEngineOutcome::Granted,
+                Some(HostResourceKind::Bridge),
+                None,
+            ),
+        ]);
+
+        assert_eq!(metrics.len(), 2);
+        let grant = metrics
+            .iter()
+            .find(|metric| metric.labels().event == "grant")
+            .unwrap();
+        assert_eq!(grant.count, 2);
+        assert_eq!(grant.resource_kind, Some(HostResourceKind::Bridge));
+        assert_eq!(grant.reason, None);
+    }
+
+    #[test]
+    fn bounded_metrics_truncates_after_aggregation_in_label_order() {
+        let duplicate_grants = (0..(MAX_ALLOCATOR_EVENTS + 8)).map(|_| {
+            AllocatorMetricEvent::new(
+                AllocatorEventKind::Grant,
+                AllocatorEngineOutcome::Granted,
+                Some(HostResourceKind::Bridge),
+                None,
+            )
+        });
+        let unique_denials = [
+            HostResourceKind::Bridge,
+            HostResourceKind::CgroupSubtree,
+            HostResourceKind::HostFilePartition,
+            HostResourceKind::NamespaceBoundary,
+            HostResourceKind::NftablesPartition,
+            HostResourceKind::NftablesTable,
+            HostResourceKind::Tap,
+            HostResourceKind::VethPair,
+        ]
+        .into_iter()
+        .map(|kind| {
+            AllocatorMetricEvent::new(
+                AllocatorEventKind::Denial,
+                AllocatorEngineOutcome::Denied,
+                Some(kind),
+                Some(AllocatorReasonCode::ResourceConflict),
+            )
+        });
+        let metrics = bounded_metrics(duplicate_grants.chain(unique_denials));
+
+        assert_eq!(metrics.len(), 9);
+        assert_eq!(metrics[8].labels().event, "grant");
+        assert_eq!(metrics[8].count, (MAX_ALLOCATOR_EVENTS + 8) as u64);
+        assert!(
+            metrics
+                .windows(2)
+                .all(|window| window[0].labels() <= window[1].labels())
+        );
+    }
+}

--- a/packages/d2b-realm-core/src/ids.rs
+++ b/packages/d2b-realm-core/src/ids.rs
@@ -10,6 +10,9 @@
 //!   non-empty, log-safe tokens. They deliberately reject path-like and
 //!   credential-shaped strings because opaque ids appear in audit and
 //!   diagnostic metadata.
+//!   Troubleshooting ids such as [`OperationId`], [`CorrelationId`],
+//!   [`AllocatorLeaseId`], and [`HostResourceId`] remain visible in `Debug`;
+//!   credential-, key-, and principal-like ids stay redacted.
 //!
 //! All constructors validate; malformed input is rejected with
 //! [`IdError`] rather than silently accepted (fail-closed).
@@ -271,7 +274,7 @@ id_newtype!(
     OperationId,
     is_opaque_token,
     OPAQUE_PATTERN,
-    IdDebug::Redacted
+    IdDebug::Clear
 );
 id_newtype!(
     /// Caller-generated key for at-least-once mutating operations.
@@ -292,7 +295,7 @@ id_newtype!(
     CorrelationId,
     is_opaque_token,
     OPAQUE_PATTERN,
-    IdDebug::Redacted
+    IdDebug::Clear
 );
 id_newtype!(
     /// Opaque controller-generation id for a realm controller's runtime keys.
@@ -300,6 +303,23 @@ id_newtype!(
     is_opaque_token,
     OPAQUE_PATTERN,
     IdDebug::Redacted
+);
+id_newtype!(
+    /// Opaque local-root allocator lease id. The token is stable metadata only:
+    /// it is not a PID, file descriptor, path, interface name, or credential.
+    AllocatorLeaseId,
+    is_opaque_token,
+    OPAQUE_PATTERN,
+    IdDebug::Clear
+);
+id_newtype!(
+    /// Opaque id for a host resource or delegated partition allocated by the
+    /// local root allocator. Callers must not infer host paths, netlink names,
+    /// or nftables object names from this token.
+    HostResourceId,
+    is_opaque_token,
+    OPAQUE_PATTERN,
+    IdDebug::Clear
 );
 id_newtype!(
     /// Opaque enrollment record id.
@@ -372,11 +392,23 @@ mod tests {
     }
 
     #[test]
-    fn debug_redacts_opaque_ids_but_not_labels() {
+    fn debug_redacts_secret_like_opaque_ids_but_keeps_operator_ids_clear() {
         let principal = PrincipalId::parse("principal-1").unwrap();
         let principal_debug = format!("{principal:?}");
         assert!(principal_debug.contains("PrincipalId(<11 bytes>)"));
         assert!(!principal_debug.contains("principal-1"));
+
+        let operation = OperationId::parse("op-1").unwrap();
+        assert_eq!(format!("{operation:?}"), "OperationId(\"op-1\")");
+
+        let correlation = CorrelationId::parse("corr-1").unwrap();
+        assert_eq!(format!("{correlation:?}"), "CorrelationId(\"corr-1\")");
+
+        let lease = AllocatorLeaseId::parse("lease-home-1").unwrap();
+        assert_eq!(format!("{lease:?}"), "AllocatorLeaseId(\"lease-home-1\")");
+
+        let resource = HostResourceId::parse("bridge-home-1").unwrap();
+        assert_eq!(format!("{resource:?}"), "HostResourceId(\"bridge-home-1\")");
 
         let node = NodeId::parse("gateway").unwrap();
         assert_eq!(format!("{node:?}"), "NodeId(\"gateway\")");

--- a/packages/d2b-realm-core/src/lib.rs
+++ b/packages/d2b-realm-core/src/lib.rs
@@ -19,6 +19,8 @@
 //!   `deny_unknown_fields` (ADR 0010 strict wire discipline).
 
 pub mod access;
+pub mod allocator;
+pub mod allocator_engine;
 pub mod audit;
 pub mod capability;
 pub mod enrollment;
@@ -41,6 +43,21 @@ pub mod trace_context;
 pub mod workload;
 
 pub use access::{AccessBindingRef, RealmAccessBinding, RealmTransportBinding, UnixSocketPath};
+pub use allocator::{
+    ALLOCATOR_REASON_CODE_COUNT, AllocatorConflict, AllocatorEventKind, AllocatorEventMetadata,
+    AllocatorLease, AllocatorLeaseState, AllocatorReasonCode, GrantedHostResource,
+    HostResourceKind, LeaseAllocationRequest, LeaseAllocationResponse, LeaseAllocationResult,
+    LeaseOwner, LeaseResourceRequest, ObservedHostResource, ObservedResourceState,
+    PersistedResourceLease, ReconciliationDecision, ReconciliationRecord, ReconciliationReport,
+    ResourceAcquisitionKey, ResourceAcquisitionOrder, ResourceDelegation,
+    ResourceObservationSource, ResourceShareMode,
+};
+pub use allocator_engine::{
+    AllocatorAllocationDecision, AllocatorEngineAllocation, AllocatorEngineDecision,
+    AllocatorEngineOutcome, AllocatorEngineReconciliation, AllocatorMetricEvent,
+    AllocatorMetricLabels, AllocatorReconciliationAction, FakeAllocatorLedger,
+    FakeAllocatorLiveness, FakeObservedAllocatorState, LocalRootAllocatorEngine,
+};
 pub use audit::{AdmissionAuditRecord, AuditEnvelope, AuthorizationScope, AuthzDecision};
 pub use capability::{Capability, CapabilityNegotiation, CapabilitySet};
 pub use enrollment::{
@@ -58,9 +75,9 @@ pub use frame::{
     StreamFlow, StreamOpen, StreamResume,
 };
 pub use ids::{
-    ControllerGenerationId, CorrelationId, EnrollmentId, ExecutionId, GatewayId, IdempotencyKey,
-    NodeId, OperationId, PrincipalId, ProviderId, RealmId, RevocationId, RouteId, StreamCursor,
-    StreamId, WorkloadId,
+    AllocatorLeaseId, ControllerGenerationId, CorrelationId, EnrollmentId, ExecutionId, GatewayId,
+    HostResourceId, IdempotencyKey, NodeId, OperationId, PrincipalId, ProviderId, RealmId,
+    RevocationId, RouteId, StreamCursor, StreamId, WorkloadId,
 };
 pub use migration::{
     LegacySurface, MigrationErrorEnvelope, MigrationLegacyId, MigrationReasonCode,

--- a/packages/d2bd/src/kernel_module_check.rs
+++ b/packages/d2bd/src/kernel_module_check.rs
@@ -542,6 +542,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: None,
             sync_path: None,
+            allocator_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/d2bd/src/net_vm_bundle_gate.rs
+++ b/packages/d2bd/src/net_vm_bundle_gate.rs
@@ -413,6 +413,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: None,
             sync_path: None,
+            allocator_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/d2bd/src/storage_lifecycle.rs
+++ b/packages/d2bd/src/storage_lifecycle.rs
@@ -418,6 +418,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: storage_contract.as_ref().map(|_| "storage.json".to_owned()),
             sync_path: sync_contract.as_ref().map(|_| "sync.json".to_owned()),
+            allocator_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/d2bd/src/supervisor/stop_dag.rs
+++ b/packages/d2bd/src/supervisor/stop_dag.rs
@@ -268,6 +268,7 @@ mod tests {
             privileges_path: "privileges.json".to_owned(),
             storage_path: None,
             sync_path: None,
+            allocator_path: None,
             closures: Vec::new(),
             minijail_profiles: Vec::new(),
             managed_keys: Default::default(),

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -22,10 +22,10 @@ use d2b_contracts::{
     },
 };
 use d2b_core::{
-    audio_policy::AudioPolicyState, bundle::Bundle, closures::ClosureMetadata, error::Error,
-    host::HostJson, manifest_v04::ManifestV04, minijail_profile::MinijailProfile,
-    privileges::PrivilegesJson, processes::ProcessesJson, storage::StorageJson,
-    storage_lifecycle::StorageLifecycleReport, sync::SyncJson,
+    allocator_config::AllocatorJson, audio_policy::AudioPolicyState, bundle::Bundle,
+    closures::ClosureMetadata, error::Error, host::HostJson, manifest_v04::ManifestV04,
+    minijail_profile::MinijailProfile, privileges::PrivilegesJson, processes::ProcessesJson,
+    storage::StorageJson, storage_lifecycle::StorageLifecycleReport, sync::SyncJson,
 };
 use d2b_realm_core::{
     AccessBindingRef, AdmissionAuditRecord, AuditEnvelope, Capability, CapabilityNegotiation,
@@ -44,6 +44,14 @@ use d2b_realm_core::{
     ShellName, ShellSessionInstanceId, ShellState, ShellSummary, SignatureRef, StreamCursor,
     StreamId, StreamResume, UnixSocketPath, WorkloadId, WorkloadPlacement,
     WorkloadPlacementSummary, WorkloadSelector, WorkloadSummary,
+    allocator::{
+        AllocatorConflict, AllocatorEventKind, AllocatorEventMetadata, AllocatorLease,
+        AllocatorLeaseState, AllocatorReasonCode, GrantedHostResource, HostResourceKind,
+        LeaseAllocationRequest, LeaseAllocationResponse, LeaseAllocationResult, LeaseOwner,
+        LeaseResourceRequest, ObservedHostResource, ObservedResourceState, PersistedResourceLease,
+        ReconciliationDecision, ReconciliationRecord, ReconciliationReport, ResourceAcquisitionKey,
+        ResourceAcquisitionOrder, ResourceDelegation, ResourceObservationSource, ResourceShareMode,
+    },
     audit::{
         AuditChainCheckFailure, AuditChainCheckResult, AuditChainLink, AuditChainRecord, AuditHash,
         AuditRetentionFloorReason, AuditRetentionFloorStatus, AuditSinkHealth,
@@ -77,6 +85,8 @@ enum D2bRealmCoreSchema {
     RouteId(RouteId),
     CorrelationId(CorrelationId),
     ControllerGenerationId(ControllerGenerationId),
+    AllocatorLeaseId(d2b_realm_core::AllocatorLeaseId),
+    HostResourceId(d2b_realm_core::HostResourceId),
     EnrollmentId(EnrollmentId),
     RevocationId(RevocationId),
     Capability(Capability),
@@ -152,6 +162,30 @@ enum D2bRealmCoreSchema {
     AuditRetentionFloorStatus(AuditRetentionFloorStatus),
     AuditSinkHealthReason(AuditSinkHealthReason),
     AuditSinkHealth(AuditSinkHealth),
+    HostResourceKind(HostResourceKind),
+    LeaseOwner(LeaseOwner),
+    ResourceShareMode(ResourceShareMode),
+    ResourceAcquisitionOrder(ResourceAcquisitionOrder),
+    LeaseResourceRequest(LeaseResourceRequest),
+    ResourceAcquisitionKey(ResourceAcquisitionKey),
+    ResourceDelegation(ResourceDelegation),
+    GrantedHostResource(GrantedHostResource),
+    AllocatorLeaseState(AllocatorLeaseState),
+    AllocatorLease(AllocatorLease),
+    AllocatorReasonCode(AllocatorReasonCode),
+    AllocatorConflict(AllocatorConflict),
+    LeaseAllocationResponse(LeaseAllocationResponse),
+    LeaseAllocationRequest(LeaseAllocationRequest),
+    LeaseAllocationResult(LeaseAllocationResult),
+    AllocatorEventKind(AllocatorEventKind),
+    AllocatorEventMetadata(AllocatorEventMetadata),
+    PersistedResourceLease(PersistedResourceLease),
+    ResourceObservationSource(ResourceObservationSource),
+    ObservedResourceState(ObservedResourceState),
+    ObservedHostResource(ObservedHostResource),
+    ReconciliationDecision(ReconciliationDecision),
+    ReconciliationRecord(ReconciliationRecord),
+    ReconciliationReport(ReconciliationReport),
     TypedError(ConstellationError),
     Frame(ConstellationFrame),
 }
@@ -364,7 +398,8 @@ fn gen_schemas() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
         .join(SCHEMA_VERSION);
     fs::create_dir_all(&out_dir)?;
 
-    let schemas: [(&str, RootSchema); 14] = [
+    let schemas: [(&str, RootSchema); 15] = [
+        ("allocator.json", schemars::schema_for!(AllocatorJson)),
         ("bundle.json", schemars::schema_for!(Bundle)),
         (
             "d2b-realm-core.json",

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -276,6 +276,7 @@ in
         work = cfg.d2b._index.envMeta.work.lanBridge;
       };
     };
+
     expected = {
       names = [ "archive" "dev" "home" "work" ];
       enabledNames = [ "dev" "home" "work" ];
@@ -300,6 +301,7 @@ in
           cidrRefs = [ "dev" "lab" ];
         };
       };
+
       home = {
         allowedUsers = [ "alice" ];
         paths = {
@@ -352,6 +354,133 @@ in
         dev = "br-dev-lan";
         home = "br-home-lan";
         work = "br-work-lan";
+      };
+    };
+  };
+
+  "realms/allocator-artifact-roots-enabled-realm-index" = {
+    expr =
+      let
+        data = cfg.d2b._bundle.allocatorJson.data;
+        firstRequest = resourceId:
+          lib.findFirst (row: row.resourceId == resourceId) null data.resourceRequests;
+        namespaceBoundaryRequests =
+          lib.filter (row: row.kind == "namespace-boundary") data.resourceRequests;
+        devNamespaceBoundaryRequests =
+          lib.filter (row: row.resourceId == "realm-dev-netns") namespaceBoundaryRequests;
+        namespaceBoundaryResourceIds = map (row: row.resourceId) namespaceBoundaryRequests;
+        envRow = realmPath: envName:
+          lib.findFirst
+            (row: row.realmPath == realmPath && row.envName == envName)
+            null
+            data.envBridge;
+      in
+      {
+        installFileName = cfg.d2b._bundle.allocatorJson.installFileName;
+        classification = cfg.d2b._bundle.allocatorJson.classification;
+        sensitivity = cfg.d2b._bundle.allocatorJson.sensitivity;
+        mode = cfg.d2b._bundle.allocatorJson.mode;
+        user = cfg.d2b._bundle.allocatorJson.user;
+        group = cfg.d2b._bundle.allocatorJson.group;
+        bundleAllocatorPath = cfg.d2b._bundle.bundle.data.allocatorPath;
+        storageCoversAllocator =
+          lib.any (path: path.pathTemplate == "/etc/d2b/allocator.json")
+            cfg.d2b._bundle.storageJson.data.paths;
+        allocatorRuntimeServices =
+          lib.filter
+            (name: lib.hasInfix "allocator" name || lib.hasInfix "local-root" name)
+            (lib.attrNames cfg.systemd.services);
+        allocator = {
+          inherit (data.allocator) enabled runtimeState rootSocket stateDir leaseLedger auditDir runtime;
+        };
+        realmPaths = map (row: row.realmPath) data.realms;
+        devNetns = firstRequest "realm-dev-netns";
+        devNetnsCount = lib.length devNamespaceBoundaryRequests;
+        namespaceBoundaryResourceIdsUnique =
+          lib.length namespaceBoundaryResourceIds == lib.length (lib.unique namespaceBoundaryResourceIds);
+        homeBridge = firstRequest "env-home-bridge";
+        workProvider = builtins.head data.providerPlacements;
+        devWorkBridge = envRow "dev.home" "work";
+        inherit (data) invariants;
+      };
+    expected = {
+      installFileName = "allocator.json";
+      classification = "contractPrivateNonSecret";
+      sensitivity = "nonSecret";
+      mode = "0640";
+      user = "root";
+      group = "d2bd";
+      bundleAllocatorPath = "/etc/d2b/allocator.json";
+      storageCoversAllocator = true;
+      allocatorRuntimeServices = [ ];
+      allocator = {
+        enabled = true;
+        runtimeState = "metadata-only";
+        rootSocket = "/run/d2b/allocator/local-root.sock";
+        stateDir = "/var/lib/d2b/allocator";
+        leaseLedger = "/var/lib/d2b/allocator/leases.jsonl";
+        auditDir = "/var/lib/d2b/allocator/audit";
+        runtime = {
+          spawnsService = false;
+          socketActivated = false;
+          serviceName = null;
+        };
+      };
+      realmPaths = [ "dev.home" "home" "work.home" ];
+      devNetns = {
+        realmPath = "dev.home";
+        resourceId = "realm-dev-netns";
+        kind = "namespace-boundary";
+        share = "exclusive";
+        acquisitionOrder = {
+          phase = 31;
+          ordinal = 0;
+        };
+        source = {
+          kind = "realm-network";
+          refName = "dev";
+        };
+      };
+      devNetnsCount = 1;
+      namespaceBoundaryResourceIdsUnique = true;
+      homeBridge = {
+        realmPath = "home";
+        resourceId = "env-home-bridge";
+        kind = "bridge";
+        share = "shared-partition";
+        acquisitionOrder = {
+          phase = 30;
+          ordinal = 0;
+        };
+        source = {
+          kind = "env-bridge";
+          refName = "home";
+        };
+      };
+      workProvider = {
+        realmPath = "work.home";
+        providerName = "aca";
+        providerId = "aca";
+        enabled = true;
+        kind = "aca";
+        placement = "provider-agent";
+        capabilityRefs = [ "aca" "relay" ];
+        configRef = "work-aca-non-secret";
+      };
+      devWorkBridge = {
+        realmPath = "dev.home";
+        envName = "work";
+        declared = true;
+        enabled = true;
+        mode = "inherit-env";
+        netVm = "sys-work-net";
+        lanBridge = "br-work-lan";
+        uplinkBridge = "br-work-up";
+      };
+      invariants = {
+        noRuntimeAllocatorService = true;
+        preservesEnvRuntimeSourceOfTruth = true;
+        privateMetadataOnly = true;
       };
     };
   };

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -587,6 +587,7 @@ readiness-waves/has-p6
 readiness-waves/has-p7
 readiness-waves/p0-implemented-default
 readiness-waves/p0-validated-default
+realms/allocator-artifact-roots-enabled-realm-index
 realms/examples-minimal-and-multi-env-still-eval
 realms/index-normalizes-enabled-disabled-and-derived-paths
 realms/rejects-duplicate-id-and-path


### PR DESCRIPTION
## Summary
- add local-root allocator DTOs and generated schemas for typed leases, opaque host resources, reconciliation, and allocator audit/metric metadata
- add a pure fake-backend allocator engine for deterministic allocation, idempotency, conflict/quarantine/reclaim decisions, and bounded metrics
- emit private allocator.json bundle metadata rooted in d2b.realms without starting any allocator runtime service
- add contract, nix-unit, and Rust allocator coverage plus reference docs

## Validation
- RUSTC_WRAPPER= cargo test --manifest-path packages/Cargo.toml --locked -p d2b-realm-core allocator_engine --lib
- RUSTC_WRAPPER= cargo test --manifest-path packages/Cargo.toml --locked -p d2b-core -p xtask
- RUSTC_WRAPPER= cargo test --manifest-path packages/Cargo.toml --locked -p d2b-contract-tests --test storage_sync_contracts allocator
- RUSTC_WRAPPER= cargo check --manifest-path packages/Cargo.toml --locked -p d2b-core -p xtask -p d2bd --tests
- (cd packages/d2b-priv-broker && RUSTC_WRAPPER= cargo check --locked)
- nix build .#checks.x86_64-linux.nix-unit .#checks.x86_64-linux.nix-unit-network .#checks.x86_64-linux.eval-minimal .#checks.x86_64-linux.eval-multi-env --no-link
- cargo run --manifest-path packages/Cargo.toml -p xtask --locked -- gen-schemas
- git diff --exit-code
- full Gemini 3.1 Pro Wave 3 panel: unanimous signoff after follow-up round

Depends on #242.