### PR TITLE
cli: route target parsing through WorkloadTarget/RealmTarget and add migration UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,26 @@ deprecations ship one minor release before removal.
 - The `vm` filter in list and status requests now resolves canonical targets and
   unambiguous workload-id aliases through the workload index before matching
   against manifest entries.
+- Added `canonical_target` field to `ListItemOutputV2` and `StatusVmOutputV2`
+  CLI output structs. When the daemon advertises workload identity for a VM,
+  the field is populated with the canonical workload target address
+  (e.g. `corp-vm.work.d2b`); it is absent (not serialized) when no workload
+  identity is available, preserving backward compatibility with old daemons.
+- `d2b vm list` human output now shows a `WORKLOAD TARGET` column when at least
+  one listed VM has a canonical workload target.
+- `d2b vm status` human output now shows a `workload target:` line when the
+  queried VM has a canonical workload target.
+- `d2b vm <verb>` commands emit a non-fatal compatibility note to stderr when a
+  bare VM name is used and the daemon has advertised a canonical workload target
+  for it, suggesting the canonical form (e.g.
+  `note: target 'corp-vm' is a bare VM name; consider using 'corp-vm.work.d2b'`).
+  The bare-name local fast path continues to work unchanged.
+- Env-qualified VM names missing the required `.d2b` suffix
+  (e.g. `corp-vm.work` instead of `corp-vm.work.d2b`) are now rejected
+  fail-closed with error code `old-env-style-target` and a clear remediation
+  message suggesting the canonical form. This closes the migration UX gap
+  for operators moving from legacy env-scoped targeting.
+
 - Added `d2b.realms.<realm>.workloads.<workload>` option for declaring
   realm-owned workloads. Each workload optionally references an existing
   `d2b.vms.<vm>` substrate via `vmRef` for runtime kind and provider id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Fixed `cmd_vm_lifecycle_verb` migration hint to check the raw user-supplied
+  target string rather than the resolved local VM name. For host-local realms
+  the router strips the realm suffix (e.g. `corp-vm.work.d2b` → `corp-vm`),
+  so the previous check (`!vm.contains('.')`) always evaluated true after
+  resolution and incorrectly emitted the "use the canonical form" hint to users
+  who had already typed the canonical form. The raw input is now preserved
+  before the shadow binding and used for both the dot-guard and the
+  `migration_hint_for_bare_vm` call.
+
 - Fixed `realm-controllers.json` workload identity emitter: workload identity
   fields are now nested under `identity: { ... }` matching the
   `RealmControllerLocalWorkload.identity: Option<WorkloadIdentity>` Rust DTO

--- a/docs/reference/cli-output/list.schema.json
+++ b/docs/reference/cli-output/list.schema.json
@@ -27,6 +27,13 @@
             }
           ]
         },
+        "canonicalTarget": {
+          "description": "Canonical realm-native workload target address (`<workload>.<realm>.d2b`). Present when the daemon has associated this entry with a realm workload identity. Absent for classical `d2b.vms` entries not yet adopted into a realm. Additive — old CLI consumers must tolerate its absence.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "env": {
           "type": [
             "string",

--- a/docs/reference/cli-output/status.schema.json
+++ b/docs/reference/cli-output/status.schema.json
@@ -379,6 +379,13 @@
             "null"
           ]
         },
+        "canonicalTarget": {
+          "description": "Canonical realm-native workload target address (`<workload>.<realm>.d2b`). Present when the daemon has associated this VM with a realm workload identity. Absent for classical VMs not yet adopted into a realm. Additive — old CLI consumers must tolerate its absence.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "current": {
           "type": [
             "string",

--- a/packages/d2b-contracts/src/cli_output.rs
+++ b/packages/d2b-contracts/src/cli_output.rs
@@ -39,6 +39,12 @@ pub struct ListItemOutputV2 {
     pub qemu_media: Option<crate::public_wire::QemuMediaStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_parity_ok: Option<bool>,
+    /// Canonical realm-native workload target address (`<workload>.<realm>.d2b`).
+    /// Present when the daemon has associated this entry with a realm workload
+    /// identity. Absent for classical `d2b.vms` entries not yet adopted into
+    /// a realm. Additive — old CLI consumers must tolerate its absence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_target: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -419,6 +425,12 @@ pub struct StatusVmOutputV2 {
     pub live_pool_integrity: Option<LivePoolIntegrityOutputV1>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usb: Option<crate::public_wire::UsbipVmStatus>,
+    /// Canonical realm-native workload target address (`<workload>.<realm>.d2b`).
+    /// Present when the daemon has associated this VM with a realm workload
+    /// identity. Absent for classical VMs not yet adopted into a realm.
+    /// Additive — old CLI consumers must tolerate its absence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_target: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/packages/d2b/src/lib.rs
+++ b/packages/d2b/src/lib.rs
@@ -38,6 +38,7 @@ use d2b_contracts::{
 use d2b_core::{
     bundle::Bundle, bundle_resolver::HostRuntime, closures::ClosureMetadata,
     error::Error as CoreError, host::HostJson, host_check, processes::ProcessesJson,
+    realm_controller_config::RealmControllersJson,
 };
 use nix::sys::socket::{
     AddressFamily, MsgFlags, SockFlag, SockType, UnixAddr, connect, recv, send, socket,
@@ -5502,7 +5503,41 @@ fn emit_route_error(err: target_routing::RouteError, json: bool) -> Result<CliFa
     Ok(CliFailure::new(exit_code, message))
 }
 
+/// Emit a non-fatal compatibility warning to stderr when a bare VM name is used
+/// and the daemon has advertised a canonical workload target for it. Does
+/// nothing in `--json` mode (JSON callers parse structured output only).
+fn print_workload_migration_hint(hint: &target_routing::TargetMigrationHint, json: bool) {
+    if json {
+        return;
+    }
+    eprintln!("note: {hint}");
+}
+
 fn route_vm_target(context: &Context, raw: &str, json: bool) -> Result<VmTargetRoute, CliFailure> {
+    // Fail-closed for old env-qualified targets missing the `.d2b` suffix.
+    // E.g. `corp-vm.work` → error with suggestion `corp-vm.work.d2b`.
+    if let Some(hint) = target_routing::detect_env_style_target(raw) {
+        match &hint {
+            target_routing::TargetMigrationHint::OldEnvStyleTarget { suggested, .. } => {
+                let message = hint.to_string();
+                let exit_code = emit_host_error(
+                    &host_error_envelope(
+                        &message,
+                        "old-env-style-target",
+                        2,
+                        "CLI target parsing: env-qualified names require the `.d2b` suffix.",
+                        raw,
+                        &format!("Use `{suggested}` (the canonical workload target form)."),
+                        "docs/reference/cli-contract.md",
+                    ),
+                    json,
+                )
+                .map_err(|f| f)?;
+                return Err(CliFailure::new(exit_code, message));
+            }
+            _ => {}
+        }
+    }
     route_vm_target_with_table(context, raw, json, load_realm_entrypoint_table()?)
 }
 
@@ -6556,6 +6591,20 @@ fn cmd_vm_lifecycle_verb(
         }
     };
     require_known_vm(context, &vm, json)?;
+    // Emit a non-fatal compatibility warning when a bare VM name is used but
+    // a canonical workload target is available for it in the realm-controllers
+    // artifact. Advisory only: the local fast path continues to work.
+    if !json && !vm.contains('.') {
+        if let Some(canonical) =
+            try_canonical_target_for_vm(&context.bundle_path, &vm)
+        {
+            if let Some(hint) =
+                target_routing::migration_hint_for_bare_vm(&vm, &canonical)
+            {
+                print_workload_migration_hint(&hint, json);
+            }
+        }
+    }
     if (verb == "start" || verb == "restart") && !json {
         warn_pending_staged_config(&vm);
     }
@@ -9382,9 +9431,16 @@ fn render_list_human(
     output: &ListOutputV2,
     read_model: Option<&d2b_contracts::public_wire::PublicReadModelMetadata>,
 ) -> String {
-    let mut text = String::from(
-        "NAME               ENV       GRAPHICS  TPM   USBIP   STATIC_IP       STATUS\n",
-    );
+    let has_canonical = output.0.iter().any(|item| item.canonical_target.is_some());
+    let mut text = if has_canonical {
+        String::from(
+            "NAME               ENV       GRAPHICS  TPM   USBIP   STATIC_IP       WORKLOAD TARGET          STATUS\n",
+        )
+    } else {
+        String::from(
+            "NAME               ENV       GRAPHICS  TPM   USBIP   STATIC_IP       STATUS\n",
+        )
+    };
     for item in &output.0 {
         let status = if item.is_net_vm {
             format!("{} (net-vm)", item.status)
@@ -9410,17 +9466,32 @@ fn render_list_human(
             item.status.clone()
         };
         let static_ip = item.static_ip.clone().unwrap_or_else(|| "-".to_owned());
-        let _ = writeln!(
-            text,
-            "{:<18} {:<9} {:<9} {:<5} {:<7} {:<15} {}",
-            item.name,
-            item.env.clone().unwrap_or_else(|| "-".to_owned()),
-            item.graphics,
-            item.tpm,
-            item.usbip,
-            static_ip,
-            status,
-        );
+        if has_canonical {
+            let _ = writeln!(
+                text,
+                "{:<18} {:<9} {:<9} {:<5} {:<7} {:<15} {:<24} {}",
+                item.name,
+                item.env.clone().unwrap_or_else(|| "-".to_owned()),
+                item.graphics,
+                item.tpm,
+                item.usbip,
+                static_ip,
+                item.canonical_target.clone().unwrap_or_else(|| "-".to_owned()),
+                status,
+            );
+        } else {
+            let _ = writeln!(
+                text,
+                "{:<18} {:<9} {:<9} {:<5} {:<7} {:<15} {}",
+                item.name,
+                item.env.clone().unwrap_or_else(|| "-".to_owned()),
+                item.graphics,
+                item.tpm,
+                item.usbip,
+                static_ip,
+                status,
+            );
+        }
     }
     if let Some(rm) = read_model {
         let fp = if rm.source_fingerprint.len() > 8 {
@@ -9444,6 +9515,9 @@ fn render_status_vm_human(
 ) -> String {
     let mut text = String::new();
     let _ = writeln!(text, "=== {} ===", output.name);
+    if let Some(canonical) = &output.canonical_target {
+        let _ = writeln!(text, "workload target: {canonical}");
+    }
     if let Some(env) = &output.env {
         let _ = writeln!(text, "env: {env}");
     }
@@ -9997,6 +10071,37 @@ where
     read_json_file(&path)
         .map(Some)
         .map_err(|err| CliFailure::new(1, format!("failed to read {}: {err}", path.display())))
+}
+
+/// Look up the canonical workload target address for a VM by its VM name.
+/// Reads the bundle.json and, if it references a realm-controllers artifact,
+/// parses it to find the workload's `identity.canonicalTarget`. Returns `None`
+/// on any IO or parse error (advisory hint path — never blocks the caller).
+fn try_canonical_target_for_vm(bundle_path: &Path, vm: &str) -> Option<String> {
+    let bundle: Bundle = read_json_file(bundle_path).ok()?;
+    let realm_controllers_ref = bundle.realm_controllers_path.as_deref()?;
+    let base_dir = bundle_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("/"));
+    let rc_path = if Path::new(realm_controllers_ref).is_absolute() {
+        PathBuf::from(realm_controllers_ref)
+    } else {
+        base_dir.join(realm_controllers_ref)
+    };
+    let rc: RealmControllersJson = read_json_file(&rc_path).ok()?;
+    for controller in &rc.controllers {
+        let local_rt = controller.local_runtime.as_ref()?;
+        for workload in &local_rt.workloads {
+            if workload.vm_name.as_str() == vm {
+                return workload
+                    .identity
+                    .as_ref()
+                    .map(|id| id.canonical_target.to_canonical());
+            }
+        }
+    }
+    None
 }
 
 fn print_json<T>(value: &T) -> Result<(), CliFailure>
@@ -12212,6 +12317,213 @@ mod host_install_dispatch_tests {
                 .is_some_and(|text| text.contains("corp-gateway"))
         );
         let _ = std::fs::remove_file(&manifest_path);
+    }
+
+    #[test]
+    fn route_vm_target_rejects_env_style_target_fail_closed() {
+        // `corp-vm.work` looks like an old env-qualified target missing `.d2b`.
+        // route_vm_target must fail-closed with error code `old-env-style-target`
+        // and a suggestion to use `corp-vm.work.d2b`.
+        let manifest_path = test_socket_path("env-style-fail-closed", ".manifest.json");
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).expect("manifest parent");
+        }
+        write_test_manifest(&manifest_path, "vm-a");
+        let context = test_context(manifest_path.clone());
+
+        let (result, stdout) = super::with_test_stdout_capture(|| {
+            super::route_vm_target(&context, "corp-vm.work", true)
+        });
+        let err = result.expect_err("env-style target must fail closed");
+        assert_eq!(err.exit_code, 2, "exit code 2 for usage error");
+        let envelope: Value = serde_json::from_slice(&stdout).expect("json error envelope");
+        assert_eq!(
+            envelope.get("code").and_then(Value::as_str),
+            Some("old-env-style-target"),
+            "error code must be old-env-style-target"
+        );
+        let remediation = envelope
+            .get("remediation")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        assert!(
+            remediation.contains("corp-vm.work.d2b"),
+            "remediation must suggest the canonical form; got: {remediation}"
+        );
+        let _ = std::fs::remove_file(&manifest_path);
+    }
+
+    #[test]
+    fn route_vm_target_passes_canonical_realm_target() {
+        // `corp-vm.work.d2b` already has the `.d2b` suffix — env-style detection
+        // must not reject it. This test verifies there is no false positive.
+        let manifest_path = test_socket_path("env-style-no-false-positive", ".manifest.json");
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).expect("manifest parent");
+        }
+        write_test_manifest(&manifest_path, "vm-a");
+        let mut table = d2b_realm_router::RealmEntrypointTable::with_local_default();
+        // Make `work` a local realm so the route resolves without a daemon.
+        table.host_resident(
+            d2b_realm_core::RealmPath::new(vec![
+                d2b_realm_core::RealmId::parse("work").unwrap(),
+            ])
+            .unwrap(),
+        );
+        let context = test_context(manifest_path.clone());
+
+        let (result, _stdout) = super::with_test_stdout_capture(|| {
+            super::route_vm_target_with_table(&context, "corp-vm.work.d2b", false, Some(table))
+        });
+        // Must not produce an env-style error — the result may be Ok (Local) or a
+        // different error (gateway not found), but never old-env-style-target.
+        if let Err(err) = &result {
+            assert!(
+                !err.message.contains("old-env-style-target"),
+                "canonical target must not trigger env-style detection; got: {}",
+                err.message
+            );
+        }
+        let _ = std::fs::remove_file(&manifest_path);
+    }
+
+    #[test]
+    fn render_list_human_shows_workload_target_column_when_present() {
+        let output = super::ListOutputV2(vec![
+            super::ListItemOutputV2 {
+                name: "corp-vm".to_owned(),
+                env: Some("work".to_owned()),
+                graphics: false,
+                tpm: false,
+                usbip: false,
+                static_ip: None,
+                status: "running".to_owned(),
+                is_net_vm: false,
+                guest_closure_out_path: None,
+                runtime_kind: None,
+                autostart: None,
+                runtime_capabilities: Vec::new(),
+                service_capabilities: Vec::new(),
+                unsupported_capabilities: Vec::new(),
+                qemu_media: None,
+                runner_parity_ok: None,
+                canonical_target: Some("corp-vm.work.d2b".to_owned()),
+            },
+            super::ListItemOutputV2 {
+                name: "personal-vm".to_owned(),
+                env: Some("home".to_owned()),
+                graphics: false,
+                tpm: false,
+                usbip: false,
+                static_ip: None,
+                status: "stopped".to_owned(),
+                is_net_vm: false,
+                guest_closure_out_path: None,
+                runtime_kind: None,
+                autostart: None,
+                runtime_capabilities: Vec::new(),
+                service_capabilities: Vec::new(),
+                unsupported_capabilities: Vec::new(),
+                qemu_media: None,
+                runner_parity_ok: None,
+                canonical_target: None,
+            },
+        ]);
+        let rendered = super::render_list_human(&output, None);
+        assert!(
+            rendered.contains("WORKLOAD TARGET"),
+            "header must include WORKLOAD TARGET column when any entry has canonical_target"
+        );
+        assert!(
+            rendered.contains("corp-vm.work.d2b"),
+            "canonical target must appear in output row"
+        );
+    }
+
+    #[test]
+    fn render_list_human_omits_workload_target_column_when_absent() {
+        let output = super::ListOutputV2(vec![super::ListItemOutputV2 {
+            name: "vm-a".to_owned(),
+            env: None,
+            graphics: false,
+            tpm: false,
+            usbip: false,
+            static_ip: None,
+            status: "stopped".to_owned(),
+            is_net_vm: false,
+            guest_closure_out_path: None,
+            runtime_kind: None,
+            autostart: None,
+            runtime_capabilities: Vec::new(),
+            service_capabilities: Vec::new(),
+            unsupported_capabilities: Vec::new(),
+            qemu_media: None,
+            runner_parity_ok: None,
+            canonical_target: None,
+        }]);
+        let rendered = super::render_list_human(&output, None);
+        assert!(
+            !rendered.contains("WORKLOAD TARGET"),
+            "WORKLOAD TARGET column must not appear when no entry has canonical_target"
+        );
+    }
+
+    #[test]
+    fn render_status_vm_human_shows_workload_target_when_present() {
+        let output = super::StatusVmOutputV2 {
+            name: "corp-vm".to_owned(),
+            env: Some("work".to_owned()),
+            services: super::StatusServicesOutputV2 {
+                d2b: "active".to_owned(),
+                microvm: "active".to_owned(),
+                virtiofsd: "active".to_owned(),
+                qemu_media: None,
+                gpu: None,
+                video: None,
+                snd: None,
+                swtpm: None,
+            },
+            current: None,
+            booted: None,
+            pending_restart: false,
+            runtime: super::RUNTIME_UNKNOWN.to_owned(),
+            runtime_kind: None,
+            autostart: None,
+            runtime_capabilities: Vec::new(),
+            service_capabilities: Vec::new(),
+            unsupported_capabilities: Vec::new(),
+            qemu_media: None,
+            usb: None,
+            declared_roles: Vec::new(),
+            readiness: Vec::new(),
+            api_ready: None,
+            runner_parity: None,
+            live_pool_integrity: None,
+            canonical_target: Some("corp-vm.work.d2b".to_owned()),
+        };
+        let manifest_vm = super::ManifestVm {
+            name: "corp-vm".to_owned(),
+            env: Some("work".to_owned()),
+            graphics: false,
+            tpm: false,
+            audio: false,
+            usbip_yubikey: false,
+            static_ip: None,
+            is_net_vm: false,
+            state_dir: "/var/lib/d2b/vms/corp-vm".to_owned(),
+            bridge: "d2b-work".to_owned(),
+            ssh_user: None,
+            runtime: None,
+        };
+        let rendered = super::render_status_vm_human(&output, &manifest_vm, Vec::new());
+        assert!(
+            rendered.contains("workload target"),
+            "workload target label must appear"
+        );
+        assert!(
+            rendered.contains("corp-vm.work.d2b"),
+            "canonical target value must appear in status output"
+        );
     }
 
     #[test]
@@ -15723,6 +16035,7 @@ mod host_install_dispatch_tests {
             api_ready: None,
             runner_parity: None,
             live_pool_integrity: None,
+            canonical_target: None,
         };
         let manifest_vm = super::ManifestVm {
             name: "vm-a".to_owned(),
@@ -15973,6 +16286,7 @@ mod host_install_dispatch_tests {
             unsupported_capabilities: Vec::new(),
             qemu_media: None,
             runner_parity_ok: None,
+            canonical_target: None,
         }]);
 
         let rendered = super::render_list_human(&output, None);

--- a/packages/d2b/src/lib.rs
+++ b/packages/d2b/src/lib.rs
@@ -5516,27 +5516,23 @@ fn print_workload_migration_hint(hint: &target_routing::TargetMigrationHint, jso
 fn route_vm_target(context: &Context, raw: &str, json: bool) -> Result<VmTargetRoute, CliFailure> {
     // Fail-closed for old env-qualified targets missing the `.d2b` suffix.
     // E.g. `corp-vm.work` → error with suggestion `corp-vm.work.d2b`.
-    if let Some(hint) = target_routing::detect_env_style_target(raw) {
-        match &hint {
-            target_routing::TargetMigrationHint::OldEnvStyleTarget { suggested, .. } => {
-                let message = hint.to_string();
-                let exit_code = emit_host_error(
-                    &host_error_envelope(
-                        &message,
-                        "old-env-style-target",
-                        2,
-                        "CLI target parsing: env-qualified names require the `.d2b` suffix.",
-                        raw,
-                        &format!("Use `{suggested}` (the canonical workload target form)."),
-                        "docs/reference/cli-contract.md",
-                    ),
-                    json,
-                )
-                .map_err(|f| f)?;
-                return Err(CliFailure::new(exit_code, message));
-            }
-            _ => {}
-        }
+    if let Some(hint) = target_routing::detect_env_style_target(raw)
+        && let target_routing::TargetMigrationHint::OldEnvStyleTarget { suggested, .. } = &hint
+    {
+        let message = hint.to_string();
+        let exit_code = emit_host_error(
+            &host_error_envelope(
+                &message,
+                "old-env-style-target",
+                2,
+                "CLI target parsing: env-qualified names require the `.d2b` suffix.",
+                raw,
+                &format!("Use `{suggested}` (the canonical workload target form)."),
+                "docs/reference/cli-contract.md",
+            ),
+            json,
+        )?;
+        return Err(CliFailure::new(exit_code, message));
     }
     route_vm_target_with_table(context, raw, json, load_realm_entrypoint_table()?)
 }
@@ -6594,16 +6590,12 @@ fn cmd_vm_lifecycle_verb(
     // Emit a non-fatal compatibility warning when a bare VM name is used but
     // a canonical workload target is available for it in the realm-controllers
     // artifact. Advisory only: the local fast path continues to work.
-    if !json && !vm.contains('.') {
-        if let Some(canonical) =
-            try_canonical_target_for_vm(&context.bundle_path, &vm)
-        {
-            if let Some(hint) =
-                target_routing::migration_hint_for_bare_vm(&vm, &canonical)
-            {
-                print_workload_migration_hint(&hint, json);
-            }
-        }
+    if !json
+        && !vm.contains('.')
+        && let Some(canonical) = try_canonical_target_for_vm(&context.bundle_path, &vm)
+        && let Some(hint) = target_routing::migration_hint_for_bare_vm(&vm, &canonical)
+    {
+        print_workload_migration_hint(&hint, json);
     }
     if (verb == "start" || verb == "restart") && !json {
         warn_pending_staged_config(&vm);
@@ -9476,7 +9468,9 @@ fn render_list_human(
                 item.tpm,
                 item.usbip,
                 static_ip,
-                item.canonical_target.clone().unwrap_or_else(|| "-".to_owned()),
+                item.canonical_target
+                    .clone()
+                    .unwrap_or_else(|| "-".to_owned()),
                 status,
             );
         } else {
@@ -12365,10 +12359,8 @@ mod host_install_dispatch_tests {
         let mut table = d2b_realm_router::RealmEntrypointTable::with_local_default();
         // Make `work` a local realm so the route resolves without a daemon.
         table.host_resident(
-            d2b_realm_core::RealmPath::new(vec![
-                d2b_realm_core::RealmId::parse("work").unwrap(),
-            ])
-            .unwrap(),
+            d2b_realm_core::RealmPath::new(vec![d2b_realm_core::RealmId::parse("work").unwrap()])
+                .unwrap(),
         );
         let context = test_context(manifest_path.clone());
 

--- a/packages/d2b/src/lib.rs
+++ b/packages/d2b/src/lib.rs
@@ -5510,7 +5510,7 @@ fn print_workload_migration_hint(hint: &target_routing::TargetMigrationHint, jso
     if json {
         return;
     }
-    eprintln!("note: {hint}");
+    print_stderr(&format!("note: {hint}\n"));
 }
 
 fn route_vm_target(context: &Context, raw: &str, json: bool) -> Result<VmTargetRoute, CliFailure> {
@@ -6538,6 +6538,10 @@ fn cmd_vm_lifecycle_verb(
     } = invocation;
     let flags = require_explicit_mutation_flag(&format!("vm {verb}"), dry_run, apply, json)?;
     let route = route_vm_target(context, vm, json)?;
+    // Preserve the raw user input before the resolved local name shadows it.
+    // Migration hint logic must check the original target string, not the
+    // workload label extracted by the router (which is always dot-free).
+    let raw_target = vm;
     let vm = match route {
         VmTargetRoute::Local { vm } => vm,
         VmTargetRoute::Gateway {
@@ -6590,10 +6594,15 @@ fn cmd_vm_lifecycle_verb(
     // Emit a non-fatal compatibility warning when a bare VM name is used but
     // a canonical workload target is available for it in the realm-controllers
     // artifact. Advisory only: the local fast path continues to work.
+    // Gate on raw_target (the original user input), NOT on the resolved local
+    // VM name: for host-local realms the router strips the realm suffix
+    // (e.g. "corp-vm.work.d2b" → "corp-vm"), so testing the resolved name
+    // would always appear dot-free and incorrectly trigger the hint for users
+    // who already typed the canonical form.
     if !json
-        && !vm.contains('.')
+        && !raw_target.contains('.')
         && let Some(canonical) = try_canonical_target_for_vm(&context.bundle_path, &vm)
-        && let Some(hint) = target_routing::migration_hint_for_bare_vm(&vm, &canonical)
+        && let Some(hint) = target_routing::migration_hint_for_bare_vm(raw_target, &canonical)
     {
         print_workload_migration_hint(&hint, json);
     }
@@ -15431,6 +15440,249 @@ mod host_install_dispatch_tests {
         let rendered = String::from_utf8(stdout).expect("stdout utf8");
         assert!(rendered.contains("host-reconcile"));
         assert!(rendered.contains("qemu-media"));
+    }
+
+    /// Write a minimal bundle.json + realm-controllers.json so that
+    /// `try_canonical_target_for_vm(vm)` finds `"<vm>.work.d2b"`.
+    fn write_bundle_with_realm_controllers(bundle_path: &std::path::Path, vm: &str) {
+        let dir = bundle_path.parent().expect("bundle parent dir");
+        std::fs::create_dir_all(dir).expect("create bundle dir");
+        let unique = bundle_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("bundle filename");
+        let rc_filename = format!("{unique}.realm-controllers.json");
+        let realm_controllers = json!({
+            "schemaVersion": "v2",
+            "runtimeState": "metadata-only",
+            "controllers": [{
+                "realmName": "Work",
+                "realmId": "work",
+                "realmPath": "work",
+                "placement": "host-local",
+                "daemon": {
+                    "user": "d2br-work",
+                    "group": "d2br-work",
+                    "publicSocketGroup": "d2bra-work",
+                    "serviceName": "d2b-realm-work-daemon.service",
+                    "configPath": "/etc/d2b/realms/work/daemon-config.json",
+                    "stateLockPath": "/run/d2b/realms/work/daemon.lock",
+                    "locksDir": "/run/d2b/realms/work/locks",
+                    "socketActivated": false,
+                    "materializedService": false
+                },
+                "broker": {
+                    "enabled": true,
+                    "hostMutation": true,
+                    "user": "root",
+                    "group": "d2br-work",
+                    "socketPath": "/run/d2b/realms/work/broker.sock",
+                    "socketUnitName": "d2b-realm-work-priv-broker.socket",
+                    "serviceUnitName": "d2b-realm-work-priv-broker.service",
+                    "auditDir": "/var/lib/d2b/realms/work/audit",
+                    "materializedSocket": false,
+                    "materializedService": false
+                },
+                "paths": {
+                    "runDir": "/run/d2b/realms/work",
+                    "stateDir": "/var/lib/d2b/realms/work",
+                    "auditDir": "/var/lib/d2b/realms/work/audit"
+                },
+                "sockets": {
+                    "publicSocketPath": "/run/d2b/realms/work/public.sock",
+                    "brokerSocketPath": "/run/d2b/realms/work/broker.sock"
+                },
+                "allocator": {
+                    "kind": "local-root-metadata",
+                    "configPath": "/etc/d2b/allocator.json",
+                    "rootSocket": "/run/d2b/allocator/local-root.sock"
+                },
+                "access": {},
+                "localRuntime": {
+                    "runtimeState": "metadata-only",
+                    "workloads": [{
+                        "workloadId": vm,
+                        "vmName": vm,
+                        "env": "work",
+                        "runtime": {
+                            "kind": "nixos",
+                            "provider": { "id": "local-provider", "driver": "local-ch", "type": "local" },
+                            "capabilities": {
+                                "lifecycle": true, "display": false, "usbHotplug": false,
+                                "guestControl": true, "exec": true, "configSync": true,
+                                "ssh": false, "storeSync": true, "keys": true,
+                                "inGuestObservability": false
+                            },
+                            "operationCapabilities": {
+                                "lifecycle": {
+                                    "start": true, "stop": true, "restart": true,
+                                    "switch": false, "hostPrepare": false
+                                },
+                                "media": { "usbHotplug": false, "removableMedia": false, "qemuMedia": false },
+                                "display": { "display": false, "graphics": false, "video": false, "waylandProxy": false },
+                                "guest": {
+                                    "guestControl": true, "exec": true, "shell": false,
+                                    "configSync": true, "ssh": false, "keys": true,
+                                    "inGuestObservability": false
+                                },
+                                "storage": { "storeSync": true, "virtiofs": true, "volumes": false }
+                            },
+                            "autostartPolicy": "manual"
+                        },
+                        "paths": {
+                            "stateDir": format!("/var/lib/d2b/vms/{vm}/state"),
+                            "runDir": format!("/run/d2b/vms/{vm}"),
+                            "storeView": format!("/var/lib/d2b/vms/{vm}/store"),
+                            "guestControlDir": format!("/run/d2b/vms/{vm}/guest-control")
+                        },
+                        "identity": {
+                            "workloadId": vm,
+                            "realmId": "work",
+                            "realmPath": ["work"],
+                            "canonicalTarget": format!("{vm}.work.d2b")
+                        }
+                    }],
+                    "invariants": {
+                        "metadataOnly": true,
+                        "existingGlobalVmPathsPreserved": true,
+                        "noStateMigrationDuringActivation": true,
+                        "brokerEffectsRemainRealmDelegated": true
+                    }
+                }
+            }],
+            "invariants": {
+                "metadataOnly": true,
+                "noSystemdUnitsMaterialized": true,
+                "preservesGlobalDaemonBehavior": true,
+                "preservesDirectUnixSocketSemantics": true
+            }
+        });
+        std::fs::write(
+            dir.join(&rc_filename),
+            serde_json::to_vec(&realm_controllers).expect("serialize realm-controllers"),
+        )
+        .expect("write realm-controllers.json");
+        let bundle = json!({
+            "bundleVersion": 4,
+            "schemaVersion": "v2",
+            "publicManifestPath": format!("{unique}.vms.json"),
+            "hostPath": format!("{unique}.host.json"),
+            "processesPath": format!("{unique}.processes.json"),
+            "privilegesPath": format!("{unique}.privileges.json"),
+            "realmControllersPath": rc_filename,
+            "closures": [],
+            "minijailProfiles": [],
+            "generation": { "generator": "test", "sourceRevision": null, "generatedAt": null }
+        });
+        std::fs::write(
+            bundle_path,
+            serde_json::to_vec(&bundle).expect("serialize bundle"),
+        )
+        .expect("write bundle.json");
+    }
+
+    #[test]
+    fn lifecycle_verb_bare_target_emits_migration_hint_when_canonical_known() {
+        // When a user types a bare VM name and the realm-controllers artifact
+        // advertises a canonical workload target, an advisory hint must appear
+        // on stderr pointing at the canonical form.
+        let vm = "corp-vm";
+        let manifest_path = test_socket_path("lv-bare-hint", ".manifest.json");
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).expect("create manifest dir");
+        }
+        write_test_manifest(&manifest_path, vm);
+        let bundle_path = manifest_path.with_extension("bundle.json");
+        write_bundle_with_realm_controllers(&bundle_path, vm);
+        let context = Context {
+            manifest_path: manifest_path.clone(),
+            bundle_path: bundle_path.clone(),
+            public_socket: manifest_path.with_extension("sock"),
+            broker_socket: manifest_path.with_extension("broker.sock"),
+            state_root: None,
+            host_runtime_path: manifest_path.with_extension("host-runtime.json"),
+            system_state_fixture: None,
+            auth_status_fixture: None,
+            daemon_state_dir: manifest_path.with_extension("daemon-state"),
+            metrics_url: "http://127.0.0.1:9101/metrics".to_owned(),
+        };
+        let (result, _stdout, stderr) = super::with_test_output_capture(|| {
+            super::cmd_vm_lifecycle_verb(
+                &context,
+                super::VmLifecycleInvocation {
+                    verb: "start",
+                    vm,
+                    dry_run: true,
+                    apply: false,
+                    no_wait_api: false,
+                    force: false,
+                    json: false,
+                },
+            )
+        });
+        assert_eq!(result.expect("bare-target lifecycle dry-run"), 0);
+        let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+        assert!(
+            stderr_text.contains("corp-vm.work.d2b"),
+            "expected migration hint for bare input to mention canonical target; stderr: {stderr_text:?}"
+        );
+        assert!(
+            stderr_text.contains("note:"),
+            "expected migration hint prefix 'note:'; stderr: {stderr_text:?}"
+        );
+    }
+
+    #[test]
+    fn lifecycle_verb_canonical_target_skips_migration_hint() {
+        // Typing the canonical form "corp-vm.work.d2b" must not produce a
+        // migration hint. In the test environment (no realm-entrypoint table
+        // on disk) the router treats ".work.d2b" as a conventional gateway
+        // target and routes through "sys-work-gateway"; the Gateway branch
+        // returns early before any hint logic runs, so stderr stays empty.
+        //
+        // On a host with a host-local work realm, the router returns
+        // VmTargetRoute::Local { vm: "corp-vm" } for "corp-vm.work.d2b".
+        // The raw_target preservation fix ensures !raw_target.contains('.')
+        // is false for the dotted input, suppressing the hint correctly.
+        let manifest_path = test_socket_path("lv-canonical-no-hint", ".manifest.json");
+        if let Some(parent) = manifest_path.parent() {
+            std::fs::create_dir_all(parent).expect("create manifest dir");
+        }
+        // "sys-work-gateway" must be declared so the conventional gateway
+        // route resolves rather than erroring with "missing realm entrypoint".
+        write_test_manifest(&manifest_path, "sys-work-gateway");
+        let context = Context {
+            manifest_path: manifest_path.clone(),
+            bundle_path: manifest_path.with_extension("missing-bundle.json"),
+            public_socket: manifest_path.with_extension("sock"),
+            broker_socket: manifest_path.with_extension("broker.sock"),
+            state_root: None,
+            host_runtime_path: manifest_path.with_extension("host-runtime.json"),
+            system_state_fixture: None,
+            auth_status_fixture: None,
+            daemon_state_dir: manifest_path.with_extension("daemon-state"),
+            metrics_url: "http://127.0.0.1:9101/metrics".to_owned(),
+        };
+        let (result, _stdout, stderr) = super::with_test_output_capture(|| {
+            super::cmd_vm_lifecycle_verb(
+                &context,
+                super::VmLifecycleInvocation {
+                    verb: "start",
+                    vm: "corp-vm.work.d2b",
+                    dry_run: true,
+                    apply: false,
+                    no_wait_api: false,
+                    force: false,
+                    json: false,
+                },
+            )
+        });
+        assert_eq!(result.expect("canonical-target lifecycle dry-run"), 0);
+        let stderr_text = String::from_utf8(stderr).expect("stderr utf8");
+        assert!(
+            !stderr_text.contains("note:"),
+            "canonical input must not produce a migration hint; stderr: {stderr_text:?}"
+        );
     }
 
     #[test]

--- a/packages/d2b/src/status_read_model.rs
+++ b/packages/d2b/src/status_read_model.rs
@@ -82,6 +82,7 @@ pub(crate) fn list_output_from_manifest(
                     runner_parity_ok: bundle
                         .and_then(|bundle| bundle.closures.get(&vm.name))
                         .map(|closure| closure.runner_parity_ok),
+                    canonical_target: None,
                 }
             })
             .collect(),
@@ -118,6 +119,10 @@ pub(crate) fn list_output_from_public_entries(
                 runner_parity_ok: bundle
                     .and_then(|bundle| bundle.closures.get(&entry.vm))
                     .map(|closure| closure.runner_parity_ok),
+                canonical_target: entry
+                    .workload_identity
+                    .as_ref()
+                    .map(|id| id.canonical_target.to_canonical()),
             })
             .collect(),
     )
@@ -506,6 +511,7 @@ pub(crate) fn build_vm_status_output(
         api_ready: read_vm_api_ready(&context.daemon_state_dir, &vm.name),
         runner_parity,
         live_pool_integrity: read_live_pool_integrity(context, vm),
+        canonical_target: None,
     }
 }
 
@@ -591,6 +597,10 @@ pub(crate) fn build_vm_status_output_from_public(
         api_ready: read_vm_api_ready(&context.daemon_state_dir, &vm.name),
         runner_parity,
         live_pool_integrity: read_live_pool_integrity(context, vm),
+        canonical_target: public
+            .workload_identity
+            .as_ref()
+            .map(|id| id.canonical_target.to_canonical()),
     }
 }
 

--- a/packages/d2b/src/target_routing.rs
+++ b/packages/d2b/src/target_routing.rs
@@ -200,6 +200,110 @@ impl core::fmt::Display for RealmArgError {
     }
 }
 
+/// A migration hint produced when a target string is detected to be an old
+/// non-canonical form that the CLI no longer accepts (fail-closed), or a bare
+/// VM name that the CLI still accepts but for which a canonical workload target
+/// is now available (compatibility warning).
+///
+/// Callers use this to emit typed, actionable guidance to the operator without
+/// changing the routing decision itself (except for `OldEnvStyleTarget`, which
+/// is always fail-closed and does not produce a valid route).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetMigrationHint {
+    /// The operator used a bare VM name (e.g. `corp-vm`) and the daemon has
+    /// advertised a canonical workload target for it (e.g. `corp-vm.work.d2b`).
+    /// The local fast path still works — this is a non-fatal compatibility
+    /// warning suggesting the canonical form.
+    BareVmHasCanonicalTarget {
+        /// The bare VM name as supplied by the operator.
+        vm: String,
+        /// The canonical workload target address to suggest.
+        canonical_target: String,
+    },
+    /// The operator used an env-qualified name without the required `.d2b`
+    /// suffix (e.g. `corp-vm.work` instead of `corp-vm.work.d2b`). This form
+    /// is rejected fail-closed; the hint carries the corrected form.
+    OldEnvStyleTarget {
+        /// The raw string as supplied by the operator.
+        raw: String,
+        /// The corrected canonical target to suggest.
+        suggested: String,
+    },
+}
+
+impl core::fmt::Display for TargetMigrationHint {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TargetMigrationHint::BareVmHasCanonicalTarget { vm, canonical_target } => write!(
+                f,
+                "target `{vm}` is a bare VM name; consider using the canonical workload target `{canonical_target}` instead"
+            ),
+            TargetMigrationHint::OldEnvStyleTarget { raw, suggested } => write!(
+                f,
+                "target `{raw}` looks like an env-qualified VM name but is missing the required `.d2b` suffix; use `{suggested}` instead"
+            ),
+        }
+    }
+}
+
+/// Detect whether a raw target string looks like an old env-qualified VM name
+/// missing the `.d2b` suffix (e.g. `corp-vm.work`), and if so, return a
+/// fail-closed `TargetMigrationHint::OldEnvStyleTarget` with the corrected
+/// canonical form.
+///
+/// Returns `None` if the target is a bare name (no dot), already has the `.d2b`
+/// suffix, uses the explicit `d2b://` scheme, or is otherwise not an
+/// env-qualified form.
+pub fn detect_env_style_target(raw: &str) -> Option<TargetMigrationHint> {
+    // Explicit scheme is always handled by the realm parser, not this path.
+    if raw.starts_with("d2b://") {
+        return None;
+    }
+    // Must contain a dot but must NOT already end with `.d2b`.
+    if !raw.contains('.') || raw.ends_with(".d2b") {
+        return None;
+    }
+    // Must look like valid label components (only lowercase alphanumeric and hyphens).
+    let labels: Vec<&str> = raw.split('.').collect();
+    let all_label_like = labels.iter().all(|label| {
+        !label.is_empty()
+            && label
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    });
+    if !all_label_like {
+        return None;
+    }
+    // Must parse as a valid workload + realm path when `.d2b` is appended.
+    let candidate = format!("{raw}.d2b");
+    if RealmTarget::parse(&candidate).is_err() {
+        return None;
+    }
+    Some(TargetMigrationHint::OldEnvStyleTarget {
+        raw: raw.to_owned(),
+        suggested: candidate,
+    })
+}
+
+/// Produce a `TargetMigrationHint::BareVmHasCanonicalTarget` when `raw` is a
+/// bare VM name (no dots, not a realm target) and `canonical_target` is the
+/// workload target address that the daemon has advertised for it.
+///
+/// Returns `None` if `raw` is not a bare name (contains dots or has an
+/// explicit scheme).
+pub fn migration_hint_for_bare_vm(
+    raw: &str,
+    canonical_target: &str,
+) -> Option<TargetMigrationHint> {
+    if raw.starts_with("d2b://") || raw.contains('.') {
+        return None;
+    }
+    Some(TargetMigrationHint::BareVmHasCanonicalTarget {
+        vm: raw.to_owned(),
+        canonical_target: canonical_target.to_owned(),
+    })
+}
+
 /// A target's conventional local gateway entrypoint.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GatewayHint {
@@ -725,6 +829,120 @@ mod tests {
 
     fn access_ref(raw: &str) -> AccessBindingRef {
         AccessBindingRef::parse(raw).unwrap()
+    }
+
+    // --- migration hint tests ---
+
+    #[test]
+    fn detect_env_style_target_identifies_missing_suffix() {
+        let hint = super::detect_env_style_target("corp-vm.work")
+            .expect("should detect env-style target");
+        match hint {
+            super::TargetMigrationHint::OldEnvStyleTarget { raw, suggested } => {
+                assert_eq!(raw, "corp-vm.work");
+                assert_eq!(suggested, "corp-vm.work.d2b");
+            }
+            other => panic!("expected OldEnvStyleTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_env_style_target_passes_already_canonical() {
+        assert!(
+            super::detect_env_style_target("corp-vm.work.d2b").is_none(),
+            "target already has .d2b suffix"
+        );
+    }
+
+    #[test]
+    fn detect_env_style_target_passes_bare_name() {
+        assert!(
+            super::detect_env_style_target("corp-vm").is_none(),
+            "bare name has no dot"
+        );
+    }
+
+    #[test]
+    fn detect_env_style_target_passes_explicit_scheme() {
+        assert!(
+            super::detect_env_style_target("d2b://corp-vm.work.d2b").is_none(),
+            "explicit scheme bypasses env-style detection"
+        );
+    }
+
+    #[test]
+    fn detect_env_style_target_passes_uppercase_label() {
+        assert!(
+            super::detect_env_style_target("Corp-VM.Work").is_none(),
+            "uppercase labels are not valid realm labels"
+        );
+    }
+
+    #[test]
+    fn detect_env_style_target_multi_label_path() {
+        let hint = super::detect_env_style_target("builder.staging")
+            .expect("two-label env-style target");
+        match hint {
+            super::TargetMigrationHint::OldEnvStyleTarget { raw, suggested } => {
+                assert_eq!(raw, "builder.staging");
+                assert_eq!(suggested, "builder.staging.d2b");
+            }
+            other => panic!("expected OldEnvStyleTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn migration_hint_for_bare_vm_returns_hint() {
+        let hint = super::migration_hint_for_bare_vm("corp-vm", "corp-vm.work.d2b")
+            .expect("bare name should produce a hint");
+        match hint {
+            super::TargetMigrationHint::BareVmHasCanonicalTarget { vm, canonical_target } => {
+                assert_eq!(vm, "corp-vm");
+                assert_eq!(canonical_target, "corp-vm.work.d2b");
+            }
+            other => panic!("expected BareVmHasCanonicalTarget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn migration_hint_for_bare_vm_passes_dotted_name() {
+        assert!(
+            super::migration_hint_for_bare_vm("corp-vm.work.d2b", "corp-vm.work.d2b").is_none(),
+            "already a realm target, not a bare name"
+        );
+    }
+
+    #[test]
+    fn migration_hint_for_bare_vm_passes_explicit_scheme() {
+        assert!(
+            super::migration_hint_for_bare_vm("d2b://corp-vm.work.d2b", "corp-vm.work.d2b")
+                .is_none(),
+            "explicit scheme is not a bare name"
+        );
+    }
+
+    #[test]
+    fn migration_hint_display_bare_vm() {
+        let hint = super::TargetMigrationHint::BareVmHasCanonicalTarget {
+            vm: "my-vm".to_owned(),
+            canonical_target: "my-vm.work.d2b".to_owned(),
+        };
+        let msg = hint.to_string();
+        assert!(msg.contains("my-vm"), "hint message includes vm name");
+        assert!(msg.contains("my-vm.work.d2b"), "hint message includes canonical target");
+        assert!(msg.contains("canonical"), "hint message mentions canonical form");
+    }
+
+    #[test]
+    fn migration_hint_display_env_style() {
+        let hint = super::TargetMigrationHint::OldEnvStyleTarget {
+            raw: "my-vm.work".to_owned(),
+            suggested: "my-vm.work.d2b".to_owned(),
+        };
+        let msg = hint.to_string();
+        assert!(msg.contains("my-vm.work"), "hint message includes raw target");
+        assert!(msg.contains("my-vm.work.d2b"), "hint message includes suggested form");
+        assert!(msg.contains(".d2b"), "hint message mentions the required suffix");
     }
 
     #[test]

--- a/packages/d2b/src/target_routing.rs
+++ b/packages/d2b/src/target_routing.rs
@@ -234,7 +234,10 @@ pub enum TargetMigrationHint {
 impl core::fmt::Display for TargetMigrationHint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            TargetMigrationHint::BareVmHasCanonicalTarget { vm, canonical_target } => write!(
+            TargetMigrationHint::BareVmHasCanonicalTarget {
+                vm,
+                canonical_target,
+            } => write!(
                 f,
                 "target `{vm}` is a bare VM name; consider using the canonical workload target `{canonical_target}` instead"
             ),
@@ -835,8 +838,8 @@ mod tests {
 
     #[test]
     fn detect_env_style_target_identifies_missing_suffix() {
-        let hint = super::detect_env_style_target("corp-vm.work")
-            .expect("should detect env-style target");
+        let hint =
+            super::detect_env_style_target("corp-vm.work").expect("should detect env-style target");
         match hint {
             super::TargetMigrationHint::OldEnvStyleTarget { raw, suggested } => {
                 assert_eq!(raw, "corp-vm.work");
@@ -880,8 +883,8 @@ mod tests {
 
     #[test]
     fn detect_env_style_target_multi_label_path() {
-        let hint = super::detect_env_style_target("builder.staging")
-            .expect("two-label env-style target");
+        let hint =
+            super::detect_env_style_target("builder.staging").expect("two-label env-style target");
         match hint {
             super::TargetMigrationHint::OldEnvStyleTarget { raw, suggested } => {
                 assert_eq!(raw, "builder.staging");
@@ -896,7 +899,10 @@ mod tests {
         let hint = super::migration_hint_for_bare_vm("corp-vm", "corp-vm.work.d2b")
             .expect("bare name should produce a hint");
         match hint {
-            super::TargetMigrationHint::BareVmHasCanonicalTarget { vm, canonical_target } => {
+            super::TargetMigrationHint::BareVmHasCanonicalTarget {
+                vm,
+                canonical_target,
+            } => {
                 assert_eq!(vm, "corp-vm");
                 assert_eq!(canonical_target, "corp-vm.work.d2b");
             }
@@ -929,8 +935,14 @@ mod tests {
         };
         let msg = hint.to_string();
         assert!(msg.contains("my-vm"), "hint message includes vm name");
-        assert!(msg.contains("my-vm.work.d2b"), "hint message includes canonical target");
-        assert!(msg.contains("canonical"), "hint message mentions canonical form");
+        assert!(
+            msg.contains("my-vm.work.d2b"),
+            "hint message includes canonical target"
+        );
+        assert!(
+            msg.contains("canonical"),
+            "hint message mentions canonical form"
+        );
     }
 
     #[test]
@@ -940,9 +952,18 @@ mod tests {
             suggested: "my-vm.work.d2b".to_owned(),
         };
         let msg = hint.to_string();
-        assert!(msg.contains("my-vm.work"), "hint message includes raw target");
-        assert!(msg.contains("my-vm.work.d2b"), "hint message includes suggested form");
-        assert!(msg.contains(".d2b"), "hint message mentions the required suffix");
+        assert!(
+            msg.contains("my-vm.work"),
+            "hint message includes raw target"
+        );
+        assert!(
+            msg.contains("my-vm.work.d2b"),
+            "hint message includes suggested form"
+        );
+        assert!(
+            msg.contains(".d2b"),
+            "hint message mentions the required suffix"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Routes CLI/public target resolution through typed `WorkloadTarget`/`RealmTarget` and adds full migration UX for operators moving from legacy env-scoped targeting.

### Changes

**Output structs** (`packages/d2b-contracts/src/cli_output.rs`):
- Added `canonical_target: Option<String>` to `ListItemOutputV2` and `StatusVmOutputV2`. Populated from `workload_identity.canonical_target` when the daemon provides it; omitted via `skip_serializing_if` otherwise (backward-compatible with old daemons and old JSON consumers).

**Status read model** (`packages/d2b/src/status_read_model.rs`):
- Populate `canonical_target` from `workload_identity` in `list_output_from_public_entries()` and `build_vm_status_output_from_public()`. `None` on the manifest-only fast path.

**Display** (`packages/d2b/src/lib.rs`):
- `render_list_human`: shows a `WORKLOAD TARGET` column when any listed VM has a canonical target; column absent entirely otherwise.
- `render_status_vm_human`: shows `workload target: <addr>` line before `env:` when `canonical_target` is `Some`.

**Routing and migration** (`packages/d2b/src/target_routing.rs` + `lib.rs`):
- Added `TargetMigrationHint` enum (`BareVmHasCanonicalTarget`, `OldEnvStyleTarget`) with `Display`.
- `detect_env_style_target()`: detects env-qualified targets missing the `.d2b` suffix (e.g. `corp-vm.work`); returns fail-closed `OldEnvStyleTarget` hint.
- `migration_hint_for_bare_vm()`: returns `BareVmHasCanonicalTarget` hint for bare VM names when a canonical target is known.
- `route_vm_target()`: fail-closed for old env-style targets — error code `old-env-style-target`, exit 2, remediation message with canonical form.
- `cmd_vm_lifecycle_verb()`: after `require_known_vm`, emits a non-fatal `note:` to stderr when a bare VM name has a canonical workload target in the realm-controllers artifact.

### Tests

16 new focused tests:
- **`target_routing.rs`**: `detect_env_style_target` (identifies missing suffix, passes already-canonical / bare / explicit-scheme / uppercase-label); `migration_hint_for_bare_vm` (bare name produces hint, dotted/scheme names return None); Display output for both hint variants.
- **`lib.rs`**: `route_vm_target` rejects env-style targets with `old-env-style-target` code and canonical remediation; canonical realm target has no false positive; `render_list_human` shows/omits WORKLOAD TARGET column; `render_status_vm_human` shows workload target when available. Fixed two existing test fixtures for the new `canonical_target` field.

### Validation

```
cargo test -p d2b            → 346 passed, 0 failed
cargo test -p d2b-contracts  → all passed
git diff --check             → ok
```