### PR TITLE
rust: update crossbeam-epoch advisory fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated the `crossbeam-epoch` lockfile entry to a non-vulnerable release for
+  the RustSec advisory check.
+
 ### Added
 
 - Added draft ADR 0043 proposing a realm-native control plane that supersedes

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- bump crossbeam-epoch from 0.9.18 to 0.9.20 in packages/Cargo.lock
- resolves RUSTSEC-2026-0204 reported by the PR test-rust gate

## Validation
- make test-rust