### PR TITLE
bundle: grant realm daemons shared artifact ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Fixed host-local realm daemon startup after `/etc/d2b` private bundle
+  artifacts are materialized. Activation now restores read ACLs for each
+  `d2br-*` daemon group on `bundle.json`, `realm-controllers.json`, and
+  `realm-identity.json`, preventing realm daemons from exiting with
+  `internal-io` / permission-denied errors on switch.
+
 - Fixed local CLI routing for realm workload targets whose workload id differs
   from the legacy VM substrate name. `d2b vm status <workload>.<realm>.d2b` and
   local lifecycle/exec routing now resolve through the generated workload

--- a/nixos-modules/bundle-artifacts.nix
+++ b/nixos-modules/bundle-artifacts.nix
@@ -306,7 +306,8 @@ in
       text = ''
         for artifact in ${lib.escapeShellArgs realmSharedArtifactPaths}; do
           if [ -e "$artifact" ]; then
-            ${pkgs.acl}/bin/setfacl -m ${lib.escapeShellArg realmReadAclSpec} "$artifact"
+            ${pkgs.acl}/bin/setfacl -m ${lib.escapeShellArg realmReadAclSpec} "$artifact" \
+              || echo "d2b: warning: failed to set realm daemon read ACLs on $artifact" >&2
           fi
         done
       '';

--- a/nixos-modules/bundle-artifacts.nix
+++ b/nixos-modules/bundle-artifacts.nix
@@ -158,6 +158,22 @@ let
       (_: artifact: shouldInstall artifact)
       (singletonArtifacts // extraArtifacts);
 
+  realmDaemonGroups = lib.unique (map
+    (realm: realm.controller.daemon.group)
+    (lib.filter (realm: realm.placement == "host-local") topConfig.d2b._index.realms.enabledList));
+
+  realmSharedArtifactPaths = [
+    "/etc/d2b/bundle.json"
+    "/etc/d2b/realm-controllers.json"
+    "/etc/d2b/realm-identity.json"
+  ];
+
+  realmReadAclSpec =
+    lib.concatStringsSep "," (
+      (map (group: "g:${group}:r--") realmDaemonGroups)
+      ++ [ "m::r--" ]
+    );
+
 in
 {
   options.d2b._bundle = {
@@ -284,5 +300,16 @@ in
         };
       })
       centrallyInstalledArtifacts);
+
+    system.activationScripts.d2bRealmBundleArtifactAcls = lib.mkIf (realmDaemonGroups != [ ]) {
+      deps = [ "etc" "users" ];
+      text = ''
+        for artifact in ${lib.escapeShellArgs realmSharedArtifactPaths}; do
+          if [ -e "$artifact" ]; then
+            ${pkgs.acl}/bin/setfacl -m ${lib.escapeShellArg realmReadAclSpec} "$artifact"
+          fi
+        done
+      '';
+    };
   };
 }

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -102,6 +102,7 @@ fn realm_controller_artifact_is_wired_into_private_bundle() {
         "/etc/d2b/realm-identity.json",
         "g:${group}:r--",
         "deps = [ \"etc\" \"users\" ];",
+        "failed to set realm daemon read ACLs",
     ] {
         assert!(
             bundle_artifacts.contains(needle),

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -92,6 +92,22 @@ fn realm_controller_artifact_is_wired_into_private_bundle() {
         bundle_artifacts.contains("realmControllersJson"),
         "bundle-artifacts.nix must declare realmControllersJson metadata"
     );
+    assert!(
+        bundle_artifacts.contains("d2bRealmBundleArtifactAcls"),
+        "bundle-artifacts.nix must restore realm daemon read ACLs for shared private bundle artifacts"
+    );
+    for needle in [
+        "/etc/d2b/bundle.json",
+        "/etc/d2b/realm-controllers.json",
+        "/etc/d2b/realm-identity.json",
+        "g:${group}:r--",
+        "deps = [ \"etc\" \"users\" ];",
+    ] {
+        assert!(
+            bundle_artifacts.contains(needle),
+            "bundle-artifacts.nix missing realm shared artifact ACL marker: {needle}"
+        );
+    }
 
     let bundle_nix = read_repo_file("nixos-modules/bundle.nix");
     for needle in [


### PR DESCRIPTION
## Summary
- restore per-realm daemon read ACLs on shared private bundle artifacts after `/etc` materialization
- cover `bundle.json`, `realm-controllers.json`, and `realm-identity.json`, which host-local realm daemons read during startup
- add a contract assertion so the ACL hook cannot regress silently

## Validation
- `cargo fmt --package d2b-contract-tests`
- `cargo test -p d2b-contract-tests realm_controller_artifact_is_wired_into_private_bundle --test storage_sync_contracts`

## Host finding
A switch to d2b `21deb182` failed because all host-local realm daemons exited with status 42 while reading `/etc/d2b/realm-controllers.json` (`Permission denied`). Temporary ACL recovery confirmed this is the missing persistent ACL, not a daemon runtime issue.
