### PR TITLE
host-daemon: narrow realm run-dir group ACL from rwx to r-x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Narrowed the group ACL on host-local realm run directories from `g::rwx` to
+  `g::r-x` so realm-access-group members can traverse and list but cannot
+  write. The previous `g::rwx` ACL combined with the sticky `1770` base mode
+  allowed a local group member to pre-create `broker.sock` or `daemon.lock`,
+  preventing the daemon from binding its sockets or acquiring its lock (local
+  DoS). The base mode `1770` and the explicit daemon-user `u:<user>:rwx` ACL
+  entry are unchanged; the mask `m::rwx` is unchanged so the daemon retains
+  full effective access.
 - Granted host-local realm daemon users read ACLs for the shared
   `realm-controllers.json` and `realm-identity.json` metadata files so startup
   can load realm metadata after switching to per-realm principals.

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -266,7 +266,7 @@ EOF
     "d ${realm.paths.auditDir} 0750 root ${realm.controller.daemon.group} -"
     "d ${realm.paths.runDir} 1770 root ${realm.controller.daemon.publicSocketGroup} -"
     "z ${realm.paths.runDir} 1770 root ${realm.controller.daemon.publicSocketGroup} -"
-    "a+ ${realm.paths.runDir} - - - - g::rwx"
+    "a+ ${realm.paths.runDir} - - - - g::r-x"
     "a+ ${realm.paths.runDir} - - - - u:${realm.controller.daemon.user}:rwx"
     "a+ ${realm.paths.runDir} - - - - m::rwx"
     "f ${realm.controller.daemon.stateLockPath} 0640 ${realm.controller.daemon.user} ${realm.controller.daemon.group} -"

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -1062,7 +1062,7 @@ in
               tmpfiles;
           runDirGroupAccessAcl =
             builtins.elem
-              "a+ /run/d2b/realms/home - - - - g::rwx"
+              "a+ /run/d2b/realms/home - - - - g::r-x"
               tmpfiles;
           daemonRunAcl =
             builtins.elem


### PR DESCRIPTION
## Summary

Hotfix for a local DoS identified by the kernel panel.

### Problem

Host-local realm run directories were created with base mode `1770 root:<realm-access-group>` (sticky, needed for `validate_lock_parent`) and an additional ACL entry `g::rwx`. That combination allows any member of the realm access group to pre-create entries such as `broker.sock` or `daemon.lock` inside the run directory. Because the sticky bit prevents non-owner deletion, the daemon user cannot unlink those entries on startup, causing a startup-time local denial of service.

### Fix

Change the group ACL entry from `g::rwx` to `g::r-x`. Group members retain traverse and list access but cannot create or replace entries. The base mode `1770`, the named daemon-user ACL `u:<user>:rwx`, and the mask `m::rwx` are unchanged, so the daemon retains full effective access and `validate_lock_parent` continues to see mode `0770`.

This matches the pattern already used for `/run/d2b` itself (`g::r-x` in `host.nix`).

### Files changed

- `nixos-modules/host-daemon.nix`: `g::rwx` → `g::r-x` in `realmTmpfilesFor`
- `tests/unit/nix/cases/realms.nix`: update `runDirGroupAccessAcl` assertion to match
- `CHANGELOG.md`: add security fix entry under `[Unreleased] → Fixed`

### Validation

```
nix build --no-link --print-out-paths '.#checks.x86_64-linux.nix-unit-network'
# → /nix/store/17wg5372spv9f8nlr9bcab150ggcpj3a-d2b-nix-unit-network  (exit 0)

git diff --check
# → whitespace check: OK
```