### PR TITLE
docs: update v2 realm-native migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ deprecations ship one minor release before removal.
   before any Azure data-plane call when endpoint status is requested.
 - Tightened remote full-host registration so provider-managed-isolation
   capability sets cannot be retained as full-host nodes.
+- Rewrote the v1.2-to-v2 migration guide for the realm-native metadata-first
+  transition, including local VM preservation, host-local realm declarations,
+  provider/remote fail-closed behavior, desktop metadata, cleanup, and rollback.
 - Added host-local realm control-plane materialization from `d2b.realms`,
   including deterministic bounded unit names, daemon/broker users and groups,
   socket access groups for allowed users, runtime/state/audit directories, and

--- a/docs/README.md
+++ b/docs/README.md
@@ -200,8 +200,8 @@ Task-oriented recipes. Prescriptive, copy-and-adapt.
   wire the sibling toolkit, launcher, and terminal flakes to d2b's public shell
   surface with aligned flake inputs.
 - [`how-to/migrate-d2b-v1-2-to-v2.md`](./how-to/migrate-d2b-v1-2-to-v2.md) —
-  migrate from local-only or implicit realm metadata to explicit gateway-backed
-  realm policy.
+  migrate from v1.x local-only host metadata to v2 realm-native controller,
+  provider, remote-host, and desktop metadata.
 
 ## Explanation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,10 +107,6 @@ The contracts. Stable interfaces a consumer can depend on.
   metadata-only discovery, strict parent/child tree routing, signed route
   advertisements, namespace validation, direct shortcut constraints, and
   bounded route audit/telemetry contracts.
-- [`explanation/realm-tree-routing.md`](./explanation/realm-tree-routing.md) —
-  conceptual boundaries for route discovery, namespace delegation, shortcuts,
-  and why the contract does not imply live relay, VPN, overlay, SSH, or raw
-  tunnel routing.
 - [`reference/constellation-observability.md`](./reference/constellation-observability.md) —
   bounded `d2b op inspect`, TraceContext propagation, degraded partial
   results, and telemetry redaction/cardinality constraints.
@@ -218,6 +214,10 @@ Understanding-oriented prose. The "why" behind the design choices.
 - [`explanation/realm-controller-boundaries.md`](./explanation/realm-controller-boundaries.md) —
   why host-local realm controller metadata keeps direct socket authorization,
   local-root resolution, state, and audit boundaries separate.
+- [`explanation/realm-tree-routing.md`](./explanation/realm-tree-routing.md) —
+  conceptual boundaries for route discovery, namespace delegation, shortcuts,
+  and why the contract does not imply live relay, VPN, overlay, SSH, or raw
+  tunnel routing.
 - [`explanation/persistent-shells.md`](./explanation/persistent-shells.md) —
   persistence boundary, local IPC model, same-UID AF_UNIX trust boundary, and
   non-goals for persistent named guest shells.

--- a/docs/how-to/migrate-d2b-v1-2-to-v2.md
+++ b/docs/how-to/migrate-d2b-v1-2-to-v2.md
@@ -1,36 +1,236 @@
-# Migrate to explicit realm gateways
+# Migrate d2b v1.2 to v2
 
 **Diataxis category:** how-to.
 
-This guide covers the realm-gateway policy transition planned for the v2
-control-plane rollout.
+This guide covers the v2 realm-native control-plane transition. It is written
+for operators with an existing v1.2/v1.3 local d2b host and one or more local
+VMs already running on `d2b.envs` / `d2b.vms.<vm>.env`.
 
 ## What changes
 
-- Bare VM names stay local.
-- The reserved `local` realm stays host-resident.
-- Work, provider, and cross-host realms use explicit gateway-backed
-  entrypoints.
-- Cross-realm operations and streams are denied by default.
-- Relay/provider credentials are enrolled inside the gateway guest, not stored
-  or minted by the host.
+- Existing local VM names and `d2b.vms.<vm>.env` placement continue to work.
+- The reserved `local` realm remains host-resident.
+- `d2b.realms.<realm>` becomes the public declaration surface for realm intent,
+  direct socket access metadata, provider declarations, policy references, and
+  future realm-local lifecycle.
+- `/etc/d2b/realm-controllers.json` records deterministic host-local realm
+  controller metadata, local runtime providers/workloads, preserved VM paths,
+  and capability summaries.
+- Desktop-facing metadata now includes d2b-provided canonical realm targets for
+  clipboard picker, Wayland proxy, and display-list JSON surfaces.
+- Provider-managed sandboxes and remote full-host nodes fail closed when their
+  advertised capability set does not match the selected provider model.
 
-## Migration steps
+The migration is intentionally **metadata-first**. NixOS activation does not move
+large VM state, rewrite `/var/lib/d2b/vms/<vm>`, or migrate network bridges.
 
-1. Declare a dedicated `d2b.envs.<realm>` for each trust-boundary realm.
-2. Declare one `d2b.gateways.<name>` per gateway-backed realm.
-3. Rebuild the host and inspect the rendered policy with
-   `d2b realm list` and `d2b realm inspect <realm>`.
-4. Start each gateway VM and enroll credentials from inside the gateway guest.
-5. Update scripts to use fully-qualified realm targets only where remote or
-   provider routing is intended.
+## Before you start
 
-If an existing deployment only uses local VMs and no gateway credentials, no
-state migration is required: local VM names and the `local` realm continue to
-use the host fast path.
+1. Commit or stash local host configuration changes.
+2. Back up `/var/lib/d2b`, especially per-VM state, store-view metadata, TPM
+   state, media registry state, and daemon state.
+3. Confirm the current host is healthy:
 
-## Verify isolation
+   ```bash
+   d2b list --json
+   d2b host doctor --read-only
+   ```
 
-Confirm that work and personal/provider realms do not share gateway guests,
-envs, or L2 bridges. Stopped gateways must fail closed with remediation rather
-than falling back to host credentials, SSH, or host routing.
+4. Note every VM's current env:
+
+   ```bash
+   d2b list --json | jq '.vms[] | {name, env, runtimeKind}'
+   ```
+
+## Step 1: keep existing envs and VMs
+
+Do not remove or rename `d2b.envs` or `d2b.vms.<vm>.env` during the v2 cutover.
+Those declarations remain the active runtime substrate.
+
+For example, keep this:
+
+```nix
+d2b.envs.work = {
+  lanSubnet = "10.44.0.0/24";
+  uplinkSubnet = "192.0.2.0/30";
+};
+
+d2b.vms.laptop = {
+  env = "work";
+  ssh.user = "alice";
+};
+```
+
+## Step 2: add host-local realm metadata
+
+Add a host-local realm that points at the existing env. This records realm
+intent and materializes deterministic host-local realm scaffolding without
+moving VM state:
+
+```nix
+d2b.realms.work = {
+  placement = "host-local";
+  env = "work";
+  network.envs = [ "work" ];
+  allowedUsers = [ "alice" ];
+  allowedGroups = [ "realm-work" ];
+};
+```
+
+After `nixos-rebuild switch`, the framework emits
+`/etc/d2b/realm-controllers.json`. Host-local rows include:
+
+- deterministic realm daemon/broker unit names and principals;
+- direct socket access metadata;
+- local-root allocator binding metadata;
+- `localRuntime.providers[]` for `local-cloud-hypervisor` and/or
+  `local-qemu-media`;
+- `localRuntime.workloads[]` rows preserving existing `/var/lib/d2b/vms/<vm>`,
+  `/run/d2b/vms/<vm>`, store-view, and guest-control paths.
+
+## Step 3: rebuild and restart the daemon
+
+```bash
+sudo nixos-rebuild switch
+sudo systemctl restart d2bd.service
+```
+
+`d2bd` restarts are continuation events. Running VMs should remain running and
+be re-adopted by the daemon. If you intentionally changed VM closures, restart
+affected VMs through normal lifecycle commands after the daemon is ready.
+
+## Step 4: verify realm metadata
+
+Check the generated realm artifact:
+
+```bash
+sudo jq '.runtimeState, .controllers[].realmPath' /etc/d2b/realm-controllers.json
+sudo jq '.controllers[] | {realmPath, placement, localRuntime}' /etc/d2b/realm-controllers.json
+```
+
+Expected properties:
+
+- `runtimeState` is `metadata-only`.
+- Host-local controllers have `placement = "host-local"`.
+- `localRuntime.invariants.metadataOnly`,
+  `existingGlobalVmPathsPreserved`, `noStateMigrationDuringActivation`, and
+  `brokerEffectsRemainRealmDelegated` are all `true`.
+- VM state paths still point at the existing per-VM roots.
+
+Then verify CLI resolver behavior:
+
+```bash
+d2b realm list --json
+d2b realm inspect work --json
+```
+
+Bare local VM commands still use the existing host fast path:
+
+```bash
+d2b status laptop
+d2b vm restart laptop --apply
+```
+
+Use fully-qualified realm targets only where you intend realm-aware routing:
+
+```bash
+d2b vm display list --target laptop.work.d2b --json
+```
+
+## Step 5: verify desktop metadata
+
+Clipboard picker requests now include optional d2b-provided realm identity and
+capability-preflight fields. The picker should treat these as trusted d2b
+metadata and keep guest titles/app ids as presentation hints only.
+
+Wayland proxy processes receive `--realm-target <vm>.local.d2b` for local VMs
+during the transition. Existing app-id and title rewriting still behaves as
+before:
+
+- app ids are still prefixed as `d2b.<vm>.<guest-app-id>`;
+- titles still receive `[<vm>] `;
+- the new realm target is separate trusted metadata for d2b-aware tooling.
+
+Display sessions listed with JSON include `canonicalTarget`, `identitySource`,
+and `capabilityPreflight`:
+
+```bash
+d2b vm display list --json | jq '.sessions[] | {canonicalTarget, identitySource, capabilityPreflight}'
+```
+
+## Step 6: migrate provider-backed and remote realms deliberately
+
+Provider-managed sandboxes and remote full-host nodes are separate models.
+Do not reuse one as the other:
+
+- Azure Container Apps sandboxes advertise `provider-managed-isolation` and the
+  capabilities the ACA adapter can honestly support. Current execute-only ACA
+  sandboxes do not advertise `persistent-shell` or a guestd endpoint.
+- Remote full-host nodes must be real full d2b hosts. Registration rejects
+  provider-managed-isolation capability sets even if the node is mislabeled as a
+  full host.
+
+For provider-backed realms, keep provider credentials outside the host Nix
+store. Declare only non-secret references in realm provider metadata:
+
+```nix
+d2b.realms.work.providers.aca = {
+  kind = "aca";
+  placement = "provider-agent";
+  capabilityRefs = [ "aca" "relay" ];
+  configRef = "work-aca-non-secret";
+};
+```
+
+If an old gateway/ACA setup cannot provide the new non-secret references and
+capability declarations, recreate or re-enroll it explicitly. Do not fall back to
+SSH, raw provider shells, raw guest-control tunnels, or host-held relay
+credentials.
+
+## Step 7: cleanup only after verification
+
+Do not delete old gateway/provider state during activation. Cleanup is an
+operator action after verification:
+
+1. Confirm all local VMs still start, stop, and report status.
+2. Confirm realm metadata and desktop metadata look correct.
+3. Confirm provider-managed sandboxes or remote full-host nodes re-enroll under
+   the new provider model.
+4. Remove only the obsolete non-secret config/state you can identify and restore
+   from backup if needed.
+
+Never delete TPM state casually. If TPM state is lost, follow the
+TPM-specific recovery and IdP re-enrollment procedures rather than treating the
+realm migration as recovery.
+
+## Rollback
+
+If the v2 metadata causes trouble before you have adopted provider/remote
+realms:
+
+1. Remove or disable the new `d2b.realms.<realm>` declaration.
+2. Rebuild and restart `d2bd`.
+3. Continue using existing `d2b.envs` and `d2b.vms.<vm>.env` declarations.
+
+Because the migration does not move per-VM state during activation, rollback
+does not require moving `/var/lib/d2b/vms/<vm>`.
+
+## Troubleshooting
+
+| Symptom | Meaning | Next step |
+| --- | --- | --- |
+| `realm-controllers.json` missing | The host did not build with realm metadata enabled. | Check `d2b.realms.*` declarations and rebuild. |
+| `localRuntime` missing for a host-local realm | No enabled VM is associated with the realm's existing env. | Check `d2b.realms.<realm>.env` and `d2b.vms.<vm>.env`. |
+| Provider sandbox denies `persistent-shell` | The sandbox image does not report a guestd-compatible agent. | Rebuild/re-enroll the sandbox with the provider-agent contract; do not use provider shell fallback. |
+| Remote full-host registration rejected as `not-full-host` | The node is not a full d2b host or advertises provider-managed isolation. | Register it as provider-managed, or install full d2b on the remote host. |
+| Desktop helper shows no canonical target | The helper is older than the v2 metadata contract or the source is host-only. | Update the helper; host clipboard sources intentionally have no VM target. |
+
+## Related references
+
+- [Realm option schema](../reference/realm-options.md)
+- [Realm controller configuration](../reference/realm-controller-config.md)
+- [Realm access resolver](../reference/realm-access-resolver.md)
+- [Provider-managed sandboxes](../reference/provider-managed-sandboxes.md)
+- [Remote full-host nodes](../reference/remote-full-host-nodes.md)
+- [Display and virtual I/O capabilities](../reference/display-io-capabilities.md)
+- [Clipboard picker protocol](../reference/clipboard-picker-protocol.md)

--- a/docs/how-to/migrate-d2b-v1-2-to-v2.md
+++ b/docs/how-to/migrate-d2b-v1-2-to-v2.md
@@ -39,7 +39,7 @@ large VM state, rewrite `/var/lib/d2b/vms/<vm>`, or migrate network bridges.
 4. Note every VM's current env:
 
    ```bash
-   d2b list --json | jq '.vms[] | {name, env, runtimeKind}'
+   d2b list --json | jq '.[] | {name, env, runtimeKind}'
    ```
 
 ## Step 1: keep existing envs and VMs
@@ -60,6 +60,13 @@ d2b.vms.laptop = {
   ssh.user = "alice";
 };
 ```
+
+Do not map distinct trust-boundary realms onto the same env unless you
+intentionally want them on the same L2 broadcast domain. Today,
+`d2b.realms.<realm>.env` and `network.envs` point at existing
+`d2b.envs` bridges; sharing that env means sharing the bridge, net VM, DHCP/NAT
+surface, and east-west policy. Work, personal, provider, and remote-host realms
+that require isolation should use separate envs, gateway guests, and L2 bridges.
 
 ## Step 2: add host-local realm metadata
 
@@ -99,6 +106,17 @@ sudo systemctl restart d2bd.service
 be re-adopted by the daemon. If you intentionally changed VM closures, restart
 affected VMs through normal lifecycle commands after the daemon is ready.
 
+For a production rollout, verify this on the host after the switch:
+
+```bash
+systemctl is-active d2bd.service
+d2b status laptop
+```
+
+The static gates cover the service posture and metadata contract; live
+running-VM adoption is still a host validation step because it depends on active
+runner processes and pidfds.
+
 ## Step 4: verify realm metadata
 
 Check the generated realm artifact:
@@ -136,6 +154,27 @@ Use fully-qualified realm targets only where you intend realm-aware routing:
 ```bash
 d2b vm display list --target laptop.work.d2b --json
 ```
+
+### Validation evidence in this repository
+
+The migration guide relies on existing Layer-1 coverage:
+
+- `tests/unit/nix/cases/realms.nix` checks that `realm-controllers.json`
+  materializes host-local controller metadata, direct socket groups, local
+  runtime rows, preserved `/var/lib/d2b/vms/<vm>` and `/run/d2b/vms/<vm>` paths,
+  and the `metadataOnly`, `existingGlobalVmPathsPreserved`,
+  `noStateMigrationDuringActivation`, and
+  `brokerEffectsRemainRealmDelegated` invariants.
+- `packages/d2b-core/tests/realm_controller_config.rs` parses and validates the
+  typed `RealmControllersJson` DTO, including local runtime provider/workload
+  rows and fail-closed invariant validation.
+- `tests/unit/nix/cases/d2bd-startup-smoke.nix` checks daemon restart posture
+  such as `restartIfChanged`, while `nixos-modules/host-daemon.nix` keeps the
+  shutdown hook guarded so normal daemon restarts are not host-shutdown teardown.
+
+These gates do not replace live host validation after a switch; they prove the
+rendered configuration preserves the metadata-first contract that the host
+validation exercises.
 
 ## Step 5: verify desktop metadata
 


### PR DESCRIPTION
## Summary
- Rewrites the v1.2-to-v2 migration guide around the implemented realm-native metadata-first transition.
- Documents local VM preservation, host-local realm declarations, `realm-controllers.json`, provider/remote fail-closed behavior, desktop metadata, cleanup, rollback, and troubleshooting.
- Updates the docs index and changelog.

## Validation
- `git diff --check`

## Stack
- Stacked on PR #257 (`adr0043-w10-remote-fullhost-guard`). Retarget after lower stack lands.