### PR TITLE
provider: fail closed ACA guestd endpoint discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ deprecations ship one minor release before removal.
 - Added trusted identity source and display capability-preflight metadata to
   `d2b vm display list --json` so desktop helpers can consume bounded
   d2b-provided realm target state instead of guest window metadata.
+- Added an explicit ACA guestd endpoint provider seam that advertises no
+  guestd/persistent-shell capability for execute-only sandboxes and fails closed
+  before any Azure data-plane call when endpoint status is requested.
 - Added host-local realm control-plane materialization from `d2b.realms`,
   including deterministic bounded unit names, daemon/broker users and groups,
   socket access groups for allowed users, runtime/state/audit directories, and

--- a/packages/d2b-provider-aca/src/lib.rs
+++ b/packages/d2b-provider-aca/src/lib.rs
@@ -1216,7 +1216,7 @@ impl WorkloadProvider for AcaWorkloadProvider {
                     realm,
                     node: self.node.clone(),
                     state: sandbox_state(&sandbox),
-                    capabilities: self.capabilities().caps,
+                    capabilities: WorkloadProvider::capabilities(self).caps,
                 })
             })
             .collect())
@@ -1303,6 +1303,30 @@ impl WorkloadProvider for AcaWorkloadProvider {
                 "failed to mint Azure Container Apps execution id",
             )
         })
+    }
+}
+
+#[async_trait]
+impl d2b_realm_provider::provider::GuestControlEndpointProvider for AcaWorkloadProvider {
+    fn provider_id(&self) -> ProviderId {
+        self.provider_id.clone()
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.node.clone()
+    }
+
+    fn capabilities(&self) -> WorkloadCapabilitySet {
+        self.guestd_bootstrap_contract().advertised_capabilities()
+    }
+
+    async fn endpoint_status(
+        &self,
+        _workload: WorkloadId,
+    ) -> ProviderResult<d2b_realm_provider::types::GuestControlEndpointStatus> {
+        Err(ProviderError::capability_denied(
+            Capability::PersistentShell,
+        ))
     }
 }
 
@@ -2021,7 +2045,7 @@ mod tests {
     #[test]
     fn capabilities_are_honest_exec_only() {
         let (p, _) = provider_seq(vec![]);
-        let caps = p.capabilities();
+        let caps = WorkloadProvider::capabilities(&p);
         assert!(caps.caps.has(Capability::Exec));
         assert!(caps.caps.has(Capability::ProviderManagedIsolation));
         assert!(!caps.caps.has(Capability::Lifecycle));
@@ -2045,7 +2069,7 @@ mod tests {
         }
 
         let (p, _) = lifecycle_provider_seq(vec![]);
-        let caps = p.capabilities();
+        let caps = WorkloadProvider::capabilities(&p);
         assert!(caps.caps.has(Capability::Exec));
         assert!(caps.caps.has(Capability::Lifecycle));
         assert!(caps.caps.has(Capability::ProviderManagedIsolation));
@@ -2061,7 +2085,31 @@ mod tests {
                 .advertised_capabilities()
                 .has(Capability::PersistentShell)
         );
-        assert!(!p.capabilities().has(Capability::PersistentShell));
+        assert!(!WorkloadProvider::capabilities(&p).has(Capability::PersistentShell));
+        assert!(
+            !d2b_realm_provider::provider::GuestControlEndpointProvider::capabilities(&p)
+                .has(Capability::PersistentShell)
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_control_endpoint_status_fails_closed_without_provider_agent() {
+        let (p, http) = provider_seq(vec![]);
+
+        let err = d2b_realm_provider::provider::GuestControlEndpointProvider::endpoint_status(
+            &p,
+            WorkloadId::parse("sandbox-a").unwrap(),
+        )
+        .await
+        .expect_err("execute-only ACA provider has no guestd endpoint");
+
+        assert_eq!(err.kind(), ErrorKind::CapabilityDenied);
+        assert_eq!(err.missing_capability(), Some(Capability::PersistentShell));
+        assert_eq!(
+            http.calls.lock().unwrap().len(),
+            0,
+            "endpoint discovery denial must happen before ACA data-plane calls"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implements the guestd endpoint provider seam for ACA execute-only sandboxes as explicit fail-closed metadata.
- Advertises no guestd/persistent-shell endpoint capability from the current ACA adapter.
- Ensures endpoint-status requests deny with `CapabilityDenied(PersistentShell)` before any Azure data-plane call.

## Validation
- `cargo test --manifest-path packages/Cargo.toml -p d2b-provider-aca -- --nocapture`
- `cargo clippy --manifest-path packages/Cargo.toml -p d2b-provider-aca --lib --tests -- -D warnings`

## Stack
- Stacked on PR #255 (`adr0043-w11-display-metadata`). Retarget after lower stack lands.