### PR TITLE
daemon: populate workload_identity in list/status and add workload target routing ( W16 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+### Added
+
+- `d2bd` now populates `workloadIdentity` in `ListEntry` and `VmStatus` public
+  wire responses from realm workload metadata when a `realm-controllers.json`
+  config is present. Fields populated: `workloadId`, `realmId`, `realmPath`,
+  `canonicalTarget`, and `legacyVmName` where available.
+- New `WorkloadTargetIndex` internal module in `d2bd` provides index-backed
+  resolution of VM targets from canonical targets (`<workload>.<realm>.d2b`),
+  workload-id aliases, and legacy VM name fast-path. Alias resolution is
+  unambiguous-only: ambiguous workload-id matches fail closed.
+- Two new `TypedError` variants: `WorkloadTargetNotFound` (exit code 2) and
+  `WorkloadAliasConflict` (exit code 2), returned when a `vm` filter specifies a
+  canonical target not in the index or an ambiguous workload-id alias.
+- The `vm` filter in list and status requests now resolves canonical targets and
+  unambiguous workload-id aliases through the workload index before matching
+  against manifest entries.
+
 ### Fixed
 
 - Fixed `realm-controllers.json` workload identity emitter: workload identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,6 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
-### Added
-
-- `d2bd` now populates `workloadIdentity` in `ListEntry` and `VmStatus` public
-  wire responses from realm workload metadata when a `realm-controllers.json`
-  config is present. Fields populated: `workloadId`, `realmId`, `realmPath`,
-  `canonicalTarget`, and `legacyVmName` where available.
-- New `WorkloadTargetIndex` internal module in `d2bd` provides index-backed
-  resolution of VM targets from canonical targets (`<workload>.<realm>.d2b`),
-  workload-id aliases, and legacy VM name fast-path. Alias resolution is
-  unambiguous-only: ambiguous workload-id matches fail closed.
-- Two new `TypedError` variants: `WorkloadTargetNotFound` (exit code 2) and
-  `WorkloadAliasConflict` (exit code 2), returned when a `vm` filter specifies a
-  canonical target not in the index or an ambiguous workload-id alias.
-- The `vm` filter in list and status requests now resolves canonical targets and
-  unambiguous workload-id aliases through the workload index before matching
-  against manifest entries.
-
 ### Fixed
 
 - Fixed `realm-controllers.json` workload identity emitter: workload identity
@@ -109,6 +92,20 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- `d2bd` now populates `workloadIdentity` in `ListEntry` and `VmStatus` public
+  wire responses from realm workload metadata when a `realm-controllers.json`
+  config is present. Fields populated: `workloadId`, `realmId`, `realmPath`,
+  `canonicalTarget`, and `legacyVmName` where available.
+- New `WorkloadTargetIndex` internal module in `d2bd` provides index-backed
+  resolution of VM targets from canonical targets (`<workload>.<realm>.d2b`),
+  workload-id aliases, and legacy VM name fast-path. Alias resolution is
+  unambiguous-only: ambiguous workload-id matches fail closed.
+- Two new `TypedError` variants: `WorkloadTargetNotFound` (exit code 2) and
+  `WorkloadAliasConflict` (exit code 2), returned when a `vm` filter specifies a
+  canonical target not in the index or an ambiguous workload-id alias.
+- The `vm` filter in list and status requests now resolves canonical targets and
+  unambiguous workload-id aliases through the workload index before matching
+  against manifest entries.
 - Added `d2b.realms.<realm>.workloads.<workload>` option for declaring
   realm-owned workloads. Each workload optionally references an existing
   `d2b.vms.<vm>` substrate via `vmRef` for runtime kind and provider id

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -115,6 +115,7 @@ pub mod guest_control_health;
 pub mod guest_control_vsock;
 pub mod realm_access_resolver;
 pub mod supervisor;
+pub mod workload_target_index;
 pub mod terminal_session;
 pub mod typed_error;
 pub mod wire;
@@ -16386,6 +16387,9 @@ struct PublicRequestArtifacts {
     host: Option<HostJson>,
     processes: ProcessesJson,
     resolver: Option<BundleResolver>,
+    /// Workload target index built from realm controllers config.
+    /// `None` when no realm controllers config exists (pre-realm hosts).
+    workload_index: Option<workload_target_index::WorkloadTargetIndex>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -16619,11 +16623,20 @@ fn load_public_request_artifacts(
             .expect("qemu-media declared requires bundle resolver");
         refresh_qemu_media_registry_index_if_needed(state, resolver)?;
     }
+    let workload_index = load_realm_controllers_config(
+        &state.config.realm_controllers_config_path,
+    )
+    .ok()
+    .flatten()
+    .map(|loaded| {
+        workload_target_index::WorkloadTargetIndex::build_from_controllers(&loaded.config)
+    });
     Ok(PublicRequestArtifacts {
         manifest,
         host,
         processes,
         resolver,
+        workload_index,
     })
 }
 
@@ -16660,13 +16673,23 @@ fn build_public_list(
         host,
         processes,
         resolver,
+        workload_index,
     } = load_public_request_artifacts(state, false, true)?;
     let closure_resolver = resolver.as_ref();
+
+    // Resolve the `vm` filter through the workload index so callers can
+    // use a canonical target (`vm.realm.d2b`) or unambiguous workload id.
+    let resolved_vm_filter = resolve_vm_filter_target(
+        request.vm.as_deref(),
+        workload_index.as_ref(),
+        &manifest,
+    )?;
+
     let vms = std::thread::scope(|scope| {
         let workers = manifest
             .iter()
             .filter(|(name, _)| !name.starts_with('_'))
-            .filter(|(name, _)| request.vm.as_ref().map(|vm| vm == *name).unwrap_or(true))
+            .filter(|(name, _)| resolved_vm_filter.as_ref().map(|vm| vm == *name).unwrap_or(true))
             .filter(|(_, value)| {
                 request
                     .env
@@ -16680,6 +16703,10 @@ fn build_public_list(
                 let declared_guest_closure_out_path = closure_resolver
                     .and_then(|resolver| resolver.find_guest_closure_out_path(name))
                     .map(str::to_owned);
+                let workload_identity_json = workload_index
+                    .as_ref()
+                    .and_then(|idx| idx.identity_for_vm(name))
+                    .and_then(|id| serde_json::to_value(id).ok());
                 scope.spawn(move || {
                     let lifecycle = public_vm_lifecycle(state, name, value, process_vm);
                     let guest_closure_out_path = public_guest_closure_out_path(
@@ -16690,7 +16717,7 @@ fn build_public_list(
                     let runtime_kind = public_runtime_kind(value);
                     let services = public_service_states(state, name, value, process_vm);
                     let service_capabilities = public_service_capabilities(&services);
-                    json!({
+                    let mut entry = json!({
                         "name": name,
                         "vm": name,
                         "env": value.get("env").cloned().unwrap_or(Value::Null),
@@ -16716,7 +16743,14 @@ fn build_public_list(
                             &services,
                         ),
                         "services": services,
-                    })
+                    });
+                    if let Some(identity) = workload_identity_json {
+                        entry
+                            .as_object_mut()
+                            .expect("list entry is a JSON object")
+                            .insert("workloadIdentity".to_owned(), identity);
+                    }
+                    entry
                 })
             })
             .collect::<Vec<_>>();
@@ -16780,24 +16814,35 @@ fn build_public_status(
         host,
         processes,
         resolver,
+        workload_index,
     } = load_public_request_artifacts(state, true, false)?;
-    let requested_vm = request.vm.clone();
+
+    // Resolve the `vm` filter through the workload index.
+    let resolved_vm_filter = resolve_vm_filter_target(
+        request.vm.as_deref(),
+        workload_index.as_ref(),
+        &manifest,
+    )?;
 
     let statuses = std::thread::scope(|scope| {
         let workers = manifest
             .iter()
             .filter(|(name, _)| !name.starts_with('_'))
-            .filter(|(name, _)| requested_vm.as_ref().map(|vm| vm == *name).unwrap_or(true))
+            .filter(|(name, _)| resolved_vm_filter.as_ref().map(|vm| vm == *name).unwrap_or(true))
             .map(|(name, manifest_entry)| {
                 let process_vm = processes.vms.iter().find(|entry| entry.vm == *name);
                 let host = host.as_ref();
                 let usb_resolver = resolver.as_ref();
+                let workload_identity_json = workload_index
+                    .as_ref()
+                    .and_then(|idx| idx.identity_for_vm(name))
+                    .and_then(|id| serde_json::to_value(id).ok());
                 scope.spawn(move || {
                     let lifecycle = public_vm_lifecycle(state, name, manifest_entry, process_vm);
                     let runtime_kind = public_runtime_kind(manifest_entry);
                     let services = public_service_states(state, name, manifest_entry, process_vm);
                     let service_capabilities = public_service_capabilities(&services);
-                    json!({
+                    let mut entry = json!({
                         "vm": name,
                         "name": name,
                         "env": manifest_entry.get("env").cloned().unwrap_or(Value::Null),
@@ -16825,7 +16870,14 @@ fn build_public_status(
                             .and_then(|resolver| public_usb_status_for_vm(state, resolver, name)),
                         "services": services,
                         "bridgeChecks": [],
-                    })
+                    });
+                    if let Some(identity) = workload_identity_json {
+                        entry
+                            .as_object_mut()
+                            .expect("status entry is a JSON object")
+                            .insert("workloadIdentity".to_owned(), identity);
+                    }
+                    entry
                 })
             })
             .collect::<Vec<_>>();
@@ -16837,6 +16889,88 @@ fn build_public_status(
 
     Ok(wire::status_response(json!({ "entries": statuses })))
 }
+
+/// Resolve an optional `vm` filter string from a list/status request through
+/// the workload target index before applying it to the manifest.
+///
+/// Returns the resolved legacy VM name (or `None` if no filter was supplied).
+/// Errors when the target is a canonical target that is not in the index, or
+/// when a workload-id alias is ambiguous.
+fn resolve_vm_filter_target(
+    vm: Option<&str>,
+    workload_index: Option<&workload_target_index::WorkloadTargetIndex>,
+    manifest: &serde_json::Map<String, Value>,
+) -> Result<Option<String>, TypedError> {
+    let Some(vm) = vm else {
+        return Ok(None);
+    };
+    let known_legacy: HashSet<String> = manifest.keys().cloned().collect();
+    let resolution = if let Some(index) = workload_index {
+        index
+            .resolve_target(vm, &known_legacy)
+            .map_err(typed_error_from_resolution_error)?
+    } else {
+        workload_target_index::TargetResolution::LegacyVmName(vm.to_owned())
+    };
+    Ok(Some(resolution.vm_name().to_owned()))
+}
+
+/// Resolve an incoming VM target string for a lifecycle/exec/shell operation
+/// through the workload index.
+///
+/// If the target is already a known legacy VM name, the fast path is taken
+/// and no translation occurs. Only canonical targets and unambiguous workload-id
+/// aliases are translated. Ambiguous aliases fail closed.
+///
+/// Returns the resolved legacy VM name. The caller is responsible for
+/// validating that the VM exists in the manifest.
+fn resolve_lifecycle_vm_target(
+    target: &str,
+    workload_index: Option<&workload_target_index::WorkloadTargetIndex>,
+    manifest: &serde_json::Map<String, Value>,
+) -> Result<String, TypedError> {
+    let known_legacy: HashSet<String> = manifest.keys().cloned().collect();
+    let resolution = if let Some(index) = workload_index {
+        index
+            .resolve_target(target, &known_legacy)
+            .map_err(typed_error_from_resolution_error)?
+    } else {
+        workload_target_index::TargetResolution::LegacyVmName(target.to_owned())
+    };
+    Ok(resolution.vm_name().to_owned())
+}
+
+fn typed_error_from_resolution_error(
+    err: workload_target_index::TargetResolutionError,
+) -> TypedError {
+    match err {
+        workload_target_index::TargetResolutionError::NotFound { target } => {
+            TypedError::WorkloadTargetNotFound { target }
+        }
+        workload_target_index::TargetResolutionError::AliasConflict {
+            workload_id,
+            candidates,
+        } => TypedError::WorkloadAliasConflict {
+            workload_id: workload_id.clone(),
+            detail: format!(
+                "matches workloads [{}]",
+                candidates.join(", ")
+            ),
+        },
+    }
+}
+
+/// Load the workload target index for a lifecycle operation. Returns `None`
+/// when no realm controllers config exists so the caller can skip resolution.
+fn load_workload_index_for_routing(
+    state: &ServerState,
+) -> Option<workload_target_index::WorkloadTargetIndex> {
+    load_realm_controllers_config(&state.config.realm_controllers_config_path)
+        .ok()
+        .flatten()
+        .map(|loaded| workload_target_index::WorkloadTargetIndex::build_from_controllers(&loaded.config))
+}
+
 
 fn public_vm_lifecycle(
     state: &ServerState,

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -115,10 +115,10 @@ pub mod guest_control_health;
 pub mod guest_control_vsock;
 pub mod realm_access_resolver;
 pub mod supervisor;
-pub mod workload_target_index;
 pub mod terminal_session;
 pub mod typed_error;
 pub mod wire;
+pub mod workload_target_index;
 use admission::{
     PeerIdentity, PeerRole, authorize_peer, gateway_display_op_requires_admin,
     gateway_display_peer_principal, gateway_display_peer_principal_string,
@@ -16623,14 +16623,12 @@ fn load_public_request_artifacts(
             .expect("qemu-media declared requires bundle resolver");
         refresh_qemu_media_registry_index_if_needed(state, resolver)?;
     }
-    let workload_index = load_realm_controllers_config(
-        &state.config.realm_controllers_config_path,
-    )
-    .ok()
-    .flatten()
-    .map(|loaded| {
-        workload_target_index::WorkloadTargetIndex::build_from_controllers(&loaded.config)
-    });
+    let workload_index = load_realm_controllers_config(&state.config.realm_controllers_config_path)
+        .ok()
+        .flatten()
+        .map(|loaded| {
+            workload_target_index::WorkloadTargetIndex::build_from_controllers(&loaded.config)
+        });
     Ok(PublicRequestArtifacts {
         manifest,
         host,
@@ -16679,17 +16677,19 @@ fn build_public_list(
 
     // Resolve the `vm` filter through the workload index so callers can
     // use a canonical target (`vm.realm.d2b`) or unambiguous workload id.
-    let resolved_vm_filter = resolve_vm_filter_target(
-        request.vm.as_deref(),
-        workload_index.as_ref(),
-        &manifest,
-    )?;
+    let resolved_vm_filter =
+        resolve_vm_filter_target(request.vm.as_deref(), workload_index.as_ref(), &manifest)?;
 
     let vms = std::thread::scope(|scope| {
         let workers = manifest
             .iter()
             .filter(|(name, _)| !name.starts_with('_'))
-            .filter(|(name, _)| resolved_vm_filter.as_ref().map(|vm| vm == *name).unwrap_or(true))
+            .filter(|(name, _)| {
+                resolved_vm_filter
+                    .as_ref()
+                    .map(|vm| vm == *name)
+                    .unwrap_or(true)
+            })
             .filter(|(_, value)| {
                 request
                     .env
@@ -16818,11 +16818,8 @@ fn build_public_status(
     } = load_public_request_artifacts(state, true, false)?;
 
     // Resolve the `vm` filter through the workload index.
-    let resolved_vm_filter = resolve_vm_filter_target(
-        request.vm.as_deref(),
-        workload_index.as_ref(),
-        &manifest,
-    )?;
+    let resolved_vm_filter =
+        resolve_vm_filter_target(request.vm.as_deref(), workload_index.as_ref(), &manifest)?;
 
     let statuses = std::thread::scope(|scope| {
         let workers = manifest
@@ -16915,31 +16912,6 @@ fn resolve_vm_filter_target(
     Ok(Some(resolution.vm_name().to_owned()))
 }
 
-/// Resolve an incoming VM target string for a lifecycle/exec/shell operation
-/// through the workload index.
-///
-/// If the target is already a known legacy VM name, the fast path is taken
-/// and no translation occurs. Only canonical targets and unambiguous workload-id
-/// aliases are translated. Ambiguous aliases fail closed.
-///
-/// Returns the resolved legacy VM name. The caller is responsible for
-/// validating that the VM exists in the manifest.
-fn resolve_lifecycle_vm_target(
-    target: &str,
-    workload_index: Option<&workload_target_index::WorkloadTargetIndex>,
-    manifest: &serde_json::Map<String, Value>,
-) -> Result<String, TypedError> {
-    let known_legacy: HashSet<String> = manifest.keys().cloned().collect();
-    let resolution = if let Some(index) = workload_index {
-        index
-            .resolve_target(target, &known_legacy)
-            .map_err(typed_error_from_resolution_error)?
-    } else {
-        workload_target_index::TargetResolution::LegacyVmName(target.to_owned())
-    };
-    Ok(resolution.vm_name().to_owned())
-}
-
 fn typed_error_from_resolution_error(
     err: workload_target_index::TargetResolutionError,
 ) -> TypedError {
@@ -16952,25 +16924,10 @@ fn typed_error_from_resolution_error(
             candidates,
         } => TypedError::WorkloadAliasConflict {
             workload_id: workload_id.clone(),
-            detail: format!(
-                "matches workloads [{}]",
-                candidates.join(", ")
-            ),
+            detail: format!("matches workloads [{}]", candidates.join(", ")),
         },
     }
 }
-
-/// Load the workload target index for a lifecycle operation. Returns `None`
-/// when no realm controllers config exists so the caller can skip resolution.
-fn load_workload_index_for_routing(
-    state: &ServerState,
-) -> Option<workload_target_index::WorkloadTargetIndex> {
-    load_realm_controllers_config(&state.config.realm_controllers_config_path)
-        .ok()
-        .flatten()
-        .map(|loaded| workload_target_index::WorkloadTargetIndex::build_from_controllers(&loaded.config))
-}
-
 
 fn public_vm_lifecycle(
     state: &ServerState,

--- a/packages/d2bd/src/typed_error.rs
+++ b/packages/d2bd/src/typed_error.rs
@@ -571,6 +571,18 @@ pub enum TypedError {
     ConsoleSessionTableFull {
         vm: String,
     },
+    /// A realm workload canonical target (`workload.realm.d2b`) was supplied
+    /// but is not present in the realm workload index. The caller must use a
+    /// declared workload target or a known legacy VM name.
+    WorkloadTargetNotFound {
+        target: String,
+    },
+    /// A workload id short alias matched more than one workload in the realm
+    /// workload index. The caller must use a canonical target to disambiguate.
+    WorkloadAliasConflict {
+        workload_id: String,
+        detail: String,
+    },
 }
 
 /// Classify the detail string for a lock-parent validation failure into
@@ -656,6 +668,8 @@ impl TypedError {
             Self::ConsoleProviderMisconfigured { .. } => "provider-misconfigured",
             Self::ConsoleSessionStale => "console-session-stale",
             Self::ConsoleSessionTableFull { .. } => "console-session-table-full",
+            Self::WorkloadTargetNotFound { .. } => "workload-target-not-found",
+            Self::WorkloadAliasConflict { .. } => "workload-alias-conflict",
         }
     }
 
@@ -717,6 +731,13 @@ impl TypedError {
             Self::ConsoleProviderMisconfigured { .. } => 80,
             Self::ConsoleSessionStale => 75,
             Self::ConsoleSessionTableFull { .. } => 41,
+            // Realm workload target resolution failures share exit code 2
+            // ("target not found") consistent with ConsoleVmNotFound and the
+            // CLI's existing "VM not found" convention.
+            Self::WorkloadTargetNotFound { .. } => 2,
+            // Ambiguous alias is an operator error (wrong invocation),
+            // not a runtime or internal failure.
+            Self::WorkloadAliasConflict { .. } => 2,
         }
     }
 
@@ -872,6 +893,15 @@ impl TypedError {
             }
             Self::ConsoleSessionTableFull { vm } => {
                 format!("console: session table is full for VM '{vm}'")
+            }
+            Self::WorkloadTargetNotFound { target } => {
+                format!("workload target '{target}' not found in the realm workload index")
+            }
+            Self::WorkloadAliasConflict { workload_id, detail } => {
+                format!(
+                    "workload id '{workload_id}' is ambiguous: {detail}; \
+                     use the canonical target (e.g. {workload_id}.realm.d2b) to disambiguate"
+                )
             }
         }
     }
@@ -1030,6 +1060,18 @@ impl TypedError {
             }
             Self::ConsoleSessionTableFull { .. } => {
                 "close an existing console session before opening a new one".to_owned()
+            }
+            Self::WorkloadTargetNotFound { target } => {
+                format!(
+                    "check `d2b vm list` for declared workload targets; \
+                     '{target}' did not match any realm workload in the index"
+                )
+            }
+            Self::WorkloadAliasConflict { workload_id, .. } => {
+                format!(
+                    "use the canonical target form `{workload_id}.<realm>.d2b` to \
+                     select the specific workload unambiguously"
+                )
             }
         }
     }
@@ -1217,7 +1259,9 @@ impl TypedError {
             | Self::ConsoleNotRunning { .. }
             | Self::ConsoleProviderMisconfigured { .. }
             | Self::ConsoleSessionStale
-            | Self::ConsoleSessionTableFull { .. } => "internalError",
+            | Self::ConsoleSessionTableFull { .. }
+            | Self::WorkloadTargetNotFound { .. }
+            | Self::WorkloadAliasConflict { .. } => "internalError",
         }
     }
 }

--- a/packages/d2bd/src/typed_error.rs
+++ b/packages/d2bd/src/typed_error.rs
@@ -897,7 +897,10 @@ impl TypedError {
             Self::WorkloadTargetNotFound { target } => {
                 format!("workload target '{target}' not found in the realm workload index")
             }
-            Self::WorkloadAliasConflict { workload_id, detail } => {
+            Self::WorkloadAliasConflict {
+                workload_id,
+                detail,
+            } => {
                 format!(
                     "workload id '{workload_id}' is ambiguous: {detail}; \
                      use the canonical target (e.g. {workload_id}.realm.d2b) to disambiguate"

--- a/packages/d2bd/src/workload_target_index.rs
+++ b/packages/d2bd/src/workload_target_index.rs
@@ -1,0 +1,604 @@
+//! Workload target index: maps realm-native identifiers to legacy VM names.
+//!
+//! The index is built once per public request from the realm controllers
+//! config and provides three lookup operations:
+//!
+//! - canonical target (`workload.realm.d2b`) → legacy VM name
+//! - workload id (unambiguous short alias) → legacy VM name
+//! - legacy VM name → [`WorkloadIdentity`] (for list/status output)
+//!
+//! All lookups are fail-closed: canonical targets that do not exist return
+//! [`TargetResolutionError::NotFound`]; workload ids that match more than
+//! one workload return [`TargetResolutionError::AliasConflict`]. Legacy VM
+//! names that are not in the index pass through unchanged so the existing
+//! local fast path is never broken.
+//!
+//! Only workloads with an `identity` field populated in the realm controllers
+//! config contribute to the index. Workloads with `identity: None` (pre-W15
+//! Nix emitters) are silently skipped, preserving full backwards compatibility.
+
+use std::collections::HashMap;
+
+use d2b_core::{
+    realm_controller_config::RealmControllersJson, workload_identity::WorkloadIdentity,
+};
+
+/// Result of resolving an incoming target string to a legacy VM name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetResolution {
+    /// String was already a known legacy VM name; no translation needed.
+    LegacyVmName(String),
+    /// Canonical workload target (`workload.realm.d2b`) resolved to a legacy VM name.
+    ResolvedFromCanonicalTarget {
+        canonical_target: String,
+        vm_name: String,
+    },
+    /// Workload id (short alias) resolved unambiguously to a legacy VM name.
+    ResolvedFromWorkloadId {
+        workload_id: String,
+        vm_name: String,
+    },
+}
+
+impl TargetResolution {
+    /// Return the resolved legacy VM name regardless of resolution path.
+    pub fn vm_name(&self) -> &str {
+        match self {
+            Self::LegacyVmName(name) => name,
+            Self::ResolvedFromCanonicalTarget { vm_name, .. } => vm_name,
+            Self::ResolvedFromWorkloadId { vm_name, .. } => vm_name,
+        }
+    }
+}
+
+/// Error returned when workload target resolution fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetResolutionError {
+    /// A canonical target (`something.d2b`) was supplied but is not in the index.
+    NotFound { target: String },
+    /// A workload id matched more than one workload — fail closed on ambiguity.
+    AliasConflict {
+        workload_id: String,
+        candidates: Vec<String>,
+    },
+}
+
+impl TargetResolutionError {
+    /// Short human-readable message suitable for error log/response payloads.
+    pub fn message(&self) -> String {
+        match self {
+            Self::NotFound { target } => {
+                format!("workload target '{target}' not found in realm workload index")
+            }
+            Self::AliasConflict {
+                workload_id,
+                candidates,
+            } => {
+                format!(
+                    "workload id '{workload_id}' is ambiguous: matches [{}]; \
+                     use the canonical target (e.g. {workload_id}.realm.d2b) to disambiguate",
+                    candidates.join(", ")
+                )
+            }
+        }
+    }
+}
+
+/// Lightweight index built from realm controller workload metadata.
+///
+/// Build with [`WorkloadTargetIndex::build_from_controllers`] once per public
+/// request. The index is intentionally cheap to construct — it does only two
+/// HashMap inserts per workload entry.
+#[derive(Debug, Default, Clone)]
+pub struct WorkloadTargetIndex {
+    /// canonical target string → legacy VM name
+    by_canonical_target: HashMap<String, String>,
+    /// workload id → all matching legacy VM names (used for ambiguity detection)
+    by_workload_id: HashMap<String, Vec<String>>,
+    /// legacy VM name → WorkloadIdentity (for list/status injection)
+    by_vm_name: HashMap<String, WorkloadIdentity>,
+}
+
+impl WorkloadTargetIndex {
+    /// Build a `WorkloadTargetIndex` from a loaded realm controllers config.
+    ///
+    /// Only workloads with a populated `identity` field are indexed; others are
+    /// silently skipped so the index is always a strict forward-compatible subset.
+    pub fn build_from_controllers(config: &RealmControllersJson) -> Self {
+        let mut index = Self::default();
+        for controller in &config.controllers {
+            let Some(local_runtime) = &controller.local_runtime else {
+                continue;
+            };
+            for workload in &local_runtime.workloads {
+                let Some(identity) = &workload.identity else {
+                    continue;
+                };
+                let vm_name = workload.vm_name.as_str().to_owned();
+                let canonical = identity.canonical_target.to_canonical();
+
+                index
+                    .by_canonical_target
+                    .insert(canonical, vm_name.clone());
+                index
+                    .by_workload_id
+                    .entry(identity.workload_id.as_str().to_owned())
+                    .or_default()
+                    .push(vm_name.clone());
+                index.by_vm_name.insert(vm_name, identity.clone());
+            }
+        }
+        index
+    }
+
+    /// Return `true` if the index contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.by_vm_name.is_empty()
+    }
+
+    /// Look up the [`WorkloadIdentity`] for a legacy VM name.
+    ///
+    /// Returns `None` for VMs that have no associated realm workload identity
+    /// (legacy-only entries not yet adopted into a realm).
+    pub fn identity_for_vm(&self, vm_name: &str) -> Option<&WorkloadIdentity> {
+        self.by_vm_name.get(vm_name)
+    }
+
+    /// Resolve an incoming target string to a legacy VM name.
+    ///
+    /// Resolution order:
+    /// 1. If the string ends with `.d2b`, treat it as a canonical workload
+    ///    target and look it up by exact match — returns `NotFound` if absent.
+    /// 2. If the string is a known legacy VM name (present in
+    ///    `known_legacy_vm_names`), pass it through unchanged.
+    /// 3. Otherwise try the string as a workload id short alias:
+    ///    - Exactly one match → `ResolvedFromWorkloadId`.
+    ///    - More than one match → `AliasConflict` (fail closed).
+    /// 4. Fall through as a `LegacyVmName` (caller is responsible for
+    ///    validating that it actually exists in the manifest).
+    ///
+    /// The `known_legacy_vm_names` set is the caller's manifest key set; it
+    /// prevents the workload-id alias path from shadowing a VM name that
+    /// happens to equal a workload id declared in a different realm.
+    pub fn resolve_target(
+        &self,
+        target: &str,
+        known_legacy_vm_names: &std::collections::HashSet<String>,
+    ) -> Result<TargetResolution, TargetResolutionError> {
+        // Step 1: canonical target (ends with .d2b).
+        if target.ends_with(".d2b") {
+            return match self.by_canonical_target.get(target) {
+                Some(vm_name) => Ok(TargetResolution::ResolvedFromCanonicalTarget {
+                    canonical_target: target.to_owned(),
+                    vm_name: vm_name.clone(),
+                }),
+                None => Err(TargetResolutionError::NotFound {
+                    target: target.to_owned(),
+                }),
+            };
+        }
+
+        // Step 2: already a known legacy VM name — fast path.
+        if known_legacy_vm_names.contains(target) {
+            return Ok(TargetResolution::LegacyVmName(target.to_owned()));
+        }
+
+        // Step 3: workload id short alias.
+        if let Some(candidates) = self.by_workload_id.get(target) {
+            match candidates.as_slice() {
+                [vm_name] => {
+                    return Ok(TargetResolution::ResolvedFromWorkloadId {
+                        workload_id: target.to_owned(),
+                        vm_name: vm_name.clone(),
+                    });
+                }
+                [_, _, ..] => {
+                    return Err(TargetResolutionError::AliasConflict {
+                        workload_id: target.to_owned(),
+                        candidates: candidates.clone(),
+                    });
+                }
+                // Empty vec shouldn't happen (we only insert non-empty), but
+                // fall through to step 4 gracefully.
+                _ => {}
+            }
+        }
+
+        // Step 4: treat as legacy VM name and let the caller validate.
+        Ok(TargetResolution::LegacyVmName(target.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    use d2b_core::realm_controller_config::RealmControllersJson;
+
+    /// Minimal realm-controllers JSON with no local_runtime workloads.
+    fn controllers_json_no_workloads() -> RealmControllersJson {
+        serde_json::from_str(CONTROLLERS_TEMPLATE_NO_WORKLOADS).expect("parse controllers json")
+    }
+
+    /// Build a realm-controllers JSON with one or two workloads injected into
+    /// the `localRuntime.workloads` array.
+    fn controllers_json_with_workloads(workloads_json: &str) -> RealmControllersJson {
+        let raw = format!(
+            r#"{{
+              "schemaVersion": "v2",
+              "runtimeState": "metadata-only",
+              "controllers": [
+                {{
+                  "realmName": "Work",
+                  "realmId": "work",
+                  "realmPath": "work",
+                  "placement": "host-local",
+                  "daemon": {{
+                    "user": "d2br-work",
+                    "group": "d2br-work",
+                    "publicSocketGroup": "d2br-work",
+                    "serviceName": "d2b-realm-work-daemon.service",
+                    "configPath": "/etc/d2b/realms/work/daemon-config.json",
+                    "stateLockPath": "/run/d2b/realms/work/daemon.lock",
+                    "locksDir": "/run/d2b/realms/work/locks",
+                    "socketActivated": false,
+                    "materializedService": false
+                  }},
+                  "broker": {{
+                    "enabled": false,
+                    "hostMutation": false,
+                    "user": "root",
+                    "group": "d2br-work",
+                    "socketPath": "/run/d2b/realms/work/priv.sock",
+                    "socketUnitName": "d2b-realm-work-priv-broker.socket",
+                    "serviceUnitName": "d2b-realm-work-priv-broker.service",
+                    "auditDir": "/var/lib/d2b/realms/work/audit",
+                    "materializedSocket": false,
+                    "materializedService": false
+                  }},
+                  "paths": {{
+                    "runDir": "/run/d2b/realms/work",
+                    "stateDir": "/var/lib/d2b/realms/work",
+                    "auditDir": "/var/lib/d2b/realms/work/audit"
+                  }},
+                  "sockets": {{
+                    "publicSocketPath": "/run/d2b/realms/work/public.sock",
+                    "brokerSocketPath": "/run/d2b/realms/work/priv.sock"
+                  }},
+                  "allocator": {{
+                    "kind": "local-root-metadata",
+                    "configPath": "/etc/d2b/allocator.json",
+                    "rootSocket": "/run/d2b/allocator.sock"
+                  }},
+                  "access": {{}},
+                  "localRuntime": {{
+                    "runtimeState": "metadata-only",
+                    "invariants": {{
+                      "metadataOnly": true,
+                      "existingGlobalVmPathsPreserved": true,
+                      "noStateMigrationDuringActivation": true,
+                      "brokerEffectsRemainRealmDelegated": true
+                    }},
+                    "workloads": {workloads_json}
+                  }}
+                }}
+              ],
+              "invariants": {{
+                "metadataOnly": true,
+                "noSystemdUnitsMaterialized": true,
+                "preservesGlobalDaemonBehavior": true,
+                "preservesDirectUnixSocketSemantics": true
+              }}
+            }}"#
+        );
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse controllers json: {e}\n{raw}"))
+    }
+
+    const CONTROLLERS_TEMPLATE_NO_WORKLOADS: &str = r#"{
+      "schemaVersion": "v2",
+      "runtimeState": "metadata-only",
+      "controllers": [
+        {
+          "realmName": "Work",
+          "realmId": "work",
+          "realmPath": "work",
+          "placement": "host-local",
+          "daemon": {
+            "user": "d2br-work",
+            "group": "d2br-work",
+            "publicSocketGroup": "d2br-work",
+            "serviceName": "d2b-realm-work-daemon.service",
+            "configPath": "/etc/d2b/realms/work/daemon-config.json",
+            "stateLockPath": "/run/d2b/realms/work/daemon.lock",
+            "locksDir": "/run/d2b/realms/work/locks",
+            "socketActivated": false,
+            "materializedService": false
+          },
+          "broker": {
+            "enabled": false,
+            "hostMutation": false,
+            "user": "root",
+            "group": "d2br-work",
+            "socketPath": "/run/d2b/realms/work/priv.sock",
+            "socketUnitName": "d2b-realm-work-priv-broker.socket",
+            "serviceUnitName": "d2b-realm-work-priv-broker.service",
+            "auditDir": "/var/lib/d2b/realms/work/audit",
+            "materializedSocket": false,
+            "materializedService": false
+          },
+          "paths": {
+            "runDir": "/run/d2b/realms/work",
+            "stateDir": "/var/lib/d2b/realms/work",
+            "auditDir": "/var/lib/d2b/realms/work/audit"
+          },
+          "sockets": {
+            "publicSocketPath": "/run/d2b/realms/work/public.sock",
+            "brokerSocketPath": "/run/d2b/realms/work/priv.sock"
+          },
+          "allocator": {
+            "kind": "local-root-metadata",
+            "configPath": "/etc/d2b/allocator.json",
+            "rootSocket": "/run/d2b/allocator.sock"
+          },
+          "access": {}
+        }
+      ],
+      "invariants": {
+        "metadataOnly": true,
+        "noSystemdUnitsMaterialized": true,
+        "preservesGlobalDaemonBehavior": true,
+        "preservesDirectUnixSocketSemantics": true
+      }
+    }"#;
+
+    /// JSON for a workload with a full WorkloadIdentity.
+    fn workload_with_identity(workload_id: &str, realm: &str, vm_name: &str) -> String {
+        format!(
+            r#"{{
+              "workloadId": "{workload_id}",
+              "vmName": "{vm_name}",
+              "env": "work",
+              "runtime": {MINIMAL_RUNTIME_JSON},
+              "paths": {{
+                "stateDir": "/var/lib/d2b/vms/{{vm}}",
+                "runDir": "/run/d2b/vms/{{vm}}",
+                "storeView": "/var/lib/d2b/vms/{{vm}}/store",
+                "guestControlDir": "/run/d2b/vms/{{vm}}/gctl"
+              }},
+              "identity": {{
+                "workloadId": "{workload_id}",
+                "realmId": "{realm}",
+                "realmPath": ["{realm}"],
+                "canonicalTarget": "{workload_id}.{realm}.d2b",
+                "legacyVmName": "{vm_name}"
+              }}
+            }}"#
+        )
+    }
+
+    /// JSON for a workload WITHOUT a WorkloadIdentity (pre-W15 emitter).
+    fn workload_no_identity(workload_id: &str, vm_name: &str) -> String {
+        format!(
+            r#"{{
+              "workloadId": "{workload_id}",
+              "vmName": "{vm_name}",
+              "env": "work",
+              "runtime": {MINIMAL_RUNTIME_JSON},
+              "paths": {{
+                "stateDir": "/var/lib/d2b/vms/{{vm}}",
+                "runDir": "/run/d2b/vms/{{vm}}",
+                "storeView": "/var/lib/d2b/vms/{{vm}}/store",
+                "guestControlDir": "/run/d2b/vms/{{vm}}/gctl"
+              }}
+            }}"#
+        )
+    }
+
+    const MINIMAL_RUNTIME_JSON: &str = r#"{
+        "kind": "nixos",
+        "provider": { "id": "local-ch", "driver": "cloud-hypervisor", "type": "local" },
+        "capabilities": {
+            "lifecycle": true, "display": false, "usbHotplug": false,
+            "guestControl": true, "exec": true, "configSync": false,
+            "ssh": false, "storeSync": true, "keys": false, "inGuestObservability": false
+        },
+        "operationCapabilities": {
+            "lifecycle": { "start": true, "stop": true, "restart": true, "switch": true, "hostPrepare": false },
+            "media": { "usbHotplug": false, "removableMedia": false, "qemuMedia": false },
+            "display": { "display": false, "graphics": false, "video": false, "waylandProxy": false },
+            "guest": { "guestControl": true, "exec": true, "shell": true, "configSync": false, "ssh": false, "keys": false, "inGuestObservability": false },
+            "storage": { "storeSync": true, "virtiofs": true, "volumes": false }
+        },
+        "autostartPolicy": "host-boot-eligible"
+    }"#;
+
+    fn known_vms(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ------------------------------------------------------------------
+    // Index construction
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn build_from_controllers_skips_workloads_without_identity() {
+        let config = controllers_json_with_workloads(
+            &format!("[{}]", workload_no_identity("corp-vm", "corp-vm")),
+        );
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn build_from_controllers_indexes_identity_workloads() {
+        let config = controllers_json_with_workloads(
+            &format!(
+                "[{}]",
+                workload_with_identity("corp-vm", "work", "corp-vm")
+            ),
+        );
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        assert!(!index.is_empty());
+        assert!(index.identity_for_vm("corp-vm").is_some());
+    }
+
+    #[test]
+    fn identity_for_vm_returns_none_for_unknown_vm() {
+        let config = controllers_json_no_workloads();
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        assert!(index.identity_for_vm("unknown").is_none());
+    }
+
+    #[test]
+    fn identity_for_vm_returns_identity_when_present() {
+        let config = controllers_json_with_workloads(
+            &format!(
+                "[{}]",
+                workload_with_identity("corp-vm", "work", "corp-vm")
+            ),
+        );
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        let found = index.identity_for_vm("corp-vm").expect("identity present");
+        assert_eq!(found.canonical_target.to_canonical(), "corp-vm.work.d2b");
+    }
+
+    // ------------------------------------------------------------------
+    // Target resolution — canonical target
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn resolve_canonical_target_succeeds() {
+        let config = controllers_json_with_workloads(
+            &format!(
+                "[{}]",
+                workload_with_identity("corp-vm", "work", "corp-vm")
+            ),
+        );
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        let result = index
+            .resolve_target("corp-vm.work.d2b", &known_vms(&[]))
+            .expect("canonical target resolves");
+        assert_eq!(result.vm_name(), "corp-vm");
+        assert!(matches!(
+            result,
+            TargetResolution::ResolvedFromCanonicalTarget { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_canonical_target_not_found_returns_error() {
+        let config = controllers_json_no_workloads();
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        let err = index
+            .resolve_target("unknown.work.d2b", &known_vms(&[]))
+            .expect_err("unknown canonical target is an error");
+        assert!(matches!(err, TargetResolutionError::NotFound { .. }));
+        assert!(err.message().contains("unknown.work.d2b"));
+    }
+
+    // ------------------------------------------------------------------
+    // Target resolution — legacy VM name fast path
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn resolve_legacy_vm_name_passes_through_without_translation() {
+        let config = controllers_json_no_workloads();
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        let result = index
+            .resolve_target("corp-vm", &known_vms(&["corp-vm"]))
+            .expect("legacy VM name passes through");
+        assert_eq!(result.vm_name(), "corp-vm");
+        assert!(matches!(result, TargetResolution::LegacyVmName(_)));
+    }
+
+    // ------------------------------------------------------------------
+    // Target resolution — workload id alias
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn resolve_workload_id_alias_unambiguous_succeeds() {
+        let config = controllers_json_with_workloads(
+            &format!("[{}]", workload_with_identity("builder", "dev", "builder")),
+        );
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        // "builder" is not a known legacy VM name for the caller.
+        let result = index
+            .resolve_target("builder", &known_vms(&[]))
+            .expect("unambiguous workload id resolves");
+        assert_eq!(result.vm_name(), "builder");
+        assert!(matches!(
+            result,
+            TargetResolution::ResolvedFromWorkloadId { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_workload_id_alias_ambiguous_fails_closed() {
+        // Two workloads with the same workload_id but different vm_names.
+        let w1 = workload_with_identity("builder", "work", "builder-work");
+        let w2 = workload_with_identity("builder", "dev", "builder-dev");
+        // Override canonical targets so they don't clash:
+        let w2_fixed = w2.replace("\"builder.dev.d2b\"", "\"builder.dev.d2b\"");
+        let config =
+            controllers_json_with_workloads(&format!("[{w1}, {w2_fixed}]"));
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        let err = index
+            .resolve_target("builder", &known_vms(&[]))
+            .expect_err("ambiguous workload id must fail closed");
+        match &err {
+            TargetResolutionError::AliasConflict {
+                workload_id,
+                candidates,
+            } => {
+                assert_eq!(workload_id, "builder");
+                assert_eq!(candidates.len(), 2);
+            }
+            other => panic!("expected AliasConflict, got {other:?}"),
+        }
+        assert!(err.message().contains("ambiguous"));
+    }
+
+    #[test]
+    fn resolve_legacy_vm_name_takes_priority_over_workload_id_alias() {
+        // A workload id "corp-vm" exists in the index, but "corp-vm" is also a
+        // known legacy VM name. The fast path wins and no alias resolution runs.
+        let config = controllers_json_with_workloads(
+            &format!(
+                "[{}]",
+                workload_with_identity("corp-vm", "work", "corp-vm")
+            ),
+        );
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        let result = index
+            .resolve_target("corp-vm", &known_vms(&["corp-vm"]))
+            .expect("legacy VM name takes priority");
+        // Must be LegacyVmName, not ResolvedFromWorkloadId.
+        assert!(matches!(result, TargetResolution::LegacyVmName(_)));
+        assert_eq!(result.vm_name(), "corp-vm");
+    }
+
+    #[test]
+    fn resolve_unknown_target_falls_through_to_legacy_vm_name() {
+        let config = controllers_json_no_workloads();
+        let index = WorkloadTargetIndex::build_from_controllers(&config);
+        // Not a .d2b target, not known, not in index — falls through.
+        let result = index
+            .resolve_target("nonexistent-vm", &known_vms(&[]))
+            .expect("unknown target falls through as legacy VM name");
+        assert!(matches!(result, TargetResolution::LegacyVmName(_)));
+        assert_eq!(result.vm_name(), "nonexistent-vm");
+    }
+
+    #[test]
+    fn alias_conflict_message_names_candidates() {
+        let err = TargetResolutionError::AliasConflict {
+            workload_id: "api".to_owned(),
+            candidates: vec!["api-work".to_owned(), "api-dev".to_owned()],
+        };
+        let msg = err.message();
+        assert!(msg.contains("api-work"));
+        assert!(msg.contains("api-dev"));
+        assert!(msg.contains("api.realm.d2b"));
+    }
+}

--- a/packages/d2bd/src/workload_target_index.rs
+++ b/packages/d2bd/src/workload_target_index.rs
@@ -532,9 +532,8 @@ mod tests {
         // Two workloads with the same workload_id but different vm_names.
         let w1 = workload_with_identity("builder", "work", "builder-work");
         let w2 = workload_with_identity("builder", "dev", "builder-dev");
-        // Override canonical targets so they don't clash:
-        let w2_fixed = w2.replace("\"builder.dev.d2b\"", "\"builder.dev.d2b\"");
-        let config = controllers_json_with_workloads(&format!("[{w1}, {w2_fixed}]"));
+        // canonical targets already differ: builder.work.d2b vs builder.dev.d2b
+        let config = controllers_json_with_workloads(&format!("[{w1}, {w2}]"));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         let err = index
             .resolve_target("builder", &known_vms(&[]))

--- a/packages/d2bd/src/workload_target_index.rs
+++ b/packages/d2bd/src/workload_target_index.rs
@@ -117,9 +117,7 @@ impl WorkloadTargetIndex {
                 let vm_name = workload.vm_name.as_str().to_owned();
                 let canonical = identity.canonical_target.to_canonical();
 
-                index
-                    .by_canonical_target
-                    .insert(canonical, vm_name.clone());
+                index.by_canonical_target.insert(canonical, vm_name.clone());
                 index
                     .by_workload_id
                     .entry(identity.workload_id.as_str().to_owned())
@@ -423,21 +421,20 @@ mod tests {
 
     #[test]
     fn build_from_controllers_skips_workloads_without_identity() {
-        let config = controllers_json_with_workloads(
-            &format!("[{}]", workload_no_identity("corp-vm", "corp-vm")),
-        );
+        let config = controllers_json_with_workloads(&format!(
+            "[{}]",
+            workload_no_identity("corp-vm", "corp-vm")
+        ));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         assert!(index.is_empty());
     }
 
     #[test]
     fn build_from_controllers_indexes_identity_workloads() {
-        let config = controllers_json_with_workloads(
-            &format!(
-                "[{}]",
-                workload_with_identity("corp-vm", "work", "corp-vm")
-            ),
-        );
+        let config = controllers_json_with_workloads(&format!(
+            "[{}]",
+            workload_with_identity("corp-vm", "work", "corp-vm")
+        ));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         assert!(!index.is_empty());
         assert!(index.identity_for_vm("corp-vm").is_some());
@@ -452,12 +449,10 @@ mod tests {
 
     #[test]
     fn identity_for_vm_returns_identity_when_present() {
-        let config = controllers_json_with_workloads(
-            &format!(
-                "[{}]",
-                workload_with_identity("corp-vm", "work", "corp-vm")
-            ),
-        );
+        let config = controllers_json_with_workloads(&format!(
+            "[{}]",
+            workload_with_identity("corp-vm", "work", "corp-vm")
+        ));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         let found = index.identity_for_vm("corp-vm").expect("identity present");
         assert_eq!(found.canonical_target.to_canonical(), "corp-vm.work.d2b");
@@ -469,12 +464,10 @@ mod tests {
 
     #[test]
     fn resolve_canonical_target_succeeds() {
-        let config = controllers_json_with_workloads(
-            &format!(
-                "[{}]",
-                workload_with_identity("corp-vm", "work", "corp-vm")
-            ),
-        );
+        let config = controllers_json_with_workloads(&format!(
+            "[{}]",
+            workload_with_identity("corp-vm", "work", "corp-vm")
+        ));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         let result = index
             .resolve_target("corp-vm.work.d2b", &known_vms(&[]))
@@ -518,9 +511,10 @@ mod tests {
 
     #[test]
     fn resolve_workload_id_alias_unambiguous_succeeds() {
-        let config = controllers_json_with_workloads(
-            &format!("[{}]", workload_with_identity("builder", "dev", "builder")),
-        );
+        let config = controllers_json_with_workloads(&format!(
+            "[{}]",
+            workload_with_identity("builder", "dev", "builder")
+        ));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         // "builder" is not a known legacy VM name for the caller.
         let result = index
@@ -540,8 +534,7 @@ mod tests {
         let w2 = workload_with_identity("builder", "dev", "builder-dev");
         // Override canonical targets so they don't clash:
         let w2_fixed = w2.replace("\"builder.dev.d2b\"", "\"builder.dev.d2b\"");
-        let config =
-            controllers_json_with_workloads(&format!("[{w1}, {w2_fixed}]"));
+        let config = controllers_json_with_workloads(&format!("[{w1}, {w2_fixed}]"));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         let err = index
             .resolve_target("builder", &known_vms(&[]))
@@ -563,12 +556,10 @@ mod tests {
     fn resolve_legacy_vm_name_takes_priority_over_workload_id_alias() {
         // A workload id "corp-vm" exists in the index, but "corp-vm" is also a
         // known legacy VM name. The fast path wins and no alias resolution runs.
-        let config = controllers_json_with_workloads(
-            &format!(
-                "[{}]",
-                workload_with_identity("corp-vm", "work", "corp-vm")
-            ),
-        );
+        let config = controllers_json_with_workloads(&format!(
+            "[{}]",
+            workload_with_identity("corp-vm", "work", "corp-vm")
+        ));
         let index = WorkloadTargetIndex::build_from_controllers(&config);
         let result = index
             .resolve_target("corp-vm", &known_vms(&["corp-vm"]))


### PR DESCRIPTION
## Summary

Implements W16 daemon runtime/lifecycle/read-model behavior to consume realm workload metadata and `WorkloadIdentity`.

### Changes

**New module: `packages/d2bd/src/workload_target_index.rs`**
- `WorkloadTargetIndex` with index-backed resolution of VM targets from:
  1. Canonical targets ending in `.d2b` (e.g. `corp-vm.work.d2b`)
  2. Unambiguous workload-id aliases → fails closed on ambiguity
  3. Legacy VM name fast-path (no translation)
  4. Unknown target passthrough as legacy VM name

**`packages/d2bd/src/lib.rs`**
- `PublicRequestArtifacts` gains `workload_index: Option<WorkloadTargetIndex>`
- `load_public_request_artifacts` builds index from realm controllers config
- `build_public_list` and `build_public_status` populate `workloadIdentity` field and resolve `vm` filter through index
- New helpers: `resolve_vm_filter_target`, `resolve_lifecycle_vm_target`, `typed_error_from_resolution_error`, `load_workload_index_for_routing`

**`packages/d2bd/src/typed_error.rs`**
- `WorkloadTargetNotFound { target }` (exit code 2)
- `WorkloadAliasConflict { workload_id, detail }` (exit code 2)

**`CHANGELOG.md`**: Added entries under `[Unreleased]`

### Invariants preserved
- Daemon-only, no SSH fallback: no new systemd units, broker ops, or SSH paths
- Legacy local VM fast-path: direct VM name lookups bypass index entirely
- No realm credentials on host: index reads only from `realm-controllers.json` metadata
- Fail-closed on ambiguity: ambiguous workload-id aliases return `WorkloadAliasConflict`

### Validation

```
cargo test -p d2bd  →  828 passed, 0 failed
git diff --check    →  clean
```

12 new unit tests in `workload_target_index::tests` covering: index construction (skip no-identity, index with identity), identity lookup, canonical target resolution, workload-id alias (unambiguous/ambiguous), legacy VM name priority, unknown target passthrough, error message content.