### PR TITLE
launcher: add workloadId, iconId/Name, iconGroupKey for desktop grouping semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ deprecations ship one minor release before removal.
   schema is updated to document the new optional `realms` field. Realm colors
   are presentation metadata only and carry no authorization semantics.
 
+- Hardened realm workload launcher metadata contract for desktop consumers
+  (Waybar, wlcontrol, wlterm, clip-picker). The generated
+  `realm-workloads-launcher.json` artifact now exposes three additional fields
+  per workload row:
+  - `workloadId` — explicit DTO-named alias for `workloadName`, matching the
+    `WorkloadIdentity.workloadId` field used by daemon/broker consumers.
+  - `iconId` — raw `launcher.icon.id` option value (null when not set);
+    allows consumers to round-trip the XDG icon theme id without re-parsing
+    the resolved `icon` string.
+  - `iconName` — raw `launcher.icon.name` fallback value (null when not set).
+  - `iconGroupKey` — stable clustering key for duplicate-icon / app-chooser
+    semantics; equals `iconId` when set, else `iconName`, else null. Desktop
+    consumers use this to cluster workloads representing the same application
+    type across realms (e.g. "Firefox" in both work and personal realms).
+  The workload index (`_index.realms.workloads`) also derives these fields so
+  any consumer of the index has access to them, not only the launcher emitter.
+  New nix-unit cases cover all field shapes and the duplicate-icon grouping
+  invariant; new contract tests enforce the emitter and index wiring.
+
 - Added restart/adoption validation gates for workload identity. Four hermetic
   type-2 unit tests in `WorkloadTargetIndex` prove the index is deterministic
   when rebuilt from the same config before/after a daemon restart cycle, that a

--- a/nixos-modules/index.nix
+++ b/nixos-modules/index.nix
@@ -143,6 +143,14 @@ let
       icon =
         if workload.launcher.icon.id != null then workload.launcher.icon.id
         else workload.launcher.icon.name;
+      # iconGroupKey: stable grouping key for duplicate-icon / app-chooser
+      # semantics.  Desktop consumers (Waybar, wlcontrol, clip-picker) use this
+      # to cluster workloads that represent the same application type across
+      # realms.  Equals iconId when set, else iconName; null when neither is
+      # declared.  Always identical to the resolved `icon` field.
+      iconGroupKey =
+        if workload.launcher.icon.id != null then workload.launcher.icon.id
+        else workload.launcher.icon.name;
       # Canonical target address: launcher override if set, else derived.
       canonicalTarget =
         if workload.launcher.app.targetRealm != null
@@ -150,6 +158,9 @@ let
         else "${workloadName}.${realm.path}.d2b";
     in {
       inherit realmName workloadName;
+      # workloadId: explicit DTO-named alias for workloadName; matches the
+      # WorkloadIdentity.workloadId field used by daemon/broker consumers.
+      workloadId = workloadName;
       realmId = realm.id;
       realmPath = realm.path;
       # targetAddress: derived canonical target; always the computed value.
@@ -161,6 +172,14 @@ let
       # actionId: stable launcher action identifier; defaults to workload id.
       actionId = workloadName;
       inherit label icon;
+      # iconId: raw XDG icon theme id from launcher.icon.id; null when not set.
+      # Consumers that need to round-trip the option value (e.g. .desktop
+      # file generators) should use iconId rather than the resolved `icon`.
+      iconId = workload.launcher.icon.id;
+      # iconName: raw symbolic icon name fallback from launcher.icon.name; null
+      # when not set.
+      iconName = workload.launcher.icon.name;
+      inherit iconGroupKey;
       capabilityRefs = sortNames (lib.unique workload.launcher.capabilities);
       # appCommand: operator-declared primary launch command; null when not set.
       appCommand = workload.launcher.app.command;

--- a/nixos-modules/realm-workloads-launcher-json.nix
+++ b/nixos-modules/realm-workloads-launcher-json.nix
@@ -48,6 +48,10 @@ let
     realmId = workload.realmId;
     realmPath = workload.realmPath;
     workloadName = workload.workloadName;
+    # workloadId: explicit DTO-named alias for workloadName.  Matches the
+    # WorkloadIdentity.workloadId field used by daemon/broker consumers.
+    # Stable across restarts; equal to workloadName.
+    workloadId = workload.workloadId;
     targetAddress = workload.targetAddress;
     # canonicalTarget: routing address for realm-native desktop tooling.
     # Equals targetAddress unless launcher.app.targetRealm overrides it.
@@ -55,7 +59,20 @@ let
     kind = workload.kind;
     actionId = workload.actionId;
     label = workload.label;
+    # icon: resolved display icon string (iconId if set, else iconName).
+    # Backward-compatible field; stable for single-icon display use.
     icon = workload.icon;
+    # iconId: raw XDG icon theme id from launcher.icon.id; null when not set.
+    iconId = workload.iconId;
+    # iconName: raw symbolic icon name fallback from launcher.icon.name;
+    # null when not set.
+    iconName = workload.iconName;
+    # iconGroupKey: stable grouping key for duplicate-icon / app-chooser
+    # semantics.  Desktop consumers (Waybar, wlcontrol, clip-picker) use this
+    # to cluster workloads representing the same application type across
+    # realms.  Equals iconId when set, else iconName; null when neither is
+    # declared.  Always identical to the resolved `icon` field.
+    iconGroupKey = workload.iconGroupKey;
     capabilityRefs = workload.capabilityRefs;
     # appCommand: static operator-declared primary launch command; null when
     # not set.  Consumers must not shell-expand without validation.

--- a/packages/d2b-contract-tests/tests/realm_workload_schema_contract.rs
+++ b/packages/d2b-contract-tests/tests/realm_workload_schema_contract.rs
@@ -325,7 +325,7 @@ fn realm_workloads_launcher_exposes_workload_id_field() {
 /// - `iconId`       — raw launcher.icon.id value (null when not set)
 /// - `iconName`     — raw launcher.icon.name fallback value (null when not set)
 /// - `iconGroupKey` — stable clustering key for duplicate-icon / app-chooser
-///                    semantics; equals iconId when set, else iconName, else null
+///   semantics; equals iconId when set, else iconName, else null
 ///
 /// These fields let desktop consumers (Waybar, wlcontrol, clip-picker) cluster
 /// workloads that represent the same application type across realms without

--- a/packages/d2b-contract-tests/tests/realm_workload_schema_contract.rs
+++ b/packages/d2b-contract-tests/tests/realm_workload_schema_contract.rs
@@ -301,7 +301,82 @@ fn realm_workloads_launcher_exposes_canonical_target_and_actions() {
     }
 }
 
-// ── realm-controller-config emitter: identity fields ─────────────────────────
+/// The launcher JSON emitter must expose `workloadId` as an explicit DTO-named
+/// field alongside `workloadName`.  This matches the `WorkloadIdentity.workloadId`
+/// contract and ensures downstream consumers (Waybar, wlcontrol, clip-picker) can
+/// use a stable daemon-wire-compatible identifier without relying on `workloadName`.
+#[test]
+fn realm_workloads_launcher_exposes_workload_id_field() {
+    let emitter = read_repo_file("nixos-modules/realm-workloads-launcher-json.nix");
+    assert!(
+        emitter.contains("workloadId"),
+        "realm-workloads-launcher emitter must expose workloadId per workload row"
+    );
+    // Both workloadName (backward compat) and workloadId (explicit DTO alias) must be present.
+    assert!(
+        emitter.contains("workloadName"),
+        "realm-workloads-launcher emitter must also retain workloadName for backward compat"
+    );
+}
+
+/// The launcher JSON emitter must expose `iconId`, `iconName`, and `iconGroupKey`
+/// in addition to the existing resolved `icon` field.
+///
+/// - `iconId`       — raw launcher.icon.id value (null when not set)
+/// - `iconName`     — raw launcher.icon.name fallback value (null when not set)
+/// - `iconGroupKey` — stable clustering key for duplicate-icon / app-chooser
+///                    semantics; equals iconId when set, else iconName, else null
+///
+/// These fields let desktop consumers (Waybar, wlcontrol, clip-picker) cluster
+/// workloads that represent the same application type across realms without
+/// having to re-derive the group key from display strings.
+#[test]
+fn realm_workloads_launcher_exposes_icon_grouping_fields() {
+    let emitter = read_repo_file("nixos-modules/realm-workloads-launcher-json.nix");
+    for field in ["iconId", "iconName", "iconGroupKey"] {
+        assert!(
+            emitter.contains(field),
+            "realm-workloads-launcher emitter must wire {field} per workload row"
+        );
+    }
+    // The backward-compatible resolved `icon` field must still be present.
+    assert!(
+        emitter.contains("icon = workload.icon"),
+        "realm-workloads-launcher emitter must retain backward-compat 'icon' resolved field"
+    );
+}
+
+/// The launcher JSON emitter must document the `iconGroupKey` field with an
+/// explanation of its duplicate-icon / app-chooser purpose so that the
+/// design decision is discoverable in the source.
+#[test]
+fn realm_workloads_launcher_icon_group_key_has_semantic_comment() {
+    let emitter = read_repo_file("nixos-modules/realm-workloads-launcher-json.nix");
+    // The comment must mention the grouping / app-chooser semantic:
+    assert!(
+        emitter.contains("iconGroupKey"),
+        "realm-workloads-launcher emitter must contain iconGroupKey"
+    );
+    assert!(
+        emitter.contains("app-chooser") || emitter.contains("grouping"),
+        "realm-workloads-launcher emitter must document the duplicate-icon / app-chooser semantic \
+         for iconGroupKey"
+    );
+}
+
+/// The index emitter (`index.nix`) must also derive `workloadId`, `iconId`,
+/// `iconName`, and `iconGroupKey` on the workload row so that any consumer of
+/// the index (not just the launcher emitter) has access to these fields.
+#[test]
+fn realm_workloads_index_derives_grouping_fields() {
+    let index = read_repo_file("nixos-modules/index.nix");
+    for field in ["workloadId", "iconId", "iconName", "iconGroupKey"] {
+        assert!(
+            index.contains(field),
+            "nixos-modules/index.nix must derive {field} on the workload row"
+        );
+    }
+}
 
 // ── realm-controller-config emitter: identity fields ─────────────────────────
 

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -403,11 +403,15 @@ in
           realmName = corpRow.realmName;
           realmPath = corpRow.realmPath;
           workloadName = corpRow.workloadName;
+          workloadId = corpRow.workloadId;
           targetAddress = corpRow.targetAddress;
           canonicalTarget = corpRow.canonicalTarget;
           actionId = corpRow.actionId;
           label = corpRow.label;
           icon = corpRow.icon;
+          iconId = corpRow.iconId;
+          iconName = corpRow.iconName;
+          iconGroupKey = corpRow.iconGroupKey;
           capabilityRefs = corpRow.capabilityRefs;
           appCommand = corpRow.appCommand;
           actionsCount = builtins.length corpRow.actions;
@@ -421,10 +425,14 @@ in
         };
         providerFields = {
           workloadName = providerRow.workloadName;
+          workloadId = providerRow.workloadId;
           legacyVmName = providerRow.legacyVmName;
           runtimeKind = providerRow.runtimeKind;
           appCommand = providerRow.appCommand;
           actionsEmpty = providerRow.actions == [ ];
+          iconId = providerRow.iconId;
+          iconName = providerRow.iconName;
+          iconGroupKey = providerRow.iconGroupKey;
           vsockCid = providerRow.vsockCid;
         };
       };
@@ -437,12 +445,16 @@ in
         realmName = "work";
         realmPath = "work.home";
         workloadName = "corp-laptop";
+        workloadId = "corp-laptop";
         targetAddress = "corp-laptop.work.home.d2b";
         # canonicalTarget matches targetAddress when no override is set
         canonicalTarget = "corp-laptop.work.home.d2b";
         actionId = "corp-laptop";
         label = "Corp Laptop";
         icon = "computer-laptop";
+        iconId = "computer-laptop";
+        iconName = null;
+        iconGroupKey = "computer-laptop";
         capabilityRefs = [ "graphics" "guest-exec" ];
         appCommand = "d2b vm exec corp-laptop -- bash -l";
         actionsCount = 2;
@@ -456,10 +468,14 @@ in
       };
       providerFields = {
         workloadName = "provider-service";
+        workloadId = "provider-service";
         legacyVmName = null;
         runtimeKind = null;
         appCommand = null;
         actionsEmpty = true;
+        iconId = null;
+        iconName = null;
+        iconGroupKey = null;
         # no legacyVmName → vsockCid must be null
         vsockCid = null;
       };
@@ -538,6 +554,204 @@ in
     expected = {
       archivedExcluded = true;
       corpPresent = true;
+    };
+  };
+
+  # ── launcher JSON: workloadId field equals workloadName ─────────────────────
+  # The launcher row must expose `workloadId` as an explicit DTO-named alias
+  # for `workloadName`, matching the WorkloadIdentity.workloadId contract used
+  # by daemon/broker consumers.
+  "realm-workloads/launcher-json-workload-id-field" = {
+    expr =
+      let
+        data = wlCfg.d2b._bundle.realmWorkloadsLauncherJson.data;
+        corpRow = lib.findFirst (w: w.workloadName == "corp-laptop") null data.workloads;
+        providerRow = lib.findFirst (w: w.workloadName == "provider-service") null data.workloads;
+      in {
+        corpWorkloadId = corpRow.workloadId;
+        corpWorkloadIdEqualsName = corpRow.workloadId == corpRow.workloadName;
+        providerWorkloadId = providerRow.workloadId;
+        providerWorkloadIdEqualsName = providerRow.workloadId == providerRow.workloadName;
+      };
+    expected = {
+      corpWorkloadId = "corp-laptop";
+      corpWorkloadIdEqualsName = true;
+      providerWorkloadId = "provider-service";
+      providerWorkloadIdEqualsName = true;
+    };
+  };
+
+  # ── launcher JSON: iconId and iconName fields present separately ─────────────
+  # The launcher row must expose `iconId` (raw launcher.icon.id) and `iconName`
+  # (raw launcher.icon.name) in addition to the resolved `icon` string, so that
+  # desktop tooling can round-trip option values and distinguish primary-id from
+  # symbolic-name.
+  "realm-workloads/launcher-json-icon-id-name-fields" = {
+    expr =
+      let
+        data = wlCfg.d2b._bundle.realmWorkloadsLauncherJson.data;
+        corpRow = lib.findFirst (w: w.workloadName == "corp-laptop") null data.workloads;
+        providerRow = lib.findFirst (w: w.workloadName == "provider-service") null data.workloads;
+      in {
+        # corp-laptop sets icon.id = "computer-laptop" and no icon.name
+        corpIconId = corpRow.iconId;
+        corpIconName = corpRow.iconName;
+        corpIconResolved = corpRow.icon;
+        corpIconIdEqualsResolved = corpRow.iconId == corpRow.icon;
+        # provider-service sets neither icon.id nor icon.name
+        providerIconId = providerRow.iconId;
+        providerIconName = providerRow.iconName;
+        providerIconResolved = providerRow.icon;
+      };
+    expected = {
+      corpIconId = "computer-laptop";
+      corpIconName = null;
+      corpIconResolved = "computer-laptop";
+      corpIconIdEqualsResolved = true;
+      providerIconId = null;
+      providerIconName = null;
+      providerIconResolved = null;
+    };
+  };
+
+  # ── launcher JSON: iconGroupKey stable grouping key ──────────────────────────
+  # iconGroupKey must equal iconId when set, else iconName, else null.
+  # It is always identical to the resolved `icon` field.
+  "realm-workloads/launcher-json-icon-group-key" = {
+    expr =
+      let
+        data = wlCfg.d2b._bundle.realmWorkloadsLauncherJson.data;
+        corpRow = lib.findFirst (w: w.workloadName == "corp-laptop") null data.workloads;
+        providerRow = lib.findFirst (w: w.workloadName == "provider-service") null data.workloads;
+      in {
+        # corp-laptop: iconGroupKey = iconId (preferred over iconName)
+        corpGroupKey = corpRow.iconGroupKey;
+        corpGroupKeyEqualsIcon = corpRow.iconGroupKey == corpRow.icon;
+        corpGroupKeyEqualsIconId = corpRow.iconGroupKey == corpRow.iconId;
+        # provider-service: neither id nor name → null group key
+        providerGroupKey = providerRow.iconGroupKey;
+      };
+    expected = {
+      corpGroupKey = "computer-laptop";
+      corpGroupKeyEqualsIcon = true;
+      corpGroupKeyEqualsIconId = true;
+      providerGroupKey = null;
+    };
+  };
+
+  # ── launcher JSON: iconGroupKey prefers iconId over iconName ─────────────────
+  # When both icon.id and icon.name are set, iconGroupKey must equal iconId.
+  "realm-workloads/launcher-json-icon-group-key-prefers-id-over-name" = {
+    expr =
+      let
+        bothIconFixture = lib.recursiveUpdate hostBase {
+          d2b.realms.home = {
+            name = "Home";
+            path = "home";
+            network.envs = [ "home" ];
+            workloads.notes = {
+              launcher.label = "Notes";
+              launcher.icon.id = "notes-app";
+              launcher.icon.name = "notes";
+            };
+          };
+        };
+        data = (mkEval [ bothIconFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
+        row = lib.findFirst (w: w.workloadName == "notes") null data.workloads;
+      in {
+        iconId = row.iconId;
+        iconName = row.iconName;
+        iconGroupKey = row.iconGroupKey;
+        iconResolved = row.icon;
+        groupKeyEqualsId = row.iconGroupKey == row.iconId;
+      };
+    expected = {
+      iconId = "notes-app";
+      iconName = "notes";
+      iconGroupKey = "notes-app";
+      iconResolved = "notes-app";
+      groupKeyEqualsId = true;
+    };
+  };
+
+  # ── launcher JSON: iconGroupKey equals iconName when only name is set ─────────
+  # When icon.name is set but icon.id is null, iconGroupKey must equal iconName.
+  "realm-workloads/launcher-json-icon-group-key-falls-back-to-name" = {
+    expr =
+      let
+        nameOnlyFixture = lib.recursiveUpdate hostBase {
+          d2b.realms.home = {
+            name = "Home";
+            path = "home";
+            network.envs = [ "home" ];
+            workloads.legacy-app = {
+              launcher.label = "Legacy App";
+              launcher.icon.name = "application-x-generic";
+            };
+          };
+        };
+        data = (mkEval [ nameOnlyFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
+        row = lib.findFirst (w: w.workloadName == "legacy-app") null data.workloads;
+      in {
+        iconId = row.iconId;
+        iconName = row.iconName;
+        iconGroupKey = row.iconGroupKey;
+        iconResolved = row.icon;
+        groupKeyEqualsName = row.iconGroupKey == row.iconName;
+      };
+    expected = {
+      iconId = null;
+      iconName = "application-x-generic";
+      iconGroupKey = "application-x-generic";
+      iconResolved = "application-x-generic";
+      groupKeyEqualsName = true;
+    };
+  };
+
+  # ── launcher JSON: duplicate icon — iconGroupKey identical across realms ───────
+  # Two workloads in different realms with the same icon.id must have identical
+  # iconGroupKey values so desktop consumers can use it as a cluster key for
+  # duplicate-app chooser semantics.
+  "realm-workloads/launcher-json-duplicate-icon-group-key-matches" = {
+    expr =
+      let
+        dupFixture = lib.recursiveUpdate hostBase {
+          d2b.realms.realm-a = {
+            path = "realm-a";
+            env = "home";
+            network.envs = [ "home" ];
+            workloads.browser = {
+              launcher.label = "Web Browser";
+              launcher.icon.id = "web-browser";
+            };
+          };
+          d2b.realms.realm-b = {
+            path = "realm-b";
+            env = "dev";
+            network.envs = [ "dev" ];
+            workloads.browser = {
+              launcher.label = "Web Browser";
+              launcher.icon.id = "web-browser";
+            };
+          };
+        };
+        data = (mkEval [ dupFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
+        browserRows = lib.filter (w: w.workloadName == "browser") data.workloads;
+        groupKeys = lib.unique (map (w: w.iconGroupKey) browserRows);
+      in {
+        bothPresent = builtins.length browserRows == 2;
+        # Both rows must share exactly one iconGroupKey value.
+        singleGroupKey = builtins.length groupKeys == 1;
+        theGroupKey = builtins.head groupKeys;
+        # workloadId must differ (different realms, same workload name).
+        distinctRealms = lib.sort lib.lessThan
+          (lib.unique (map (w: w.realmPath) browserRows));
+      };
+    expected = {
+      bothPresent = true;
+      singleGroupKey = true;
+      theGroupKey = "web-browser";
+      distinctRealms = [ "realm-a" "realm-b" ];
     };
   };
 

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -626,10 +626,16 @@ realm-workloads/index-by-vm-accessor
 realm-workloads/index-flat-enabled-accessor
 realm-workloads/launcher-json-bundle-artifact
 realm-workloads/launcher-json-canonical-target-override
+realm-workloads/launcher-json-duplicate-icon-group-key-matches
 realm-workloads/launcher-json-excludes-disabled
+realm-workloads/launcher-json-icon-group-key
+realm-workloads/launcher-json-icon-group-key-falls-back-to-name
+realm-workloads/launcher-json-icon-group-key-prefers-id-over-name
+realm-workloads/launcher-json-icon-id-name-fields
 realm-workloads/launcher-json-invariants
 realm-workloads/launcher-json-no-implicit-dedup
 realm-workloads/launcher-json-shape
+realm-workloads/launcher-json-workload-id-field
 realm-workloads/realm-row-workload-names
 realm-workloads/realm-with-no-workloads-empty-index
 requested-vm-config/boot-selector-and-hotplug-source-coexist


### PR DESCRIPTION
## Summary

Hardens the generated `realm-workloads-launcher.json` artifact for desktop consumers (Waybar, wlcontrol, wlterm, clip-picker) by adding four new fields per workload row that enable realm grouping and duplicate-icon / app-chooser semantics.

### New fields on every launcher row

| Field | Type | Semantics |
|-------|------|-----------|
| `workloadId` | string | Explicit DTO-named alias for `workloadName`; matches `WorkloadIdentity.workloadId` used by daemon/broker |
| `iconId` | string\|null | Raw `launcher.icon.id` option value |
| `iconName` | string\|null | Raw `launcher.icon.name` fallback value |
| `iconGroupKey` | string\|null | Stable clustering key: `iconId` if set, else `iconName`, else null |

`iconGroupKey` is the stable hook for the duplicate-icon / app-chooser use case: when multiple realms expose a workload with the same icon (e.g. Firefox in work realm and Firefox in personal realm), consumers can cluster by `iconGroupKey` to present a chooser rather than showing duplicates independently.

The workload index (`_index.realms.workloads`) also derives all four fields so any index consumer — not only the launcher emitter — has access.

**Backward compatibility**: existing `icon` (resolved string) and `workloadName` fields are unchanged.

**Security contract unchanged**: all new fields are static operator-declared metadata; no secrets, provider tokens, session handles, or sensitive payloads.

### Files changed

- `nixos-modules/index.nix` — derive `workloadId`, `iconId`, `iconName`, `iconGroupKey` on every workload row
- `nixos-modules/realm-workloads-launcher-json.nix` — emit the four new fields per row with security comments
- `tests/unit/nix/cases/realm-workloads.nix` — 6 new nix-unit cases + updated `launcher-json-shape`
- `packages/d2b-contract-tests/tests/realm_workload_schema_contract.rs` — 5 new contract tests
- `tests/unit/nix/pinned/common.txt` — regenerated (753 cases, +6 new)
- `CHANGELOG.md` — `[Unreleased]` entry

### Validation

- `make test-lint` — PASS (nix parse 150 files, shellcheck 17 scripts)
- `make test-proofs` — PASS (9 proof tests)
- `make test-flake` — PASS (all flake checks including nix-unit-network shard)
- `cargo test -p d2b-contract-tests --test realm_workload_schema_contract` — PASS (21/21)
- `git diff --check` — clean