### PR TITLE
realm: add local runtime provider metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ deprecations ship one minor release before removal.
 - Added private `realm-controllers.json` bundle metadata rooted in `d2b.realms`,
   covering deterministic per-realm daemon, broker, socket, state, audit,
   allocator binding, provider placement, and direct-access metadata.
+- Added metadata-only local runtime provider/workload rows to
+  `realm-controllers.json`, binding host-local realms to existing VM runtime
+  providers, preserved VM state/run/store-view paths, and explicit runtime
+  operation capability summaries without moving state during activation.
 - Added host-local realm control-plane materialization from `d2b.realms`,
   including deterministic bounded unit names, daemon/broker users and groups,
   socket access groups for allowed users, runtime/state/audit directories, and

--- a/docs/reference/realm-controller-config.md
+++ b/docs/reference/realm-controller-config.md
@@ -114,6 +114,35 @@ runtime code must load identity metadata from controller state, fail closed on
 stale or revoked generations, and write bounded audit records to the realm
 audit surface described by this file.
 
+## Local runtime metadata
+
+Host-local controller rows may include a `localRuntime` block. This is still
+metadata-only: it binds the realm to existing local runtime providers and VM
+workloads so the realm daemon can later consume one typed contract instead of
+re-deriving provider ids, VM paths, and operation capabilities from host-global
+state.
+
+`localRuntime.providers[]` copies the local runtime provider catalog entries
+used by the realm's workloads, including the provider id (`local-cloud-hypervisor`
+or `local-qemu-media`), local driver, legacy capability summary, operation
+capability summary, autostart policy, and role/service summaries.
+
+`localRuntime.workloads[]` records the VM workload id, VM name, owning env,
+runtime metadata, and the preserved host paths:
+
+| Field | Meaning |
+| --- | --- |
+| `paths.stateDir` | Existing per-VM persistent state root, such as `/var/lib/d2b/vms/<vm>`. |
+| `paths.runDir` | Existing per-VM runtime directory under `/run/d2b/vms/<vm>`. |
+| `paths.storeView` | Existing per-VM store-view hardlink farm root. |
+| `paths.guestControlDir` | Existing guest-control socket directory. |
+
+The `localRuntime.invariants` block must keep `metadataOnly`,
+`existingGlobalVmPathsPreserved`, `noStateMigrationDuringActivation`, and
+`brokerEffectsRemainRealmDelegated` true. The contract therefore does not move
+large state in activation and does not authorize a realm broker to mutate host
+state outside allocator-delegated effects.
+
 ## State, locks, and audit separation
 
 Realm controller metadata keeps three storage classes distinct:
@@ -139,14 +168,16 @@ deterministic users/groups, daemon config files, tmpfiles directories and ACLs,
 realm daemon services, and broker socket/service units for host-local realms
 whose broker is enabled. The artifact is still metadata-only for access,
 routing, and identity behavior: it describes the local surfaces and allocator
-bindings but does not make the global host daemon a realm router.
+bindings plus the existing local runtime providers/workloads, but does not make
+the global host daemon a realm router.
 
 It does not implement:
 
 - host-resource allocation or mutation through the allocator binding;
 - identity enrollment, relay connectivity, route advertisement, or provider
   controller runtime;
-- migration of existing VMs from `d2b.envs` to a realm-owned network model;
+- state-path migration for existing VMs or migration from `d2b.envs` to a
+  realm-owned network model;
 - a realm-local lifecycle API that replaces the existing global public socket.
 
 Existing `d2b.envs` and `d2b.vms.<vm>.env` behavior remains the implemented

--- a/docs/reference/schemas/v2/realm-controllers.json
+++ b/docs/reference/schemas/v2/realm-controllers.json
@@ -171,6 +171,16 @@
         "daemon": {
           "$ref": "#/definitions/RealmDaemonConfig"
         },
+        "localRuntime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RealmControllerLocalRuntime"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "paths": {
           "$ref": "#/definitions/RealmControllerPaths"
         },
@@ -208,6 +218,66 @@
       },
       "additionalProperties": false
     },
+    "RealmControllerDisplayOperationCapabilities": {
+      "type": "object",
+      "required": [
+        "display",
+        "graphics",
+        "video",
+        "waylandProxy"
+      ],
+      "properties": {
+        "display": {
+          "type": "boolean"
+        },
+        "graphics": {
+          "type": "boolean"
+        },
+        "video": {
+          "type": "boolean"
+        },
+        "waylandProxy": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerGuestOperationCapabilities": {
+      "type": "object",
+      "required": [
+        "configSync",
+        "exec",
+        "guestControl",
+        "inGuestObservability",
+        "keys",
+        "shell",
+        "ssh"
+      ],
+      "properties": {
+        "configSync": {
+          "type": "boolean"
+        },
+        "exec": {
+          "type": "boolean"
+        },
+        "guestControl": {
+          "type": "boolean"
+        },
+        "inGuestObservability": {
+          "type": "boolean"
+        },
+        "keys": {
+          "type": "boolean"
+        },
+        "shell": {
+          "type": "boolean"
+        },
+        "ssh": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "RealmControllerInvariants": {
       "type": "object",
       "required": [
@@ -227,6 +297,158 @@
           "type": "boolean"
         },
         "preservesGlobalDaemonBehavior": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerLifecycleOperationCapabilities": {
+      "type": "object",
+      "required": [
+        "hostPrepare",
+        "restart",
+        "start",
+        "stop",
+        "switch"
+      ],
+      "properties": {
+        "hostPrepare": {
+          "type": "boolean"
+        },
+        "restart": {
+          "type": "boolean"
+        },
+        "start": {
+          "type": "boolean"
+        },
+        "stop": {
+          "type": "boolean"
+        },
+        "switch": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerLocalRuntime": {
+      "type": "object",
+      "required": [
+        "invariants",
+        "runtimeState"
+      ],
+      "properties": {
+        "invariants": {
+          "$ref": "#/definitions/RealmControllerLocalRuntimeInvariants"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RealmControllerRuntimeMetadata"
+          }
+        },
+        "runtimeState": {
+          "$ref": "#/definitions/RealmControllerRuntimeState"
+        },
+        "workloads": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RealmControllerLocalWorkload"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerLocalRuntimeInvariants": {
+      "type": "object",
+      "required": [
+        "brokerEffectsRemainRealmDelegated",
+        "existingGlobalVmPathsPreserved",
+        "metadataOnly",
+        "noStateMigrationDuringActivation"
+      ],
+      "properties": {
+        "brokerEffectsRemainRealmDelegated": {
+          "type": "boolean"
+        },
+        "existingGlobalVmPathsPreserved": {
+          "type": "boolean"
+        },
+        "metadataOnly": {
+          "type": "boolean"
+        },
+        "noStateMigrationDuringActivation": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerLocalWorkload": {
+      "type": "object",
+      "required": [
+        "env",
+        "paths",
+        "runtime",
+        "vmName",
+        "workloadId"
+      ],
+      "properties": {
+        "env": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "paths": {
+          "$ref": "#/definitions/RealmControllerLocalWorkloadPaths"
+        },
+        "runtime": {
+          "$ref": "#/definitions/RealmControllerRuntimeMetadata"
+        },
+        "vmName": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "workloadId": {
+          "$ref": "#/definitions/ContractId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerLocalWorkloadPaths": {
+      "type": "object",
+      "required": [
+        "guestControlDir",
+        "runDir",
+        "stateDir",
+        "storeView"
+      ],
+      "properties": {
+        "guestControlDir": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "runDir": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "stateDir": {
+          "$ref": "#/definitions/PathTemplate"
+        },
+        "storeView": {
+          "$ref": "#/definitions/PathTemplate"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerMediaOperationCapabilities": {
+      "type": "object",
+      "required": [
+        "qemuMedia",
+        "removableMedia",
+        "usbHotplug"
+      ],
+      "properties": {
+        "qemuMedia": {
+          "type": "boolean"
+        },
+        "removableMedia": {
+          "type": "boolean"
+        },
+        "usbHotplug": {
           "type": "boolean"
         }
       },
@@ -355,6 +577,162 @@
       "minLength": 1,
       "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){0,15}$"
     },
+    "RealmControllerRuntimeCapabilities": {
+      "type": "object",
+      "required": [
+        "configSync",
+        "display",
+        "exec",
+        "guestControl",
+        "inGuestObservability",
+        "keys",
+        "lifecycle",
+        "ssh",
+        "storeSync",
+        "usbHotplug"
+      ],
+      "properties": {
+        "configSync": {
+          "type": "boolean"
+        },
+        "display": {
+          "type": "boolean"
+        },
+        "exec": {
+          "type": "boolean"
+        },
+        "guestControl": {
+          "type": "boolean"
+        },
+        "inGuestObservability": {
+          "type": "boolean"
+        },
+        "keys": {
+          "type": "boolean"
+        },
+        "lifecycle": {
+          "type": "boolean"
+        },
+        "ssh": {
+          "type": "boolean"
+        },
+        "storeSync": {
+          "type": "boolean"
+        },
+        "usbHotplug": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerRuntimeMetadata": {
+      "type": "object",
+      "required": [
+        "autostartPolicy",
+        "capabilities",
+        "kind",
+        "operationCapabilities",
+        "provider"
+      ],
+      "properties": {
+        "autostartPolicy": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/RealmControllerRuntimeCapabilities"
+        },
+        "kind": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "operationCapabilities": {
+          "$ref": "#/definitions/RealmControllerRuntimeOperationCapabilities"
+        },
+        "provider": {
+          "$ref": "#/definitions/RealmControllerRuntimeProviderRef"
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RealmControllerRuntimeServiceSummary"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerRuntimeOperationCapabilities": {
+      "type": "object",
+      "required": [
+        "display",
+        "guest",
+        "lifecycle",
+        "media",
+        "storage"
+      ],
+      "properties": {
+        "display": {
+          "$ref": "#/definitions/RealmControllerDisplayOperationCapabilities"
+        },
+        "guest": {
+          "$ref": "#/definitions/RealmControllerGuestOperationCapabilities"
+        },
+        "lifecycle": {
+          "$ref": "#/definitions/RealmControllerLifecycleOperationCapabilities"
+        },
+        "media": {
+          "$ref": "#/definitions/RealmControllerMediaOperationCapabilities"
+        },
+        "storage": {
+          "$ref": "#/definitions/RealmControllerStorageOperationCapabilities"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerRuntimeProviderRef": {
+      "type": "object",
+      "required": [
+        "driver",
+        "id",
+        "type"
+      ],
+      "properties": {
+        "driver": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "id": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "type": {
+          "$ref": "#/definitions/RealmControllerRuntimeProviderType"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerRuntimeProviderType": {
+      "type": "string",
+      "enum": [
+        "local"
+      ]
+    },
+    "RealmControllerRuntimeServiceSummary": {
+      "type": "object",
+      "required": [
+        "id",
+        "role"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/ContractId"
+        },
+        "optional": {
+          "default": false,
+          "type": "boolean"
+        },
+        "role": {
+          "$ref": "#/definitions/ContractId"
+        }
+      },
+      "additionalProperties": false
+    },
     "RealmControllerRuntimeState": {
       "type": "string",
       "enum": [
@@ -373,6 +751,26 @@
         },
         "publicSocketPath": {
           "$ref": "#/definitions/PathTemplate"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RealmControllerStorageOperationCapabilities": {
+      "type": "object",
+      "required": [
+        "storeSync",
+        "virtiofs",
+        "volumes"
+      ],
+      "properties": {
+        "storeSync": {
+          "type": "boolean"
+        },
+        "virtiofs": {
+          "type": "boolean"
+        },
+        "volumes": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/docs/reference/schemas/v2/realm-controllers.md
+++ b/docs/reference/schemas/v2/realm-controllers.md
@@ -4,9 +4,9 @@ Schema: [`realm-controllers.json`](./realm-controllers.json)
 
 `realm-controllers.json` is private realm controller configuration. It records
 deterministic per-realm daemon, broker, socket, state, audit, allocator,
-provider-placement, and access metadata rooted in `d2b.realms`; host-local
-realms use the same rows to materialise users, groups, systemd services, and
-sockets.
+provider-placement, local-runtime, and access metadata rooted in `d2b.realms`;
+host-local realms use the same rows to materialise users, groups, systemd
+services, and sockets.
 
 ## Top-level fields
 
@@ -35,6 +35,9 @@ sockets.
   references.
 - `access` — declared direct-access users/groups plus inherited host admin
   users for socket ACL planning.
+- `localRuntime` — metadata-only local runtime providers, VM workload rows,
+  preserved VM paths, and runtime operation capability summaries for host-local
+  realms.
 - `providers` — provider declarations copied from the realm index.
 
 ## Contract notes
@@ -47,3 +50,6 @@ sockets.
   rather than proxying authority through an unrelated transport.
 - Principal names are deterministic metadata derived from the realm path; the
   NixOS host module creates them for host-local realms.
+- `localRuntime` does not move VM state during activation. Its invariants require
+  existing global VM paths to remain the source of truth until realm-local
+  lifecycle code consumes the provider contract.

--- a/nixos-modules/realm-controller-config-json.nix
+++ b/nixos-modules/realm-controller-config-json.nix
@@ -9,6 +9,9 @@ let
     map (name: f name attrs.${name}) (sortedAttrNames attrs);
 
   realmRows = cfg._index.realms.enabledList;
+  enabledVms = cfg._index.enabledVms;
+  runtimeRows = cfg._index.runtime.byVm;
+  runtimeProviders = cfg._index.runtime.providers;
   allocatorData = cfg._bundle.allocatorJson.data;
   allocatorConfigPath = "/etc/d2b/allocator.json";
 
@@ -49,6 +52,56 @@ let
       (lib.filter (request: request.realmPath == realm.path)
         allocatorData.resourceRequests));
 
+  localRuntimeWorkloadsFor = realm:
+    if realm.placement != "host-local" || realm.network.env == null then [ ]
+    else
+      sortedMapAttrsToList
+        (vmName: vm:
+          if vm.env == realm.network.env then
+            let
+              runtime = runtimeRows.${vmName}.metadata;
+            in
+            {
+              workloadId = vmName;
+              inherit vmName;
+              env = vm.env;
+              inherit runtime;
+              paths = {
+                stateDir = cfg.manifest.${vmName}.stateDir;
+                runDir = "/run/d2b/vms/${vmName}";
+                storeView = "${toString cfg.store.stateDir}/${vmName}/store-view";
+                guestControlDir = "/run/d2b/vms/${vmName}/guest-control";
+              };
+            }
+          else null)
+        enabledVms;
+
+  compact = values: lib.filter (value: value != null) values;
+
+  runtimeProviderById = providerId:
+    lib.findFirst
+      (provider: provider.provider.id == providerId)
+      (throw "d2b realm-controller-config: local runtime provider '${providerId}' is missing from runtime provider catalog")
+      runtimeProviders;
+
+  localRuntimeFor = realm:
+    let
+      workloads = compact (localRuntimeWorkloadsFor realm);
+      providerIds = sortNames (lib.unique (map (workload: workload.runtime.provider.id) workloads));
+    in
+    if workloads == [ ] then null
+    else {
+      runtimeState = "metadata-only";
+      providers = map runtimeProviderById providerIds;
+      inherit workloads;
+      invariants = {
+        metadataOnly = true;
+        existingGlobalVmPathsPreserved = true;
+        noStateMigrationDuringActivation = true;
+        brokerEffectsRemainRealmDelegated = true;
+      };
+    };
+
   controllerConfig = realm:
     let
       controller = realm.controller;
@@ -81,6 +134,7 @@ let
         allowedGroups = realm.allowedGroups;
         inheritedAdminUsers = sortNames (lib.unique cfg.site.adminUsers);
       };
+      localRuntime = localRuntimeFor realm;
       providers = sortedMapAttrsToList providerConfig realm.providers;
     };
 

--- a/packages/d2b-core/src/realm_controller_config.rs
+++ b/packages/d2b-core/src/realm_controller_config.rs
@@ -4,6 +4,7 @@ use schemars::{
     schema::{InstanceType, Schema, SchemaObject, SingleOrVec, StringValidation},
 };
 use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeSet;
 
 use crate::contract_id::{ContractId, ContractStringError, PathTemplate};
 
@@ -198,6 +199,8 @@ pub struct RealmControllerConfig {
     pub sockets: RealmControllerSockets,
     pub allocator: RealmAllocatorBinding,
     pub access: RealmControllerAccess,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_runtime: Option<RealmControllerLocalRuntime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub providers: Vec<RealmControllerProvider>,
 }
@@ -240,6 +243,9 @@ impl RealmControllerConfig {
                 found: self.broker.socket_path.as_str().to_owned(),
             });
         }
+        if let Some(local_runtime) = &self.local_runtime {
+            local_runtime.validate_metadata_only(&realm, self.placement)?;
+        }
         Ok(())
     }
 }
@@ -264,6 +270,220 @@ pub struct RealmControllerProviderPlacement {
     pub kind: Option<RealmControllerProviderKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_specific_placement: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerLocalRuntime {
+    pub runtime_state: RealmControllerRuntimeState,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<RealmControllerRuntimeMetadata>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workloads: Vec<RealmControllerLocalWorkload>,
+    pub invariants: RealmControllerLocalRuntimeInvariants,
+}
+
+impl RealmControllerLocalRuntime {
+    fn validate_metadata_only(
+        &self,
+        realm: &str,
+        placement: RealmControllerPlacement,
+    ) -> Result<(), RealmControllerConfigError> {
+        if placement != RealmControllerPlacement::HostLocal {
+            return Err(RealmControllerConfigError::LocalRuntimeForNonHostLocal {
+                realm: realm.to_owned(),
+                placement,
+            });
+        }
+        if self.runtime_state != RealmControllerRuntimeState::MetadataOnly {
+            return Err(RealmControllerConfigError::UnsupportedLocalRuntimeState {
+                realm: realm.to_owned(),
+            });
+        }
+        self.invariants.validate(realm)?;
+
+        let provider_ids = self
+            .providers
+            .iter()
+            .map(|provider| provider.provider.id.as_str())
+            .collect::<BTreeSet<_>>();
+        for workload in &self.workloads {
+            if !provider_ids.contains(workload.runtime.provider.id.as_str()) {
+                return Err(RealmControllerConfigError::MissingLocalRuntimeProvider {
+                    realm: realm.to_owned(),
+                    workload: workload.workload_id.as_str().to_owned(),
+                    provider_id: workload.runtime.provider.id.as_str().to_owned(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerRuntimeMetadata {
+    pub kind: ContractId,
+    pub provider: RealmControllerRuntimeProviderRef,
+    pub capabilities: RealmControllerRuntimeCapabilities,
+    pub operation_capabilities: RealmControllerRuntimeOperationCapabilities,
+    pub autostart_policy: ContractId,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub services: Vec<RealmControllerRuntimeServiceSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerRuntimeProviderRef {
+    pub id: ContractId,
+    pub driver: ContractId,
+    #[serde(rename = "type")]
+    pub provider_type: RealmControllerRuntimeProviderType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealmControllerRuntimeProviderType {
+    Local,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerRuntimeCapabilities {
+    pub lifecycle: bool,
+    pub display: bool,
+    pub usb_hotplug: bool,
+    pub guest_control: bool,
+    pub exec: bool,
+    pub config_sync: bool,
+    pub ssh: bool,
+    pub store_sync: bool,
+    pub keys: bool,
+    pub in_guest_observability: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerRuntimeOperationCapabilities {
+    pub lifecycle: RealmControllerLifecycleOperationCapabilities,
+    pub media: RealmControllerMediaOperationCapabilities,
+    pub display: RealmControllerDisplayOperationCapabilities,
+    pub guest: RealmControllerGuestOperationCapabilities,
+    pub storage: RealmControllerStorageOperationCapabilities,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerLifecycleOperationCapabilities {
+    pub start: bool,
+    pub stop: bool,
+    pub restart: bool,
+    pub switch: bool,
+    pub host_prepare: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerMediaOperationCapabilities {
+    pub usb_hotplug: bool,
+    pub removable_media: bool,
+    pub qemu_media: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerDisplayOperationCapabilities {
+    pub display: bool,
+    pub graphics: bool,
+    pub video: bool,
+    pub wayland_proxy: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerGuestOperationCapabilities {
+    pub guest_control: bool,
+    pub exec: bool,
+    pub shell: bool,
+    pub config_sync: bool,
+    pub ssh: bool,
+    pub keys: bool,
+    pub in_guest_observability: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerStorageOperationCapabilities {
+    pub store_sync: bool,
+    pub virtiofs: bool,
+    pub volumes: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerRuntimeServiceSummary {
+    pub id: ContractId,
+    pub role: ContractId,
+    #[serde(default)]
+    pub optional: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerLocalWorkload {
+    pub workload_id: ContractId,
+    pub vm_name: ContractId,
+    pub env: ContractId,
+    pub runtime: RealmControllerRuntimeMetadata,
+    pub paths: RealmControllerLocalWorkloadPaths,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerLocalWorkloadPaths {
+    pub state_dir: PathTemplate,
+    pub run_dir: PathTemplate,
+    pub store_view: PathTemplate,
+    pub guest_control_dir: PathTemplate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RealmControllerLocalRuntimeInvariants {
+    pub metadata_only: bool,
+    pub existing_global_vm_paths_preserved: bool,
+    pub no_state_migration_during_activation: bool,
+    pub broker_effects_remain_realm_delegated: bool,
+}
+
+impl RealmControllerLocalRuntimeInvariants {
+    fn validate(&self, realm: &str) -> Result<(), RealmControllerConfigError> {
+        if !self.metadata_only {
+            return Err(RealmControllerConfigError::LocalRuntimeInvariantDisabled {
+                realm: realm.to_owned(),
+                field: "metadataOnly",
+            });
+        }
+        if !self.existing_global_vm_paths_preserved {
+            return Err(RealmControllerConfigError::LocalRuntimeInvariantDisabled {
+                realm: realm.to_owned(),
+                field: "existingGlobalVmPathsPreserved",
+            });
+        }
+        if !self.no_state_migration_during_activation {
+            return Err(RealmControllerConfigError::LocalRuntimeInvariantDisabled {
+                realm: realm.to_owned(),
+                field: "noStateMigrationDuringActivation",
+            });
+        }
+        if !self.broker_effects_remain_realm_delegated {
+            return Err(RealmControllerConfigError::LocalRuntimeInvariantDisabled {
+                realm: realm.to_owned(),
+                field: "brokerEffectsRemainRealmDelegated",
+            });
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -406,6 +626,22 @@ pub enum RealmControllerConfigError {
         expected: String,
         found: String,
     },
+    LocalRuntimeForNonHostLocal {
+        realm: String,
+        placement: RealmControllerPlacement,
+    },
+    UnsupportedLocalRuntimeState {
+        realm: String,
+    },
+    LocalRuntimeInvariantDisabled {
+        realm: String,
+        field: &'static str,
+    },
+    MissingLocalRuntimeProvider {
+        realm: String,
+        workload: String,
+        provider_id: String,
+    },
 }
 
 impl std::fmt::Display for RealmControllerConfigError {
@@ -438,6 +674,34 @@ impl std::fmt::Display for RealmControllerConfigError {
                 write!(
                     f,
                     "realm controller {realm} field {field} is {found:?}; expected {expected:?}"
+                )
+            }
+            Self::LocalRuntimeForNonHostLocal { realm, placement } => {
+                write!(
+                    f,
+                    "realm controller {realm} has localRuntime metadata but placement is {placement:?}; expected host-local"
+                )
+            }
+            Self::UnsupportedLocalRuntimeState { realm } => {
+                write!(
+                    f,
+                    "realm controller {realm} localRuntime.runtimeState must remain metadata-only"
+                )
+            }
+            Self::LocalRuntimeInvariantDisabled { realm, field } => {
+                write!(
+                    f,
+                    "realm controller {realm} localRuntime invariant {field} must be true"
+                )
+            }
+            Self::MissingLocalRuntimeProvider {
+                realm,
+                workload,
+                provider_id,
+            } => {
+                write!(
+                    f,
+                    "realm controller {realm} localRuntime workload {workload} references undeclared provider {provider_id}"
                 )
             }
         }

--- a/packages/d2b-core/tests/realm_controller_config.rs
+++ b/packages/d2b-core/tests/realm_controller_config.rs
@@ -54,6 +54,148 @@ fn realm_controllers_fixture() -> serde_json::Value {
                     "allowedGroups": ["d2b"],
                     "inheritedAdminUsers": ["admin"]
                 },
+                "localRuntime": {
+                    "runtimeState": "metadata-only",
+                    "providers": [
+                        {
+                            "kind": "nixos",
+                            "provider": {
+                                "id": "local-cloud-hypervisor",
+                                "driver": "cloud-hypervisor",
+                                "type": "local"
+                            },
+                            "capabilities": {
+                                "lifecycle": true,
+                                "display": true,
+                                "usbHotplug": true,
+                                "guestControl": true,
+                                "exec": true,
+                                "configSync": true,
+                                "ssh": true,
+                                "storeSync": true,
+                                "keys": true,
+                                "inGuestObservability": true
+                            },
+                            "operationCapabilities": {
+                                "lifecycle": {
+                                    "start": true,
+                                    "stop": true,
+                                    "restart": true,
+                                    "switch": true,
+                                    "hostPrepare": true
+                                },
+                                "media": {
+                                    "usbHotplug": true,
+                                    "removableMedia": false,
+                                    "qemuMedia": false
+                                },
+                                "display": {
+                                    "display": true,
+                                    "graphics": true,
+                                    "video": true,
+                                    "waylandProxy": true
+                                },
+                                "guest": {
+                                    "guestControl": true,
+                                    "exec": true,
+                                    "shell": true,
+                                    "configSync": true,
+                                    "ssh": true,
+                                    "keys": true,
+                                    "inGuestObservability": true
+                                },
+                                "storage": {
+                                    "storeSync": true,
+                                    "virtiofs": true,
+                                    "volumes": true
+                                }
+                            },
+                            "autostartPolicy": "host-boot-eligible",
+                            "services": [
+                                { "id": "host-reconcile", "role": "host", "optional": false },
+                                { "id": "cloud-hypervisor", "role": "hypervisor", "optional": false }
+                            ]
+                        }
+                    ],
+                    "workloads": [
+                        {
+                            "workloadId": "corp-vm",
+                            "vmName": "corp-vm",
+                            "env": "work",
+                            "runtime": {
+                                "kind": "nixos",
+                                "provider": {
+                                    "id": "local-cloud-hypervisor",
+                                    "driver": "cloud-hypervisor",
+                                    "type": "local"
+                                },
+                                "capabilities": {
+                                    "lifecycle": true,
+                                    "display": true,
+                                    "usbHotplug": true,
+                                    "guestControl": true,
+                                    "exec": true,
+                                    "configSync": true,
+                                    "ssh": true,
+                                    "storeSync": true,
+                                    "keys": true,
+                                    "inGuestObservability": true
+                                },
+                                "operationCapabilities": {
+                                    "lifecycle": {
+                                        "start": true,
+                                        "stop": true,
+                                        "restart": true,
+                                        "switch": true,
+                                        "hostPrepare": true
+                                    },
+                                    "media": {
+                                        "usbHotplug": true,
+                                        "removableMedia": false,
+                                        "qemuMedia": false
+                                    },
+                                    "display": {
+                                        "display": true,
+                                        "graphics": true,
+                                        "video": true,
+                                        "waylandProxy": true
+                                    },
+                                    "guest": {
+                                        "guestControl": true,
+                                        "exec": true,
+                                        "shell": true,
+                                        "configSync": true,
+                                        "ssh": true,
+                                        "keys": true,
+                                        "inGuestObservability": true
+                                    },
+                                    "storage": {
+                                        "storeSync": true,
+                                        "virtiofs": true,
+                                        "volumes": true
+                                    }
+                                },
+                                "autostartPolicy": "host-boot-eligible",
+                                "services": [
+                                    { "id": "host-reconcile", "role": "host", "optional": false },
+                                    { "id": "cloud-hypervisor", "role": "hypervisor", "optional": false }
+                                ]
+                            },
+                            "paths": {
+                                "stateDir": "/var/lib/d2b/vms/corp-vm",
+                                "runDir": "/run/d2b/vms/corp-vm",
+                                "storeView": "/var/lib/d2b/vms/corp-vm/store-view",
+                                "guestControlDir": "/run/d2b/vms/corp-vm/guest-control"
+                            }
+                        }
+                    ],
+                    "invariants": {
+                        "metadataOnly": true,
+                        "existingGlobalVmPathsPreserved": true,
+                        "noStateMigrationDuringActivation": true,
+                        "brokerEffectsRemainRealmDelegated": true
+                    }
+                },
                 "providers": [
                     {
                         "providerName": "entra",
@@ -102,6 +244,24 @@ fn realm_controller_metadata_parses_and_validates_socket_path_user_group_metadat
     assert_eq!(
         controller.sockets.public_socket_path.as_str(),
         "/run/d2b/realms/work/public.sock"
+    );
+    let local_runtime = controller
+        .local_runtime
+        .as_ref()
+        .expect("local runtime metadata exists");
+    assert_eq!(local_runtime.providers.len(), 1);
+    assert_eq!(
+        local_runtime.providers[0].provider.id.as_str(),
+        "local-cloud-hypervisor"
+    );
+    assert_eq!(local_runtime.workloads.len(), 1);
+    assert_eq!(local_runtime.workloads[0].vm_name.as_str(), "corp-vm");
+    assert!(
+        local_runtime.workloads[0]
+            .runtime
+            .operation_capabilities
+            .guest
+            .exec
     );
 }
 
@@ -159,4 +319,31 @@ fn realm_controller_metadata_accepts_emitted_host_local_unit_metadata() {
     assert_eq!(summary.controller_count, 1);
     assert_eq!(summary.host_local_controller_count, 1);
     assert_eq!(summary.broker_enabled_count, 1);
+}
+
+#[test]
+fn realm_controller_metadata_rejects_invalid_local_runtime_metadata() {
+    let mut non_host_local = realm_controllers_fixture();
+    non_host_local["controllers"][0]["placement"] = json!("provider-controller");
+    let config: RealmControllersJson =
+        serde_json::from_value(non_host_local).expect("non-host-local fixture parses");
+    assert!(
+        config
+            .validate_metadata_only()
+            .expect_err("local runtime is host-local only")
+            .to_string()
+            .contains("localRuntime metadata")
+    );
+
+    let mut missing_provider = realm_controllers_fixture();
+    missing_provider["controllers"][0]["localRuntime"]["providers"] = json!([]);
+    let config: RealmControllersJson =
+        serde_json::from_value(missing_provider).expect("missing provider fixture parses");
+    assert!(
+        config
+            .validate_metadata_only()
+            .expect_err("workload runtime provider must be declared")
+            .to_string()
+            .contains("references undeclared provider")
+    );
 }

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -720,7 +720,25 @@ in
             hasPublicSocketRef = builtins.elem "realm-home-public-socket" homeResourceRefs;
             hasBrokerSocketRef = builtins.elem "realm-home-broker-socket" homeResourceRefs;
           };
+          localRuntime = {
+            runtimeState = home.localRuntime.runtimeState;
+            providerIds = map (provider: provider.provider.id) home.localRuntime.providers;
+            workloads = map
+              (workload: {
+                inherit (workload) workloadId vmName env paths;
+                runtimeKind = workload.runtime.kind;
+                providerId = workload.runtime.provider.id;
+                driver = workload.runtime.provider.driver;
+                lifecycleStart = workload.runtime.operationCapabilities.lifecycle.start;
+                guestExec = workload.runtime.operationCapabilities.guest.exec;
+                storageStoreSync = workload.runtime.operationCapabilities.storage.storeSync;
+                serviceIds = map (service: service.id) workload.runtime.services;
+              })
+              home.localRuntime.workloads;
+            inherit (home.localRuntime) invariants;
+          };
         };
+        workLocalRuntime = work.localRuntime;
         workProviderCount = lib.length work.providers;
         workProvider = builtins.head work.providers;
         providerPlacement = validProviderController.providerPlacement;
@@ -851,7 +869,49 @@ in
           hasPublicSocketRef = true;
           hasBrokerSocketRef = true;
         };
+        localRuntime = {
+          runtimeState = "metadata-only";
+          providerIds = [ "local-cloud-hypervisor" ];
+          workloads = [
+            {
+              workloadId = "homebox";
+              vmName = "homebox";
+              env = "home";
+              paths = {
+                stateDir = "/var/lib/d2b/vms/homebox";
+                runDir = "/run/d2b/vms/homebox";
+                storeView = "/var/lib/d2b/vms/homebox/store-view";
+                guestControlDir = "/run/d2b/vms/homebox/guest-control";
+              };
+              runtimeKind = "nixos";
+              providerId = "local-cloud-hypervisor";
+              driver = "cloud-hypervisor";
+              lifecycleStart = true;
+              guestExec = true;
+              storageStoreSync = true;
+              serviceIds = [
+                "host-reconcile"
+                "store-virtiofs-preflight"
+                "virtiofsd"
+                "cloud-hypervisor"
+                "guest-control-health"
+                "swtpm"
+                "gpu"
+                "audio"
+                "video"
+                "usbip"
+              ];
+            }
+          ];
+          invariants = {
+            metadataOnly = true;
+            existingGlobalVmPathsPreserved = true;
+            noStateMigrationDuringActivation = true;
+            brokerEffectsRemainRealmDelegated = true;
+          };
+        };
       };
+      workLocalRuntime = null;
       workProviderCount = 1;
       workProvider = {
         providerName = "aca";


### PR DESCRIPTION
## Summary
- Adds metadata-only local runtime provider/workload rows to `realm-controllers.json` for host-local realms.
- Preserves existing per-VM state/run/store-view/guest-control paths while exposing explicit runtime provider and operation capability summaries.
- Extends the typed Rust realm-controller DTO, generated schema, reference docs, changelog, and nix-unit/Rust coverage.

## Validation
- `cargo test --manifest-path packages/Cargo.toml -p d2b-core --test realm_controller_config -- --nocapture`
- `nix build --no-link .#checks.x86_64-linux.nix-unit-network`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-contract-tests realm_controller -- --nocapture`

## Stack
- Stacked on PR #249 (`adr0043-w8-rebuilt`). Retarget to `main` after #249 merges.