### PR TITLE
realm: use d2bd group for daemon artifact reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,11 @@ deprecations ship one minor release before removal.
 ### Fixed
 
 - Fixed host-local realm daemon startup after `/etc/d2b` private bundle
-  artifacts are materialized. Activation now restores read ACLs for each
-  `d2br-*` daemon group on `bundle.json`, `realm-controllers.json`, and
-  `realm-identity.json`, preventing realm daemons from exiting with
-  `internal-io` / permission-denied errors on switch.
+  artifacts are materialized. Realm daemon users and services now carry the
+  canonical `d2bd` supplementary group, preserving read access to
+  `root:d2bd 0640` private bundle artifacts (`bundle.json`,
+  `realm-controllers.json`, and `realm-identity.json`) without a parallel
+  activation-time ACL path.
 
 - Fixed local CLI routing for realm workload targets whose workload id differs
   from the legacy VM substrate name. `d2b vm status <workload>.<realm>.d2b` and

--- a/nixos-modules/bundle-artifacts.nix
+++ b/nixos-modules/bundle-artifacts.nix
@@ -158,22 +158,6 @@ let
       (_: artifact: shouldInstall artifact)
       (singletonArtifacts // extraArtifacts);
 
-  realmDaemonGroups = lib.unique (map
-    (realm: realm.controller.daemon.group)
-    (lib.filter (realm: realm.placement == "host-local") topConfig.d2b._index.realms.enabledList));
-
-  realmSharedArtifactPaths = [
-    "/etc/d2b/bundle.json"
-    "/etc/d2b/realm-controllers.json"
-    "/etc/d2b/realm-identity.json"
-  ];
-
-  realmReadAclSpec =
-    lib.concatStringsSep "," (
-      (map (group: "g:${group}:r--") realmDaemonGroups)
-      ++ [ "m::r--" ]
-    );
-
 in
 {
   options.d2b._bundle = {
@@ -300,17 +284,5 @@ in
         };
       })
       centrallyInstalledArtifacts);
-
-    system.activationScripts.d2bRealmBundleArtifactAcls = lib.mkIf (realmDaemonGroups != [ ]) {
-      deps = [ "etc" "users" ];
-      text = ''
-        for artifact in ${lib.escapeShellArgs realmSharedArtifactPaths}; do
-          if [ -e "$artifact" ]; then
-            ${pkgs.acl}/bin/setfacl -m ${lib.escapeShellArg realmReadAclSpec} "$artifact" \
-              || echo "d2b: warning: failed to set realm daemon read ACLs on $artifact" >&2
-          fi
-        done
-      '';
-    };
   };
 }

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -327,7 +327,7 @@ EOF
         ProtectHome = true;
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
         UMask = "0027";
-        SupplementaryGroups = [ realm.controller.daemon.publicSocketGroup ];
+        SupplementaryGroups = [ realm.controller.daemon.publicSocketGroup "d2bd" ];
         Slice = "d2b.slice";
       };
     };

--- a/nixos-modules/host-users.nix
+++ b/nixos-modules/host-users.nix
@@ -102,7 +102,7 @@ in
           isSystemUser = true;
           uid = stablePrincipalId realm.controller.daemon.user;
           group = realm.controller.daemon.group;
-          extraGroups = [ realm.controller.daemon.publicSocketGroup ];
+          extraGroups = [ realm.controller.daemon.publicSocketGroup "d2bd" ];
           description = "d2b realm daemon user for ${realm.path}";
         })
       hostLocalRealms))

--- a/nixos-modules/options-realms.nix
+++ b/nixos-modules/options-realms.nix
@@ -112,7 +112,7 @@ in
       let
         realmConfig = config;
         realmStateDir = "${toString outerConfig.d2b.site.stateDir}/realms/${realmConfig.id}";
-        realmAuditDir = "/var/lib/d2b/audit/realms/${realmConfig.id}";
+        realmLogDir = "/var/lib/d2b/audit/realms/${realmConfig.id}";
         realmRunDir = "/run/d2b/realms/${realmConfig.id}";
       in
       {
@@ -427,7 +427,7 @@ in
 
             auditDir = lib.mkOption {
               type = lib.types.strMatching absolutePath;
-              default = realmAuditDir;
+              default = realmLogDir;
               defaultText = lib.literalExpression "\"/var/lib/d2b/audit/realms/<realm>\"";
               description = ''
                 Derived per-realm audit directory. The default is deliberately

--- a/packages/d2b-contract-tests/tests/policy_state.rs
+++ b/packages/d2b-contract-tests/tests/policy_state.rs
@@ -102,8 +102,8 @@ fn group_rename_semantic() {
     );
     require_match(
         &host_users,
-        r#"extraGroups = \[ "d2b" \];"#,
-        "launcherUsers are not added to d2b",
+        r#"lib\.optional \(builtins\.elem user cfg\.site\.launcherUsers\) "d2b""#,
+        "launcherUsers are not added to d2b through hostAccessGroupsForUser",
     );
     require_match(
         &host_daemon,

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -92,23 +92,22 @@ fn realm_controller_artifact_is_wired_into_private_bundle() {
         bundle_artifacts.contains("realmControllersJson"),
         "bundle-artifacts.nix must declare realmControllersJson metadata"
     );
-    assert!(
-        bundle_artifacts.contains("d2bRealmBundleArtifactAcls"),
-        "bundle-artifacts.nix must restore realm daemon read ACLs for shared private bundle artifacts"
-    );
-    for needle in [
-        "/etc/d2b/bundle.json",
-        "/etc/d2b/realm-controllers.json",
-        "/etc/d2b/realm-identity.json",
-        "g:${group}:r--",
-        "deps = [ \"etc\" \"users\" ];",
-        "failed to set realm daemon read ACLs",
-    ] {
+    let host_users = read_repo_file("nixos-modules/host-users.nix");
+    let host_daemon = read_repo_file("nixos-modules/host-daemon.nix");
+    for needle in ["realm.controller.daemon.publicSocketGroup \"d2bd\""] {
         assert!(
-            bundle_artifacts.contains(needle),
-            "bundle-artifacts.nix missing realm shared artifact ACL marker: {needle}"
+            host_users.contains(needle),
+            "host-users.nix must put realm daemon users in d2bd for private bundle artifact reads: {needle}"
+        );
+        assert!(
+            host_daemon.contains(needle),
+            "host-daemon.nix must run realm daemon services with d2bd as a supplementary group: {needle}"
         );
     }
+    assert!(
+        !bundle_artifacts.contains("d2bRealmBundleArtifactAcls"),
+        "realm daemon private artifact access must use canonical group membership, not a parallel activation ACL hook"
+    );
 
     let bundle_nix = read_repo_file("nixos-modules/bundle.nix");
     for needle in [

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -94,16 +94,15 @@ fn realm_controller_artifact_is_wired_into_private_bundle() {
     );
     let host_users = read_repo_file("nixos-modules/host-users.nix");
     let host_daemon = read_repo_file("nixos-modules/host-daemon.nix");
-    for needle in ["realm.controller.daemon.publicSocketGroup \"d2bd\""] {
-        assert!(
-            host_users.contains(needle),
-            "host-users.nix must put realm daemon users in d2bd for private bundle artifact reads: {needle}"
-        );
-        assert!(
-            host_daemon.contains(needle),
-            "host-daemon.nix must run realm daemon services with d2bd as a supplementary group: {needle}"
-        );
-    }
+    let d2bd_group_marker = "realm.controller.daemon.publicSocketGroup \"d2bd\"";
+    assert!(
+        host_users.contains(d2bd_group_marker),
+        "host-users.nix must put realm daemon users in d2bd for private bundle artifact reads: {d2bd_group_marker}"
+    );
+    assert!(
+        host_daemon.contains(d2bd_group_marker),
+        "host-daemon.nix must run realm daemon services with d2bd as a supplementary group: {d2bd_group_marker}"
+    );
     assert!(
         !bundle_artifacts.contains("d2bRealmBundleArtifactAcls"),
         "realm daemon private artifact access must use canonical group membership, not a parallel activation ACL hook"

--- a/packages/d2b-realm-router/src/mux_session.rs
+++ b/packages/d2b-realm-router/src/mux_session.rs
@@ -424,7 +424,6 @@ impl<C: ProtocolCodec> MuxSession<C> {
             .map(TraceContext::span_id);
         tracing::warn!(
             event = "stream-open-denied",
-            stream = %open.descriptor.id.as_str(),
             "stream-kind" = %open.descriptor.kind.code(),
             "operation-id" = %open.operation_id.as_str(),
             "operation-kind" = %operation_kind,

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -914,7 +914,7 @@ in
           Group = "d2br-${realmHash "home"}";
           ExecStart = "${cfg.d2b._hostToolPackages.d2bd}/bin/d2bd serve --config /etc/d2b/realms/home/daemon-config.json --daemon-state-dir /var/lib/d2b/realms/home";
           execStartHasDaemonStateDir = true;
-          SupplementaryGroups = [ "d2bra-${realmHash "home"}" ];
+          SupplementaryGroups = [ "d2bra-${realmHash "home"}" "d2bd" ];
           Slice = "d2b.slice";
         };
         devDaemonAfterHome = true;
@@ -1262,7 +1262,7 @@ in
           isSystemUser = true;
           group = "d2br-${realmHash "home"}";
           description = "d2b realm daemon user for home";
-          extraGroups = [ "d2bra-${realmHash "home"}" ];
+          extraGroups = [ "d2bra-${realmHash "home"}" "d2bd" ];
         };
         disabledDaemonUserAbsent = true;
       };


### PR DESCRIPTION
## Summary
- replace the activation-time realm artifact ACL hook with canonical `d2bd` supplementary group membership for host-local realm daemons
- ensure systemd services also run with `d2bd` as a supplementary group so `root:d2bd 0640` private bundle artifacts are readable at startup
- keep the contract test guarding against reintroducing parallel activation ACL logic

## Validation
- `cargo fmt --package d2b-contract-tests`
- `cargo test -p d2b-contract-tests realm_controller_artifact_is_wired_into_private_bundle --test storage_sync_contracts`

## Panel follow-up
Addresses the Wave 17/18 panel findings that the previous ACL-hook approach was a parallel permission path and should be replaced with canonical group membership.
