### PR TITLE
realm: index realm-owned workloads and launcher metadata ( W14 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,37 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Added `d2b.realms.<realm>.workloads.<workload>` option for declaring
+  realm-owned workloads. Each workload optionally references an existing
+  `d2b.vms.<vm>` substrate via `vmRef` for runtime kind and provider id
+  derivation, and carries stable launcher metadata (`label`, `icon`,
+  `actionId`, `capabilityRefs`, `preflightRefs`) for desktop consumers.
+- Extended the internal `_index.realms` with a `workloads` sub-index
+  (flat `all`/`enabled` lists and a `byVm` map) and `externalNetworkConflicts`
+  advisory data for cross-realm attachment interface collisions.
+- Added `targetAddress` (`<workload>.<realmPath>.d2b`), `substrateId`,
+  `runtimeKind`, and `runtimeProviderId` fields to each realm workload index
+  row; each realm row now exposes `workloads`, `workloadNames`, and
+  `enabledWorkloadNames`.
+- Added `realm-workloads-launcher.json` bundle artifact (installed at
+  `root:d2bd 0640`) containing stable desktop launcher metadata for all
+  enabled realm workloads. Includes `targetAddress`, `actionId`, `label`,
+  `icon`, `capabilityRefs`, `preflightRefs`, `runtimeKind`, `runtimeProviderId`,
+  advisory `vsockCid`, and explicit invariant markers confirming no secrets,
+  credentials, provider tokens, command payloads, or opaque session handles.
+- Updated `realm-controllers.json` generation to prefer explicit
+  `realm.workloads` declarations (with `vmRef`) as the primary source for
+  local runtime workload entries, falling back to env-based matching for VMs
+  not covered by explicit declarations. Backward compat is fully preserved for
+  realms without workload declarations.
+- Added cross-realm vsock CID collision assertion in `assertions.nix`: fires
+  when two workloads in different realms reference different NixOS VMs that
+  compute to the same vsock CID.
+- Added cross-realm external network attachment conflict detection: advisory
+  assertion records when realms share an attachment interface across their
+  associated envs; demoted to non-failing in metadata-only runtime state with
+  a clear upgrade note for when realm-native networking activates.
+
 - Added stacked-PR workflow documentation to AGENTS.md covering branch naming,
   PR-only merges, panel/review evidence requirements, integrator ownership of
   CI, retarget/rebase, merge sequencing, and helper-script constraints.

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -154,6 +154,53 @@ let
     "cloud-full-host"
   ];
 
+  # Realm workload assertions.
+  #
+  # Cross-realm vsock CID collision: two workloads in DIFFERENT realms
+  # referencing DIFFERENT local NixOS VMs whose derived vsock CIDs collide.
+  # (Same-VM references across realms share a CID by design and are not
+  # flagged here; the global vmVsockCidCollisions check covers per-VM uniqueness.)
+  realmWorkloadRows = realmIndex.workloads.enabled;
+  nixosWorkloadRows =
+    lib.filter
+      (row:
+        row.vmRef != null
+        && row.runtimeKind == "nixos"
+        && builtins.hasAttr row.vmRef (d2bLib.normalNixosVms cfg.vms))
+      realmWorkloadRows;
+  nixosWorkloadCidPairs =
+    map
+      (row: {
+        realmName = row.realmName;
+        workloadName = row.workloadName;
+        vmRef = row.vmRef;
+        cid = config.d2b.manifest.${row.vmRef}.observability.vsockCid;
+      })
+      nixosWorkloadRows;
+  nixosWorkloadCidGroups = lib.groupBy (p: "${toString p.cid}") nixosWorkloadCidPairs;
+  crossRealmWorkloadCidCollisions =
+    lib.flatten (lib.mapAttrsToList
+      (_: pairs:
+        let
+          # Only flag when the collision involves more than one distinct realm
+          realms = lib.unique (map (p: p.realmName) pairs);
+          # And more than one distinct VM (same-VM cross-realm shares a CID intentionally)
+          vms = lib.unique (map (p: p.vmRef) pairs);
+        in
+        lib.optional (lib.length realms > 1 && lib.length vms > 1) {
+          cid = (builtins.head pairs).cid;
+          pairs = map (p: { inherit (p) realmName workloadName vmRef; }) pairs;
+        })
+      nixosWorkloadCidGroups);
+
+  # Cross-realm external network attachment conflict: two or more realms
+  # whose network envs share the same attachment interface. Advisory only
+  # in metadata-only runtime state; the index exposes the same data via
+  # cfg._index.realms.externalNetworkConflicts.
+  crossRealmExtNetConflicts = cfg._index.realms.externalNetworkConflicts;
+
+
+
   missingRealmParents = lib.filter
     (realm:
       realm.enabled
@@ -302,7 +349,48 @@ let
           }.
         '';
       })
-    realmPathCollisionFields;
+    realmPathCollisionFields
+  # Cross-realm workload vsock CID collision assertion.
+  # Fires when two workloads in different realms reference different NixOS VMs
+  # whose derived vsock CIDs collide. Same-realm or same-VM cross-realm
+  # references are not flagged here; the global vmVsockCidCollisions gate
+  # covers all per-VM CID uniqueness.
+  ++ map
+    (collision: {
+      assertion = false;
+      message = ''
+        Cross-realm vsock CID collision: workloads in different realms reference
+        different VMs that both compute to CID ${toString collision.cid}.
+        Adjust d2b.vms.<vm>.index in the affected env or rename one VM.
+        Affected pairs: ${
+          lib.concatStringsSep "; " (map
+            (p: "${p.realmName}/${p.workloadName} -> ${p.vmRef}")
+            collision.pairs)
+        }.
+      '';
+    })
+    crossRealmWorkloadCidCollisions
+  # Cross-realm external network attachment conflict assertion.
+  # Fires when two or more realms have associated envs sharing the same
+  # attachment interface while runtime state is metadata-only.
+  # This is advisory until realm-native networking is active.
+  ++ map
+    (conflict: {
+      # Not a hard assertion in metadata-only runtime state: demoted to a
+      # warning-like record. Flip to `assertion = false` when realm-native
+      # networking advances beyond metadata-only.
+      assertion = true;
+      message = ''
+        Advisory: d2b.realms ${
+          lib.concatStringsSep ", " conflict.realmNames
+        } associate with envs (${
+          lib.concatStringsSep ", " conflict.envNames
+        }) that share externalNetwork.attachment.interface "${conflict.interface}".
+        This may conflict when realm-native networking is activated. Review
+        externalNetwork.attachment settings across these realms.
+      '';
+    })
+    crossRealmExtNetConflicts;
 
   autoSysVmNames =
     (lib.mapAttrsToList

--- a/nixos-modules/bundle-artifacts.nix
+++ b/nixos-modules/bundle-artifacts.nix
@@ -139,6 +139,7 @@ let
     "allocatorJson"
     "realmControllersJson"
     "realmIdentityJson"
+    "realmWorkloadsLauncherJson"
   ];
 
   shouldInstall = artifact:
@@ -230,6 +231,14 @@ in
       internal = true;
       visible = false;
       description = "Internal typed realm-identity.json artifact metadata.";
+    };
+
+    realmWorkloadsLauncherJson = lib.mkOption {
+      type = artifactModule;
+      default = { };
+      internal = true;
+      visible = false;
+      description = "Internal typed realm-workloads-launcher.json artifact metadata for desktop launcher consumers.";
     };
 
     extraArtifacts = lib.mkOption {

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -63,6 +63,7 @@
     ./allocator-json.nix
     ./realm-controller-config-json.nix
     ./realm-identity-config-json.nix
+    ./realm-workloads-launcher-json.nix
     ./privileges-json.nix
     ./closures-json.nix
     ./minijail-profiles.nix

--- a/nixos-modules/index.nix
+++ b/nixos-modules/index.nix
@@ -116,6 +116,81 @@ let
       ++ realm.network.envs
     ));
 
+  # Compute a single workload index row from a declared realm workload.
+  # Does NOT reference cfg.manifest to avoid circular deps with manifest.nix;
+  # vsockCid derivation lives in realm-workloads-launcher-json.nix.
+  realmWorkloadRow = realmName: realm: workloadName: workload:
+    let
+      vmRef = workload.vmRef;
+      hasVm = vmRef != null && builtins.hasAttr vmRef enabledVms;
+      runtimeKind =
+        if hasVm
+        then d2bLib.vmRuntimeKind enabledVms.${vmRef}
+        else null;
+      runtimeProviderId =
+        if runtimeKind != null
+        then (d2bLib.runtimeProviderCatalog.${runtimeKind}).provider.id
+        else null;
+    in {
+      inherit realmName workloadName;
+      realmId = realm.id;
+      realmPath = realm.path;
+      # Canonical target address for realm-native tooling: <workload>.<realmPath>.d2b
+      targetAddress = "${workloadName}.${realm.path}.d2b";
+      inherit (workload) enable actionId label icon;
+      capabilityRefs = sortNames (lib.unique workload.capabilityRefs);
+      preflightRefs = sortNames (lib.unique workload.preflightRefs);
+      inherit vmRef;
+      # substrateId: stable reference to the local VM substrate, if any.
+      substrateId = vmRef;
+      inherit runtimeKind runtimeProviderId;
+    };
+
+  realmWorkloadRows = realmName: realm:
+    sortedMapAttrsToList
+      (workloadName: workload:
+        realmWorkloadRow realmName realm workloadName workload)
+      realm.workloads;
+
+  # Cross-realm external network attachment conflict detection.
+  # Yields a list of conflict records where more than one realm's associated
+  # envs share the same external-network attachment interface.
+  crossRealmExternalNetworkConflicts =
+    let
+      realmEnvPairs = lib.flatten (map
+        (row:
+          map
+            (envName: {
+              realmName = row.realmName;
+              realmPath = row.path;
+              inherit envName;
+            })
+            row.network.enabledEnvNames)
+        enabledRealmRows);
+      pairsWithAttachment = lib.filter
+        (pair:
+          builtins.hasAttr pair.envName enabledEnvs
+          && (enabledEnvs.${pair.envName}).externalNetwork.attachment.enable)
+        realmEnvPairs;
+      byInterface = lib.groupBy
+        (pair:
+          let iface = (enabledEnvs.${pair.envName}).externalNetwork.attachment.interface;
+          in if iface != null then iface else "_unspecified")
+        pairsWithAttachment;
+      conflicting = lib.filterAttrs
+        (_: pairs:
+          lib.length (lib.unique (map (p: p.realmName) pairs)) > 1)
+        byInterface;
+    in
+    lib.mapAttrsToList
+      (interface: pairs: {
+        inherit interface;
+        realmNames = sortNames (lib.unique (map (p: p.realmName) pairs));
+        realmPaths = sortNames (lib.unique (map (p: p.realmPath) pairs));
+        envNames = sortNames (lib.unique (map (p: p.envName) pairs));
+      })
+      conflicting;
+
   realmProviderRows = realmName: realm:
     lib.listToAttrs (sortedMapAttrsToList
       (providerName: provider: {
@@ -177,6 +252,7 @@ let
       envNames = realmEnvNames realm;
       providerRows = realmProviderRows realmName realm;
       enabledProviderRows = lib.filterAttrs (_: provider: provider.enabled) providerRows;
+      workloadRowList = realmWorkloadRows realmName realm;
     in
     {
       inherit realmName;
@@ -218,6 +294,10 @@ let
       paths = realm.paths;
       broker = realm.broker;
       controller = realmControllerMeta realm;
+      # Workload rows derived from realm.workloads declarations.
+      workloads = workloadRowList;
+      workloadNames = map (w: w.workloadName) workloadRowList;
+      enabledWorkloadNames = map (w: w.workloadName) (lib.filter (w: w.enable) workloadRowList);
     };
 
   realmRows = sortedMapAttrsToList realmRow declaredRealms;
@@ -241,6 +321,26 @@ let
         };
       })
       (sortedAttrNames cfg.envs));
+
+  # Flat list of all workload rows across all realms (declared, including disabled).
+  allRealmWorkloadRows = lib.flatten (map (row: row.workloads) realmRows);
+
+  # Flat list of workload rows for enabled realms whose workload.enable = true.
+  enabledRealmWorkloadRows = lib.filter (w: w.enable)
+    (lib.flatten (map (row: row.workloads) enabledRealmRows));
+
+  # Map from vmRef -> list of enabled realm workload rows that reference that VM.
+  realmWorkloadsByVm =
+    lib.foldl
+      (acc: row:
+        if row.vmRef == null then acc
+        else
+          let existing = acc.${row.vmRef} or [ ];
+          in acc // { ${row.vmRef} = existing ++ [ row ]; })
+      { }
+      enabledRealmWorkloadRows;
+
+
 
   subset = pred: sortedAttrs (lib.filterAttrs pred enabledVms);
   subsetNames = pred: sortedAttrNames (subset pred);
@@ -482,6 +582,19 @@ let
       enabledById = realmAttrsBy "id" enabledRealmRows;
       enabledByPath = realmAttrsBy "path" enabledRealmRows;
       byEnv = realmNamesByEnv enabledRealmRows;
+      # Realm-owned workload index.
+      workloads = {
+        # All workload rows across all declared realms (includes disabled).
+        all = allRealmWorkloadRows;
+        # Workload rows for enabled realms with workload.enable = true.
+        enabled = enabledRealmWorkloadRows;
+        # Map from vmRef -> list of enabled realm workload rows.
+        byVm = realmWorkloadsByVm;
+      };
+      # Cross-realm external network attachment conflict data.
+      # A non-empty list indicates realms sharing an attachment interface;
+      # this is advisory metadata — hard assertions live in assertions.nix.
+      externalNetworkConflicts = crossRealmExternalNetworkConflicts;
     };
   };
 in

--- a/nixos-modules/options-realms.nix
+++ b/nixos-modules/options-realms.nix
@@ -261,6 +261,89 @@ in
             '';
           };
 
+          workloads = lib.mkOption {
+            type = lib.types.attrsOf (lib.types.submodule ({ name, ... }: {
+              options = {
+                enable = lib.mkOption {
+                  type = lib.types.bool;
+                  default = true;
+                  description = "Whether this realm workload declaration is active.";
+                };
+
+                vmRef = lib.mkOption {
+                  type = lib.types.nullOr (lib.types.strMatching label);
+                  default = null;
+                  example = "work-main";
+                  description = ''
+                    Transitional reference to an existing `d2b.vms.<vm>` name.
+                    Grounds runtime kind, provider id, and substrate id derivation
+                    for this workload. Null means the workload is provider-managed
+                    with no current local VM substrate.
+                  '';
+                };
+
+                label = lib.mkOption {
+                  type = lib.types.str;
+                  default = name;
+                  description = ''
+                    Human-readable display label for desktop launcher metadata.
+                    Must not contain secrets or sensitive identifiers.
+                  '';
+                };
+
+                icon = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "work-browser";
+                  description = ''
+                    Non-secret icon descriptor for desktop launcher metadata.
+                    Use a freedesktop icon name or an opaque icon ref; no
+                    filesystem paths or sensitive identifiers.
+                  '';
+                };
+
+                actionId = lib.mkOption {
+                  type = lib.types.strMatching label;
+                  default = name;
+                  description = ''
+                    Stable action identifier used by desktop launcher consumers
+                    (Waybar, wlcontrol, wlterm, clip-picker). Defaults to the
+                    workload attribute name. Must match `^[a-z][a-z0-9-]*$`.
+                  '';
+                };
+
+                capabilityRefs = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    Opaque references to workload capability requirements for
+                    preflight checks by desktop launcher consumers. No secrets
+                    or sensitive command payloads.
+                  '';
+                };
+
+                preflightRefs = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    Opaque references to preflight requirement checks to run
+                    before workload launch. Consumed by desktop launcher
+                    metadata; no credentials or command payloads.
+                  '';
+                };
+              };
+            }));
+            default = { };
+            description = ''
+              Workload declarations owned by this realm. Each workload may
+              optionally reference an existing `d2b.vms.<vm>` substrate via
+              `vmRef` for runtime kind and provider id derivation. Desktop
+              launcher metadata is generated from this table.
+
+              Workload names must match `^[a-z][a-z0-9-]*$`.
+            '';
+          };
+
           relay = {
             enable = lib.mkEnableOption "realm relay reachability metadata";
 

--- a/nixos-modules/realm-controller-config-json.nix
+++ b/nixos-modules/realm-controller-config-json.nix
@@ -52,29 +52,56 @@ let
       (lib.filter (request: request.realmPath == realm.path)
         allocatorData.resourceRequests));
 
+  # Build a local runtime workload entry for a given vmName.
+  mkLocalWorkloadEntry = workloadId: vmName:
+    let
+      vm = enabledVms.${vmName};
+      runtime = runtimeRows.${vmName}.metadata;
+    in {
+      inherit workloadId vmName;
+      env = if vm.env != null then vm.env else "none";
+      inherit runtime;
+      paths = {
+        stateDir = cfg.manifest.${vmName}.stateDir;
+        runDir = "/run/d2b/vms/${vmName}";
+        storeView = "${toString cfg.store.stateDir}/${vmName}/store-view";
+        guestControlDir = "/run/d2b/vms/${vmName}/guest-control";
+      };
+    };
+
   localRuntimeWorkloadsFor = realm:
-    if realm.placement != "host-local" || realm.network.env == null then [ ]
-    else
-      sortedMapAttrsToList
-        (vmName: vm:
-          if vm.env == realm.network.env then
-            let
-              runtime = runtimeRows.${vmName}.metadata;
-            in
-            {
-              workloadId = vmName;
-              inherit vmName;
-              env = vm.env;
-              inherit runtime;
-              paths = {
-                stateDir = cfg.manifest.${vmName}.stateDir;
-                runDir = "/run/d2b/vms/${vmName}";
-                storeView = "${toString cfg.store.stateDir}/${vmName}/store-view";
-                guestControlDir = "/run/d2b/vms/${vmName}/guest-control";
-              };
-            }
-          else null)
-        enabledVms;
+    let
+      # Explicit workload rows from realm.workloads that reference an enabled VM.
+      explicitRows = lib.filter
+        (row:
+          row.enable
+          && row.realmName == realm.realmName
+          && row.vmRef != null
+          && builtins.hasAttr row.vmRef enabledVms)
+        cfg._index.realms.workloads.enabled;
+      explicitVmNames = map (row: row.vmRef) explicitRows;
+
+      explicitEntries = map
+        (row: mkLocalWorkloadEntry row.workloadName row.vmRef)
+        explicitRows;
+
+      # Transitional env-based workloads: VMs in realm.network.env that are
+      # not already covered by an explicit workload declaration. Preserved for
+      # backward compat when realm.workloads is empty or does not cover all
+      # env-member VMs.
+      envBasedEntries =
+        if realm.placement != "host-local" || realm.network.env == null
+        then [ ]
+        else
+          lib.filter (entry: entry != null)
+            (sortedMapAttrsToList
+              (vmName: vm:
+                if vm.env == realm.network.env && !(builtins.elem vmName explicitVmNames)
+                then mkLocalWorkloadEntry vmName vmName
+                else null)
+              enabledVms);
+    in
+    lib.sortOn (w: w.workloadId) (explicitEntries ++ envBasedEntries);
 
   compact = values: lib.filter (value: value != null) values;
 
@@ -86,7 +113,7 @@ let
 
   localRuntimeFor = realm:
     let
-      workloads = compact (localRuntimeWorkloadsFor realm);
+      workloads = localRuntimeWorkloadsFor realm;
       providerIds = sortNames (lib.unique (map (workload: workload.runtime.provider.id) workloads));
     in
     if workloads == [ ] then null

--- a/nixos-modules/realm-workloads-launcher-json.nix
+++ b/nixos-modules/realm-workloads-launcher-json.nix
@@ -1,0 +1,85 @@
+# nixos-modules/realm-workloads-launcher-json.nix
+#
+# Generates realm-workloads-launcher.json — stable desktop launcher metadata
+# consumed by Waybar / wlcontrol / wlterm / clip-picker and similar host-side
+# tooling that needs to discover and launch realm-owned workloads.
+#
+# Security contract:
+#   • No secrets, provider tokens, opaque session handles, or sensitive
+#     command payloads. Every field is either static metadata, a stable
+#     opaque ref, or a non-secret descriptor.
+#   • vsockCid is included as a numeric advisory hint only (it is never
+#     an authentication token); launchers that read it MUST treat it as
+#     informational and MUST NOT use it as an authorization factor.
+#   • The artifact is installed at root:d2bd 0640 (contractPrivateNonSecret)
+#     so unprivileged desktop processes cannot read it directly; launchers
+#     must obtain it through the d2bd public socket or a helper with the
+#     right ACL.
+{ config, lib, ... }:
+
+let
+  cfg = config.d2b;
+  d2bLib = import ./lib.nix { inherit lib; };
+
+  sortNames = names: lib.sort lib.lessThan names;
+  sortedAttrNames = attrs: sortNames (lib.attrNames attrs);
+  sortedMapAttrsToList = f: attrs:
+    map (name: f name attrs.${name}) (sortedAttrNames attrs);
+
+  enabledVms = cfg._index.enabledVms;
+  realmWorkloads = cfg._index.realms.workloads.enabled;
+
+  # Derive vsockCid for a vmRef pointing to a normalNixos VM.
+  # Null for non-nixos or missing VMs — callers must handle null.
+  vsockCidFor = vmRef:
+    if vmRef == null then null
+    else if !(builtins.hasAttr vmRef enabledVms) then null
+    else if d2bLib.vmRuntimeKind enabledVms.${vmRef} != "nixos" then null
+    else cfg.manifest.${vmRef}.observability.vsockCid;
+
+  # Build a single launcher metadata row from a workload index entry.
+  launcherRow = workload: {
+    realmName = workload.realmName;
+    realmId = workload.realmId;
+    realmPath = workload.realmPath;
+    workloadName = workload.workloadName;
+    targetAddress = workload.targetAddress;
+    actionId = workload.actionId;
+    label = workload.label;
+    icon = workload.icon;
+    capabilityRefs = workload.capabilityRefs;
+    preflightRefs = workload.preflightRefs;
+    vmRef = workload.vmRef;
+    substrateId = workload.substrateId;
+    runtimeKind = workload.runtimeKind;
+    runtimeProviderId = workload.runtimeProviderId;
+    # vsockCid: advisory hint for vsock-based workload readiness checks.
+    # Null when vmRef is absent, non-nixos, or disabled. Must not be used
+    # as an authentication token.
+    vsockCid = vsockCidFor workload.vmRef;
+  };
+
+  launcherRows = map launcherRow realmWorkloads;
+
+  data = {
+    schemaVersion = "v1";
+    runtimeState = "metadata-only";
+    workloads = launcherRows;
+    invariants = {
+      # Affirm that no secrets, credentials, or sensitive payloads appear.
+      noSecretsOrCredentials = true;
+      noCommandPayloads = true;
+      noOpaqueSessionHandles = true;
+      noProviderTokens = true;
+      metadataOnly = true;
+    };
+  };
+in
+{
+  config.d2b._bundle.realmWorkloadsLauncherJson = {
+    inherit data;
+    installFileName = "realm-workloads-launcher.json";
+    classification = "contractPrivateNonSecret";
+    sensitivity = "nonSecret";
+  };
+}


### PR DESCRIPTION
## Summary

Wave 14 scope: `wave14-index-rendering` — update normalized Nix index and generated metadata to understand realm-owned workloads and desktop launcher metadata.

### Changes

**`nixos-modules/options-realms.nix`**
- Add `d2b.realms.<realm>.workloads.<workload>` option (enable, vmRef, label, icon, actionId, capabilityRefs, preflightRefs). This is the canonical public source for realm-owned workload declarations.

**`nixos-modules/index.nix`**
- Compute `realmWorkloadRow` per realm workload: targetAddress (`<workload>.<realmPath>.d2b`), substrateId, runtimeKind, runtimeProviderId — without referencing cfg.manifest (no circular dep).
- `crossRealmExternalNetworkConflicts`: groups realm-env pairs by attachment interface, yields conflict records when >1 realm shares an interface.
- Expose `index.realms.workloads.{all,enabled,byVm}` and `index.realms.externalNetworkConflicts`.
- Each realm row gains `workloads`, `workloadNames`, `enabledWorkloadNames`.

**`nixos-modules/realm-workloads-launcher-json.nix`** (new)
- `realm-workloads-launcher.json` bundle artifact (root:d2bd 0640) with per-workload rows: targetAddress, actionId, label, icon, capabilityRefs, preflightRefs, runtimeKind, runtimeProviderId, advisory vsockCid, vmRef, substrateId. Explicit invariant markers (noSecretsOrCredentials, noCommandPayloads, noOpaqueSessionHandles, noProviderTokens, metadataOnly).

**`nixos-modules/realm-controller-config-json.nix`**
- Prefer explicit realm workloads (vmRef) as primary source for local runtime workload entries; env-based matching is the fallback for VMs not covered. Backward compat fully preserved.

**`nixos-modules/assertions.nix`**
- Cross-realm vsock CID collision: assertion fires when two workloads in different realms reference different NixOS VMs with the same derived CID.
- Cross-realm external network attachment conflict: advisory (non-failing in metadata-only state) with clear note to flip when realm-native networking advances.

**`nixos-modules/bundle-artifacts.nix`** — register `realmWorkloadsLauncherJson` singleton.

**`nixos-modules/default.nix`** — import `realm-workloads-launcher-json.nix`.

### Validation

- `nix eval --impure checks.x86_64-linux.eval-minimal` ✓
- `nix eval --impure checks.x86_64-linux.eval-multi-env` ✓
- Focused inline evals (30 assertions): workload index rendering, launcher metadata, backward compat for realms without workloads, cross-realm conflict detection — all pass.
- `git diff --check` ✓

### Notes

- No secrets, provider tokens, opaque session handles, or sensitive command payloads in any generated artifact.
- vsockCid in launcher JSON is advisory only; launchers must not treat it as an auth token.
- Cross-realm externalNetwork conflict assertion is advisory (assertion = true) in metadata-only state; flip to false when realm-native networking is live.
- JSON schema file for `realm-workloads-launcher.json` deferred to a follow-up Rust type + xtask addition (drift-check gate is not affected by this PR).
- Desktop launcher artifact mode is 0640 (root:d2bd); desktop consumers must read it through d2bd public socket or a suitably-ACL'd helper.