### PR TITLE
wayland: expose realm target proxy metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ deprecations ship one minor release before removal.
 - Added canonical realm-target and picker/clipd capability-preflight metadata
   to the clipboard picker protocol so desktop pickers can display trusted
   d2b-provided VM identity without using guest titles or app ids as authority.
+- Added d2b-asserted Wayland proxy `realmTarget` / `--realm-target` metadata so
+  downstream desktop tools can identify proxied VM windows from host-provided
+  realm metadata while preserving the existing app-id/title rewrite behavior.
 - Added host-local realm control-plane materialization from `d2b.realms`,
   including deterministic bounded unit names, daemon/broker users and groups,
   socket access groups for allowed users, runtime/state/audit directories, and

--- a/docs/how-to/migrate-to-wayland-proxy.md
+++ b/docs/how-to/migrate-to-wayland-proxy.md
@@ -27,6 +27,12 @@ that match by app-id.  Rules that matched `org.mozilla.firefox` must
 be updated to match `d2b.work.org.mozilla.firefox` or the regex
 pattern `^d2b\.work\.`.
 
+The proxy process also receives a d2b-asserted canonical realm target
+(`--realm-target <vm>.local.d2b` during the host-local transition). This
+metadata is separate from guest-provided titles and app ids: downstream d2b
+tools should prefer the d2b-provided realm target when they need trusted VM
+identity, and treat rewritten app ids as presentation/routing hints only.
+
 ### Window title prefix is retained
 
 The window title prefix `[<vm>] ` behavior is preserved for

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -639,6 +639,7 @@ EOF
       upstreamSock = waylandHostSock;
       bridgeSock = "${config.d2b.site.clipboard.runtime.bridgeRoot}/${waylandUid}/bridge/${vmName}/${config.d2b.site.clipboard.runtime.bridgeSocketName}";
       appIdPrefix = "d2b.${vmName}.";
+      realmTarget = "${vmName}.local.d2b";
       titlePrefix = "[${vmName}] ";
       border = vm.graphics.waylandProxy.border;
       borderColors = cfg._uiColors.vms.${vmName}.border;
@@ -679,6 +680,7 @@ EOF
         "--connect" upstreamSock
         "--vm-name" vmName
         "--app-id-prefix" appIdPrefix
+        "--realm-target" realmTarget
         "--title-prefix" titlePrefix
       ] ++ borderArgs ++ lib.optionals config.d2b.site.clipboard.enable [
         "--clipd-bridge-socket" bridgeSock

--- a/packages/d2b-host-providers/src/lib.rs
+++ b/packages/d2b-host-providers/src/lib.rs
@@ -683,6 +683,8 @@ mod tests {
             "corp-vm",
             "--app-id-prefix",
             "d2b.corp-vm.",
+            "--realm-target",
+            "corp-vm.local.d2b",
             "--title-prefix",
             "[corp-vm] ",
         ]

--- a/packages/d2b-host/src/wayland_proxy_argv.rs
+++ b/packages/d2b-host/src/wayland_proxy_argv.rs
@@ -49,6 +49,11 @@ pub struct WaylandProxyArgvInput {
     ///
     /// Default: `d2b.<vm>.`
     pub app_id_prefix: String,
+    /// Canonical realm target asserted by d2b host metadata.
+    ///
+    /// Default: `<vm>.local.d2b` for the transitional host-local realm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub realm_target: Option<String>,
     /// Title prefix prepended to guest window titles.
     ///
     /// Default: `[<vm>] `
@@ -125,12 +130,14 @@ impl WaylandProxyArgvInput {
         let listen_socket = format!("/run/d2b-wlproxy/{vm_name}/wayland-0");
         let upstream_socket = format!("/run/d2b-wlproxy/{vm_name}/upstream");
         let app_id_prefix = format!("d2b.{vm_name}.");
+        let realm_target = Some(format!("{vm_name}.local.d2b"));
         let title_prefix = format!("[{vm_name}] ");
         Self {
             vm_name,
             listen_socket,
             upstream_socket,
             app_id_prefix,
+            realm_target,
             title_prefix,
             border: None,
         }
@@ -177,6 +184,12 @@ pub fn generate_wayland_proxy_argv(
     if !input.app_id_prefix.is_empty() {
         argv.push("--app-id-prefix".to_owned());
         argv.push(input.app_id_prefix.clone());
+    }
+    if let Some(realm_target) = &input.realm_target
+        && !realm_target.is_empty()
+    {
+        argv.push("--realm-target".to_owned());
+        argv.push(realm_target.clone());
     }
     if !input.title_prefix.is_empty() {
         argv.push("--title-prefix".to_owned());
@@ -244,6 +257,7 @@ mod tests {
         assert_eq!(argv[listen_idx + 1], "/run/d2b-wlproxy/work/wayland-0");
         let connect_idx = argv.iter().position(|a| a == "--connect").unwrap();
         assert_eq!(argv[connect_idx + 1], "/run/d2b-wlproxy/work/upstream");
+        assert_eq!(flag_value(&argv, "--realm-target"), Some("work.local.d2b"));
     }
 
     #[test]
@@ -283,6 +297,13 @@ mod tests {
         let argv = generate_wayland_proxy_argv(&input).expect("valid");
         let prefix_idx = argv.iter().position(|a| a == "--app-id-prefix").unwrap();
         assert_eq!(argv[prefix_idx + 1], "d2b.dev.");
+    }
+
+    #[test]
+    fn realm_target_in_argv() {
+        let input = WaylandProxyArgvInput::for_vm("dev");
+        let argv = generate_wayland_proxy_argv(&input).expect("valid");
+        assert_eq!(flag_value(&argv, "--realm-target"), Some("dev.local.d2b"));
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/main.rs
+++ b/packages/d2b-wayland-proxy/src/main.rs
@@ -62,6 +62,10 @@ struct Args {
     #[arg(long)]
     app_id_prefix: Option<String>,
 
+    /// Canonical d2b realm target asserted by host metadata.
+    #[arg(long = "realm-target", value_name = "TARGET")]
+    realm_target: Option<String>,
+
     /// Override the xdg_toplevel title prefix (default: `[<vm>] `).
     #[arg(long)]
     title_prefix: Option<String>,
@@ -242,6 +246,7 @@ fn main() {
     let input = PolicyInput {
         vm_name: args.vm_name.clone(),
         app_id_prefix: args.app_id_prefix.clone(),
+        realm_target: args.realm_target.clone(),
         title_prefix: args.title_prefix.clone(),
         deny_globals: args.deny_globals.clone(),
         allow_globals: args.allow_globals.clone(),
@@ -723,6 +728,8 @@ mod tests {
             "wayland-1",
             "--vm-name",
             "work",
+            "--realm-target",
+            "work.local.d2b",
             "--border-enable",
             "--border-color-active",
             "#112233",
@@ -746,6 +753,7 @@ mod tests {
         assert_eq!(args.border_thickness, 9);
         assert_eq!(args.border_label.as_deref(), Some("work vm"));
         assert_eq!(args.border_label_position, LabelPosition::TopCenter);
+        assert_eq!(args.realm_target.as_deref(), Some("work.local.d2b"));
     }
 
     #[test]

--- a/packages/d2b-wayland-proxy/src/policy.rs
+++ b/packages/d2b-wayland-proxy/src/policy.rs
@@ -146,6 +146,8 @@ pub struct PolicyInput {
     /// Prefix prepended to `xdg_toplevel.set_app_id` values.
     /// Default: `d2b.<vm>.`
     pub app_id_prefix: Option<String>,
+    /// Canonical d2b realm target asserted by host metadata.
+    pub realm_target: Option<String>,
     /// Prefix prepended to `xdg_toplevel.set_title` values.
     /// Default: `[<vm>] `
     pub title_prefix: Option<String>,
@@ -168,6 +170,7 @@ pub struct PolicyInput {
 pub struct FilterPolicy {
     entries: HashMap<String, PolicyEntry>,
     pub app_id_prefix: String,
+    pub realm_target: Option<String>,
     pub title_prefix: String,
     pub vm_name: String,
     pub dmabuf_filters: std::sync::Arc<crate::dmabuf::DmabufFilterList>,
@@ -182,6 +185,7 @@ impl FilterPolicy {
         let vm = &input.vm_name;
 
         let app_id_prefix = input.app_id_prefix.unwrap_or_else(|| format!("d2b.{vm}."));
+        let realm_target = input.realm_target;
         let title_prefix = input.title_prefix.unwrap_or_else(|| format!("[{vm}] "));
 
         // Populate the default entries from the classified allowlist.
@@ -293,6 +297,7 @@ impl FilterPolicy {
         Self {
             entries,
             app_id_prefix,
+            realm_target,
             title_prefix,
             vm_name: vm.clone(),
             dmabuf_filters: std::sync::Arc::new(crate::dmabuf::DmabufFilterList::new(
@@ -557,6 +562,21 @@ mod tests {
             p.warnings.is_empty(),
             "secure defaults must produce zero warnings; got: {:?}",
             p.warnings
+        );
+    }
+
+    #[test]
+    fn realm_target_is_d2b_asserted_metadata_not_app_id_authority() {
+        let p = FilterPolicy::build(PolicyInput {
+            vm_name: "work".to_owned(),
+            realm_target: Some("work.local.d2b".to_owned()),
+            ..Default::default()
+        });
+
+        assert_eq!(p.realm_target.as_deref(), Some("work.local.d2b"));
+        assert_eq!(
+            p.rewrite_app_id("org.example.App"),
+            "d2b.work.org.example.App"
         );
     }
 

--- a/tests/unit/nix/cases/external-vm-kind.nix
+++ b/tests/unit/nix/cases/external-vm-kind.nix
@@ -629,6 +629,8 @@ in
           "media"
           "--app-id-prefix"
           "d2b.media."
+          "--realm-target"
+          "media.local.d2b"
           "--title-prefix"
           "[media] "
           "--border-enable"

--- a/tests/unit/nix/cases/niri-vm-borders.nix
+++ b/tests/unit/nix/cases/niri-vm-borders.nix
@@ -316,6 +316,7 @@ in
       inactive = flagValue "--border-color-inactive" proxyDefaultArgv;
       urgent = flagValue "--border-color-urgent" proxyDefaultArgv;
       label = flagValue "--border-label" proxyDefaultArgv;
+      realmTarget = flagValue "--realm-target" proxyDefaultArgv;
       legacyThickness = builtins.elem "--border-thickness" proxyDefaultArgv;
       legacyLabelPosition = builtins.elem "--border-label-position" proxyDefaultArgv;
     };
@@ -325,6 +326,7 @@ in
       inactive = proxyDefaultColors.inactive;
       urgent = proxyDefaultColors.urgent;
       label = "work";
+      realmTarget = "work.local.d2b";
       legacyThickness = false;
       legacyLabelPosition = false;
     };


### PR DESCRIPTION
## Summary
- Adds `realmTarget` / `--realm-target` metadata to Wayland proxy argv and process JSON.
- Threads the canonical target through proxy CLI/policy state as d2b-asserted metadata without changing app-id/title rewriting behavior.
- Updates Wayland migration docs and focused Rust/Nix coverage.

## Validation
- `cargo test --manifest-path packages/Cargo.toml -p d2b-host wayland_proxy_argv -- --nocapture`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-host-providers local_wayland_adapter_matches_generator_byte_for_byte -- --nocapture`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-wayland-proxy -- --nocapture`
- `nix build --no-link .#checks.x86_64-linux.nix-unit-runtime`
- `cargo clippy --manifest-path packages/Cargo.toml -p d2b-host -p d2b-host-providers -p d2b-wayland-proxy --lib --bins --tests -- -D warnings`

## Stack
- Stacked on PR #253 (`adr0043-w11-clipboard-metadata`). Retarget after lower stack lands.