### PR TITLE
realm: order host daemons after broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Ordered generated host-local realm daemon units after the root privileged
+  broker socket/service so switch-time activation does not race broker
+  socket-activation startup.
 - Made the privileged broker's generated UID/GID environment file optional at
   `ExecStartPre` time so socket activation works on a fresh `/run` without a
   pre-existing `/run/d2b/broker/priv-broker.env`.

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -254,6 +254,9 @@ EOF
     })
     hostLocalRealms);
   realmTmpfilesFor = realm: [
+    "a+ /etc/d2b - - - - u:${realm.controller.daemon.user}:--x"
+    "a+ /etc/d2b/realms - - - - u:${realm.controller.daemon.user}:--x"
+    "a+ /etc/d2b/realms/${realm.id} - - - - u:${realm.controller.daemon.user}:--x"
     "d ${realm.paths.stateDir} 0750 ${realm.controller.daemon.user} ${realm.controller.daemon.group} -"
     "d /var/lib/d2b/audit/realms 0750 root d2bd -"
     "d ${realm.paths.auditDir} 0750 root ${realm.controller.daemon.group} -"
@@ -281,11 +284,16 @@ EOF
       description = "d2b host-local realm daemon";
       wantedBy = [ "multi-user.target" ];
       wants =
-        [ "systemd-tmpfiles-setup.service" ]
+        [
+          "systemd-tmpfiles-setup.service"
+          "d2b-priv-broker.socket"
+        ]
         ++ lib.optional (brokerSocketUnit != null) brokerSocketUnit;
       after =
         [
           "systemd-tmpfiles-setup.service"
+          "d2b-priv-broker.socket"
+          "d2b-priv-broker.service"
           "network.target"
           "dbus.socket"
           "dbus.service"

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -659,6 +659,9 @@ in
         units = {
           homeDaemon = {
             wantedBy = homeDaemonUnit.wantedBy;
+            wantsRootBrokerSocket = builtins.elem "d2b-priv-broker.socket" homeDaemonUnit.wants;
+            afterRootBrokerSocket = builtins.elem "d2b-priv-broker.socket" homeDaemonUnit.after;
+            afterRootBrokerService = builtins.elem "d2b-priv-broker.service" homeDaemonUnit.after;
             wantsBrokerSocket = builtins.elem home.broker.socketUnitName homeDaemonUnit.wants;
             afterBrokerSocket = builtins.elem home.broker.socketUnitName homeDaemonUnit.after;
             afterBrokerService = builtins.elem home.broker.serviceUnitName homeDaemonUnit.after;
@@ -786,6 +789,9 @@ in
       units = {
         homeDaemon = {
           wantedBy = [ "multi-user.target" ];
+          wantsRootBrokerSocket = true;
+          afterRootBrokerSocket = true;
+          afterRootBrokerService = true;
           wantsBrokerSocket = true;
           afterBrokerSocket = true;
           afterBrokerService = true;
@@ -1070,6 +1076,18 @@ in
             builtins.elem
               "d /run/d2b/realms/home/locks 0700 ${home.daemon.user} ${home.daemon.group} -"
               tmpfiles;
+          etcD2bTraverseAcl =
+            builtins.elem
+              "a+ /etc/d2b - - - - u:${home.daemon.user}:--x"
+              tmpfiles;
+          etcRealmsTraverseAcl =
+            builtins.elem
+              "a+ /etc/d2b/realms - - - - u:${home.daemon.user}:--x"
+              tmpfiles;
+          etcRealmConfigDirTraverseAcl =
+            builtins.elem
+              "a+ /etc/d2b/realms/home - - - - u:${home.daemon.user}:--x"
+              tmpfiles;
         };
         daemonConfig = {
           inherit (homeDaemonEtc) mode user group;
@@ -1086,6 +1104,8 @@ in
         unitOrdering = {
           childAfterParent = builtins.elem home.daemon.serviceName devDaemonUnit.after;
           parentDoesNotAfterChild = !(builtins.elem dev.daemon.serviceName homeDaemonUnit.after);
+          parentAfterRootBrokerSocket = builtins.elem "d2b-priv-broker.socket" homeDaemonUnit.after;
+          parentAfterRootBrokerService = builtins.elem "d2b-priv-broker.service" homeDaemonUnit.after;
         };
         socketAccess = {
           inherit (homeBrokerSocket.socketConfig) ListenSequentialPacket SocketGroup SocketMode;
@@ -1125,6 +1145,9 @@ in
         daemonRunAcl = true;
         stateLock = true;
         locksDir = true;
+        etcD2bTraverseAcl = true;
+        etcRealmsTraverseAcl = true;
+        etcRealmConfigDirTraverseAcl = true;
       };
       daemonConfig = {
         mode = "0640";
@@ -1149,6 +1172,8 @@ in
       unitOrdering = {
         childAfterParent = true;
         parentDoesNotAfterChild = true;
+        parentAfterRootBrokerSocket = true;
+        parentAfterRootBrokerService = true;
       };
       socketAccess = {
         ListenSequentialPacket = "/run/d2b/realms/home/broker.sock";


### PR DESCRIPTION
## Summary
- order generated host-local realm daemon units after the root broker socket/service
- grant realm daemon users execute-only traversal to their `/etc/d2b/realms/<id>` config path
- cover ordering and ACLs in the realm nix-unit case

## Validation
- nix build --no-link --print-out-paths .#checks.x86_64-linux.nix-unit-network
