### PR TITLE
clipboard: expose realm target picker metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ deprecations ship one minor release before removal.
 - Extended the realm access resolver so host-local `localRuntime` metadata
   contributes bounded operation capabilities to capability preflight, while
   preserving typed denials for missing capabilities.
+- Added canonical realm-target and picker/clipd capability-preflight metadata
+  to the clipboard picker protocol so desktop pickers can display trusted
+  d2b-provided VM identity without using guest titles or app ids as authority.
 - Added host-local realm control-plane materialization from `d2b.realms`,
   including deterministic bounded unit names, daemon/broker users and groups,
   socket access groups for allowed users, runtime/state/audit directories, and

--- a/docs/reference/clipboard-picker-protocol.md
+++ b/docs/reference/clipboard-picker-protocol.md
@@ -50,12 +50,20 @@ filtered candidates. Clipboard payload bytes are not included.
   "destination": {
     "realm": "Personal",
     "realm_kind": "vm",
+    "canonical_target": "firefox.personal.local.d2b",
     "application": "Firefox",
     "app_id": "org.mozilla.firefox",
     "title": null,
     "workspace": "dev",
     "output": "DP-1",
-    "attribution": "exact_client"
+    "attribution": "exact_client",
+    "capability_preflight": {
+      "status": "satisfied",
+      "required_capabilities": ["clipboard"],
+      "advertised_capabilities": ["clipboard"],
+      "missing_capabilities": [],
+      "authority": "picker_clipd"
+    }
   },
   "requested_mime_type": "text/plain",
   "expires_at_unix_ms": 1760000000000,
@@ -65,6 +73,7 @@ filtered candidates. Clipboard payload bytes are not included.
       "entry_id": "opaque-entry",
       "source_realm": "Host",
       "source_realm_kind": "host",
+      "source_canonical_target": null,
       "source_app": "Text Editor",
       "source_app_id": "org.gnome.TextEditor",
       "source_attribution": "focused_window_guess",
@@ -73,7 +82,14 @@ filtered candidates. Clipboard payload bytes are not included.
       "timestamp_unix_ms": 1760000000000,
       "thumbnail_png_base64": null,
       "byte_count": 128,
-      "confirmation_required": false
+      "confirmation_required": false,
+      "capability_preflight": {
+        "status": "satisfied",
+        "required_capabilities": ["clipboard"],
+        "advertised_capabilities": ["clipboard"],
+        "missing_capabilities": [],
+        "authority": "picker_clipd"
+      }
     }
   ]
 }
@@ -107,6 +123,19 @@ destination output, but placement never affects policy. Fields are:
 - `overlay_width`, `overlay_height`: desired picker size.
 - `output`: optional output label, such as a Niri output name.
 
+## Realm identity and capability metadata
+
+`canonical_target` and `source_canonical_target` are optional canonical realm
+addresses in `<workload>.<realm>.d2b` form. For current local VM clipboard
+sources, `d2b-clipd` emits `<vm>.local.d2b`; host clipboard sources use `null`.
+These fields are asserted by d2b metadata, not by guest-provided titles or app
+ids.
+
+`capability_preflight` records the bounded preflight status that the picker may
+display. Clipboard transfers are still fulfilled only by d2b-clipd after picker
+selection; `authority: "picker_clipd"` means direct host/VM clipboard offers are
+discovery metadata only.
+
 ## Candidate metadata
 
 Candidates may include:
@@ -114,6 +143,7 @@ Candidates may include:
 - `entry_id`
 - `source_realm`
 - `source_realm_kind` (`host`, `vm`)
+- `source_canonical_target`
 - `source_app`
 - `source_app_id`
 - `source_attribution` (`exact_client`, `focused_window_guess`,
@@ -123,6 +153,7 @@ Candidates may include:
 - `timestamp_unix_ms`
 - optional capped PNG thumbnail metadata
 - `confirmation_required`
+- `capability_preflight`
 
 Text and HTML previews are rendered as plain text only. ANSI escapes,
 non-printable controls, rich HTML, Pango markup, and remote resources are not

--- a/docs/reference/schemas/clipboard-picker-protocol-v1.json
+++ b/docs/reference/schemas/clipboard-picker-protocol-v1.json
@@ -118,11 +118,13 @@
       "properties": {
         "realm": { "type": "string", "minLength": 1, "maxLength": 128 },
         "realm_kind": { "enum": ["host", "vm"] },
+        "canonical_target": { "type": ["string", "null"], "minLength": 1, "maxLength": 256, "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+\\.d2b$" },
         "app_id": { "type": ["string", "null"], "maxLength": 256 },
         "application": { "type": ["string", "null"], "maxLength": 256 },
         "workspace": { "type": ["string", "null"], "maxLength": 128 },
         "output": { "type": ["string", "null"], "maxLength": 128 },
-        "attribution": { "enum": ["exact_client", "focused_window_guess", "cache_stale_focused_window_guess", "broker_injected_debug"] }
+        "attribution": { "enum": ["exact_client", "focused_window_guess", "cache_stale_focused_window_guess", "broker_injected_debug"] },
+        "capability_preflight": { "anyOf": [{ "$ref": "#/$defs/CapabilityPreflight" }, { "type": "null" }] }
       }
     },
     "PlacementHints": {
@@ -154,6 +156,7 @@
         "entry_id": { "$ref": "#/$defs/OpaqueId" },
         "source_realm": { "type": "string", "minLength": 1, "maxLength": 128 },
         "source_realm_kind": { "enum": ["host", "vm"] },
+        "source_canonical_target": { "type": ["string", "null"], "minLength": 1, "maxLength": 256, "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+\\.d2b$" },
         "source_app": { "type": ["string", "null"], "maxLength": 256 },
         "source_app_id": { "type": ["string", "null"], "maxLength": 256 },
         "source_attribution": { "enum": ["exact_client", "focused_window_guess", "cache_stale_focused_window_guess", "broker_injected_debug"] },
@@ -161,8 +164,64 @@
         "content_type": { "$ref": "#/$defs/Mime" },
         "timestamp_unix_ms": { "type": "integer", "minimum": 0 },
         "thumbnail_png_base64": { "type": ["string", "null"], "maxLength": 0 },
-        "confirmation_required": { "type": "boolean" }
+        "confirmation_required": { "type": "boolean" },
+        "capability_preflight": { "anyOf": [{ "$ref": "#/$defs/CapabilityPreflight" }, { "type": "null" }] }
       }
+    },
+    "CapabilityPreflight": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "required_capabilities",
+        "advertised_capabilities",
+        "missing_capabilities",
+        "authority"
+      ],
+      "properties": {
+        "status": { "enum": ["satisfied", "denied", "unknown"] },
+        "required_capabilities": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/Capability" }
+        },
+        "advertised_capabilities": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/Capability" }
+        },
+        "missing_capabilities": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/Capability" }
+        },
+        "authority": { "enum": ["picker_clipd"] }
+      }
+    },
+    "Capability": {
+      "enum": [
+        "lifecycle",
+        "exec",
+        "pty",
+        "logs",
+        "file-copy",
+        "port-forward",
+        "persistent-shell",
+        "vsock",
+        "virtiofs",
+        "window-forwarding",
+        "display-streaming",
+        "clipboard",
+        "audio-playback",
+        "audio-capture",
+        "hid",
+        "usb",
+        "gpu-accel",
+        "snapshots",
+        "hotplug",
+        "ephemeral-sessions",
+        "provider-managed-isolation"
+      ]
     },
     "Mime": {
       "enum": ["text/plain;charset=utf-8", "text/plain", "text/html", "image/png"]

--- a/packages/d2b-clipd/src/main.rs
+++ b/packages/d2b-clipd/src/main.rs
@@ -42,8 +42,9 @@ use d2b_clipd::picker::{
 };
 use d2b_clipd::policy::{ReasonCode, is_mime_allowed};
 use d2b_clipd::protocol::{
-    AttributionQuality, Candidate, ClientHello, DaemonToPickerMessage, DestinationMetadata,
-    OpenRequest, PickerToDaemonMessage, PlacementHint, RealmKind,
+    AttributionQuality, Candidate, ClientHello, ClipboardCapabilityPreflight,
+    ClipboardCapabilityPreflightStatus, ClipboardTransferAuthority, DaemonToPickerMessage,
+    DestinationMetadata, OpenRequest, PickerToDaemonMessage, PlacementHint, RealmKind,
 };
 use d2b_clipd::wayland::{DataControlClient, DataControlSource, HostClipboardEvent};
 use rustix::event::{PollFd, PollFlags, poll};
@@ -899,6 +900,10 @@ impl ClipboardHistory {
                     entry_id: entry.entry_id.clone(),
                     source_realm: entry.source_realm.clone(),
                     source_realm_kind: entry.source_realm_kind,
+                    source_canonical_target: canonical_target_for_realm(
+                        &entry.source_realm,
+                        entry.source_realm_kind,
+                    ),
                     source_app: entry.source_app.clone(),
                     source_app_id: entry.source_app_id.clone(),
                     source_attribution: entry.source_attribution,
@@ -910,6 +915,7 @@ impl ClipboardHistory {
                     thumbnail_png_base64: None,
                     byte_count: Some(bytes.len() as u64),
                     confirmation_required: false,
+                    capability_preflight: Some(clipboard_capability_preflight()),
                 })
             })
             .collect()
@@ -2075,6 +2081,10 @@ fn handle_wayland_event(event: HostClipboardEvent, context: &mut WaylandEventCon
                                     entry_id: CURRENT_HOST_ENTRY_ID.to_owned(),
                                     source_realm: current_host_entry.source_realm.clone(),
                                     source_realm_kind: current_host_entry.source_realm_kind,
+                                    source_canonical_target: canonical_target_for_realm(
+                                        &current_host_entry.source_realm,
+                                        current_host_entry.source_realm_kind,
+                                    ),
                                     source_app: current_host_entry.source_app.clone(),
                                     source_app_id: current_host_entry.source_app_id.clone(),
                                     source_attribution: current_host_entry.source_attribution,
@@ -2086,6 +2096,7 @@ fn handle_wayland_event(event: HostClipboardEvent, context: &mut WaylandEventCon
                                     thumbnail_png_base64: None,
                                     byte_count: Some(bytes.len() as u64),
                                     confirmation_required: false,
+                                    capability_preflight: Some(clipboard_capability_preflight()),
                                 },
                             );
                         }
@@ -2825,12 +2836,14 @@ fn picker_handshake(
         destination: DestinationMetadata {
             realm: "Host".to_owned(),
             realm_kind: RealmKind::Host,
+            canonical_target: None,
             application: dest.app_id.clone(),
             app_id: dest.app_id.clone(),
             title: dest.title.clone(),
             workspace: None,
             output: dest.output_label.clone(),
             attribution: AttributionQuality::FocusedWindowGuess,
+            capability_preflight: Some(clipboard_capability_preflight()),
         },
         requested_mime_type: requested_mime_type.to_owned(),
         expires_at_unix_ms: unix_millis().saturating_add(30_000),
@@ -2892,6 +2905,10 @@ fn picker_candidates(
                 entry_id: CURRENT_HOST_ENTRY_ID.to_owned(),
                 source_realm: entry.source_realm.clone(),
                 source_realm_kind: entry.source_realm_kind,
+                source_canonical_target: canonical_target_for_realm(
+                    &entry.source_realm,
+                    entry.source_realm_kind,
+                ),
                 source_app: entry.source_app.clone(),
                 source_app_id: entry.source_app_id.clone(),
                 source_attribution: entry.source_attribution,
@@ -2903,6 +2920,7 @@ fn picker_candidates(
                 thumbnail_png_base64: None,
                 byte_count: Some(bytes.len() as u64),
                 confirmation_required: false,
+                capability_preflight: Some(clipboard_capability_preflight()),
             },
         );
         return candidates;
@@ -2939,6 +2957,7 @@ fn insert_live_host_candidate(
             entry_id: CURRENT_HOST_ENTRY_ID.to_owned(),
             source_realm: "Host".to_owned(),
             source_realm_kind: RealmKind::Host,
+            source_canonical_target: None,
             source_app: window
                 .and_then(|window| window.title.clone())
                 .or_else(|| Some("Host clipboard".to_owned())),
@@ -2950,6 +2969,7 @@ fn insert_live_host_candidate(
             thumbnail_png_base64: None,
             byte_count: None,
             confirmation_required: false,
+            capability_preflight: Some(clipboard_capability_preflight()),
         },
     );
 }
@@ -2965,6 +2985,7 @@ fn picker_bridge_candidates(
         entry_id: CURRENT_BRIDGE_ENTRY_ID.to_owned(),
         source_realm: selection.vm_name.clone(),
         source_realm_kind: RealmKind::Vm,
+        source_canonical_target: canonical_target_for_vm(&selection.vm_name),
         source_app: Some(format!("{} VM", selection.vm_name)),
         source_app_id: Some(format!("d2b.{}", selection.vm_name)),
         source_attribution: AttributionQuality::ExactClient,
@@ -2976,6 +2997,7 @@ fn picker_bridge_candidates(
         thumbnail_png_base64: None,
         byte_count: Some(bytes.len() as u64),
         confirmation_required: false,
+        capability_preflight: Some(clipboard_capability_preflight()),
     }]
 }
 
@@ -3007,8 +3029,9 @@ fn picker_bridge_candidates_for_published(
         };
     vec![Candidate {
         entry_id,
-        source_realm,
+        source_realm: source_realm.clone(),
         source_realm_kind: RealmKind::Vm,
+        source_canonical_target: canonical_target_for_vm(&source_realm),
         source_app,
         source_app_id,
         source_attribution: AttributionQuality::ExactClient,
@@ -3020,7 +3043,39 @@ fn picker_bridge_candidates_for_published(
         thumbnail_png_base64: None,
         byte_count: Some(bytes.len() as u64),
         confirmation_required: false,
+        capability_preflight: Some(clipboard_capability_preflight()),
     }]
+}
+
+fn canonical_target_for_realm(realm: &str, kind: RealmKind) -> Option<String> {
+    match kind {
+        RealmKind::Host => None,
+        RealmKind::Vm => canonical_target_for_vm(realm),
+    }
+}
+
+fn canonical_target_for_vm(vm: &str) -> Option<String> {
+    if is_canonical_vm_label(vm) {
+        Some(format!("{vm}.local.d2b"))
+    } else {
+        None
+    }
+}
+
+fn is_canonical_vm_label(value: &str) -> bool {
+    let mut chars = value.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+fn clipboard_capability_preflight() -> ClipboardCapabilityPreflight {
+    ClipboardCapabilityPreflight {
+        status: ClipboardCapabilityPreflightStatus::Satisfied,
+        required_capabilities: vec!["clipboard".to_owned()],
+        advertised_capabilities: vec!["clipboard".to_owned()],
+        missing_capabilities: Vec::new(),
+        authority: ClipboardTransferAuthority::PickerClipd,
+    }
 }
 
 fn summarize_candidates(candidates: &[Candidate]) -> String {
@@ -3698,6 +3753,7 @@ mod tests {
             entry_id: "history-1".to_owned(),
             source_realm: "Host".to_owned(),
             source_realm_kind: RealmKind::Host,
+            source_canonical_target: None,
             source_app: Some("old copy".to_owned()),
             source_app_id: Some("old.app".to_owned()),
             source_attribution: AttributionQuality::FocusedWindowGuess,
@@ -3707,6 +3763,7 @@ mod tests {
             thumbnail_png_base64: None,
             byte_count: Some(3),
             confirmation_required: false,
+            capability_preflight: Some(clipboard_capability_preflight()),
         }];
         let window = FocusedWindowSnapshot {
             app_id: Some("firefox".to_owned()),
@@ -3783,6 +3840,17 @@ mod tests {
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].entry_id, CURRENT_BRIDGE_ENTRY_ID);
+        assert_eq!(
+            candidates[0].source_canonical_target.as_deref(),
+            Some("personal-dev.local.d2b")
+        );
+        assert_eq!(
+            candidates[0]
+                .capability_preflight
+                .as_ref()
+                .map(|preflight| preflight.status),
+            Some(ClipboardCapabilityPreflightStatus::Satisfied)
+        );
         assert_eq!(candidates[0].preview_text.as_deref(), Some("vm text"));
         assert_eq!(candidates[0].byte_count, Some(7));
     }

--- a/packages/d2b-clipd/src/protocol.rs
+++ b/packages/d2b-clipd/src/protocol.rs
@@ -74,6 +74,8 @@ pub struct Candidate {
     pub entry_id: String,
     pub source_realm: String,
     pub source_realm_kind: RealmKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_canonical_target: Option<String>,
     pub source_app: Option<String>,
     pub source_app_id: Option<String>,
     pub source_attribution: AttributionQuality,
@@ -83,18 +85,47 @@ pub struct Candidate {
     pub thumbnail_png_base64: Option<String>,
     pub byte_count: Option<u64>,
     pub confirmation_required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_preflight: Option<ClipboardCapabilityPreflight>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DestinationMetadata {
     pub realm: String,
     pub realm_kind: RealmKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_target: Option<String>,
     pub application: Option<String>,
     pub app_id: Option<String>,
     pub title: Option<String>,
     pub workspace: Option<String>,
     pub output: Option<String>,
     pub attribution: AttributionQuality,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_preflight: Option<ClipboardCapabilityPreflight>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardCapabilityPreflight {
+    pub status: ClipboardCapabilityPreflightStatus,
+    pub required_capabilities: Vec<String>,
+    pub advertised_capabilities: Vec<String>,
+    pub missing_capabilities: Vec<String>,
+    pub authority: ClipboardTransferAuthority,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClipboardCapabilityPreflightStatus {
+    Satisfied,
+    Denied,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClipboardTransferAuthority {
+    PickerClipd,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -159,6 +190,7 @@ mod tests {
           "entry_id":"e",
           "source_realm":"Host",
           "source_realm_kind":"host",
+          "source_canonical_target":null,
           "source_app":null,
           "source_app_id":null,
           "source_attribution":"focused_window_guess",
@@ -168,10 +200,79 @@ mod tests {
           "thumbnail_png_base64":null,
           "byte_count":12,
           "confirmation_required":false,
+          "capability_preflight":{
+            "status":"satisfied",
+            "required_capabilities":["clipboard"],
+            "advertised_capabilities":["clipboard"],
+            "missing_capabilities":[],
+            "authority":"picker_clipd"
+          },
           "future_display_field":"ignored"
         }"#;
         let candidate: Candidate = serde_json::from_str(json).expect("candidate");
         assert_eq!(candidate.entry_id, "e");
+        assert_eq!(
+            candidate.capability_preflight.as_ref().map(|p| p.status),
+            Some(ClipboardCapabilityPreflightStatus::Satisfied)
+        );
+    }
+
+    #[test]
+    fn daemon_open_request_can_carry_canonical_realm_metadata() {
+        let msg = DaemonToPickerMessage::OpenRequest(Box::new(OpenRequest {
+            selected_protocol_version: 1,
+            clipd_version: "0.0.0".to_owned(),
+            picker_version: "picker".to_owned(),
+            request_id: "req".to_owned(),
+            destination: DestinationMetadata {
+                realm: "builder".to_owned(),
+                realm_kind: RealmKind::Vm,
+                canonical_target: Some("builder.local.d2b".to_owned()),
+                application: None,
+                app_id: None,
+                title: None,
+                workspace: None,
+                output: None,
+                attribution: AttributionQuality::ExactClient,
+                capability_preflight: Some(ClipboardCapabilityPreflight {
+                    status: ClipboardCapabilityPreflightStatus::Satisfied,
+                    required_capabilities: vec!["clipboard".to_owned()],
+                    advertised_capabilities: vec!["clipboard".to_owned()],
+                    missing_capabilities: Vec::new(),
+                    authority: ClipboardTransferAuthority::PickerClipd,
+                }),
+            },
+            requested_mime_type: "text/plain".to_owned(),
+            expires_at_unix_ms: 7,
+            placement_hints: None,
+            candidates: vec![Candidate {
+                entry_id: "entry".to_owned(),
+                source_realm: "builder".to_owned(),
+                source_realm_kind: RealmKind::Vm,
+                source_canonical_target: Some("builder.local.d2b".to_owned()),
+                source_app: None,
+                source_app_id: None,
+                source_attribution: AttributionQuality::ExactClient,
+                preview_text: None,
+                content_type: "text/plain".to_owned(),
+                timestamp_unix_ms: 7,
+                thumbnail_png_base64: None,
+                byte_count: Some(4),
+                confirmation_required: false,
+                capability_preflight: Some(ClipboardCapabilityPreflight {
+                    status: ClipboardCapabilityPreflightStatus::Satisfied,
+                    required_capabilities: vec!["clipboard".to_owned()],
+                    advertised_capabilities: vec!["clipboard".to_owned()],
+                    missing_capabilities: Vec::new(),
+                    authority: ClipboardTransferAuthority::PickerClipd,
+                }),
+            }],
+        }));
+
+        let json = serde_json::to_string(&msg).expect("serialize open request");
+        assert!(json.contains(r#""canonical_target":"builder.local.d2b""#));
+        assert!(json.contains(r#""source_canonical_target":"builder.local.d2b""#));
+        assert!(json.contains(r#""authority":"picker_clipd""#));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds optional canonical realm target metadata to clipboard picker OpenRequest destination/candidates.
- Adds bounded picker/clipd capability-preflight metadata so desktop pickers can display trusted d2b authority state.
- Populates VM source targets as `<vm>.local.d2b` while keeping host sources null and preserving picker/clipd as the only transfer authority.
- Updates the public picker protocol docs/schema and focused tests.

## Validation
- `cargo test --manifest-path packages/Cargo.toml -p d2b-clipd protocol -- --nocapture`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-clipd current_vm_candidate_accepts_text_plain_aliases -- --nocapture`
- `cargo clippy --manifest-path packages/Cargo.toml -p d2b-clipd --lib --bins --tests -- -D warnings`
- `jq empty docs/reference/schemas/clipboard-picker-protocol-v1.json`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-contract-tests --test policy_clipboard -- --nocapture`

## Stack
- Stacked on PR #252 (`adr0043-w9-runtime-preflight`). Retarget after lower stack lands.