### PR TITLE
wayland-proxy: default rail to realm identity when VM maps unambiguously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Wayland proxy rail now defaults to realm identity when a VM maps
+  unambiguously to a single realm workload via `legacyVmName`. The active
+  rail color defaults to the realm's resolved accent color (from
+  `d2b.realms.<realm>.network.ui.accentColor`), the rail label defaults to
+  `<workload>.<realmPath>`, and the realm target defaults to
+  `<workload>.<realmPath>.d2b`. Inactive and urgent colors remain derived
+  from the VM border palette. Explicit operator `border.label.text` overrides
+  are fully preserved. When the mapping is ambiguous (multiple realms claim
+  the same VM) or absent (classical `d2b.vms` entry without a realm
+  workload), behavior is unchanged: VM border colors, VM-name label, and
+  `<vmName>.local.d2b` transitional target.
+
 - Added first-class realm colors to the UI color contract. Enabled realms are
   now included in `ui-colors.json` under a `realms` key, each with `path` and
   `accent` fields. Corresponding `@define-color d2b_realm_<id>_accent` entries

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -639,17 +639,42 @@ EOF
       upstreamSock = waylandHostSock;
       bridgeSock = "${config.d2b.site.clipboard.runtime.bridgeRoot}/${waylandUid}/bridge/${vmName}/${config.d2b.site.clipboard.runtime.bridgeSocketName}";
       appIdPrefix = "d2b.${vmName}.";
-      realmTarget = "${vmName}.local.d2b";
+      # Realm identity: unambiguous when exactly one enabled realm workload
+      # row references this VM (via legacyVmName).  Multiple rows (cross-realm
+      # VM) or no rows (classical d2b.vms entry) both fall back to the
+      # host-local transitional defaults.
+      vmRealmRows = cfg._index.realms.workloads.byVm.${vmName} or [];
+      unambiguousRow = if lib.length vmRealmRows == 1 then builtins.head vmRealmRows else null;
+      # Default realm target: <workload>.<realmPath>.d2b when unambiguous,
+      # else <vmName>.local.d2b for the transitional host-local realm.
+      realmTarget =
+        if unambiguousRow != null
+        then "${unambiguousRow.workloadName}.${unambiguousRow.realmPath}.d2b"
+        else "${vmName}.local.d2b";
       titlePrefix = "[${vmName}] ";
       border = vm.graphics.waylandProxy.border;
       borderColors = cfg._uiColors.vms.${vmName}.border;
-      borderLabelText = if border.label.text == null then vmName else border.label.text;
+      # Active rail color: realm accent when the VM maps unambiguously to a
+      # realm and that realm has a resolved accent entry; falls back to the
+      # VM border active color.
+      realmActiveColor =
+        if unambiguousRow != null
+          && builtins.hasAttr unambiguousRow.realmName cfg._uiColors.realms
+        then cfg._uiColors.realms.${unambiguousRow.realmName}.accent
+        else borderColors.active;
+      # Default rail label: <workload>.<realmPath> when unambiguous, else VM
+      # name.  Explicit operator border.label.text always takes precedence.
+      defaultBorderLabel =
+        if unambiguousRow != null
+        then "${unambiguousRow.workloadName}.${unambiguousRow.realmPath}"
+        else vmName;
+      borderLabelText = if border.label.text != null then border.label.text else defaultBorderLabel;
       borderLabelArgs = lib.optionals (border.label.enable && borderLabelText != "") [
         "--border-label" borderLabelText
       ];
       borderArgs = lib.optionals border.enable ([
         "--border-enable"
-        "--border-color-active" borderColors.active
+        "--border-color-active" realmActiveColor
         "--border-color-inactive" borderColors.inactive
         "--border-color-urgent" borderColors.urgent
       ] ++ borderLabelArgs);

--- a/tests/unit/nix/cases/niri-vm-borders.nix
+++ b/tests/unit/nix/cases/niri-vm-borders.nix
@@ -187,6 +187,66 @@ let
     })
   ];
   realmDisabledJson = builtins.fromJSON (jsonText realmDisabledEtc);
+
+  # Wayland proxy realm rail fixtures.
+  # Single-realm unambiguous mapping: work VM -> corp realm workload.
+  # The proxy should use the realm accent as active color, the
+  # workload-qualified label, and the canonical realm target.
+  proxyRealmCfg = cfgOf [
+    ({ ... }: {
+      d2b.realms.corp = {
+        network.ui.accentColor = "#ff8800";
+        workloads.work = {
+          kind = "local-vm";
+          legacyVmName = "work";
+          localVm.graphics.enable = true;
+        };
+      };
+    })
+  ];
+  proxyRealmArgv = (processNode proxyRealmCfg "wayland-proxy").argv;
+  proxyRealmAccent = proxyRealmCfg.d2b._uiColors.realms.corp.accent;
+  proxyRealmVmBorder = proxyRealmCfg.d2b._uiColors.vms.work.border;
+
+  # Single realm mapping with an explicit operator border label override.
+  proxyRealmLabelOverrideCfg = cfgOf [
+    ({ ... }: {
+      d2b.realms.corp = {
+        network.ui.accentColor = "#ff8800";
+        workloads.work = {
+          kind = "local-vm";
+          legacyVmName = "work";
+          localVm.graphics.enable = true;
+        };
+      };
+      d2b.vms.work.graphics.waylandProxy.border.label.text = "My Work VM";
+    })
+  ];
+  proxyRealmLabelOverrideArgv = (processNode proxyRealmLabelOverrideCfg "wayland-proxy").argv;
+
+  # Ambiguous multi-realm mapping: two realms both claim the work VM via
+  # legacyVmName.  The proxy must fall back to host-local defaults.
+  proxyMultiRealmCfg = cfgOf [
+    ({ ... }: {
+      d2b.realms.corp = {
+        network.ui.accentColor = "#ff8800";
+        workloads.work = {
+          kind = "local-vm";
+          legacyVmName = "work";
+          localVm.graphics.enable = true;
+        };
+      };
+      d2b.realms.personal = {
+        network.ui.accentColor = "#00cc88";
+        workloads.work = {
+          kind = "local-vm";
+          legacyVmName = "work";
+          localVm.graphics.enable = true;
+        };
+      };
+    })
+  ];
+  proxyMultiRealmArgv = (processNode proxyMultiRealmCfg "wayland-proxy").argv;
 in
 {
   "niri-vm-borders/disabled-no-kdl" = {
@@ -419,6 +479,55 @@ in
     # No realms declared: the realms key is present but empty.
     expr = realmUiJson.realms == { } || builtins.hasAttr "work" realmUiJson.realms;
     expected = true;
+  };
+
+  # --- wayland proxy realm rail cases ---
+
+  "niri-vm-borders/wayland-proxy-realm-workload-active-color-is-realm-accent" = {
+    # When the VM maps unambiguously to a realm, active rail color is the
+    # realm's resolved accent; inactive and urgent retain the VM border colors.
+    expr = {
+      active = flagValue "--border-color-active" proxyRealmArgv;
+      inactive = flagValue "--border-color-inactive" proxyRealmArgv;
+      urgent = flagValue "--border-color-urgent" proxyRealmArgv;
+    };
+    expected = {
+      active = proxyRealmAccent;
+      inactive = proxyRealmVmBorder.inactive;
+      urgent = proxyRealmVmBorder.urgent;
+    };
+  };
+  "niri-vm-borders/wayland-proxy-realm-workload-label-is-workload-realmpath" = {
+    # Default rail label is <workload>.<realmPath> for a realm-mapped VM.
+    expr = flagValue "--border-label" proxyRealmArgv;
+    expected = "work.corp";
+  };
+  "niri-vm-borders/wayland-proxy-realm-workload-target-is-canonical" = {
+    # Realm target is <workload>.<realmPath>.d2b for a realm-mapped VM.
+    expr = flagValue "--realm-target" proxyRealmArgv;
+    expected = "work.corp.d2b";
+  };
+  "niri-vm-borders/wayland-proxy-realm-explicit-label-override-preserved" = {
+    # Explicit operator border.label.text overrides the derived realm label.
+    expr = flagValue "--border-label" proxyRealmLabelOverrideArgv;
+    expected = "My Work VM";
+  };
+  "niri-vm-borders/wayland-proxy-realm-explicit-label-override-target-unchanged" = {
+    # Even with a label override, the realm target is still the canonical form.
+    expr = flagValue "--realm-target" proxyRealmLabelOverrideArgv;
+    expected = "work.corp.d2b";
+  };
+  "niri-vm-borders/wayland-proxy-ambiguous-realm-uses-vm-defaults" = {
+    # When >1 realm claims the same VM via legacyVmName, the proxy falls back
+    # to the host-local transitional defaults (vmName label, vmName.local.d2b).
+    expr = {
+      label = flagValue "--border-label" proxyMultiRealmArgv;
+      realmTarget = flagValue "--realm-target" proxyMultiRealmArgv;
+    };
+    expected = {
+      label = "work";
+      realmTarget = "work.local.d2b";
+    };
   };
 }
 )

--- a/tests/unit/nix/pinned/x86_64-linux.txt
+++ b/tests/unit/nix/pinned/x86_64-linux.txt
@@ -46,8 +46,14 @@ niri-vm-borders/ui-json-default-vm-border
 niri-vm-borders/ui-json-env-accent-present
 niri-vm-borders/ui-json-mode
 niri-vm-borders/ui-json-version
+niri-vm-borders/wayland-proxy-ambiguous-realm-uses-vm-defaults
 niri-vm-borders/wayland-proxy-border-default-uses-resolved-colors
 niri-vm-borders/wayland-proxy-border-disable-omits-border-flags
+niri-vm-borders/wayland-proxy-realm-explicit-label-override-preserved
+niri-vm-borders/wayland-proxy-realm-explicit-label-override-target-unchanged
+niri-vm-borders/wayland-proxy-realm-workload-active-color-is-realm-accent
+niri-vm-borders/wayland-proxy-realm-workload-label-is-workload-realmpath
+niri-vm-borders/wayland-proxy-realm-workload-target-is-canonical
 umask-roundtrip/audio
 umask-roundtrip/gpu
 umask-roundtrip/swtpm


### PR DESCRIPTION
## Summary

Stacked on PR #278 (`realm-workloads-w17-ui-colors`). Base branch: `realm-workloads-w17-ui-colors`.

Updates the host-side Wayland proxy runner (`waylandProxyRunner` in `nixos-modules/processes-json.nix`) so that proxied windows carry realm identity in their rail decoration when the VM maps unambiguously to a single realm workload.

## Behavior

**Unambiguous realm mapping** (exactly one enabled realm workload declares `legacyVmName = "<vm>"`):
- Active rail color → resolved realm accent (`d2b.realms.<r>.network.ui.accentColor`, deterministic palette fallback)
- Rail label → `<workload>.<realmPath>`
- Realm target → `<workload>.<realmPath>.d2b`
- Inactive + urgent colors unchanged (VM border palette)
- Explicit operator `border.label.text` override fully preserved

**Ambiguous** (>1 realm claims the same VM) or **absent** (classical `d2b.vms` entry with no realm workload declaration):
- No behavior change: VM border active color, VM-name label, `<vmName>.local.d2b` transitional target

## What changed

**`nixos-modules/processes-json.nix`**
- `waylandProxyRunner`: look up `cfg._index.realms.workloads.byVm.${vmName}`; proceed with realm path only when exactly one row is present
- `realmActiveColor`: reads `cfg._uiColors.realms.${realmName}.accent` (populated by PR #278), falls back to VM border active
- `defaultBorderLabel`: `${workloadName}.${realmPath}` when unambiguous, else `vmName`
- `realmTarget`: `${workloadName}.${realmPath}.d2b` when unambiguous, else `${vmName}.local.d2b`

**`tests/unit/nix/cases/niri-vm-borders.nix`**
- 3 new let-binding fixtures: `proxyRealmCfg` (single-realm), `proxyRealmLabelOverrideCfg` (explicit override), `proxyMultiRealmCfg` (ambiguous)
- 6 new nix-unit eval cases covering all branches of the logic

**`tests/unit/nix/pinned/x86_64-linux.txt`**
- Regenerated with `make nix-unit-pin`; +6 new case names

**`CHANGELOG.md`**
- Added entry under `## [Unreleased]`

## No docs change needed

`docs/reference/wayland-proxy-warnings.md` documents trust posture; the label/color defaults are operator-visible config behavior. PR #278 already extended `docs/reference/ui-colors.md` for the realm color contract that feeds this feature.

## Validation

```
make nix-unit-pin  → wrote 747 common, 85 x86_64-linux cases (+6 new)
make test-nix-unit → PASS (all shards: nix-unit, daemon, guest, misc, network, runtime, state)
git diff --check   → clean
```

## PR stack

- #278 `realm-workloads-w17-ui-colors` ← **this PR** bases here
- This PR: `realm-workloads-w17-wayland-rail`