### PR TITLE
display: expose realm target session metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ deprecations ship one minor release before removal.
 - Added d2b-asserted Wayland proxy `realmTarget` / `--realm-target` metadata so
   downstream desktop tools can identify proxied VM windows from host-provided
   realm metadata while preserving the existing app-id/title rewrite behavior.
+- Added trusted identity source and display capability-preflight metadata to
+  `d2b vm display list --json` so desktop helpers can consume bounded
+  d2b-provided realm target state instead of guest window metadata.
 - Added host-local realm control-plane materialization from `d2b.realms`,
   including deterministic bounded unit names, daemon/broker users and groups,
   socket access groups for allowed users, runtime/state/audit directories, and

--- a/docs/reference/cli-output/vm-display-list.schema.json
+++ b/docs/reference/cli-output/vm-display-list.schema.json
@@ -25,9 +25,59 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "VmDisplayCapabilityPreflight": {
+      "type": "object",
+      "required": [
+        "advertisedCapabilities",
+        "missingCapabilities",
+        "requiredCapabilities",
+        "status"
+      ],
+      "properties": {
+        "advertisedCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "missingCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/VmDisplayCapabilityPreflightStatus"
+        }
+      },
+      "additionalProperties": false
+    },
+    "VmDisplayCapabilityPreflightStatus": {
+      "type": "string",
+      "enum": [
+        "satisfied",
+        "denied",
+        "unknown"
+      ]
+    },
+    "VmDisplayIdentitySource": {
+      "type": "string",
+      "enum": [
+        "d2b-realm-target"
+      ]
+    },
     "VmDisplaySessionOutputV1": {
       "type": "object",
       "required": [
+        "canonicalTarget",
+        "capabilityPreflight",
+        "identitySource",
         "operationId",
         "principal",
         "sessionId",
@@ -35,6 +85,15 @@
         "target"
       ],
       "properties": {
+        "canonicalTarget": {
+          "type": "string"
+        },
+        "capabilityPreflight": {
+          "$ref": "#/definitions/VmDisplayCapabilityPreflight"
+        },
+        "identitySource": {
+          "$ref": "#/definitions/VmDisplayIdentitySource"
+        },
         "operationId": {
           "type": "string"
         },

--- a/docs/reference/display-io-capabilities.md
+++ b/docs/reference/display-io-capabilities.md
@@ -55,6 +55,13 @@ It never exposes session secrets, app argv, Wayland socket paths, relay
 endpoints, file descriptors, pidfds, cgroup paths, namespace identifiers, or
 process output. Closed and failed sessions are removed from active listings.
 
+`d2b vm display list --json` includes `canonicalTarget`,
+`identitySource`, and `capabilityPreflight` for each active session. The
+canonical target is d2b-provided realm metadata, not a guest title or app id;
+desktop helpers should prefer it when displaying or correlating trusted VM
+identity. `capabilityPreflight` is bounded metadata over display capabilities
+only and does not grant clipboard, audio, USB, HID, GPU, or video access.
+
 The current gateway orchestrator already owns open and close sequencing:
 it mints a one-shot display credential, arms the listener before the sandbox
 sender connects, spawns the provider agent, waits for the verified handshake,

--- a/packages/d2b-contracts/src/cli_output.rs
+++ b/packages/d2b-contracts/src/cli_output.rs
@@ -197,9 +197,35 @@ pub struct VmDisplayListOutputV1 {
 pub struct VmDisplaySessionOutputV1 {
     pub session_id: String,
     pub target: String,
+    pub canonical_target: String,
+    pub identity_source: VmDisplayIdentitySource,
     pub state: String,
     pub operation_id: String,
     pub principal: String,
+    pub capability_preflight: VmDisplayCapabilityPreflight,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum VmDisplayIdentitySource {
+    D2bRealmTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VmDisplayCapabilityPreflight {
+    pub status: VmDisplayCapabilityPreflightStatus,
+    pub required_capabilities: Vec<String>,
+    pub advertised_capabilities: Vec<String>,
+    pub missing_capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum VmDisplayCapabilityPreflightStatus {
+    Satisfied,
+    Denied,
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -208,6 +234,44 @@ pub struct VmDisplayCloseOutputV1 {
     pub command: String,
     pub session_id: String,
     pub closed: bool,
+}
+
+#[cfg(test)]
+mod display_output_tests {
+    use super::*;
+
+    #[test]
+    fn display_session_output_carries_trusted_identity_and_preflight_metadata() {
+        let output = VmDisplayListOutputV1 {
+            command: "vm display list".to_owned(),
+            target: Some("demo.work.d2b".to_owned()),
+            sessions: vec![VmDisplaySessionOutputV1 {
+                session_id: "s0".to_owned(),
+                target: "demo.work.d2b".to_owned(),
+                canonical_target: "demo.work.d2b".to_owned(),
+                identity_source: VmDisplayIdentitySource::D2bRealmTarget,
+                state: "running".to_owned(),
+                operation_id: "op-1".to_owned(),
+                principal: "uid-1000".to_owned(),
+                capability_preflight: VmDisplayCapabilityPreflight {
+                    status: VmDisplayCapabilityPreflightStatus::Satisfied,
+                    required_capabilities: vec!["window-forwarding".to_owned()],
+                    advertised_capabilities: vec!["window-forwarding".to_owned()],
+                    missing_capabilities: Vec::new(),
+                },
+            }],
+        };
+
+        let json = serde_json::to_value(output).expect("display output serializes");
+        let session = &json["sessions"][0];
+        assert_eq!(session["canonicalTarget"], "demo.work.d2b");
+        assert_eq!(session["identitySource"], "d2b-realm-target");
+        assert_eq!(session["capabilityPreflight"]["status"], "satisfied");
+        assert_eq!(
+            session["capabilityPreflight"]["requiredCapabilities"][0],
+            "window-forwarding"
+        );
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/packages/d2b/src/lib.rs
+++ b/packages/d2b/src/lib.rs
@@ -6320,10 +6320,13 @@ fn cmd_vm_display_list(context: &Context, args: &VmDisplayListArgs) -> Result<i3
             .into_iter()
             .map(|session| VmDisplaySessionOutputV1 {
                 session_id: session.session_id,
+                canonical_target: session.target.clone(),
                 target: session.target,
+                identity_source: VmDisplayIdentitySource::D2bRealmTarget,
                 state: session.state,
                 operation_id: session.operation_id,
                 principal: session.principal,
+                capability_preflight: vm_display_capability_preflight_satisfied(),
             })
             .collect(),
     };
@@ -6350,6 +6353,15 @@ fn cmd_vm_display_list(context: &Context, args: &VmDisplayListArgs) -> Result<i3
         }
     }
     Ok(0)
+}
+
+fn vm_display_capability_preflight_satisfied() -> VmDisplayCapabilityPreflight {
+    VmDisplayCapabilityPreflight {
+        status: VmDisplayCapabilityPreflightStatus::Satisfied,
+        required_capabilities: vec!["window-forwarding".to_owned()],
+        advertised_capabilities: vec!["window-forwarding".to_owned()],
+        missing_capabilities: Vec::new(),
+    }
 }
 
 fn cmd_vm_display_close(context: &Context, args: &VmDisplayCloseArgs) -> Result<i32, CliFailure> {


### PR DESCRIPTION
## Summary
- Adds trusted `canonicalTarget` / `identitySource` metadata to `d2b vm display list --json` sessions.
- Adds bounded display capability-preflight metadata for desktop helpers.
- Regenerates the CLI output schema and documents that helpers should use d2b-provided realm target state instead of guest window metadata for identity.

## Validation
- `cargo run --manifest-path packages/Cargo.toml -p xtask -- gen-cli-schemas`
- `cargo test --manifest-path packages/Cargo.toml -p d2b-contracts display_output_tests -- --nocapture`
- `cargo test --manifest-path packages/Cargo.toml -p d2b gateway_display_reply_parser_accepts_bounded_list_response -- --nocapture`
- `cargo clippy --manifest-path packages/Cargo.toml -p d2b -p d2b-contracts --lib --tests -- -D warnings`
- `jq empty docs/reference/cli-output/vm-display-list.schema.json`

## Stack
- Stacked on PR #254 (`adr0043-w11-wayland-metadata`). Retarget after lower stack lands.