### PR TITLE
broker: allow first-start envfile creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Made the privileged broker's generated UID/GID environment file optional at
+  `ExecStartPre` time so socket activation works on a fresh `/run` without a
+  pre-existing `/run/d2b/broker/priv-broker.env`.
 - Aligned realm gateway target routing and generated entrypoints with ADR 0043's
   canonical `<workload>.<realm>.d2b` form so the Rust CI gate no longer hangs
   on stale node-qualified gateway tests.

--- a/nixos-modules/host-broker.nix
+++ b/nixos-modules/host-broker.nix
@@ -386,8 +386,11 @@ in
         # Resolve d2bd uid/gid at start time into a unit-local
         # EnvironmentFile. This avoids mutating global systemd manager
         # environment while still supporting systems that allocated d2bd
-        # dynamically before stable numeric ids were introduced.
-        EnvironmentFile = "/run/d2b/broker/priv-broker.env";
+        # dynamically before stable numeric ids were introduced. The file
+        # must be optional for ExecStartPre: systemd loads EnvironmentFile
+        # before every command in the service, and ExecStartPre is what
+        # creates the file before ExecStart consumes it.
+        EnvironmentFile = "-/run/d2b/broker/priv-broker.env";
         ExecStartPre = "+${pkgs.writeShellScript "d2b-priv-broker-prep" ''
           set -euo pipefail
           env_file=/run/d2b/broker/priv-broker.env

--- a/tests/unit/nix/cases/broker-service-posture.nix
+++ b/tests/unit/nix/cases/broker-service-posture.nix
@@ -49,14 +49,14 @@ in
         !(lib.hasInfix "set-environment" (svcCfg.ExecStartPre or ""));
       execStartAvoidsSetEnvironment =
         !(lib.hasInfix "set-environment" (svcCfg.ExecStart or ""));
-      usesUnitLocalEnvironmentFile = svcCfg.EnvironmentFile or "";
+      usesOptionalUnitLocalEnvironmentFile = svcCfg.EnvironmentFile or "";
       environmentFileParentNotGroupWritable =
         builtins.elem "d /run/d2b/broker 0750 root d2bd -" tmpfiles;
     };
     expected = {
       execStartPreAvoidsSetEnvironment = true;
       execStartAvoidsSetEnvironment = true;
-      usesUnitLocalEnvironmentFile = "/run/d2b/broker/priv-broker.env";
+      usesOptionalUnitLocalEnvironmentFile = "-/run/d2b/broker/priv-broker.env";
       environmentFileParentNotGroupWritable = true;
     };
   };


### PR DESCRIPTION
## Summary
- make the broker UID/GID EnvironmentFile optional so ExecStartPre can create it on fresh /run
- keep the unit-local env file posture covered by the broker service nix-unit case
- document the activation fix in CHANGELOG

## Validation
- nix build --no-link --print-out-paths .#checks.x86_64-linux.nix-unit-daemon
