### PR TITLE
docs: document realm workload desktop cutover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ deprecations ship one minor release before removal.
   `ServerState`, `identity_for_vm` is used in list/status population, and the
   hermetic restart-invariant unit test is present.
 
+### Changed
+
+- Updated the consumer-facing realm/workload documentation to describe
+  `d2b.realms.<realm>.workloads.<workload>` as the realm-native workload and
+  desktop metadata surface, with `d2b.envs`/`d2b.vms` documented as the v2
+  transition runtime substrate.
+
 ### Fixed
 
 - Fixed host-local realm daemon startup after `/etc/d2b` private bundle

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ the runner contract is shaped so additional VMM backends can fit later.
 
 d2b gives you boundaries without device juggling:
 
-- **Isolated networking:** per-env bridges, firewalling, and an
-  auto-declared NAT/DHCP "net VM".
+- **Realm-owned topology:** realms are the user-facing trust boundaries.
+  During the v2 transition they point at existing env bridges; new workload
+  metadata lives under `d2b.realms.<realm>.workloads`.
 - **Isolated store views:** each guest sees a per-VM `/nix/store`
   hardlink farm containing only its own closure.
 - **Mediated I/O:** software TPM, USB passthrough, audio, graphics,
@@ -33,13 +34,14 @@ d2b gives you boundaries without device juggling:
   broker-supervised per-VM sidecars instead of ad-hoc host services.
 - **One Wayland desktop:** graphical realms integrate with the host
   compositor without asking you to live in a separate desktop.
-- **Shared UI colors:** d2b can emit a compositor-agnostic JSON and
-  GTK-compatible CSS color contract so niri, Waybar, and desktop control
-  tools use the same host/env/VM identity colors.
+- **Shared realm UI identity:** d2b emits compositor-agnostic JSON and
+  GTK-compatible CSS so niri, Waybar, wlcontrol, wlterm, clip-picker, and
+  Wayland rails use the same host/realm/workload/state colors.
 - **One operator surface:** the Rust `d2b` CLI talks to `d2bd`
   and the privileged broker for lifecycle, keys, USB, and host prep.
-- **Persistent guest shells:** `d2b shell <vm>` can reconnect to
-  named interactive guest shells when `guest.shell` is enabled.
+- **Persistent guest shells:** `d2b shell <workload>.<realm>.d2b` (or a
+  still-supported legacy VM name) can reconnect to named interactive guest
+  shells when `guest.shell` is enabled.
 
 Get on the bus: separate sides, shared experience.
 
@@ -121,13 +123,14 @@ Concretely:
   NixOS module that composes into your existing host instead of a new OS
   and Xen stack.
 - You could build the pieces with raw microVMs, but you would rather
-  declare "work" and "personal" environments and let the framework keep
-  the host/guest boundary consistent.
+  declare "work" and "personal" realms with owned workloads and let the
+  framework keep the host/guest boundary consistent.
 - One human, one host. Multi-tenant trust boundaries are out of scope.
 - Wayland-native. There is no X11 fallback for graphics VMs.
-- Headless workloads also work — the same `d2b.envs.<env>`
-  + `d2b.vms.<vm>` shape covers CI runners or
-  background-service VMs without graphics + audio bits.
+- Headless workloads also work. During the v2 migration the runtime
+  substrate is still `d2b.envs.<env>` + `d2b.vms.<vm>`, while
+  `d2b.realms.<realm>.workloads.<workload>` carries realm-native workload
+  identity and desktop metadata.
 
 ## What d2b is NOT
 
@@ -174,7 +177,7 @@ d2b into an existing host config.
 | [`templates/default`](./templates/default) | New host, fastest setup | `nix flake init -t github:vicondoa/d2b` — sentinel TODOs + assertion gates |
 | [`examples/personal-dev`](./examples/personal-dev) | Read-and-copy headless starter | Alias of the checked [`examples/minimal`](./examples/minimal) flake; VM name `personal-dev`. |
 | [`examples/graphics-workstation`](./examples/graphics-workstation) | Desktop VM with Wayland + audio + USBIP | Requires a compositor on the host; `waylandUser` must be non-null. |
-| [`examples/multi-env`](./examples/multi-env) | Two isolated envs (work + personal) | Demonstrates per-env isolation and route preflight. |
+| [`examples/multi-env`](./examples/multi-env) | Two isolated runtime envs (work + personal) | Demonstrates the transition substrate that realms can point at with `network.mode = "inherit-env"`. |
 | [`examples/with-observability`](./examples/with-observability) | Single-host telemetry sink + monitored workload VM | Auto-declares the `sys-obs` VM (native SigNoz + ClickHouse) and wires host/guest OTel collectors over virtio-vsock. |
 
 ## Quick start (Rust CLI / examples)
@@ -215,7 +218,10 @@ d2b status                        # same table + bridge-health footer
 d2b vm start corp-vm --apply
 ```
 
-The scaffold is ~150 lines and is documented inline. See
+For v2-ready configs, add `d2b.realms.<realm>.workloads.<workload>` metadata
+with `legacyVmName = "<existing-vm>"` so desktop tools and CLI output expose
+canonical targets such as `corp-vm.work.d2b` without moving state. The
+scaffold is ~150 lines and is documented inline. See
 [`templates/default/README.md`](./templates/default/README.md) for
 the full TODO walk-through.
 

--- a/docs/how-to/configure-desktop-terminal-integration.md
+++ b/docs/how-to/configure-desktop-terminal-integration.md
@@ -20,7 +20,9 @@ launcher, or terminal emulator.
 
 ## Prerequisites
 
-Enable persistent shells on every VM that should appear in the launcher:
+Enable persistent shells on every workload that should appear in the launcher.
+During the v2 transition, keep the legacy VM runtime declaration and add a
+realm workload row that points at it:
 
 ```nix
 d2b.vms.work = {
@@ -29,6 +31,16 @@ d2b.vms.work = {
   guest.control.enable = true;
   guest.exec.enable = true;
   guest.shell.enable = true;
+};
+
+d2b.realms.work.workloads.shellbox = {
+  kind = "local-vm";
+  legacyVmName = "work";
+  launcher = {
+    enable = true;
+    label = "Work Shell";
+    capabilities = [ "persistent-shell" "guest-exec" ];
+  };
 };
 ```
 
@@ -102,6 +114,11 @@ operators who manage Waybar outside Home Manager. The upstream `d2b-wlterm`
 flake has a `checks.<system>.home-manager-module` evaluation check that exercises
 this rendered shape.
 
+When realm workload metadata is present, d2b-wlterm groups shell-capable
+workloads by realm and displays canonical targets such as
+`shellbox.work.d2b`. It still uses the d2bd public socket and guest-control
+capability checks; it does not read root-owned d2b bundle artifacts directly.
+
 ## Configure Waybar
 
 When Waybar is managed by Home Manager, enable native injection instead of
@@ -132,6 +149,7 @@ nix flake check
 home-manager build --flake .#alice
 d2b shell work list
 d2b-wlterm list work
+d2b vm status shellbox.work.d2b
 ```
 
 If `d2b-wlterm list` reports a typed shell capability error, confirm that the

--- a/docs/how-to/migrate-d2b-v1-2-to-v2.md
+++ b/docs/how-to/migrate-d2b-v1-2-to-v2.md
@@ -123,7 +123,8 @@ d2b.realms.work = {
     legacyVmName = "laptop";    # maps stateDir → /var/lib/d2b/vms/laptop
     localVm.ssh.user = "alice";
 
-    # Optional desktop-launcher metadata for d2b-wlterm and Waybar.
+    # Optional desktop-launcher metadata for Waybar, wlcontrol, wlterm,
+    # clip-picker, and other realm-aware desktop consumers.
     launcher = {
       enable = true;
       label = "Work Laptop";
@@ -138,6 +139,19 @@ The workload `stateDir` defaults to `/var/lib/d2b/vms/<workload-id>`.  If
 the workload id matches the legacy VM name (e.g. both are `laptop`) the
 paths are identical and no data moves.  Setting `legacyVmName` is required
 only when the realm workload id differs from the legacy VM name.
+
+After this metadata is present, d2b emits
+`/etc/d2b/realm-workloads-launcher.json`. Desktop consumers use that private
+non-secret artifact (or public daemon surfaces derived from it) to group
+launchers by realm, show canonical targets such as `laptop.work.d2b`, and
+cluster duplicate app icons within one realm. The canonical target is also
+accepted by local CLI status and guest-exec paths while the legacy VM remains
+the underlying substrate:
+
+```bash
+d2b vm status laptop.work.d2b
+d2b vm exec -d laptop.work.d2b -- firefox
+```
 
 `qemu-media` workloads use the same shape with `kind = "qemu-media"` and
 `qemuMedia.*` options mirroring `d2b.vms.<vm>.qemuMedia.*`:
@@ -221,6 +235,7 @@ For a production rollout, verify this on the host after the switch:
 ```bash
 systemctl is-active d2bd.service
 d2b status laptop
+d2b vm status laptop.work.d2b
 ```
 
 The static gates cover the service posture and metadata contract; live
@@ -259,9 +274,12 @@ d2b status laptop
 d2b vm restart laptop --apply
 ```
 
-Use fully-qualified realm targets only where you intend realm-aware routing:
+Use fully-qualified realm targets for realm-aware status, detached exec, and
+desktop launchers:
 
 ```bash
+d2b vm status laptop.work.d2b
+d2b vm exec -d laptop.work.d2b -- true
 d2b vm display list --target laptop.work.d2b --json
 ```
 
@@ -292,13 +310,20 @@ Clipboard picker requests now include optional d2b-provided realm identity and
 capability-preflight fields. The picker should treat these as trusted d2b
 metadata and keep guest titles/app ids as presentation hints only.
 
-Wayland proxy processes receive `--realm-target <vm>.local.d2b` for local VMs
-during the transition. Existing app-id and title rewriting still behaves as
-before:
+Wayland proxy processes use the workload's canonical realm target when the
+VM maps unambiguously to a realm workload. Existing app-id and title rewriting
+still behaves as before:
 
 - app ids are still prefixed as `d2b.<vm>.<guest-app-id>`;
 - titles still receive `[<vm>] `;
-- the new realm target is separate trusted metadata for d2b-aware tooling.
+- the realm target is separate trusted metadata for d2b-aware tooling.
+
+The generated launcher metadata should also expose the canonical target:
+
+```bash
+sudo jq '.workloads[] | {legacyVmName, canonicalTarget, realmName, workloadName}' \
+  /etc/d2b/realm-workloads-launcher.json
+```
 
 Display sessions listed with JSON include `canonicalTarget`, `identitySource`,
 and `capabilityPreflight`:

--- a/docs/reference/naming-conventions.md
+++ b/docs/reference/naming-conventions.md
@@ -41,14 +41,29 @@ See [ADR 0015](../adr/0015-daemon-only-clean-break.md) for the
 daemon-only authz/audit invariants that make these labels stable across
 host-side group renames.
 
-## VM and env identifiers
+## Realm, workload, VM, and env identifiers
 
 - VM name regex: `^[a-z][a-z0-9-]*$`
 - Reserved VM prefix: `sys-`
 - Reserved VM name: `launcher`
 - `sys-<env>-net` is framework-reserved for the auto-declared net VM.
 
-These constraints let the CLI, manifest, and host-side units resolve resources mechanically without collisions. When docs and code differ, the passing code is canon; see [AGENTS.md](../../AGENTS.md#existing-code-is-canon).
+Realm and workload labels use the same lowercase label shape. The canonical
+public workload target form is:
+
+```text
+<workload>.<realm>[.<ancestor>...].d2b
+```
+
+During the v2 transition, `d2b.realms.<realm>.workloads.<workload>.legacyVmName`
+maps that public workload id to the existing local VM substrate. For example,
+`workloads.aad.legacyVmName = "work-aad"` makes `aad.work.d2b` resolve to the
+local `work-aad` VM for status and guest-control exec while preserving
+`/var/lib/d2b/vms/work-aad`.
+
+These constraints let the CLI, manifest, and host-side units resolve resources
+mechanically without collisions. When docs and code differ, the passing code is
+canon; see [AGENTS.md](../../AGENTS.md#existing-code-is-canon).
 
 ## Persistent shell session names
 
@@ -64,10 +79,10 @@ operator commands, but daemon metrics never use them as labels. Daemon audit
 records use a fixed-length digest for shell correlation instead of raw shell
 names or terminal session handles.
 
-## Constellation target and model identifiers
+## Realm target and model identifiers
 
-Constellation targets extend the VM/env naming rules without making a
-target address a network address. The canonical realm target form is:
+Realm targets extend the VM/env naming rules without making a target address a
+network address. The canonical realm target form is:
 
 ```text
 <workload>.<realm>[.<ancestor>...].d2b
@@ -97,11 +112,9 @@ transition metadata only in the current implementation; bridge and TAP
 names below are still generated from `d2b.envs` and `d2b.vms.<vm>.env`.
 See [Realm option schema](./realm-options.md).
 
-Gateway-backed realms use a local gateway VM entrypoint. The default
-gateway VM name is `sys-<realm-path-with-dashes>-gateway`, but
-operators may override `d2b.gateways.<name>.vmName`; consumers
-should read the generated `realm-entrypoints.json` table rather than
-reconstructing the name from the realm path.
+Gateway-backed realms use a configured realm entrypoint. Consumers should read
+the generated access/entrypoint metadata rather than reconstructing gateway
+names from realm paths.
 
 ## Network device names
 

--- a/docs/reference/realm-options.md
+++ b/docs/reference/realm-options.md
@@ -3,7 +3,7 @@
 **Diataxis category:** reference.
 
 `d2b.realms.<realm>` is the public Nix option namespace for the
-realm-native control-plane model. It records intent,
+realm-native control-plane model. It records intent and owned workloads,
 validates option shape, emits private host-local controller metadata in
 `/etc/d2b/realm-controllers.json`, and materializes host-local scaffolding:
 deterministic daemon/broker units and sockets, realm users and groups,
@@ -12,11 +12,11 @@ socket access ACLs. It does not allocate realm-owned network resources,
 migrate VMs, start provider adapters, or enable realm routing/identity/access
 policy beyond that inert host-local scaffolding.
 
-Existing `d2b.envs` declarations remain the network substrate.
-Workload VMs still join that substrate with `d2b.vms.<vm>.env = "<env>"`.
-Realm declarations may point at existing envs as transition metadata so runtime
-support can map realm policy to the bridge, net-VM, NAT, DHCP, and firewall
-substrate without changing VM placement behavior.
+Existing `d2b.envs` declarations remain the network substrate during the v2
+transition. Workload VMs still join that substrate with
+`d2b.vms.<vm>.env = "<env>"`, while `d2b.realms.<realm>.workloads` records the
+realm-native workload identity, runtime kind, state mapping, and desktop
+launcher metadata.
 
 ## Minimal declaration
 
@@ -34,11 +34,18 @@ d2b.envs.work = {
 };
 
 d2b.vms.laptop.env = "work";
+
+d2b.realms.work.workloads.laptop = {
+  kind = "local-vm";
+  legacyVmName = "laptop";
+  launcher.enable = true;
+};
 ```
 
 The realm above does not move `laptop` into a new runtime namespace. The
 active VM placement remains `d2b.vms.laptop.env = "work"` until runtime
-support consumes the realm declaration.
+support consumes the realm declaration. The workload row still emits the
+canonical target `laptop.work.d2b` for CLI output and desktop consumers.
 
 ## Identifier and path fields
 
@@ -185,6 +192,30 @@ binding to `/etc/d2b/allocator.json`. That binding is a typed resolver
 contract for host-resource leases; it is not permission for a realm
 broker to send raw commands, raw host paths, or free-form network rules through
 the host daemon.
+
+## Workload launcher metadata
+
+`d2b.realms.<realm>.workloads.<workload>.launcher` is the shared desktop
+metadata source for d2b-aware launchers and bars. Enabled workload rows appear
+in `/etc/d2b/realm-workloads-launcher.json`, a private non-secret bundle
+artifact installed as `root:d2bd 0640`. Desktop tools should receive this data
+through d2bd/public helper surfaces or generated user config, not by reading the
+root-owned artifact directly.
+
+Each row includes:
+
+| Field | Meaning |
+| --- | --- |
+| `realmName`, `realmId`, `realmPath` | Owning realm identity. |
+| `workloadName`, `workloadId` | Workload identity. |
+| `targetAddress`, `canonicalTarget` | Public workload target such as `laptop.work.d2b`. |
+| `legacyVmName` | Existing VM substrate when the workload wraps `d2b.vms.<vm>`. |
+| `label`, `icon`, `iconId`, `iconName`, `iconGroupKey` | Presentation and duplicate-app grouping metadata. |
+| `appCommand`, `actions[]` | Operator-declared launch actions. |
+
+Waybar quick-launch buttons, wlcontrol realm cards, wlterm shell grouping, and
+clip-picker realm grouping all consume the same realm/workload identity model.
+Realm colors come from the UI color contract, not from authorization state.
 
 ## Related references
 

--- a/docs/reference/ui-colors.md
+++ b/docs/reference/ui-colors.md
@@ -1,8 +1,8 @@
 # UI color contract
 
 D2b can emit a compositor-agnostic, resolved UI color contract for
-desktop components that want to share the same host, environment, VM, and
-state colors. Enable the generic artifacts with:
+desktop components that want to share the same host, realm, workload, VM,
+environment, and state colors. Enable the generic artifacts with:
 
 ```nix
 d2b.site.ui.enable = true;
@@ -83,11 +83,14 @@ proxy is active and can be disabled per VM:
 d2b.vms.work.graphics.waylandProxy.border.enable = false;
 ```
 
-The proxy uses the same resolved VM border colors documented above. It exposes a
-proxy-owned wrapper toplevel and draws only proxy-owned rail pixels; guest
-application buffers and dma-bufs stay forwarded as Wayland objects and file
-descriptors and are not copied or sampled to render the rail. The default
-identity rail appears on the left side with the authenticated VM-name label.
+The proxy uses the resolved realm color when a VM maps unambiguously to a
+realm workload, falling back to the resolved VM border colors documented
+above. It exposes a proxy-owned wrapper toplevel and draws only proxy-owned
+rail pixels; guest application buffers and dma-bufs stay forwarded as Wayland
+objects and file descriptors and are not copied or sampled to render the rail.
+The default identity rail appears on the left side with the
+`<workload>.<realmPath>` label when realm workload identity is available, and
+with the authenticated VM-name label otherwise.
 
 Proxy borders are visual-only. They do not intercept pointer input, and
 popup/menu positioning remains based on the guest surface geometry.
@@ -171,8 +174,8 @@ compositor-adjacent stylesheets:
 ```css
 @import url("/etc/d2b/ui-colors.css");
 
-#work {
-  border-left-color: @d2b_env_work_accent;
+#realm-work {
+  border-left-color: @d2b_realm_work_accent;
 }
 ```
 
@@ -188,8 +191,8 @@ Definition names include:
 | `d2b_state_error` | Error state accent |
 | `d2b_state_denied` | Authorization-denied state accent |
 | `d2b_state_unknown` | Unknown/unavailable state accent |
-| `d2b_env_<env>_accent` | Environment identity accent |
 | `d2b_realm_<realm>_accent` | Realm identity accent |
+| `d2b_env_<env>_accent` | Environment identity accent for the transition substrate |
 | `d2b_vm_<vm>_border_active` | VM active border color |
 | `d2b_vm_<vm>_border_inactive` | VM inactive border color |
 | `d2b_vm_<vm>_border_urgent` | VM urgent border color |


### PR DESCRIPTION
## Summary
- document realm-owned workloads as the v2 public workload/desktop metadata surface
- clarify that `d2b.envs`/`d2b.vms` remain the transition runtime substrate while `legacyVmName` preserves state
- document canonical workload targets for status/exec, launcher metadata, realm UI colors, and sibling desktop consumers

## Validation
- `make check-tier0`
- `git diff --check`
