### PR TITLE
router: reject provider-managed full-host registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ deprecations ship one minor release before removal.
 - Added an explicit ACA guestd endpoint provider seam that advertises no
   guestd/persistent-shell capability for execute-only sandboxes and fails closed
   before any Azure data-plane call when endpoint status is requested.
+- Tightened remote full-host registration so provider-managed-isolation
+  capability sets cannot be retained as full-host nodes.
 - Added host-local realm control-plane materialization from `d2b.realms`,
   including deterministic bounded unit names, daemon/broker users and groups,
   socket access groups for allowed users, runtime/state/audit directories, and

--- a/packages/d2b-realm-router/src/remote_node.rs
+++ b/packages/d2b-realm-router/src/remote_node.rs
@@ -309,6 +309,13 @@ impl RemoteNodeRegistry {
         if registration.summary.kind != NodeKind::FullHost {
             return Err(RemoteNodeError::new(RemoteNodeErrorKind::NotFullHost));
         }
+        if registration
+            .summary
+            .capabilities
+            .has(Capability::ProviderManagedIsolation)
+        {
+            return Err(RemoteNodeError::new(RemoteNodeErrorKind::NotFullHost));
+        }
         if registration.summary.realm != self.managed_realm {
             return Err(RemoteNodeError::new(RemoteNodeErrorKind::WrongRealm));
         }
@@ -984,6 +991,25 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.kind, RemoteNodeErrorKind::NotFullHost);
         assert_eq!(err.code(), "not-full-host");
+    }
+
+    #[test]
+    fn provider_managed_isolation_capability_cannot_register_as_full_host() {
+        let reg = registration(
+            "gen-1",
+            CapabilitySet::empty()
+                .with(Capability::Lifecycle)
+                .with(Capability::ProviderManagedIsolation),
+        );
+        let mut registry = RemoteNodeRegistry::new();
+
+        let err = registry.register(reg, instant(0)).unwrap_err();
+
+        assert_eq!(err.kind, RemoteNodeErrorKind::NotFullHost);
+        assert!(
+            registry.is_empty(),
+            "provider-managed isolation fingerprints must not be retained as full-host nodes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Rejects remote full-host registration when the advertised capability set includes `provider-managed-isolation`.
- Keeps provider-managed sandbox fingerprints out of the full-host registry even if a caller mislabels the node kind as `FullHost`.
- Adds focused remote-node registry coverage.

## Validation
- `cargo test --manifest-path packages/Cargo.toml -p d2b-realm-router remote_node -- --nocapture`
- `cargo clippy --manifest-path packages/Cargo.toml -p d2b-realm-router --lib --tests -- -D warnings`

## Stack
- Stacked on PR #256 (`adr0043-w10-aca-capabilities`). Retarget after lower stack lands.