### PR TITLE
store-sync: preserve first boot before tmpfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Fixed first boot with d2b enabled. Store-sync activation now defers
+  next-generation pointer publication when `/run/d2b` has not yet been
+  materialized, while systemd-tmpfiles owns boot-time pointer creation and
+  activation continues to reject unsafe parent and leaf path types.
+
 - Fixed host-local realm daemon startup after `/etc/d2b` private bundle
   artifacts are materialized. Realm daemon users and services now carry the
   canonical `d2bd` supplementary group, preserving read access to

--- a/nixos-modules/store.nix
+++ b/nixos-modules/store.nix
@@ -793,9 +793,12 @@ in
     environment.systemPackages = [ spectrumCh ];
 
     systemd.tmpfiles.rules =
-      lib.mapAttrsToList
-        (name: _: "d /run/d2b/${name} 0755 root root -")
-        normalNixosVms;
+      lib.concatLists (lib.mapAttrsToList
+        (name: gen: [
+          "d /run/d2b/${name} 0755 root root -"
+          "L+ /run/d2b/${name}/next-generation - - - - ${gen}"
+        ])
+        vmGenPaths);
 
     # Force every VM's nix-store share to point at its per-VM hardlink
     # farm instead of the host's full /nix/store. microvm.nix's
@@ -873,9 +876,11 @@ in
     # also tmpfiles-owned, but activation can run before tmpfiles has
     # materialised newly-declared VM leaves on the first switch that
     # introduces a VM, so this hook idempotently creates ONLY the leaf
-    # before updating the pointer. The daemon-native Rust StoreSync
-    # broker op is the canonical writer for store-view; activation must
-    # not build/sweep/activate per-VM store closures.
+    # before updating the pointer. On first boot, activation runs before
+    # tmpfiles and defers pointer publication to the matching L+ rule
+    # above. The daemon-native Rust StoreSync broker op is the canonical
+    # writer for store-view; activation must not build/sweep/activate
+    # per-VM store closures.
     #
     # /run/d2b is created by
     # host-daemon.nix tmpfiles (root:d2b 1770 with ACLs) under
@@ -885,26 +890,32 @@ in
     # ---------------------------------------------------------------------------
     system.activationScripts.d2bStoreSync = lib.stringAfter [ "specialfs" "users" ] ''
       set -u
-      ${lib.concatStringsSep "\n" (lib.mapAttrsToList
-        (name: gen: ''
-          if [ ! -d /run/d2b ]; then
-            echo "d2bStoreSync: /run/d2b parent missing; tmpfiles/host runtime posture did not run" >&2
-            exit 1
-          fi
-          if [ -L /run/d2b/${name} ]; then
-            echo "d2bStoreSync: refusing symlinked runtime leaf /run/d2b/${name}" >&2
-            exit 1
-          fi
-          if [ ! -e /run/d2b/${name} ]; then
-            mkdir /run/d2b/${name}
-          elif [ ! -d /run/d2b/${name} ]; then
-            echo "d2bStoreSync: refusing non-directory runtime leaf /run/d2b/${name}" >&2
-            exit 1
-          fi
-          ${activationHelper} enforce-dir-posture --path /run/d2b/${name} --uid 0 --gid 0 --mode 0755
-          ln -sfT ${gen} /run/d2b/${name}/next-generation
-        '')
-        vmGenPaths)}
+      if [ -L /run/d2b ]; then
+        echo "d2bStoreSync: refusing symlinked runtime parent /run/d2b" >&2
+        exit 1
+      elif [ ! -e /run/d2b ]; then
+        echo "d2bStoreSync: /run/d2b parent not materialized; deferring pointer publication to systemd-tmpfiles" >&2
+      elif [ ! -d /run/d2b ]; then
+        echo "d2bStoreSync: refusing non-directory runtime parent /run/d2b" >&2
+        exit 1
+      else
+        ${lib.concatStringsSep "\n" (lib.mapAttrsToList
+          (name: gen: ''
+            if [ -L /run/d2b/${name} ]; then
+              echo "d2bStoreSync: refusing symlinked runtime leaf /run/d2b/${name}" >&2
+              exit 1
+            fi
+            if [ ! -e /run/d2b/${name} ]; then
+              mkdir /run/d2b/${name}
+            elif [ ! -d /run/d2b/${name} ]; then
+              echo "d2bStoreSync: refusing non-directory runtime leaf /run/d2b/${name}" >&2
+              exit 1
+            fi
+            ${activationHelper} enforce-dir-posture --path /run/d2b/${name} --uid 0 --gid 0 --mode 0755
+            ln -sfT ${gen} /run/d2b/${name}/next-generation
+          '')
+          vmGenPaths)}
+      fi
     '';
 
     # ---------------------------------------------------------------------------

--- a/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
+++ b/tests/unit/nix/cases/activation-runtime-tmpfiles.nix
@@ -236,6 +236,17 @@ in
     ];
   };
 
+  "activation-runtime-tmpfiles/run-store-sync-pointer" = {
+    expr =
+      let
+        rules = rulesForPath "/run/d2b/corp-vm/next-generation";
+      in
+      builtins.length rules == 1
+      && lib.hasPrefix "L+ /run/d2b/corp-vm/next-generation - - - - /nix/store/" (lib.head rules)
+      && lib.hasSuffix "-d2b-corp-vm-generation" (lib.head rules);
+    expected = true;
+  };
+
   "activation-runtime-tmpfiles/gpu-dir" = {
     expr = !x86 || lib.all (rule: builtins.elem rule tmpfiles) [
       "d /run/d2b-gpu/corp-vm 0770 d2bd d2b -"
@@ -369,6 +380,18 @@ in
       && !(lib.hasInfix "chmod 0755 /run/d2b/corp-vm" storeSyncText)
       && !(lib.hasInfix "mkdir -p /run/d2b/corp-vm" storeSyncText)
       && !(lib.hasInfix "install -d -m 0755 -o root -g root /run/d2b/corp-vm" storeSyncText);
+    expected = true;
+  };
+
+  "activation-runtime-tmpfiles/store-sync-defers-missing-run-parent" = {
+    expr =
+      lib.hasInfix "if [ -L /run/d2b ]; then" storeSyncText
+      && lib.hasInfix "refusing symlinked runtime parent /run/d2b" storeSyncText
+      && lib.hasInfix "elif [ ! -e /run/d2b ]; then" storeSyncText
+      && lib.hasInfix "deferring pointer publication to systemd-tmpfiles" storeSyncText
+      && lib.hasInfix "elif [ ! -d /run/d2b ]; then" storeSyncText
+      && lib.hasInfix "refusing non-directory runtime parent /run/d2b" storeSyncText
+      && !(lib.hasInfix "parent missing; tmpfiles/host runtime posture did not run" storeSyncText);
     expected = true;
   };
 

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -16,6 +16,7 @@ activation-runtime-tmpfiles/role-acl-script-no-raw-runtime-dir-mutation
 activation-runtime-tmpfiles/run-guest-control-dir
 activation-runtime-tmpfiles/run-parent-mask-after-traversal-acls
 activation-runtime-tmpfiles/run-store-sync-dir
+activation-runtime-tmpfiles/run-store-sync-pointer
 activation-runtime-tmpfiles/runtime-posture-no-store-view-mkdir
 activation-runtime-tmpfiles/run-vm-dir
 activation-runtime-tmpfiles/run-vms-parent
@@ -25,6 +26,7 @@ activation-runtime-tmpfiles/storage-json-has-audio-lock-in-locks-dir
 activation-runtime-tmpfiles/storage-json-has-audio-state-dir
 activation-runtime-tmpfiles/storage-json-has-audio-state-file
 activation-runtime-tmpfiles/store-sync-creates-only-run-leaf
+activation-runtime-tmpfiles/store-sync-defers-missing-run-parent
 activation-runtime-tmpfiles/store-view-live-dir
 activation-runtime-tmpfiles/tpm-state-perms-tmpfiles-owned
 activation-runtime-tmpfiles/video-dir


### PR DESCRIPTION
## Change

- defer next-generation activation when `/run/d2b` is not yet materialized
- publish boot-time per-VM pointers through systemd-tmpfiles
- retain fail-closed parent/leaf path checks and pin regression coverage

## Validation

- `make test-nix-unit`
- KVM-backed `vmChecks.x86_64-linux.daemon-smoke`
- integrated downstream `make check`

## Review

- Unanimous multidisciplinary Wave 1 review after follow-up hardening.