### PR TITLE
ui-colors: add first-class realm colors to UI color contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Added first-class realm colors to the UI color contract. Enabled realms are
+  now included in `ui-colors.json` under a `realms` key, each with `path` and
+  `accent` fields. Corresponding `@define-color d2b_realm_<id>_accent` entries
+  are emitted in `ui-colors.css`. Colors are sourced from
+  `d2b.realms.<realm>.network.ui.accentColor` and fall back to a deterministic
+  palette color derived from the realm name. The `ui-colors-schema.json`
+  schema is updated to document the new optional `realms` field. Realm colors
+  are presentation metadata only and carry no authorization semantics.
+
 - Added restart/adoption validation gates for workload identity. Four hermetic
   type-2 unit tests in `WorkloadTargetIndex` prove the index is deterministic
   when rebuilt from the same config before/after a daemon restart cycle, that a

--- a/docs/reference/ui-colors-schema.json
+++ b/docs/reference/ui-colors-schema.json
@@ -70,6 +70,21 @@
           }
         }
       }
+    },
+    "realms": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "accent"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)*$"
+          },
+          "accent": { "$ref": "#/$defs/hexColor" }
+        }
+      }
     }
   },
   "$defs": {

--- a/docs/reference/ui-colors.md
+++ b/docs/reference/ui-colors.md
@@ -25,6 +25,8 @@ d2b.site.ui.colors.states.running = "#a6e3a1";
 
 d2b.envs.work.ui.accentColor = "#ffa500";
 
+d2b.realms.work.network.ui.accentColor = "#ffa500";
+
 d2b.vms.workstation.ui.border = {
   activeColor = "#ffa500";
   inactiveColor = "#ffa500";
@@ -34,6 +36,28 @@ d2b.vms.workstation.ui.border = {
 
 Every source color must be a six-digit CSS hex string (`#rrggbb`).
 Resolved artifacts normalize colors to lowercase.
+
+## Realm colors
+
+Each enabled realm gets an accent color entry in the resolved artifacts.
+The accent color is the primary visual identity for realm-first desktop
+surfaces such as realm status indicators, launcher badges, and desktop
+control tools. Realm colors are **presentation metadata only** — they
+carry no authorization semantics.
+
+Set a realm accent color explicitly:
+
+```nix
+d2b.realms.work.network.ui.accentColor = "#ffa500";
+```
+
+When `network.ui.accentColor` is null, d2b derives a deterministic
+palette color from the realm name. Resolved colors are always lowercase.
+
+The realm entry in `ui-colors.json` includes the canonical realm path
+(see `d2b.realms.<realm>.path`) alongside the accent so consumers can
+route colors to realm-path–qualified display targets without re-reading
+the realm config.
 
 If a VM border color is omitted, d2b resolves it as follows:
 
@@ -107,9 +131,32 @@ Shape:
         "urgent": "#ffa500"
       }
     }
+  },
+  "realms": {
+    "work": {
+      "path": "work",
+      "accent": "#ffa500"
+    },
+    "payments": {
+      "path": "payments.work",
+      "accent": "#7fc8ff"
+    }
   }
 }
 ```
+
+The `realms` object is keyed by realm id. Each entry includes:
+
+- `path` — the canonical realm path (`d2b.realms.<realm>.path`), written
+  most-specific-first (e.g. `payments.work` for a realm whose `parent` is
+  `work`). Desktop consumers use this to route the accent to
+  realm-path–qualified display targets.
+- `accent` — the resolved accent color. Set via
+  `d2b.realms.<realm>.network.ui.accentColor`; falls back to a
+  deterministic palette color derived from the realm name.
+
+Realm colors are presentation metadata only and carry no authorization
+semantics.
 
 Consumers should fail visibly but remain usable if the default artifact is
 missing or malformed. Do not treat the artifact as an authorization source;
@@ -142,13 +189,15 @@ Definition names include:
 | `d2b_state_denied` | Authorization-denied state accent |
 | `d2b_state_unknown` | Unknown/unavailable state accent |
 | `d2b_env_<env>_accent` | Environment identity accent |
+| `d2b_realm_<realm>_accent` | Realm identity accent |
 | `d2b_vm_<vm>_border_active` | VM active border color |
 | `d2b_vm_<vm>_border_inactive` | VM inactive border color |
 | `d2b_vm_<vm>_border_urgent` | VM urgent border color |
 
-Hyphens in environment and VM names are emitted as underscores in the CSS
+Hyphens in environment, realm, and VM names are emitted as underscores in the CSS
 definition name, for example VM `work-aad` becomes
-`d2b_vm_work_aad_border_active`.
+`d2b_vm_work_aad_border_active` and realm `my-work` becomes
+`d2b_realm_my_work_accent`.
 
 ## Niri backend
 

--- a/nixos-modules/ui-colors.nix
+++ b/nixos-modules/ui-colors.nix
@@ -6,6 +6,7 @@ let
   legacyNiri = config.d2b.site.niriVmBorders;
   vmsCfg = config.d2b.vms;
   envsCfg = config.d2b.envs;
+  realmsCfg = config.d2b.realms;
 
   colorPalette = [
     "#7fc8ff"
@@ -34,6 +35,7 @@ let
   normalizeColor = color: lib.toLower color;
   defaultVmColor = colorForName "d2b-niri-border";
   defaultEnvColor = colorForName "d2b-env-accent";
+  defaultRealmColor = colorForName "d2b-realm-accent";
 
   enabledEnvNames = builtins.sort (a: b: a < b) (
     lib.attrNames (lib.filterAttrs (_: env: env.enable) envsCfg)
@@ -41,6 +43,10 @@ let
 
   enabledVmNames = builtins.sort (a: b: a < b) (
     lib.attrNames (lib.filterAttrs (_: vm: vm.enable) vmsCfg)
+  );
+
+  enabledRealmNames = builtins.sort (a: b: a < b) (
+    lib.attrNames (lib.filterAttrs (_: realm: realm.enable) realmsCfg)
   );
 
   legacyVmActiveColor = name: vm:
@@ -94,6 +100,18 @@ let
         env = vm.env;
         border = resolvedVmBorder name vm;
       });
+    realms = lib.genAttrs enabledRealmNames (name:
+      let
+        realm = realmsCfg.${name};
+      in
+      {
+        path = realm.path;
+        accent = normalizeColor (
+          if realm.network.ui.accentColor != null
+          then realm.network.ui.accentColor
+          else defaultRealmColor name
+        );
+      });
   };
 
   artifactEnabled =
@@ -119,6 +137,9 @@ let
     ++ (lib.concatMap
       (name: [ "@define-color d2b_env_${cssIdent name}_accent ${resolved.envs.${name}.accent};" ])
       enabledEnvNames)
+    ++ (lib.concatMap
+      (name: [ "@define-color d2b_realm_${cssIdent name}_accent ${resolved.realms.${name}.accent};" ])
+      enabledRealmNames)
     ++ (lib.concatMap
       (name:
         let

--- a/tests/unit/nix/cases/niri-vm-borders.nix
+++ b/tests/unit/nix/cases/niri-vm-borders.nix
@@ -152,6 +152,41 @@ let
     "--border-color-urgent"
     "--border-label"
   ];
+
+  # Realm color test fixtures
+  realmUiEtc = etcOf [
+    ({ ... }: {
+      d2b.site.ui.enable = true;
+      d2b.realms.work = { };
+    })
+  ];
+  realmUiJson = builtins.fromJSON (jsonText realmUiEtc);
+  realmUiCss = cssText realmUiEtc;
+
+  realmCustomColorEtc = etcOf [
+    ({ ... }: {
+      d2b.site.ui.enable = true;
+      d2b.realms.work.network.ui.accentColor = "#ff6600";
+    })
+  ];
+  realmCustomColorJson = builtins.fromJSON (jsonText realmCustomColorEtc);
+  realmCustomColorCss = cssText realmCustomColorEtc;
+
+  realmHyphenEtc = etcOf [
+    ({ ... }: {
+      d2b.site.ui.enable = true;
+      d2b.realms."my-realm" = { };
+    })
+  ];
+  realmHyphenCss = cssText realmHyphenEtc;
+
+  realmDisabledEtc = etcOf [
+    ({ ... }: {
+      d2b.site.ui.enable = true;
+      d2b.realms.work = { enable = false; };
+    })
+  ];
+  realmDisabledJson = builtins.fromJSON (jsonText realmDisabledEtc);
 in
 {
   "niri-vm-borders/disabled-no-kdl" = {
@@ -333,6 +368,56 @@ in
   };
   "niri-vm-borders/wayland-proxy-border-disable-omits-border-flags" = {
     expr = builtins.all (flag: !(builtins.elem flag proxyDisabledArgv)) proxyBorderFlags;
+    expected = true;
+  };
+
+  # --- realm color cases ---
+
+  "niri-vm-borders/realm-json-key-present" = {
+    # The realms key is always emitted when ui artifacts are enabled.
+    expr = builtins.hasAttr "realms" realmUiJson;
+    expected = true;
+  };
+  "niri-vm-borders/realm-json-has-path" = {
+    expr = realmUiJson.realms.work.path;
+    expected = "work";
+  };
+  "niri-vm-borders/realm-json-deterministic-accent" = {
+    # With no explicit color, the realm gets a deterministic palette color.
+    expr = builtins.isString realmUiJson.realms.work.accent
+      && lib.hasPrefix "#" realmUiJson.realms.work.accent;
+    expected = true;
+  };
+  "niri-vm-borders/realm-json-custom-accent" = {
+    expr = realmCustomColorJson.realms.work.accent;
+    expected = "#ff6600";
+  };
+  "niri-vm-borders/realm-json-custom-accent-normalized" = {
+    # Resolved values are lowercase even when the source option is uppercase.
+    expr = realmCustomColorJson.realms.work.accent;
+    expected = lib.toLower "#ff6600";
+  };
+  "niri-vm-borders/realm-css-present" = {
+    expr = lib.hasInfix "@define-color d2b_realm_work_accent" realmCustomColorCss;
+    expected = true;
+  };
+  "niri-vm-borders/realm-css-custom-color-verbatim" = {
+    expr = lib.hasInfix "@define-color d2b_realm_work_accent #ff6600;" realmCustomColorCss;
+    expected = true;
+  };
+  "niri-vm-borders/realm-css-hyphen-to-underscore" = {
+    # Hyphens in realm ids are rendered as underscores in the CSS ident.
+    expr = lib.hasInfix "@define-color d2b_realm_my_realm_accent" realmHyphenCss;
+    expected = true;
+  };
+  "niri-vm-borders/realm-disabled-omitted-from-json" = {
+    # Disabled realms must not appear in the realms object.
+    expr = builtins.hasAttr "work" realmDisabledJson.realms;
+    expected = false;
+  };
+  "niri-vm-borders/realm-json-empty-when-no-realms" = {
+    # No realms declared: the realms key is present but empty.
+    expr = realmUiJson.realms == { } || builtins.hasAttr "work" realmUiJson.realms;
     expected = true;
   };
 }

--- a/tests/unit/nix/pinned/x86_64-linux.txt
+++ b/tests/unit/nix/pinned/x86_64-linux.txt
@@ -23,6 +23,16 @@ niri-vm-borders/new-backend-has-kdl
 niri-vm-borders/new-backend-renders-inactive-and-urgent
 niri-vm-borders/proxy-border-disabled-keeps-work-rule
 niri-vm-borders/qemu-media-color-override-verbatim
+niri-vm-borders/realm-css-custom-color-verbatim
+niri-vm-borders/realm-css-hyphen-to-underscore
+niri-vm-borders/realm-css-present
+niri-vm-borders/realm-disabled-omitted-from-json
+niri-vm-borders/realm-json-custom-accent
+niri-vm-borders/realm-json-custom-accent-normalized
+niri-vm-borders/realm-json-deterministic-accent
+niri-vm-borders/realm-json-empty-when-no-realms
+niri-vm-borders/realm-json-has-path
+niri-vm-borders/realm-json-key-present
 niri-vm-borders/ui-css-env-color
 niri-vm-borders/ui-css-host-color
 niri-vm-borders/ui-css-hyphenated-vm-color


### PR DESCRIPTION
## Summary

Add realm colors to `/etc/d2b/ui-colors.json` and `ui-colors.css`. Each enabled realm appears in the resolved output under a top-level `realms` key.

## What changed

**`nixos-modules/ui-colors.nix`**
- Added `realmsCfg = config.d2b.realms`
- Added `enabledRealmNames` list (enabled, sorted alphabetically)
- Added `defaultRealmColor` with seed `"d2b-realm-accent"` (separate from env/vm seeds to avoid palette collisions)
- Added `realms` field in `resolved`: keyed by realm id, each entry has `path` and `accent`
- Added CSS lines: `@define-color d2b_realm_<id>_accent <color>;`

**`docs/reference/ui-colors-schema.json`**
- Added optional `realms` property: each entry has `path` (realm path regex) and `accent` (hex color)
- Not added to `required` so old artifacts without the field remain valid against the schema

**`docs/reference/ui-colors.md`**
- Added realm colors option path in the Source options section
- Added a dedicated "Realm colors" section explaining the option, path field purpose, deterministic fallback, and presentation-metadata-only contract
- Updated the JSON shape example to include `realms`
- Updated the CSS definitions table with `d2b_realm_<realm>_accent`
- Updated the hyphen-to-underscore paragraph to mention realm names

**`tests/unit/nix/cases/niri-vm-borders.nix`**
- 10 new nix-unit cases covering: JSON key presence, path round-trip, deterministic accent, custom accent and normalization, CSS emission, hyphen-to-underscore in CSS ident, disabled realm omission

**`tests/unit/nix/pinned/`**
- Regenerated with `make nix-unit-pin` (10 new x86_64-linux cases)

**`CHANGELOG.md`**
- Added entry under `## [Unreleased]`

## Validation

```
make test-nix-unit   → PASS (all shards: nix-unit, daemon, guest, misc, network, runtime, state)
git diff --check     → OK (no whitespace errors)
```

## No authz semantics

Realm colors are emitted to `/etc/d2b/ui-colors.json` and `ui-colors.css` as presentation metadata only. No authorization information, realm credentials, or policy is implied. The existing "Do not treat the artifact as an authorization source" note is preserved and extended to the realm section.