### PR TITLE
realm: grant daemon metadata read ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Granted host-local realm daemon users read ACLs for the shared
+  `realm-controllers.json` and `realm-identity.json` metadata files so startup
+  can load realm metadata after switching to per-realm principals.
 - Gave host-local realm daemon users traverse access to `/run/d2b` and made
   realm run directories match the daemon lock-parent contract
   (`root:<realm-access-group>` sticky `1770`) so realm daemons can validate

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -255,6 +255,8 @@ EOF
     hostLocalRealms);
   realmTmpfilesFor = realm: [
     "a+ /etc/d2b - - - - u:${realm.controller.daemon.user}:--x"
+    "a+ /etc/d2b/realm-controllers.json - - - - u:${realm.controller.daemon.user}:r--"
+    "a+ /etc/d2b/realm-identity.json - - - - u:${realm.controller.daemon.user}:r--"
     "a+ /etc/d2b/realms - - - - u:${realm.controller.daemon.user}:--x"
     "a+ /etc/d2b/realms/${realm.id} - - - - u:${realm.controller.daemon.user}:--x"
     "a+ /run/d2b - - - - u:${realm.controller.daemon.user}:--x"

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -1080,6 +1080,14 @@ in
             builtins.elem
               "a+ /etc/d2b - - - - u:${home.daemon.user}:--x"
               tmpfiles;
+          realmControllersReadAcl =
+            builtins.elem
+              "a+ /etc/d2b/realm-controllers.json - - - - u:${home.daemon.user}:r--"
+              tmpfiles;
+          realmIdentityReadAcl =
+            builtins.elem
+              "a+ /etc/d2b/realm-identity.json - - - - u:${home.daemon.user}:r--"
+              tmpfiles;
           etcRealmsTraverseAcl =
             builtins.elem
               "a+ /etc/d2b/realms - - - - u:${home.daemon.user}:--x"
@@ -1154,6 +1162,8 @@ in
         stateLock = true;
         locksDir = true;
         etcD2bTraverseAcl = true;
+        realmControllersReadAcl = true;
+        realmIdentityReadAcl = true;
         etcRealmsTraverseAcl = true;
         etcRealmConfigDirTraverseAcl = true;
         runD2bTraverseAcl = true;


### PR DESCRIPTION
## Summary
- grant host-local realm daemon users read ACLs for realm-controllers.json and realm-identity.json
- cover the metadata ACLs in the realm nix-unit case
- document the switch-time startup fix

## Validation
- nix build --no-link --print-out-paths .#checks.x86_64-linux.nix-unit-network
