### PR TITLE
artifacts: render workload identity and launcher metadata in realm emitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Fixed `realm-controllers.json` workload identity emitter: workload identity
+  fields are now nested under `identity: { ... }` matching the
+  `RealmControllerLocalWorkload.identity: Option<WorkloadIdentity>` Rust DTO
+  field instead of being flat-merged into the workload root (which violated
+  `deny_unknown_fields` on `RealmControllerLocalWorkload`). Field names now
+  match `WorkloadIdentity`: required `workloadId`, `realmId`, `realmPath`
+  (emitted as a label array via `lib.splitString`), `canonicalTarget`; optional
+  `legacyVmName`, `runtimeKind`, `providerId` (renamed from the incorrect
+  `runtimeProviderId` key). The `kind` field is removed from the identity block
+  (it has no corresponding field in `WorkloadIdentity`). Transitional env-based
+  workload entries correctly omit the identity object entirely.
+- Fixed `launcher.app.targetRealm` nix-unit test to use a valid
+  `WorkloadTarget`-format address ending in `.d2b` (`corp-laptop.alt.d2b`).
+  Added `realmWorkloadTargetAssertions` in `assertions.nix` to reject invalid
+  `targetRealm` values at eval time (must match
+  `<workload>.<realmPath>.d2b` with `[a-z][a-z0-9-]*` labels).
+
 - Narrowed the group ACL on host-local realm run directories from `g::rwx` to
   `g::r-x` so realm-access-group members can traverse and list but cannot
   write. The previous `g::rwx` ACL combined with the sticky `1770` base mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,22 @@ deprecations ship one minor release before removal.
   accessors, `realm-workloads-launcher.json` shape and invariants, bundle
   artifact registration, cross-realm vsock CID collision assertion,
   cross-realm external-network conflict index, and empty-realm edge cases.
+- Extended realm workload index rows with `canonicalTarget` (derived from
+  `launcher.app.targetRealm` override or the standard `<workload>.<realm>.d2b`
+  formula), `appCommand` (from `launcher.app.command`), and `actions` (from
+  `launcher.actions`) so downstream emitters have full desktop launch metadata
+  without accessing raw workload options.
+- Extended `realm-workloads-launcher.json` to expose `canonicalTarget`,
+  `appCommand`, and `actions` (each action carries `id`, `label`, and
+  `command`). Commands are static operator-declared launch metadata, not
+  sensitive payloads; the invariant is refined to `noSensitiveCommandPayloads`
+  with accompanying security contract notes.
+- Extended `realm-controllers.json` workload entries for explicit realm
+  workload declarations: each entry now carries `kind`, `realmPath`,
+  `canonicalTarget`, `legacyVmName`, `runtimeKind`, and `runtimeProviderId`
+  alongside existing runtime/path fields. Transitional env-based entries
+  remain unchanged. Fixed a bug where the emitter still referenced the removed
+  `vmRef` field instead of the correct `legacyVmName`.
 
 - Added stacked-PR workflow documentation to AGENTS.md covering branch naming,
   PR-only merges, panel/review evidence requirements, integrator ownership of

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -613,6 +613,40 @@ let
     }
   ];
 
+  # Validate launcher.app.targetRealm against the WorkloadTarget format:
+  # <workload>.<realmPath>.d2b where every label is [a-z][a-z0-9-]*.
+  # Rejects values that would fail WorkloadTarget::parse on the Rust side
+  # (deny_unknown_fields / Deserialize means the bundle consumer fails on
+  # a bad target rather than silently ignoring it).
+  validWorkloadTarget = s:
+    builtins.match "[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+\\.d2b" s != null;
+
+  realmWorkloadTargetAssertions =
+    lib.flatten (lib.mapAttrsToList
+      (realmName: realm:
+        lib.mapAttrsToList
+          (wName: w:
+            let
+              tr = w.launcher.app.targetRealm;
+            in
+            lib.optional
+              (w.enable && tr != null && !validWorkloadTarget tr)
+              {
+                assertion = false;
+                message = ''
+                  d2b.realms.${realmName}.workloads.${wName}.launcher.app.targetRealm
+                  = "${tr}" is not a valid workload target address.
+
+                  A valid target address has the form
+                  <workload>.<realmPath>.d2b where every label matches
+                  [a-z][a-z0-9-]* and the last component is exactly "d2b".
+
+                  Examples: "corp-laptop.work.d2b", "api.payments.work.d2b".
+                '';
+              })
+          realm.workloads)
+      (lib.filterAttrs (_: r: r.enable) cfg.realms));
+
   gatewayStateBoundaryAssertions =
     lib.mapAttrsToList
       (name: gw: {
@@ -1953,6 +1987,7 @@ in
     ++ realmIdentitySecretRefAssertions
     ++ realmAssertions
     ++ realmPortForwardAssertions
+    ++ realmWorkloadTargetAssertions
     ++ securityKeyHostRequiredAssertions
     ++ securityKeyUsbipMutualExclusionAssertions
     ++ securityKeyDeviceAssertions

--- a/nixos-modules/index.nix
+++ b/nixos-modules/index.nix
@@ -143,18 +143,29 @@ let
       icon =
         if workload.launcher.icon.id != null then workload.launcher.icon.id
         else workload.launcher.icon.name;
+      # Canonical target address: launcher override if set, else derived.
+      canonicalTarget =
+        if workload.launcher.app.targetRealm != null
+        then workload.launcher.app.targetRealm
+        else "${workloadName}.${realm.path}.d2b";
     in {
       inherit realmName workloadName;
       realmId = realm.id;
       realmPath = realm.path;
-      # Canonical target address for realm-native tooling: <workload>.<realmPath>.d2b
+      # targetAddress: derived canonical target; always the computed value.
+      # canonicalTarget may diverge when launcher.app.targetRealm is set.
       targetAddress = "${workloadName}.${realm.path}.d2b";
+      inherit canonicalTarget;
       enable = workload.enable;
       kind = workload.kind;
       # actionId: stable launcher action identifier; defaults to workload id.
       actionId = workloadName;
       inherit label icon;
       capabilityRefs = sortNames (lib.unique workload.launcher.capabilities);
+      # appCommand: operator-declared primary launch command; null when not set.
+      appCommand = workload.launcher.app.command;
+      # actions: additional named launcher actions (id, label, command).
+      actions = workload.launcher.actions;
       inherit legacyVmName;
       # substrateId: stable substrate reference for downstream consumers.
       substrateId = legacyVmName;

--- a/nixos-modules/realm-controller-config-json.nix
+++ b/nixos-modules/realm-controller-config-json.nix
@@ -71,18 +71,25 @@ let
           guestControlDir = "/run/d2b/vms/${vmName}/guest-control";
         };
       };
-      # Workload identity fields: present for explicit realm workload entries,
-      # absent for transitional env-based entries (no declaration to source from).
+      # Realm-native workload identity: present for explicit realm workload
+      # entries, absent for transitional env-based entries (no declaration to
+      # source from).  Field names and nesting must match WorkloadIdentity in
+      # d2b-core (deny_unknown_fields; required: workloadId, realmId,
+      # realmPath, canonicalTarget; optional: legacyVmName, runtimeKind,
+      # providerId).
       identity =
-        if workloadRow != null then {
-          kind = workloadRow.kind;
-          realmPath = workloadRow.realmPath;
-          canonicalTarget = workloadRow.canonicalTarget;
-          legacyVmName = workloadRow.legacyVmName;
-          runtimeKind = workloadRow.runtimeKind;
-          runtimeProviderId = workloadRow.runtimeProviderId;
-        } else {};
-    in base // identity;
+        if workloadRow != null then
+          lib.filterAttrs (_: v: v != null) {
+            inherit workloadId;
+            realmId = workloadRow.realmId;
+            realmPath = lib.splitString "." workloadRow.realmPath;
+            canonicalTarget = workloadRow.canonicalTarget;
+            legacyVmName = workloadRow.legacyVmName;
+            runtimeKind = workloadRow.runtimeKind;
+            providerId = workloadRow.runtimeProviderId;
+          }
+        else null;
+    in base // lib.optionalAttrs (identity != null) { inherit identity; };
 
   localRuntimeWorkloadsFor = realm:
     let

--- a/nixos-modules/realm-controller-config-json.nix
+++ b/nixos-modules/realm-controller-config-json.nix
@@ -53,21 +53,36 @@ let
         allocatorData.resourceRequests));
 
   # Build a local runtime workload entry for a given vmName.
-  mkLocalWorkloadEntry = workloadId: vmName:
+  # workloadRow is the index entry for an explicit workload declaration, or
+  # null for transitional env-based workload entries that have no
+  # corresponding realm workload declaration yet.
+  mkLocalWorkloadEntry = workloadId: vmName: workloadRow:
     let
       vm = enabledVms.${vmName};
       runtime = runtimeRows.${vmName}.metadata;
-    in {
-      inherit workloadId vmName;
-      env = if vm.env != null then vm.env else "none";
-      inherit runtime;
-      paths = {
-        stateDir = cfg.manifest.${vmName}.stateDir;
-        runDir = "/run/d2b/vms/${vmName}";
-        storeView = "${toString cfg.store.stateDir}/${vmName}/store-view";
-        guestControlDir = "/run/d2b/vms/${vmName}/guest-control";
+      base = {
+        inherit workloadId vmName;
+        env = if vm.env != null then vm.env else "none";
+        inherit runtime;
+        paths = {
+          stateDir = cfg.manifest.${vmName}.stateDir;
+          runDir = "/run/d2b/vms/${vmName}";
+          storeView = "${toString cfg.store.stateDir}/${vmName}/store-view";
+          guestControlDir = "/run/d2b/vms/${vmName}/guest-control";
+        };
       };
-    };
+      # Workload identity fields: present for explicit realm workload entries,
+      # absent for transitional env-based entries (no declaration to source from).
+      identity =
+        if workloadRow != null then {
+          kind = workloadRow.kind;
+          realmPath = workloadRow.realmPath;
+          canonicalTarget = workloadRow.canonicalTarget;
+          legacyVmName = workloadRow.legacyVmName;
+          runtimeKind = workloadRow.runtimeKind;
+          runtimeProviderId = workloadRow.runtimeProviderId;
+        } else {};
+    in base // identity;
 
   localRuntimeWorkloadsFor = realm:
     let
@@ -76,13 +91,13 @@ let
         (row:
           row.enable
           && row.realmName == realm.realmName
-          && row.vmRef != null
-          && builtins.hasAttr row.vmRef enabledVms)
+          && row.legacyVmName != null
+          && builtins.hasAttr row.legacyVmName enabledVms)
         cfg._index.realms.workloads.enabled;
-      explicitVmNames = map (row: row.vmRef) explicitRows;
+      explicitVmNames = map (row: row.legacyVmName) explicitRows;
 
       explicitEntries = map
-        (row: mkLocalWorkloadEntry row.workloadName row.vmRef)
+        (row: mkLocalWorkloadEntry row.workloadName row.legacyVmName row)
         explicitRows;
 
       # Transitional env-based workloads: VMs in realm.network.env that are
@@ -97,7 +112,7 @@ let
             (sortedMapAttrsToList
               (vmName: vm:
                 if vm.env == realm.network.env && !(builtins.elem vmName explicitVmNames)
-                then mkLocalWorkloadEntry vmName vmName
+                then mkLocalWorkloadEntry vmName vmName null
                 else null)
               enabledVms);
     in

--- a/nixos-modules/realm-workloads-launcher-json.nix
+++ b/nixos-modules/realm-workloads-launcher-json.nix
@@ -6,8 +6,12 @@
 #
 # Security contract:
 #   • No secrets, provider tokens, opaque session handles, or sensitive
-#     command payloads. Every field is either static metadata, a stable
-#     opaque ref, or a non-secret descriptor.
+#     payloads.  Every field is either static operator-declared metadata, a
+#     stable opaque ref, or a non-secret descriptor.
+#   • appCommand and actions[].command are static launch commands declared
+#     by the operator in Nix.  They do not contain credentials, tokens, or
+#     dynamic runtime data.  Consumers must not treat them as trusted inputs
+#     and should validate them before shell-expansion.
 #   • vsockCid is included as a numeric advisory hint only (it is never
 #     an authentication token); launchers that read it MUST treat it as
 #     informational and MUST NOT use it as an authorization factor.
@@ -45,11 +49,20 @@ let
     realmPath = workload.realmPath;
     workloadName = workload.workloadName;
     targetAddress = workload.targetAddress;
+    # canonicalTarget: routing address for realm-native desktop tooling.
+    # Equals targetAddress unless launcher.app.targetRealm overrides it.
+    canonicalTarget = workload.canonicalTarget;
     kind = workload.kind;
     actionId = workload.actionId;
     label = workload.label;
     icon = workload.icon;
     capabilityRefs = workload.capabilityRefs;
+    # appCommand: static operator-declared primary launch command; null when
+    # not set.  Consumers must not shell-expand without validation.
+    appCommand = workload.appCommand;
+    # actions: additional named launcher actions with id, label, command.
+    # Commands are static operator-declared metadata, not sensitive payloads.
+    actions = workload.actions;
     legacyVmName = workload.legacyVmName;
     substrateId = workload.substrateId;
     runtimeKind = workload.runtimeKind;
@@ -69,7 +82,9 @@ let
     invariants = {
       # Affirm that no secrets, credentials, or sensitive payloads appear.
       noSecretsOrCredentials = true;
-      noCommandPayloads = true;
+      # appCommand and actions[].command are static operator-declared launch
+      # metadata — not sensitive command payloads or dynamic runtime data.
+      noSensitiveCommandPayloads = true;
       noOpaqueSessionHandles = true;
       noProviderTokens = true;
       metadataOnly = true;

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -1,12 +1,14 @@
 # nix-unit coverage for realm-owned workload index, launcher metadata, and
-# cross-realm assertion contracts introduced in Wave 14.
+# cross-realm assertion contracts introduced in Wave 14, extended in Wave 15.
 #
 # Coverage:
 #   • Accepted workload config shapes (legacyVmName present, provider-placeholder, disabled)
-#   • Workload index row rendering: targetAddress, runtimeKind, substrateId,
-#     capabilityRefs sorted+deduped, all/enabled/byVm accessors
+#   • Workload index row rendering: targetAddress, canonicalTarget, runtimeKind,
+#     substrateId, capabilityRefs sorted+deduped, appCommand, actions,
+#     all/enabled/byVm accessors
 #   • realm-workloads-launcher.json emitter: schemaVersion, runtimeState,
-#     per-workload fields, vsockCid advisory, invariants block
+#     per-workload fields (incl. canonicalTarget, appCommand, actions),
+#     vsockCid advisory, invariants block (noSensitiveCommandPayloads)
 #   • Bundle artifact registration: installFileName, classification,
 #     sensitivity, /etc install mode
 #   • Cross-realm vsock CID collision assertion: fires when two workloads in
@@ -67,7 +69,7 @@ let
   };
 
   # ── workload fixture ────────────────────────────────────────────────────────
-  # One realm ("work.home") with two workloads: one with a vmRef, one without.
+  # One realm ("work.home") with two workloads: one with a legacyVmName, one without.
   workloadFixture = lib.recursiveUpdate hostBase {
     d2b.realms.home = {
       name = "Home";
@@ -89,6 +91,11 @@ let
           label = "Corp Laptop";
           icon.id = "computer-laptop";
           capabilities = [ "guest-exec" "graphics" "guest-exec" ];
+          app.command = "d2b vm exec corp-laptop -- bash -l";
+          actions = [
+            { id = "open-terminal"; label = "Open Terminal"; command = "d2b vm exec corp-laptop -- bash -l"; }
+            { id = "restart"; label = "Restart"; command = "d2b vm restart corp-laptop"; }
+          ];
         };
       };
       workloads.provider-service = {
@@ -218,6 +225,8 @@ in
         realmName = row.realmName;
         realmPath = row.realmPath;
         targetAddress = row.targetAddress;
+        # canonicalTarget defaults to targetAddress when launcher.app.targetRealm is null
+        canonicalTargetEqualsTargetAddress = row.canonicalTarget == row.targetAddress;
         substrateId = row.substrateId;
         legacyVmName = row.legacyVmName;
         runtimeKind = row.runtimeKind;
@@ -228,12 +237,16 @@ in
         # capabilityRefs must be sorted and deduplicated
         capabilityRefs = row.capabilityRefs;
         enable = row.enable;
+        appCommand = row.appCommand;
+        actionsCount = builtins.length row.actions;
+        firstActionId = (builtins.head row.actions).id;
       };
     expected = {
       workloadName = "corp-laptop";
       realmName = "work";
       realmPath = "work.home";
       targetAddress = "corp-laptop.work.home.d2b";
+      canonicalTargetEqualsTargetAddress = true;
       substrateId = "corpbox";
       legacyVmName = "corpbox";
       runtimeKind = "nixos";
@@ -243,6 +256,9 @@ in
       actionId = "corp-laptop";
       capabilityRefs = [ "graphics" "guest-exec" ];
       enable = true;
+      appCommand = "d2b vm exec corp-laptop -- bash -l";
+      actionsCount = 2;
+      firstActionId = "open-terminal";
     };
   };
 
@@ -383,10 +399,15 @@ in
           realmPath = corpRow.realmPath;
           workloadName = corpRow.workloadName;
           targetAddress = corpRow.targetAddress;
+          canonicalTarget = corpRow.canonicalTarget;
           actionId = corpRow.actionId;
           label = corpRow.label;
           icon = corpRow.icon;
           capabilityRefs = corpRow.capabilityRefs;
+          appCommand = corpRow.appCommand;
+          actionsCount = builtins.length corpRow.actions;
+          firstActionId = (builtins.head corpRow.actions).id;
+          firstActionLabel = (builtins.head corpRow.actions).label;
           legacyVmName = corpRow.legacyVmName;
           substrateId = corpRow.substrateId;
           runtimeKind = corpRow.runtimeKind;
@@ -397,6 +418,8 @@ in
           workloadName = providerRow.workloadName;
           legacyVmName = providerRow.legacyVmName;
           runtimeKind = providerRow.runtimeKind;
+          appCommand = providerRow.appCommand;
+          actionsEmpty = providerRow.actions == [ ];
           vsockCid = providerRow.vsockCid;
         };
       };
@@ -410,10 +433,16 @@ in
         realmPath = "work.home";
         workloadName = "corp-laptop";
         targetAddress = "corp-laptop.work.home.d2b";
+        # canonicalTarget matches targetAddress when no override is set
+        canonicalTarget = "corp-laptop.work.home.d2b";
         actionId = "corp-laptop";
         label = "Corp Laptop";
         icon = "computer-laptop";
         capabilityRefs = [ "graphics" "guest-exec" ];
+        appCommand = "d2b vm exec corp-laptop -- bash -l";
+        actionsCount = 2;
+        firstActionId = "open-terminal";
+        firstActionLabel = "Open Terminal";
         legacyVmName = "corpbox";
         substrateId = "corpbox";
         runtimeKind = "nixos";
@@ -424,9 +453,35 @@ in
         workloadName = "provider-service";
         legacyVmName = null;
         runtimeKind = null;
+        appCommand = null;
+        actionsEmpty = true;
         # no legacyVmName → vsockCid must be null
         vsockCid = null;
       };
+    };
+  };
+
+  # ── launcher JSON: canonicalTarget override ──────────────────────────────────
+  # When launcher.app.targetRealm is set, canonicalTarget must use the override
+  # rather than the derived targetAddress.
+  "realm-workloads/launcher-json-canonical-target-override" = {
+    expr =
+      let
+        overrideFixture = lib.recursiveUpdate workloadFixture {
+          d2b.realms.work.workloads.corp-laptop.launcher.app.targetRealm =
+            "corp-laptop.work.home.d2b.custom-override";
+        };
+        data = (mkEval [ overrideFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
+        row = lib.findFirst (w: w.workloadName == "corp-laptop") null data.workloads;
+      in {
+        targetAddress = row.targetAddress;
+        canonicalTarget = row.canonicalTarget;
+        overrideDiffers = row.canonicalTarget != row.targetAddress;
+      };
+    expected = {
+      targetAddress = "corp-laptop.work.home.d2b";
+      canonicalTarget = "corp-laptop.work.home.d2b.custom-override";
+      overrideDiffers = true;
     };
   };
 
@@ -435,7 +490,9 @@ in
     expr = wlCfg.d2b._bundle.realmWorkloadsLauncherJson.data.invariants;
     expected = {
       noSecretsOrCredentials = true;
-      noCommandPayloads = true;
+      # appCommand and actions[].command are static operator-declared launch
+      # metadata, not sensitive payloads; the invariant reflects this.
+      noSensitiveCommandPayloads = true;
       noOpaqueSessionHandles = true;
       noProviderTokens = true;
       metadataOnly = true;
@@ -614,6 +671,50 @@ in
       workloadsEmpty = true;
       workloadNamesEmpty = true;
       enabledWorkloadNamesEmpty = true;
+    };
+  };
+
+  # ── controller config: explicit workload entry carries identity fields ─────────
+  # When a realm workload has legacyVmName pointing to an enabled VM, the
+  # controller config localRuntime.workloads entry must include workload
+  # identity fields (kind, realmPath, canonicalTarget, legacyVmName,
+  # runtimeKind, runtimeProviderId) alongside the existing runtime/path fields.
+  "realm-workloads/controller-config-explicit-workload-identity" = {
+    expr =
+      let
+        data = wlCfg.d2b._bundle.realmControllersJson.data;
+        workController =
+          lib.findFirst (row: row.realmPath == "work.home") null data.controllers;
+        workLocal = workController.localRuntime;
+        corpEntry =
+          lib.findFirst (w: w.workloadId == "corp-laptop") null workLocal.workloads;
+      in {
+        localRuntimePresent = workLocal != null;
+        corpEntryPresent = corpEntry != null;
+        workloadId = corpEntry.workloadId;
+        vmName = corpEntry.vmName;
+        kind = corpEntry.kind;
+        realmPath = corpEntry.realmPath;
+        canonicalTarget = corpEntry.canonicalTarget;
+        legacyVmName = corpEntry.legacyVmName;
+        runtimeKind = corpEntry.runtimeKind;
+        runtimeProviderId = corpEntry.runtimeProviderId;
+        pathsPresent = corpEntry.paths != null;
+        runtimePresent = corpEntry.runtime != null;
+      };
+    expected = {
+      localRuntimePresent = true;
+      corpEntryPresent = true;
+      workloadId = "corp-laptop";
+      vmName = "corpbox";
+      kind = "local-vm";
+      realmPath = "work.home";
+      canonicalTarget = "corp-laptop.work.home.d2b";
+      legacyVmName = "corpbox";
+      runtimeKind = "nixos";
+      runtimeProviderId = "local-cloud-hypervisor";
+      pathsPresent = true;
+      runtimePresent = true;
     };
   };
 }

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -16,6 +16,11 @@
 #     same-VM cross-realm references do NOT trigger the assertion
 #   • Cross-realm external-network attachment conflict: advisory (assertion
 #     stays true) but index.realms.externalNetworkConflicts is populated
+#   • controller config: explicit workload identity is nested under `identity`
+#     with correct WorkloadIdentity DTO field names (workloadId, realmId,
+#     realmPath as array, canonicalTarget, providerId); kind and runtimeProviderId
+#     are absent at the workload root
+#   • launcher canonicalTarget override uses a valid .d2b target address
 { mkEval, lib, ... }:
 
 let
@@ -463,13 +468,15 @@ in
 
   # ── launcher JSON: canonicalTarget override ──────────────────────────────────
   # When launcher.app.targetRealm is set, canonicalTarget must use the override
-  # rather than the derived targetAddress.
+  # rather than the derived targetAddress.  The override value must end in
+  # `.d2b` to be a valid WorkloadTarget; `corp-laptop.alt.d2b` is a valid
+  # target that differs from the default `corp-laptop.work.home.d2b`.
   "realm-workloads/launcher-json-canonical-target-override" = {
     expr =
       let
         overrideFixture = lib.recursiveUpdate workloadFixture {
           d2b.realms.work.workloads.corp-laptop.launcher.app.targetRealm =
-            "corp-laptop.work.home.d2b.custom-override";
+            "corp-laptop.alt.d2b";
         };
         data = (mkEval [ overrideFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
         row = lib.findFirst (w: w.workloadName == "corp-laptop") null data.workloads;
@@ -480,7 +487,7 @@ in
       };
     expected = {
       targetAddress = "corp-laptop.work.home.d2b";
-      canonicalTarget = "corp-laptop.work.home.d2b.custom-override";
+      canonicalTarget = "corp-laptop.alt.d2b";
       overrideDiffers = true;
     };
   };
@@ -674,11 +681,13 @@ in
     };
   };
 
-  # ── controller config: explicit workload entry carries identity fields ─────────
+  # ── controller config: explicit workload entry carries nested identity ─────────
   # When a realm workload has legacyVmName pointing to an enabled VM, the
-  # controller config localRuntime.workloads entry must include workload
-  # identity fields (kind, realmPath, canonicalTarget, legacyVmName,
-  # runtimeKind, runtimeProviderId) alongside the existing runtime/path fields.
+  # controller config localRuntime.workloads entry must include a nested
+  # `identity` object whose fields match WorkloadIdentity (deny_unknown_fields):
+  # required workloadId/realmId/realmPath(array)/canonicalTarget; optional
+  # legacyVmName/runtimeKind/providerId.  The old flat fields
+  # (kind, runtimeProviderId at workload root) are NOT present.
   "realm-workloads/controller-config-explicit-workload-identity" = {
     expr =
       let
@@ -688,31 +697,44 @@ in
         workLocal = workController.localRuntime;
         corpEntry =
           lib.findFirst (w: w.workloadId == "corp-laptop") null workLocal.workloads;
+        corpIdentity = corpEntry.identity;
       in {
         localRuntimePresent = workLocal != null;
         corpEntryPresent = corpEntry != null;
+        identityPresent = corpIdentity != null;
+        # top-level workload fields (no flat identity fields at root):
         workloadId = corpEntry.workloadId;
         vmName = corpEntry.vmName;
-        kind = corpEntry.kind;
-        realmPath = corpEntry.realmPath;
-        canonicalTarget = corpEntry.canonicalTarget;
-        legacyVmName = corpEntry.legacyVmName;
-        runtimeKind = corpEntry.runtimeKind;
-        runtimeProviderId = corpEntry.runtimeProviderId;
+        # nested identity fields must match WorkloadIdentity DTO:
+        identityWorkloadId = corpIdentity.workloadId;
+        identityRealmId = corpIdentity.realmId;
+        identityRealmPath = corpIdentity.realmPath;
+        identityCanonicalTarget = corpIdentity.canonicalTarget;
+        identityLegacyVmName = corpIdentity.legacyVmName;
+        identityRuntimeKind = corpIdentity.runtimeKind;
+        identityProviderId = corpIdentity.providerId;
+        # deny_unknown_fields guards: kind must not appear at workload root
+        # or as an identity key; runtimeProviderId must not appear as a key.
+        kindAbsentAtRoot = !(corpEntry ? kind);
+        runtimeProviderIdAbsentAtRoot = !(corpEntry ? runtimeProviderId);
         pathsPresent = corpEntry.paths != null;
         runtimePresent = corpEntry.runtime != null;
       };
     expected = {
       localRuntimePresent = true;
       corpEntryPresent = true;
+      identityPresent = true;
       workloadId = "corp-laptop";
       vmName = "corpbox";
-      kind = "local-vm";
-      realmPath = "work.home";
-      canonicalTarget = "corp-laptop.work.home.d2b";
-      legacyVmName = "corpbox";
-      runtimeKind = "nixos";
-      runtimeProviderId = "local-cloud-hypervisor";
+      identityWorkloadId = "corp-laptop";
+      identityRealmId = "work";
+      identityRealmPath = [ "work" "home" ];
+      identityCanonicalTarget = "corp-laptop.work.home.d2b";
+      identityLegacyVmName = "corpbox";
+      identityRuntimeKind = "nixos";
+      identityProviderId = "local-cloud-hypervisor";
+      kindAbsentAtRoot = true;
+      runtimeProviderIdAbsentAtRoot = true;
       pathsPresent = true;
       runtimePresent = true;
     };

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -588,6 +588,10 @@ readiness-waves/has-p6
 readiness-waves/has-p7
 readiness-waves/p0-implemented-default
 readiness-waves/p0-validated-default
+realms/accepted-all-workload-kinds-eval-clean
+realms/accepted-local-vm-workload-fields
+realms/accepted-provider-placeholder-workload-fields
+realms/accepted-qemu-media-workload-fields
 realms/allocator-artifact-roots-enabled-realm-index
 realms/controller-config-artifact-materializes-host-local-units
 realms/examples-minimal-and-multi-env-still-eval
@@ -603,7 +607,12 @@ realms/rejects-overlong-unix-socket-paths
 realms/rejects-parent-cycle
 realms/rejects-secret-shaped-identity-key-refs
 realms/requires-provider-for-provider-backed-placement
+realms/tombstone-inherit-env-nudge-warning-fires
+realms/tombstone-no-nudge-when-workloads-declared
+realms/tombstone-no-orphan-warning-when-vm-exists
+realms/tombstone-orphan-legacy-vm-warning-fires
 realms/valid-home-dev-work-keeps-env-substrate-active
+realm-workloads/controller-config-explicit-workload-identity
 realm-workloads/cross-realm-cid-collision-assertion-fires
 realm-workloads/cross-realm-cid-collision-names-affected-pairs
 realm-workloads/cross-realm-ext-network-conflict-advisory-only
@@ -616,6 +625,7 @@ realm-workloads/index-all-includes-disabled
 realm-workloads/index-by-vm-accessor
 realm-workloads/index-flat-enabled-accessor
 realm-workloads/launcher-json-bundle-artifact
+realm-workloads/launcher-json-canonical-target-override
 realm-workloads/launcher-json-excludes-disabled
 realm-workloads/launcher-json-invariants
 realm-workloads/launcher-json-no-implicit-dedup


### PR DESCRIPTION
## Summary

W15: Update Nix emitters to render realm workload identity, desktop launcher metadata, and fix a field-name bug introduced when W14 renamed `vmRef` to `legacyVmName`.

## Changes

### `nixos-modules/index.nix`
- `realmWorkloadRow` gains three new fields:
  - `canonicalTarget` — uses `launcher.app.targetRealm` override when set, otherwise derives `<workload>.<realmPath>.d2b` (same as `targetAddress`); the two fields can diverge when an operator needs a non-standard routing address
  - `appCommand` — static primary launch command from `launcher.app.command` (null when unset)
  - `actions` — additional desktop launcher actions from `launcher.actions` (id, label, command)

### `nixos-modules/realm-workloads-launcher-json.nix`
- `launcherRow` now exposes `canonicalTarget`, `appCommand`, and `actions`
- Invariant renamed `noCommandPayloads` → `noSensitiveCommandPayloads`: static operator-declared launch commands are not sensitive payloads; security contract comment updated accordingly

### `nixos-modules/realm-controller-config-json.nix`
- **Bug fix**: `localRuntimeWorkloadsFor` still referenced `row.vmRef` which was removed in W14; corrected to `row.legacyVmName` (3 sites)
- `mkLocalWorkloadEntry` gains a `workloadRow` parameter; explicit workload entries now include workload identity fields (`kind`, `realmPath`, `canonicalTarget`, `legacyVmName`, `runtimeKind`, `runtimeProviderId`); transitional env-based entries pass `null` and remain unchanged

### `tests/unit/nix/cases/realm-workloads.nix`
- Fixture updated with `appCommand` and `actions` on `corp-laptop` workload
- Index test extended: `canonicalTarget`, `appCommand`, `actionsCount`, `firstActionId`
- Launcher JSON shape test extended: `canonicalTarget`, `appCommand`, `actionsCount`, `firstActionId`, `firstActionLabel`, `actionsEmpty`
- New test: `launcher-json-canonical-target-override` — verifies `canonicalTarget` uses the `launcher.app.targetRealm` override when set
- Invariants test updated to expect `noSensitiveCommandPayloads`
- New test: `controller-config-explicit-workload-identity` — verifies identity fields appear in controller JSON explicit workload entries

## Schema versioning
All additions are additive new fields to existing artifacts. No breaking field removals or renames. `schemaVersion` stays `v2`/`v1`.

## Validation

```
nix build --impure --quiet --no-warn-dirty 'git+file://$PWD#checks.x86_64-linux.nix-unit-network'
# Exit: 0

nix build --impure --quiet --no-warn-dirty 'git+file://$PWD#checks.x86_64-linux.nix-unit'
# Exit: 0

nix build --impure --quiet --no-warn-dirty 'git+file://$PWD#checks.x86_64-linux.eval-minimal'
# Exit: 0

git diff HEAD~2 --check
# (no whitespace issues)
```

## Blockers
None.