### PR TITLE
unsafe-local: add same-UID helper runtime

### DIFF
--- a/.github/workflows/release-host-binaries.yml
+++ b/.github/workflows/release-host-binaries.yml
@@ -77,6 +77,7 @@ jobs:
           cargo build --release --package d2bd --manifest-path packages/Cargo.toml
           cargo build --release --package d2b --manifest-path packages/Cargo.toml
           cargo build --release --package d2b-wayland-proxy --manifest-path packages/Cargo.toml
+          cargo build --release --package d2b-unsafe-local-helper --manifest-path packages/Cargo.toml
           cargo build --release --bin d2b-activation-helper --package d2b-host --manifest-path packages/Cargo.toml
           cargo build --release --package d2b-priv-broker --manifest-path packages/d2b-priv-broker/Cargo.toml
 
@@ -85,6 +86,7 @@ jobs:
           cp packages/target/release/d2bd dist/bin/
           cp packages/target/release/d2b dist/bin/
           cp packages/target/release/d2b-wayland-proxy dist/bin/
+          cp packages/target/release/d2b-unsafe-local-helper dist/bin/
           cp packages/target/release/d2b-activation-helper dist/bin/
           cp packages/d2b-priv-broker/target/release/d2b-priv-broker dist/bin/
 
@@ -92,6 +94,7 @@ jobs:
             d2bd \
             d2b \
             d2b-wayland-proxy \
+            d2b-unsafe-local-helper \
             d2b-activation-helper \
             d2b-priv-broker
           do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,8 +100,8 @@ deprecations ship one minor release before removal.
 - Fixed unsafe-local launches stalling behind an idle control-socket read or
   racing systemd's asynchronous transient-unit property publication. Completed
   operations now wake the bounded control loop immediately, and scope identity
-  verification retries within a strict deadline without weakening mismatch
-  rejection.
+  verification reads cgroup identity from the scope interface and retries
+  within a strict deadline without weakening mismatch rejection.
 
 - Fixed first boot with d2b enabled. Store-sync activation now defers
   next-generation pointer publication when `/run/d2b` has not yet been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Added the same-UID unsafe-local runtime foundation: `d2bd` now owns the
+  bounded, peer-credential-authenticated helper socket and one-generation-per-
+  UID registry; eligible users receive a fail-closed global systemd user
+  service; and the new `d2b-unsafe-local-helper` copies the current user-manager
+  environment into verified transient scopes with bounded operation ledgers,
+  reconnect snapshots, exact InvocationID/cgroup adoption, and no graphical
+  direct-display fallback.
+
 - Added the provider-neutral launcher contract for realm workloads. Generic
   `launcher.items.<id>` entries can describe configured `exec` actions or
   persistent `shell` actions with item-owned names and icons; applications such

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Fixed unsafe-local operation responses stalling behind an idle control-socket
+  read. Completed helper operations now wake the bounded control loop
+  immediately without delaying daemon heartbeats or polling continuously.
+
 - Fixed first boot with d2b enabled. Store-sync activation now defers
   next-generation pointer publication when `/run/d2b` has not yet been
   materialized, while systemd-tmpfiles owns boot-time pointer creation and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,11 @@ deprecations ship one minor release before removal.
 
 - Fixed unsafe-local launches stalling behind an idle control-socket read or
   racing systemd's asynchronous transient-unit property publication. Completed
-  operations now wake the bounded control loop immediately, and scope identity
-  verification reads cgroup identity from the scope interface and retries
-  within a strict deadline without weakening mismatch rejection.
+  operations now wake both bounded control loops immediately; sockets are
+  created close-on-exec, writes are time-bounded, and receive buffers are reused.
+  The helper reuses one D-Bus connection with bounded method calls, while scope
+  identity verification reads cgroup identity from the scope interface and
+  retries within a strict deadline without weakening mismatch rejection.
 
 - Fixed first boot with d2b enabled. Store-sync activation now defers
   next-generation pointer publication when `/run/d2b` has not yet been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,11 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
-- Fixed unsafe-local operation responses stalling behind an idle control-socket
-  read. Completed helper operations now wake the bounded control loop
-  immediately without delaying daemon heartbeats or polling continuously.
+- Fixed unsafe-local launches stalling behind an idle control-socket read or
+  racing systemd's asynchronous transient-unit property publication. Completed
+  operations now wake the bounded control loop immediately, and scope identity
+  verification retries within a strict deadline without weakening mismatch
+  rejection.
 
 - Fixed first boot with d2b enabled. Store-sync activation now defers
   next-generation pointer publication when `/run/d2b` has not yet been

--- a/docs/reference/unsafe-local-provider.md
+++ b/docs/reference/unsafe-local-provider.md
@@ -4,8 +4,9 @@
 
 `unsafe-local` is an explicit realm workload provider for commands and
 persistent shells that run as the authenticated host user. It provides **no
-isolation boundary**. The contract is staged behind protocol features until the
-daemon/helper runtime is enabled.
+isolation boundary**. The helper connection and user-scope runtime are enabled
+for configured eligible users. Public workload launch and shell dispatch remain
+feature-negotiated until their provider routes are enabled.
 
 ## Nix options
 
@@ -110,6 +111,29 @@ limits. Operators may raise restrictive host limits independently; helper
 registration remains fail-closed if the effective per-socket requirement is not
 met.
 
+The globally installed `d2b-unsafe-local-helper.service` is a systemd user
+service. `ConditionGroup=d2b-unsafe-local` prevents users who are not allowed to
+access an enabled unsafe-local realm from registering or entering a restart
+loop. The helper connects outward; `d2bd` does not discover a user bus or
+impersonate a user. Both peers verify `SO_PEERCRED`, and a valid reconnect
+atomically supersedes the prior generation for that UID.
+
+For each operation the helper reads
+`org.freedesktop.systemd1.Manager.Environment` from the current user manager.
+It rejects malformed or oversized data rather than trimming it, clears the
+child's inherited environment, and copies the complete manager environment.
+Graphical operations additionally remove `DISPLAY` and require a proxy-owned
+`WAYLAND_DISPLAY`; if no proxy endpoint is ready, launch fails without a direct
+display fallback.
+
+Every launched process begins behind a blocked supervisor. The helper calls
+`StartTransientUnit`, verifies the returned scope's `InvocationID` and exact
+control-group identity, and only then releases the supervisor to start the
+child. Reconnect snapshots re-query that identity. An ambiguous scope is
+preserved and reported degraded rather than killed by PID, name, or a broad
+cgroup sweep. These scopes last only for the systemd user-manager lifetime;
+d2b does not enable lingering.
+
 Terminal data uses exactly one connected `AF_UNIX`
 `SOCK_STREAM` passed with `SCM_RIGHTS`; listeners, datagram sockets, zero fds,
 and multiple fds are rejected. The receiver requires
@@ -122,14 +146,13 @@ Every socket is created with `SOCK_CLOEXEC`, every other control or PTY fd uses
 `O_CLOEXEC`, and rights are received with `MSG_CMSG_CLOEXEC`. Only descriptors
 explicitly remapped for a child may survive `exec`.
 
-## Runtime observability staging
+## Runtime observability
 
-This contract-only stage freezes DTO, schema, redaction, and cardinality rules;
-it does not emit runtime events or metrics. The helper registration, scope,
-proxy, launcher, and shell lifecycle signals are implemented with their owning
-runtime paths. Those implementations must use bounded event kinds and result
-classes and must never expose uid, argv, environment, cwd, paths, PIDs, unit
-names, shell names, transcripts, or terminal bytes.
+Helper registration, reconnect, supersede, and stale events use bounded event
+kinds and result classes. Runtime signals never expose uid, argv, environment,
+cwd, paths, PIDs, unit names, shell names, transcripts, or terminal bytes.
+Scope, proxy, launcher, and shell signals follow the same rule as those provider
+routes become available.
 
 Generated schemas:
 

--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,17 @@
           doCheck = false;
           meta.mainProgram = "d2b-wayland-proxy";
         };
+        d2b-unsafe-local-helper = rustWorkspace {
+          pname = "d2b-unsafe-local-helper";
+          cargoBuildFlags = [
+            "--package"
+            "d2b-unsafe-local-helper"
+            "--bin"
+            "d2b-unsafe-local-helper"
+          ];
+          doCheck = false;
+          meta.mainProgram = "d2b-unsafe-local-helper";
+        };
 
         signoz = import ./pkgs/signoz { inherit pkgs; };
         signozOtelCollector = import ./pkgs/signoz-otel-collector { inherit pkgs; };

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -35,6 +35,7 @@
     ./network.nix
     ./gateway-vm.nix
     (import ./host.nix { inherit inputs; })
+    ./unsafe-local-helper.nix
     # host-otel-relay-acl.nix retired per ADR 0018.
     # The OTel host-bridge + per-VM relay ACL contract moved into the
     # broker pre-spawn pipeline (`SpawnRunner{role: OtelHostBridge}`

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -88,6 +88,15 @@ EOF
     cfg.vms);
   hostLocalRealms =
     lib.filter (realm: realm.placement == "host-local") cfg._index.realms.enabledList;
+  unsafeLocalRealms = lib.filter
+    (realm:
+      lib.any
+        (workload: workload.enable && workload.kind == "unsafe-local")
+        realm.workloads)
+    cfg._index.realms.enabledList;
+  unsafeLocalHelperUsers = lib.sort lib.lessThan
+    (lib.unique (lib.concatMap (realm: realm.allowedUsers) unsafeLocalRealms));
+  unsafeLocalHelperEnabled = unsafeLocalHelperUsers != [ ];
   brokerMaterializedFor = realm:
     realm.controller.broker.materializedSocket && realm.controller.broker.materializedService;
   serviceAttrName = unitName: lib.removeSuffix ".service" unitName;
@@ -198,6 +207,11 @@ EOF
     daemonUser = "d2bd";
     daemonGroup = "d2bd";
     publicSocketGroup = "d2b";
+    unsafeLocalHelperSocketPath =
+      if unsafeLocalHelperEnabled then "/run/d2b/unsafe-local-helper.sock" else null;
+    unsafeLocalHelperSocketGroup =
+      if unsafeLocalHelperEnabled then "d2b-unsafe-local" else null;
+    inherit unsafeLocalHelperUsers;
     launcherUsers = cfg.site.launcherUsers;
     adminUsers = cfg.site.adminUsers;
     serverVersion = "0.4.0";
@@ -224,6 +238,9 @@ EOF
     daemonUser = realm.controller.daemon.user;
     daemonGroup = realm.controller.daemon.group;
     publicSocketGroup = realm.controller.daemon.publicSocketGroup;
+    unsafeLocalHelperSocketPath = null;
+    unsafeLocalHelperSocketGroup = null;
+    unsafeLocalHelperUsers = [ ];
     launcherUsers = realm.allowedUsers;
     adminUsers = cfg.site.adminUsers;
     serverVersion = "0.4.0";
@@ -441,7 +458,7 @@ in
         # supplementary). The daemon failed at startup with
         # "internal-io" when chown(public.sock, -1, 1000)
         # returned EPERM.
-        extraGroups = [ "d2b" ];
+        extraGroups = [ "d2b" ] ++ lib.optional unsafeLocalHelperEnabled "d2b-unsafe-local";
       };
     };
 
@@ -500,6 +517,9 @@ in
       "z /run/d2b 1770 root d2b -"
       "a+ /run/d2b - - - - g::r-x"
       "a+ /run/d2b - - - - u:d2bd:rwx"
+    ] ++ lib.optional unsafeLocalHelperEnabled
+      "a+ /run/d2b - - - - g:d2b-unsafe-local:r-x"
+    ++ [
       "a+ /run/d2b - - - - m::rwx"
       "f /run/d2b/daemon.lock 0640 d2bd d2bd -"
       # /run/d2b/locks holds per-VM `flock(LOCK_EX |
@@ -586,7 +606,8 @@ in
         # the public socket group; this SupplementaryGroups entry
         # gives the systemd unit's primary uid the second gid it
         # needs to chgrp the socket.
-        SupplementaryGroups = [ "d2b" ];
+        SupplementaryGroups =
+          [ "d2b" ] ++ lib.optional unsafeLocalHelperEnabled "d2b-unsafe-local";
       };
       };
     } // realmDaemonServices;

--- a/nixos-modules/options-gateway.nix
+++ b/nixos-modules/options-gateway.nix
@@ -26,6 +26,13 @@ in
       description = "Internal: resolved host d2bd package.";
     };
 
+    d2bUnsafeLocalHelper = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      internal = true;
+      description = "Internal: resolved same-uid unsafe-local user helper package.";
+    };
+
     d2bGatewayRuntime = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
       default = null;

--- a/nixos-modules/unsafe-local-helper.nix
+++ b/nixos-modules/unsafe-local-helper.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.d2b;
+  d2bLib = import ./lib.nix { inherit lib; };
+  prebuilt =
+    if cfg.site.usePrebuiltHostTools
+    then import ./prebuilt-packages.nix { inherit pkgs lib; }
+    else { };
+  packagesSrc = d2bLib.cleanRustPackagesSource ../packages;
+  sourcePackage = pkgs.rustPlatform.buildRustPackage {
+    pname = "d2b-unsafe-local-helper";
+    version = "0.0.0-bootstrap";
+    src = packagesSrc;
+    cargoLock = {
+      lockFile = ../packages/Cargo.lock;
+      outputHashes."wl-proxy-0.1.2" = "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
+    };
+    cargoBuildFlags = [ "--package" "d2b-unsafe-local-helper" ];
+    doCheck = false;
+    postPatch = ''
+      mkdir -p .cargo
+      cat > .cargo/config.toml <<EOF
+[build]
+rustc-wrapper = ""
+EOF
+      rm -f .cargo/rustc-wrapper.sh
+    '';
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 target/x86_64-unknown-linux-gnu/release/d2b-unsafe-local-helper \
+        $out/bin/d2b-unsafe-local-helper 2>/dev/null \
+        || install -Dm755 target/release/d2b-unsafe-local-helper \
+          $out/bin/d2b-unsafe-local-helper
+      runHook postInstall
+    '';
+  };
+  helperPackage =
+    if prebuilt != null && prebuilt ? "d2b-unsafe-local-helper"
+    then prebuilt."d2b-unsafe-local-helper"
+    else sourcePackage;
+  unsafeLocalRealms = lib.filter
+    (realm:
+      lib.any
+        (workload: workload.enable && workload.kind == "unsafe-local")
+        realm.workloads)
+    cfg._index.realms.enabledList;
+  eligibleUsers = lib.sort lib.lessThan
+    (lib.unique (lib.concatMap (realm: realm.allowedUsers) unsafeLocalRealms));
+in
+{
+  config = lib.mkIf cfg.daemonExperimental.enable {
+    users.groups.d2b-unsafe-local = { };
+    users.users = lib.genAttrs eligibleUsers (_: {
+      extraGroups = [ "d2b-unsafe-local" ];
+    });
+
+    d2b._hostToolPackages.d2bUnsafeLocalHelper = helperPackage;
+    environment.systemPackages = [ helperPackage ];
+
+    systemd.user.services.d2b-unsafe-local-helper = {
+      description = "d2b same-uid unsafe-local runtime helper";
+      wantedBy = [ "default.target" ];
+      unitConfig.ConditionGroup = "d2b-unsafe-local";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${helperPackage}/bin/d2b-unsafe-local-helper";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        Slice = "app.slice";
+      };
+    };
+  };
+}

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1141,6 +1141,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "d2b-unsafe-local-helper"
+version = "0.0.0-bootstrap"
+dependencies = [
+ "clap",
+ "d2b-contracts",
+ "d2b-core",
+ "d2b-realm-core",
+ "getrandom 0.2.17",
+ "nix 0.29.0",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "uzers",
+ "zbus",
+]
+
+[[package]]
 name = "d2b-userd"
 version = "0.0.0-bootstrap"
 dependencies = [

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "d2b-host",
     "d2b-guestd",
     "d2b-userd",
+    "d2b-unsafe-local-helper",
     "d2b-exec-runner",
     "d2b-sk-frontend",
     "d2b-contracts",

--- a/packages/d2b-unsafe-local-helper/Cargo.toml
+++ b/packages/d2b-unsafe-local-helper/Cargo.toml
@@ -15,7 +15,7 @@ d2b-contracts = { path = "../d2b-contracts", version = "0.0.0-bootstrap" }
 d2b-core = { path = "../d2b-core", version = "0.0.0-bootstrap" }
 d2b-realm-core = { path = "../d2b-realm-core", version = "0.0.0-bootstrap" }
 getrandom = "0.2"
-nix = { version = "0.29", features = ["fs", "socket", "uio", "user", "signal", "process"] }
+nix = { version = "0.29", features = ["fs", "poll", "socket", "uio", "user", "signal", "process"] }
 serde.workspace = true
 serde_json.workspace = true
 socket2 = "0.5"

--- a/packages/d2b-unsafe-local-helper/Cargo.toml
+++ b/packages/d2b-unsafe-local-helper/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "d2b-unsafe-local-helper"
+version = "0.0.0-bootstrap"
+edition = "2024"
+publish = false
+license.workspace = true
+description = "Same-uid user-session runtime helper for d2b unsafe-local workloads"
+
+[lints]
+workspace = true
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+d2b-contracts = { path = "../d2b-contracts", version = "0.0.0-bootstrap" }
+d2b-core = { path = "../d2b-core", version = "0.0.0-bootstrap" }
+d2b-realm-core = { path = "../d2b-realm-core", version = "0.0.0-bootstrap" }
+getrandom = "0.2"
+nix = { version = "0.29", features = ["fs", "socket", "uio", "user", "signal", "process"] }
+serde.workspace = true
+serde_json.workspace = true
+socket2 = "0.5"
+uzers = "0.12"
+zbus = { version = "5.16", features = ["blocking-api"] }

--- a/packages/d2b-unsafe-local-helper/src/environment.rs
+++ b/packages/d2b-unsafe-local-helper/src/environment.rs
@@ -1,0 +1,202 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+pub const MAX_MANAGER_ENVIRONMENT_ENTRIES: usize = 4096;
+pub const MAX_MANAGER_ENVIRONMENT_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvironmentError {
+    TooManyEntries,
+    TooLarge,
+    InvalidEntry,
+    DuplicateKey,
+    PathMissing,
+    ExecutableUnavailable,
+    ProxyUnavailable,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ManagerEnvironment {
+    entries: BTreeMap<String, String>,
+    encoded_bytes: usize,
+}
+
+impl fmt::Debug for ManagerEnvironment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ManagerEnvironment")
+            .field("entry_count", &self.entries.len())
+            .field("encoded_bytes", &self.encoded_bytes)
+            .finish()
+    }
+}
+
+impl ManagerEnvironment {
+    pub fn parse(raw: Vec<String>) -> Result<Self, EnvironmentError> {
+        if raw.len() > MAX_MANAGER_ENVIRONMENT_ENTRIES {
+            return Err(EnvironmentError::TooManyEntries);
+        }
+        let encoded_bytes = raw.iter().try_fold(0usize, |total, entry| {
+            total
+                .checked_add(entry.len())
+                .and_then(|value| value.checked_add(1))
+                .ok_or(EnvironmentError::TooLarge)
+        })?;
+        if encoded_bytes > MAX_MANAGER_ENVIRONMENT_BYTES {
+            return Err(EnvironmentError::TooLarge);
+        }
+
+        let mut entries = BTreeMap::new();
+        for entry in raw {
+            let (key, value) = entry
+                .split_once('=')
+                .ok_or(EnvironmentError::InvalidEntry)?;
+            if !valid_key(key) || value.contains('\0') {
+                return Err(EnvironmentError::InvalidEntry);
+            }
+            if entries.insert(key.to_owned(), value.to_owned()).is_some() {
+                return Err(EnvironmentError::DuplicateKey);
+            }
+        }
+        Ok(Self {
+            entries,
+            encoded_bytes,
+        })
+    }
+
+    pub fn child_entries(
+        &self,
+        graphical: bool,
+        proxy_wayland_display: Option<&str>,
+    ) -> Result<BTreeMap<String, String>, EnvironmentError> {
+        let mut entries = self.entries.clone();
+        if graphical {
+            let display = proxy_wayland_display.ok_or(EnvironmentError::ProxyUnavailable)?;
+            if display.is_empty() || display.contains('\0') || display.contains('/') {
+                return Err(EnvironmentError::ProxyUnavailable);
+            }
+            entries.remove("DISPLAY");
+            entries.insert("WAYLAND_DISPLAY".to_owned(), display.to_owned());
+        }
+        Ok(entries)
+    }
+
+    pub fn path(&self) -> Result<&str, EnvironmentError> {
+        self.entries
+            .get("PATH")
+            .map(String::as_str)
+            .filter(|path| !path.is_empty())
+            .ok_or(EnvironmentError::PathMissing)
+    }
+
+    pub fn state_home(&self, passwd_home: &Path) -> PathBuf {
+        self.entries
+            .get("XDG_STATE_HOME")
+            .filter(|value| value.starts_with('/') && !value.contains('\0'))
+            .map(PathBuf::from)
+            .unwrap_or_else(|| passwd_home.join(".local/state"))
+    }
+
+    pub fn resolve_program(&self, program: &str) -> Result<PathBuf, EnvironmentError> {
+        if program.is_empty() || program.contains('\0') {
+            return Err(EnvironmentError::ExecutableUnavailable);
+        }
+        if program.contains('/') {
+            let path = PathBuf::from(program);
+            return executable_file(&path)
+                .then_some(path)
+                .ok_or(EnvironmentError::ExecutableUnavailable);
+        }
+
+        let mut seen = BTreeSet::new();
+        for directory in self.path()?.split(':') {
+            if directory.is_empty() || !directory.starts_with('/') || !seen.insert(directory) {
+                continue;
+            }
+            let candidate = Path::new(directory).join(program);
+            if executable_file(&candidate) {
+                return Ok(candidate);
+            }
+        }
+        Err(EnvironmentError::ExecutableUnavailable)
+    }
+}
+
+fn valid_key(key: &str) -> bool {
+    let mut bytes = key.bytes();
+    matches!(bytes.next(), Some(first) if first == b'_' || first.is_ascii_alphabetic())
+        && bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+}
+
+fn executable_file(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manager_environment_is_complete_and_debug_redacted() {
+        let canary = "environment-value-canary";
+        let environment = ManagerEnvironment::parse(vec![
+            "PATH=/run/current-system/sw/bin".to_owned(),
+            format!("PRIVATE_VALUE={canary}"),
+            "DISPLAY=:0".to_owned(),
+            "WAYLAND_DISPLAY=wayland-1".to_owned(),
+        ])
+        .unwrap();
+        let debug = format!("{environment:?}");
+        assert!(!debug.contains(canary));
+        assert!(!debug.contains("PRIVATE_VALUE"));
+
+        let child = environment.child_entries(false, None).unwrap();
+        assert_eq!(child.get("PRIVATE_VALUE").map(String::as_str), Some(canary));
+        assert_eq!(child.get("DISPLAY").map(String::as_str), Some(":0"));
+        assert_eq!(
+            child.get("WAYLAND_DISPLAY").map(String::as_str),
+            Some("wayland-1")
+        );
+    }
+
+    #[test]
+    fn graphical_environment_never_falls_back_to_real_display() {
+        let environment = ManagerEnvironment::parse(vec![
+            "PATH=/bin".to_owned(),
+            "DISPLAY=:0".to_owned(),
+            "WAYLAND_DISPLAY=wayland-real".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(
+            environment.child_entries(true, None),
+            Err(EnvironmentError::ProxyUnavailable)
+        );
+        let child = environment
+            .child_entries(true, Some("d2b-wayland-proxy-1"))
+            .unwrap();
+        assert!(!child.contains_key("DISPLAY"));
+        assert_eq!(
+            child.get("WAYLAND_DISPLAY").map(String::as_str),
+            Some("d2b-wayland-proxy-1")
+        );
+    }
+
+    #[test]
+    fn malformed_or_ambiguous_environment_fails_closed() {
+        assert_eq!(
+            ManagerEnvironment::parse(vec!["NO_EQUALS".to_owned()]),
+            Err(EnvironmentError::InvalidEntry)
+        );
+        assert_eq!(
+            ManagerEnvironment::parse(vec!["A=1".to_owned(), "A=2".to_owned()]),
+            Err(EnvironmentError::DuplicateKey)
+        );
+        assert_eq!(
+            ManagerEnvironment::parse(vec!["1BAD=value".to_owned()]),
+            Err(EnvironmentError::InvalidEntry)
+        );
+    }
+}

--- a/packages/d2b-unsafe-local-helper/src/lib.rs
+++ b/packages/d2b-unsafe-local-helper/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod environment;
+pub mod protocol;
+pub mod runtime;
+pub mod systemd;

--- a/packages/d2b-unsafe-local-helper/src/main.rs
+++ b/packages/d2b-unsafe-local-helper/src/main.rs
@@ -1,0 +1,42 @@
+use clap::{Parser, Subcommand};
+use d2b_unsafe_local_helper::protocol::{HelperClient, default_helper_socket_path};
+use d2b_unsafe_local_helper::runtime::{ScopeRuntime, run_scope_supervisor};
+use d2b_unsafe_local_helper::systemd::SystemdUserScopeManager;
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+#[command(name = "d2b-unsafe-local-helper")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+    #[arg(long, default_value_os_t = default_helper_socket_path().to_path_buf())]
+    socket: PathBuf,
+    #[arg(long, default_value = "d2bd")]
+    daemon_user: String,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    #[command(hide = true)]
+    ScopeSupervisor,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let result = match cli.command {
+        Some(Command::ScopeSupervisor) => {
+            run_scope_supervisor().map_err(|_| "scope runtime failed")
+        }
+        None => ScopeRuntime::new(SystemdUserScopeManager)
+            .map_err(|_| "helper runtime unavailable")
+            .and_then(|runtime| {
+                HelperClient::new(cli.socket, &cli.daemon_user, runtime)
+                    .map_err(|_| "helper registration failed")
+            })
+            .and_then(|client| client.run().map_err(|_| "helper connection failed")),
+    };
+    if let Err(message) = result {
+        eprintln!("{message}");
+        std::process::exit(1);
+    }
+}

--- a/packages/d2b-unsafe-local-helper/src/main.rs
+++ b/packages/d2b-unsafe-local-helper/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
         Some(Command::ScopeSupervisor) => {
             run_scope_supervisor().map_err(|_| "scope runtime failed")
         }
-        None => ScopeRuntime::new(SystemdUserScopeManager)
+        None => ScopeRuntime::new(SystemdUserScopeManager::new())
             .map_err(|_| "helper runtime unavailable")
             .and_then(|runtime| {
                 HelperClient::new(cli.socket, &cli.daemon_user, runtime)

--- a/packages/d2b-unsafe-local-helper/src/protocol.rs
+++ b/packages/d2b-unsafe-local-helper/src/protocol.rs
@@ -11,21 +11,20 @@ use d2b_realm_core::ids::OperationId;
 use nix::cmsg_space;
 use nix::fcntl::{FcntlArg, FdFlag, fcntl};
 use nix::libc;
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use nix::sys::socket::{
     ControlMessageOwned, MsgFlags, UnixAddr, getsockopt, recvmsg, send, sockopt::PeerCredentials,
 };
 use nix::unistd;
 use socket2::{Domain, SockAddr, Socket, Type};
 use std::fmt;
-use std::io::IoSliceMut;
-use std::os::fd::{AsRawFd, RawFd};
+use std::io::{IoSliceMut, Read, Write};
+use std::os::fd::{AsFd, AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, mpsc};
-use std::time::Duration;
 use uzers::get_user_by_name;
-
-const CONTROL_READ_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProtocolError {
@@ -117,22 +116,25 @@ impl<M: UserScopeManager> HelperClient<M> {
             .map_err(|_| ProtocolError::RuntimeUnavailable)?;
         send_frame(&socket, &UnsafeLocalHelperToDaemon::Snapshot(snapshot))?;
 
-        socket
-            .set_read_timeout(Some(CONTROL_READ_TIMEOUT))
+        let (response_wakeup_read, response_wakeup_write) =
+            UnixStream::pair().map_err(|_| ProtocolError::RuntimeUnavailable)?;
+        response_wakeup_read
+            .set_nonblocking(true)
             .map_err(|_| ProtocolError::ConnectFailed)?;
         let (responses_tx, responses_rx) =
             mpsc::sync_channel::<UnsafeLocalHelperToDaemon>(MAX_HELPER_QUEUE_DEPTH);
+        let response_wakeup_write = Arc::new(response_wakeup_write);
         let active = Arc::new(AtomicUsize::new(0));
 
         loop {
             while let Ok(response) = responses_rx.try_recv() {
                 send_frame(&socket, &response)?;
             }
-            let frame: DaemonToUnsafeLocalHelper = match receive_frame(&socket) {
-                Ok(frame) => frame,
-                Err(ProtocolError::ConnectFailed) => continue,
-                Err(error) => return Err(error),
-            };
+            match wait_for_control_or_response(&socket, &response_wakeup_read)? {
+                ControlEvent::Response => continue,
+                ControlEvent::Control => {}
+            }
+            let frame: DaemonToUnsafeLocalHelper = receive_frame(&socket)?;
             match frame {
                 DaemonToUnsafeLocalHelper::Heartbeat(heartbeat) => {
                     if heartbeat.generation != generation {
@@ -159,6 +161,7 @@ impl<M: UserScopeManager> HelperClient<M> {
                     }
                     let runtime = Arc::clone(&self.runtime);
                     let responses = responses_tx.clone();
+                    let response_wakeup = Arc::clone(&response_wakeup_write);
                     let active = Arc::clone(&active);
                     std::thread::Builder::new()
                         .name("d2b-unsafe-local-operation".to_owned())
@@ -171,7 +174,9 @@ impl<M: UserScopeManager> HelperClient<M> {
                                     rejection(request_id, operation_id, failure_code(error))
                                 }
                             };
-                            let _ = responses.try_send(response);
+                            if responses.send(response).is_ok() {
+                                let _ = wake_response_loop(&response_wakeup);
+                            }
                             active.fetch_sub(1, Ordering::AcqRel);
                         })
                         .map_err(|_| ProtocolError::RuntimeUnavailable)?;
@@ -192,6 +197,69 @@ impl<M: UserScopeManager> HelperClient<M> {
                     return Err(ProtocolError::ProtocolMismatch);
                 }
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ControlEvent {
+    Control,
+    Response,
+}
+
+fn wait_for_control_or_response(
+    socket: &Socket,
+    response_wakeup: &UnixStream,
+) -> Result<ControlEvent, ProtocolError> {
+    let interests = PollFlags::POLLIN | PollFlags::POLLERR | PollFlags::POLLHUP;
+    let mut fds = [
+        PollFd::new(socket.as_fd(), interests),
+        PollFd::new(response_wakeup.as_fd(), interests),
+    ];
+    loop {
+        match poll(&mut fds, PollTimeout::NONE) {
+            Ok(_) => break,
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(_) => return Err(ProtocolError::ConnectFailed),
+        }
+    }
+
+    let response_events = fds[1].revents().unwrap_or(PollFlags::empty());
+    if response_events.intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL) {
+        return Err(ProtocolError::QueueClosed);
+    }
+    if response_events.contains(PollFlags::POLLIN) {
+        drain_response_wakeup(response_wakeup)?;
+        return Ok(ControlEvent::Response);
+    }
+
+    let control_events = fds[0].revents().unwrap_or(PollFlags::empty());
+    if control_events.intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL) {
+        return Err(ProtocolError::ConnectFailed);
+    }
+    if control_events.contains(PollFlags::POLLIN) {
+        return Ok(ControlEvent::Control);
+    }
+    Err(ProtocolError::ConnectFailed)
+}
+
+fn wake_response_loop(response_wakeup: &UnixStream) -> Result<(), ProtocolError> {
+    let mut response_wakeup = response_wakeup;
+    response_wakeup
+        .write_all(&[1])
+        .map_err(|_| ProtocolError::QueueClosed)
+}
+
+fn drain_response_wakeup(response_wakeup: &UnixStream) -> Result<(), ProtocolError> {
+    let mut response_wakeup = response_wakeup;
+    let mut buffer = [0u8; MAX_HELPER_QUEUE_DEPTH];
+    loop {
+        match response_wakeup.read(&mut buffer) {
+            Ok(0) => return Err(ProtocolError::QueueClosed),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => return Err(ProtocolError::QueueClosed),
         }
     }
 }
@@ -393,5 +461,26 @@ mod tests {
 
     fn socket_from_owned(fd: OwnedFd) -> Socket {
         Socket::from(fd)
+    }
+
+    #[test]
+    fn completed_operation_wakes_idle_control_loop() {
+        let (control, _peer) = socketpair(
+            AddressFamily::Unix,
+            SockType::SeqPacket,
+            None,
+            SockFlag::SOCK_CLOEXEC,
+        )
+        .unwrap();
+        let control = socket_from_owned(control);
+        let (wakeup_read, wakeup_write) = UnixStream::pair().unwrap();
+        wakeup_read.set_nonblocking(true).unwrap();
+
+        wake_response_loop(&wakeup_write).unwrap();
+
+        assert_eq!(
+            wait_for_control_or_response(&control, &wakeup_read).unwrap(),
+            ControlEvent::Response
+        );
     }
 }

--- a/packages/d2b-unsafe-local-helper/src/protocol.rs
+++ b/packages/d2b-unsafe-local-helper/src/protocol.rs
@@ -1,0 +1,397 @@
+use crate::runtime::{RuntimeError, ScopeRuntime};
+use crate::systemd::UserScopeManager;
+use d2b_contracts::UNSAFE_LOCAL_HELPER_SOCKET_PATH;
+use d2b_contracts::unsafe_local_wire::{
+    DaemonToUnsafeLocalHelper, HELPER_SOCKET_BUFFER_REQUEST_BYTES, HelperFailureCode,
+    HelperHeartbeat, HelperHello, HelperOperationRejected, MAX_HELPER_FRAME_SIZE,
+    MAX_HELPER_QUEUE_DEPTH, MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES,
+    UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION, UnsafeLocalHelperToDaemon,
+};
+use d2b_realm_core::ids::OperationId;
+use nix::cmsg_space;
+use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+use nix::libc;
+use nix::sys::socket::{
+    ControlMessageOwned, MsgFlags, UnixAddr, getsockopt, recvmsg, send, sockopt::PeerCredentials,
+};
+use nix::unistd;
+use socket2::{Domain, SockAddr, Socket, Type};
+use std::fmt;
+use std::io::IoSliceMut;
+use std::os::fd::{AsRawFd, RawFd};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, mpsc};
+use std::time::Duration;
+use uzers::get_user_by_name;
+
+const CONTROL_READ_TIMEOUT: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtocolError {
+    InvalidIdentity,
+    ConnectFailed,
+    PeerCredentialMismatch,
+    BufferTooSmall,
+    InvalidFrame,
+    FrameTooLarge,
+    ProtocolMismatch,
+    GenerationMismatch,
+    QueueClosed,
+    RuntimeUnavailable,
+}
+
+pub struct HelperClient<M: UserScopeManager> {
+    socket_path: PathBuf,
+    expected_daemon_uid: u32,
+    runtime: Arc<ScopeRuntime<M>>,
+}
+
+impl<M: UserScopeManager> fmt::Debug for HelperClient<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperClient")
+            .field("socket_path", &"<redacted>")
+            .field("expected_daemon_uid", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M: UserScopeManager> HelperClient<M> {
+    pub fn new(
+        socket_path: impl Into<PathBuf>,
+        daemon_user: &str,
+        runtime: ScopeRuntime<M>,
+    ) -> Result<Self, ProtocolError> {
+        let daemon = get_user_by_name(daemon_user).ok_or(ProtocolError::InvalidIdentity)?;
+        if daemon.uid() == 0 {
+            return Err(ProtocolError::InvalidIdentity);
+        }
+        Ok(Self {
+            socket_path: socket_path.into(),
+            expected_daemon_uid: daemon.uid(),
+            runtime: Arc::new(runtime),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn with_daemon_uid(
+        socket_path: impl Into<PathBuf>,
+        expected_daemon_uid: u32,
+        runtime: ScopeRuntime<M>,
+    ) -> Result<Self, ProtocolError> {
+        if expected_daemon_uid == 0 {
+            return Err(ProtocolError::InvalidIdentity);
+        }
+        Ok(Self {
+            socket_path: socket_path.into(),
+            expected_daemon_uid,
+            runtime: Arc::new(runtime),
+        })
+    }
+
+    pub fn run(&self) -> Result<(), ProtocolError> {
+        let socket = connect_control_socket(&self.socket_path, self.expected_daemon_uid)?;
+        let generation = random_generation()?;
+        send_frame(
+            &socket,
+            &UnsafeLocalHelperToDaemon::Hello(HelperHello {
+                protocol_version: UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION,
+                generation,
+                features: Vec::new(),
+            }),
+        )?;
+
+        let accepted: DaemonToUnsafeLocalHelper = receive_frame(&socket)?;
+        match accepted {
+            DaemonToUnsafeLocalHelper::HelloAccepted(accepted)
+                if accepted.protocol_version == UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION
+                    && accepted.generation == generation => {}
+            DaemonToUnsafeLocalHelper::HelloAccepted(_) => {
+                return Err(ProtocolError::GenerationMismatch);
+            }
+            _ => return Err(ProtocolError::ProtocolMismatch),
+        }
+        let snapshot = self
+            .runtime
+            .snapshot(generation)
+            .map_err(|_| ProtocolError::RuntimeUnavailable)?;
+        send_frame(&socket, &UnsafeLocalHelperToDaemon::Snapshot(snapshot))?;
+
+        socket
+            .set_read_timeout(Some(CONTROL_READ_TIMEOUT))
+            .map_err(|_| ProtocolError::ConnectFailed)?;
+        let (responses_tx, responses_rx) =
+            mpsc::sync_channel::<UnsafeLocalHelperToDaemon>(MAX_HELPER_QUEUE_DEPTH);
+        let active = Arc::new(AtomicUsize::new(0));
+
+        loop {
+            while let Ok(response) = responses_rx.try_recv() {
+                send_frame(&socket, &response)?;
+            }
+            let frame: DaemonToUnsafeLocalHelper = match receive_frame(&socket) {
+                Ok(frame) => frame,
+                Err(ProtocolError::ConnectFailed) => continue,
+                Err(error) => return Err(error),
+            };
+            match frame {
+                DaemonToUnsafeLocalHelper::Heartbeat(heartbeat) => {
+                    if heartbeat.generation != generation {
+                        return Err(ProtocolError::GenerationMismatch);
+                    }
+                    send_frame(
+                        &socket,
+                        &UnsafeLocalHelperToDaemon::Heartbeat(HelperHeartbeat {
+                            generation,
+                            sequence: heartbeat.sequence,
+                        }),
+                    )?;
+                }
+                DaemonToUnsafeLocalHelper::Launch(request) => {
+                    if active.fetch_add(1, Ordering::AcqRel) >= MAX_HELPER_QUEUE_DEPTH {
+                        active.fetch_sub(1, Ordering::AcqRel);
+                        let rejected = rejection(
+                            request.request_id,
+                            request.operation_id,
+                            HelperFailureCode::QueueFull,
+                        );
+                        send_frame(&socket, &rejected)?;
+                        continue;
+                    }
+                    let runtime = Arc::clone(&self.runtime);
+                    let responses = responses_tx.clone();
+                    let active = Arc::clone(&active);
+                    std::thread::Builder::new()
+                        .name("d2b-unsafe-local-operation".to_owned())
+                        .spawn(move || {
+                            let request_id = request.request_id;
+                            let operation_id = request.operation_id.clone();
+                            let response = match runtime.launch(request) {
+                                Ok(result) => UnsafeLocalHelperToDaemon::Operation(result),
+                                Err(error) => {
+                                    rejection(request_id, operation_id, failure_code(error))
+                                }
+                            };
+                            let _ = responses.try_send(response);
+                            active.fetch_sub(1, Ordering::AcqRel);
+                        })
+                        .map_err(|_| ProtocolError::RuntimeUnavailable)?;
+                }
+                DaemonToUnsafeLocalHelper::Shell(request) => {
+                    if let Some((request_id, operation_id)) = shell_operation_identity(request) {
+                        send_frame(
+                            &socket,
+                            &rejection(
+                                request_id,
+                                operation_id,
+                                HelperFailureCode::ShellUnavailable,
+                            ),
+                        )?;
+                    }
+                }
+                DaemonToUnsafeLocalHelper::HelloAccepted(_) => {
+                    return Err(ProtocolError::ProtocolMismatch);
+                }
+            }
+        }
+    }
+}
+
+pub fn default_helper_socket_path() -> &'static Path {
+    Path::new(UNSAFE_LOCAL_HELPER_SOCKET_PATH)
+}
+
+fn connect_control_socket(path: &Path, expected_daemon_uid: u32) -> Result<Socket, ProtocolError> {
+    let socket = Socket::new(Domain::UNIX, Type::from(libc::SOCK_SEQPACKET), None)
+        .map_err(|_| ProtocolError::ConnectFailed)?;
+    mark_cloexec(&socket)?;
+    configure_socket_buffers(&socket)?;
+    let address = SockAddr::unix(path).map_err(|_| ProtocolError::ConnectFailed)?;
+    socket
+        .connect(&address)
+        .map_err(|_| ProtocolError::ConnectFailed)?;
+    let peer =
+        getsockopt(&socket, PeerCredentials).map_err(|_| ProtocolError::PeerCredentialMismatch)?;
+    if peer.uid() as u32 != expected_daemon_uid || peer.uid() == 0 {
+        return Err(ProtocolError::PeerCredentialMismatch);
+    }
+    Ok(socket)
+}
+
+pub fn configure_socket_buffers(socket: &Socket) -> Result<(), ProtocolError> {
+    socket
+        .set_send_buffer_size(HELPER_SOCKET_BUFFER_REQUEST_BYTES)
+        .map_err(|_| ProtocolError::BufferTooSmall)?;
+    socket
+        .set_recv_buffer_size(HELPER_SOCKET_BUFFER_REQUEST_BYTES)
+        .map_err(|_| ProtocolError::BufferTooSmall)?;
+    let send_size = socket
+        .send_buffer_size()
+        .map_err(|_| ProtocolError::BufferTooSmall)?;
+    let recv_size = socket
+        .recv_buffer_size()
+        .map_err(|_| ProtocolError::BufferTooSmall)?;
+    if send_size < MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES
+        || recv_size < MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES
+    {
+        return Err(ProtocolError::BufferTooSmall);
+    }
+    Ok(())
+}
+
+fn mark_cloexec(socket: &Socket) -> Result<(), ProtocolError> {
+    fcntl(socket.as_raw_fd(), FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))
+        .map_err(|_| ProtocolError::ConnectFailed)?;
+    Ok(())
+}
+
+pub fn send_frame<T: serde::Serialize>(socket: &Socket, frame: &T) -> Result<(), ProtocolError> {
+    let payload = serde_json::to_vec(frame).map_err(|_| ProtocolError::InvalidFrame)?;
+    if payload.len() > MAX_HELPER_FRAME_SIZE {
+        return Err(ProtocolError::FrameTooLarge);
+    }
+    let length = u32::try_from(payload.len()).map_err(|_| ProtocolError::FrameTooLarge)?;
+    let mut encoded = Vec::with_capacity(payload.len() + 4);
+    encoded.extend_from_slice(&length.to_le_bytes());
+    encoded.extend_from_slice(&payload);
+    let sent = send(socket.as_raw_fd(), &encoded, MsgFlags::MSG_NOSIGNAL)
+        .map_err(|_| ProtocolError::ConnectFailed)?;
+    if sent != encoded.len() {
+        return Err(ProtocolError::InvalidFrame);
+    }
+    Ok(())
+}
+
+pub fn receive_frame<T: serde::de::DeserializeOwned>(socket: &Socket) -> Result<T, ProtocolError> {
+    let mut encoded = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
+    let mut iov = [IoSliceMut::new(&mut encoded)];
+    let mut control = cmsg_space!([RawFd; 2]);
+    let message = recvmsg::<UnixAddr>(
+        socket.as_raw_fd(),
+        &mut iov,
+        Some(&mut control),
+        MsgFlags::MSG_CMSG_CLOEXEC,
+    )
+    .map_err(|_| ProtocolError::ConnectFailed)?;
+    let read = message.bytes;
+    if message
+        .flags
+        .intersects(MsgFlags::MSG_TRUNC | MsgFlags::MSG_CTRUNC)
+    {
+        return Err(ProtocolError::FrameTooLarge);
+    }
+    let mut received_fds = Vec::new();
+    for control in message.cmsgs().map_err(|_| ProtocolError::InvalidFrame)? {
+        if let ControlMessageOwned::ScmRights(fds) = control {
+            received_fds.extend(fds);
+        }
+    }
+    let had_fds = !received_fds.is_empty();
+    for fd in received_fds {
+        let _ = unistd::close(fd);
+    }
+    if had_fds {
+        return Err(ProtocolError::InvalidFrame);
+    }
+    if read < 4 {
+        return Err(ProtocolError::InvalidFrame);
+    }
+    let declared = u32::from_le_bytes(
+        encoded[..4]
+            .try_into()
+            .map_err(|_| ProtocolError::InvalidFrame)?,
+    ) as usize;
+    if declared > MAX_HELPER_FRAME_SIZE {
+        return Err(ProtocolError::FrameTooLarge);
+    }
+    if read != declared + 4 {
+        return Err(ProtocolError::InvalidFrame);
+    }
+    serde_json::from_slice(&encoded[4..read]).map_err(|_| ProtocolError::InvalidFrame)
+}
+
+fn random_generation() -> Result<u64, ProtocolError> {
+    let mut bytes = [0u8; 8];
+    getrandom::getrandom(&mut bytes).map_err(|_| ProtocolError::RuntimeUnavailable)?;
+    let generation = u64::from_le_bytes(bytes);
+    Ok(if generation == 0 { 1 } else { generation })
+}
+
+fn rejection(
+    request_id: u64,
+    operation_id: OperationId,
+    code: HelperFailureCode,
+) -> UnsafeLocalHelperToDaemon {
+    UnsafeLocalHelperToDaemon::Rejected(HelperOperationRejected {
+        request_id,
+        operation_id,
+        code,
+    })
+}
+
+fn failure_code(error: RuntimeError) -> HelperFailureCode {
+    match error {
+        RuntimeError::InvalidIdentity => HelperFailureCode::InvalidRequest,
+        RuntimeError::UserManagerUnavailable => HelperFailureCode::UserManagerUnavailable,
+        RuntimeError::EnvironmentInvalid | RuntimeError::LedgerInvalid => {
+            HelperFailureCode::EnvironmentInvalid
+        }
+        RuntimeError::ExecutableUnavailable => HelperFailureCode::ExecutableUnavailable,
+        RuntimeError::ProxyUnavailable => HelperFailureCode::ProxyUnavailable,
+        RuntimeError::ScopeCreateFailed => HelperFailureCode::ScopeCreateFailed,
+        RuntimeError::ScopeIdentityMismatch => HelperFailureCode::ScopeIdentityMismatch,
+        RuntimeError::Timeout => HelperFailureCode::Timeout,
+        RuntimeError::Internal => HelperFailureCode::Internal,
+    }
+}
+
+fn shell_operation_identity(
+    request: d2b_contracts::unsafe_local_wire::HelperShellRequest,
+) -> Option<(u64, OperationId)> {
+    use d2b_contracts::unsafe_local_wire::HelperShellRequest;
+    match request {
+        HelperShellRequest::List { .. } => None,
+        HelperShellRequest::Attach {
+            request_id,
+            operation_id,
+            ..
+        }
+        | HelperShellRequest::Detach {
+            request_id,
+            operation_id,
+            ..
+        }
+        | HelperShellRequest::Kill {
+            request_id,
+            operation_id,
+            ..
+        } => Some((request_id, operation_id)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::sys::socket::{AddressFamily, SockFlag, SockType, socketpair};
+    use std::os::fd::OwnedFd;
+
+    #[test]
+    fn socket_buffers_meet_frozen_effective_minimum() {
+        let (left, right) = socketpair(
+            AddressFamily::Unix,
+            SockType::SeqPacket,
+            None,
+            SockFlag::SOCK_CLOEXEC,
+        )
+        .unwrap();
+        let left = socket_from_owned(left);
+        let right = socket_from_owned(right);
+        configure_socket_buffers(&left).unwrap();
+        configure_socket_buffers(&right).unwrap();
+        assert!(left.send_buffer_size().unwrap() >= MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES);
+        assert!(right.recv_buffer_size().unwrap() >= MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES);
+    }
+
+    fn socket_from_owned(fd: OwnedFd) -> Socket {
+        Socket::from(fd)
+    }
+}

--- a/packages/d2b-unsafe-local-helper/src/protocol.rs
+++ b/packages/d2b-unsafe-local-helper/src/protocol.rs
@@ -9,7 +9,6 @@ use d2b_contracts::unsafe_local_wire::{
 };
 use d2b_realm_core::ids::OperationId;
 use nix::cmsg_space;
-use nix::fcntl::{FcntlArg, FdFlag, fcntl};
 use nix::libc;
 use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use nix::sys::socket::{
@@ -100,7 +99,8 @@ impl<M: UserScopeManager> HelperClient<M> {
             }),
         )?;
 
-        let accepted: DaemonToUnsafeLocalHelper = receive_frame(&socket)?;
+        let mut receive_buffer = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
+        let accepted: DaemonToUnsafeLocalHelper = receive_frame(&socket, &mut receive_buffer)?;
         match accepted {
             DaemonToUnsafeLocalHelper::HelloAccepted(accepted)
                 if accepted.protocol_version == UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION
@@ -121,6 +121,9 @@ impl<M: UserScopeManager> HelperClient<M> {
         response_wakeup_read
             .set_nonblocking(true)
             .map_err(|_| ProtocolError::ConnectFailed)?;
+        response_wakeup_write
+            .set_nonblocking(true)
+            .map_err(|_| ProtocolError::ConnectFailed)?;
         let (responses_tx, responses_rx) =
             mpsc::sync_channel::<UnsafeLocalHelperToDaemon>(MAX_HELPER_QUEUE_DEPTH);
         let response_wakeup_write = Arc::new(response_wakeup_write);
@@ -134,7 +137,7 @@ impl<M: UserScopeManager> HelperClient<M> {
                 ControlEvent::Response => continue,
                 ControlEvent::Control => {}
             }
-            let frame: DaemonToUnsafeLocalHelper = receive_frame(&socket)?;
+            let frame: DaemonToUnsafeLocalHelper = receive_frame(&socket, &mut receive_buffer)?;
             match frame {
                 DaemonToUnsafeLocalHelper::Heartbeat(heartbeat) => {
                     if heartbeat.generation != generation {
@@ -245,9 +248,14 @@ fn wait_for_control_or_response(
 
 fn wake_response_loop(response_wakeup: &UnixStream) -> Result<(), ProtocolError> {
     let mut response_wakeup = response_wakeup;
-    response_wakeup
-        .write_all(&[1])
-        .map_err(|_| ProtocolError::QueueClosed)
+    loop {
+        match response_wakeup.write_all(&[1]) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => return Err(ProtocolError::QueueClosed),
+        }
+    }
 }
 
 fn drain_response_wakeup(response_wakeup: &UnixStream) -> Result<(), ProtocolError> {
@@ -269,9 +277,12 @@ pub fn default_helper_socket_path() -> &'static Path {
 }
 
 fn connect_control_socket(path: &Path, expected_daemon_uid: u32) -> Result<Socket, ProtocolError> {
-    let socket = Socket::new(Domain::UNIX, Type::from(libc::SOCK_SEQPACKET), None)
-        .map_err(|_| ProtocolError::ConnectFailed)?;
-    mark_cloexec(&socket)?;
+    let socket = Socket::new(
+        Domain::UNIX,
+        Type::from(libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC),
+        None,
+    )
+    .map_err(|_| ProtocolError::ConnectFailed)?;
     configure_socket_buffers(&socket)?;
     let address = SockAddr::unix(path).map_err(|_| ProtocolError::ConnectFailed)?;
     socket
@@ -306,12 +317,6 @@ pub fn configure_socket_buffers(socket: &Socket) -> Result<(), ProtocolError> {
     Ok(())
 }
 
-fn mark_cloexec(socket: &Socket) -> Result<(), ProtocolError> {
-    fcntl(socket.as_raw_fd(), FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))
-        .map_err(|_| ProtocolError::ConnectFailed)?;
-    Ok(())
-}
-
 pub fn send_frame<T: serde::Serialize>(socket: &Socket, frame: &T) -> Result<(), ProtocolError> {
     let payload = serde_json::to_vec(frame).map_err(|_| ProtocolError::InvalidFrame)?;
     if payload.len() > MAX_HELPER_FRAME_SIZE {
@@ -329,9 +334,14 @@ pub fn send_frame<T: serde::Serialize>(socket: &Socket, frame: &T) -> Result<(),
     Ok(())
 }
 
-pub fn receive_frame<T: serde::de::DeserializeOwned>(socket: &Socket) -> Result<T, ProtocolError> {
-    let mut encoded = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
-    let mut iov = [IoSliceMut::new(&mut encoded)];
+pub fn receive_frame<T: serde::de::DeserializeOwned>(
+    socket: &Socket,
+    encoded: &mut [u8],
+) -> Result<T, ProtocolError> {
+    if encoded.len() < MAX_HELPER_FRAME_SIZE + 5 {
+        return Err(ProtocolError::FrameTooLarge);
+    }
+    let mut iov = [IoSliceMut::new(encoded)];
     let mut control = cmsg_space!([RawFd; 2]);
     let message = recvmsg::<UnixAddr>(
         socket.as_raw_fd(),
@@ -475,6 +485,7 @@ mod tests {
         let control = socket_from_owned(control);
         let (wakeup_read, wakeup_write) = UnixStream::pair().unwrap();
         wakeup_read.set_nonblocking(true).unwrap();
+        wakeup_write.set_nonblocking(true).unwrap();
 
         wake_response_loop(&wakeup_write).unwrap();
 

--- a/packages/d2b-unsafe-local-helper/src/runtime.rs
+++ b/packages/d2b-unsafe-local-helper/src/runtime.rs
@@ -16,12 +16,10 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, mpsc};
-use std::time::Duration;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use uzers::os::unix::UserExt;
 use uzers::{get_current_uid, get_user_by_uid};
 
-pub const MANAGER_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
 pub const SUPERVISOR_START_TIMEOUT: Duration = Duration::from_secs(5);
 pub const SNAPSHOT_RECONCILE_TIMEOUT: Duration = Duration::from_secs(20);
 const MAX_LEDGER_BYTES: u64 = 1024 * 1024;
@@ -165,9 +163,7 @@ impl<M: UserScopeManager> ScopeRuntime<M> {
         &self,
         request: HelperLaunchRequest,
     ) -> Result<HelperOperationResult, RuntimeError> {
-        let environment = timed_manager_call(Arc::clone(&self.manager), |manager| {
-            manager.manager_environment()
-        })??;
+        let environment = self.manager.manager_environment()?;
         let argv = request.argv.as_slice();
         let program = environment.resolve_program(&argv[0])?;
         let child_environment = environment.child_entries(request.graphical, None)?;
@@ -179,14 +175,11 @@ impl<M: UserScopeManager> ScopeRuntime<M> {
         };
         let mut supervisor = BlockedSupervisor::spawn(&spec)?;
         let supervisor_pid = supervisor.id();
-        let scope = match timed_manager_call(Arc::clone(&self.manager), move |manager| {
-            manager.start_scope(supervisor_pid, HelperScopeKind::LauncherApp)
-        }) {
-            Ok(Ok(scope)) => scope,
-            Ok(Err(error)) => {
-                supervisor.abort();
-                return Err(error.into());
-            }
+        let scope = match self
+            .manager
+            .start_scope(supervisor_pid, HelperScopeKind::LauncherApp)
+        {
+            Ok(scope) => scope,
             Err(error) => {
                 supervisor.abort();
                 return Err(error.into());
@@ -237,14 +230,8 @@ impl<M: UserScopeManager> ScopeRuntime<M> {
     }
 
     fn stop_failed_scope(&self, scope: &VerifiedScope) {
-        let scope_for_kill = scope.clone();
-        let manager = Arc::clone(&self.manager);
-        let _ = timed_manager_call(manager, move |manager| {
-            manager.terminate_scope(&scope_for_kill, libc::SIGKILL)
-        });
-        let scope_for_stop = scope.clone();
-        let manager = Arc::clone(&self.manager);
-        let _ = timed_manager_call(manager, move |manager| manager.stop_scope(&scope_for_stop));
+        let _ = self.manager.terminate_scope(scope, libc::SIGKILL);
+        let _ = self.manager.stop_scope(scope);
     }
 
     fn remove_scope_record(&self, operation_id: &OperationId) {
@@ -275,14 +262,11 @@ impl<M: UserScopeManager> ScopeRuntime<M> {
                 HelperScopeState::Degraded
             } else {
                 let verified = entry.verified();
-                let manager = Arc::clone(&self.manager);
-                let observed =
-                    timed_manager_call(manager, move |manager| manager.inspect_scope(&verified));
-                match observed {
-                    Ok(Ok(ScopeInspection {
+                match self.manager.inspect_scope(&verified) {
+                    Ok(ScopeInspection {
                         state,
                         identity_matches: true,
-                    })) => state,
+                    }) => state,
                     _ => HelperScopeState::Degraded,
                 }
             };
@@ -296,40 +280,6 @@ impl<M: UserScopeManager> ScopeRuntime<M> {
         }
         Ok(HelperSnapshot { generation, scopes })
     }
-}
-
-fn timed_manager_call<M, T, F>(
-    manager: Arc<M>,
-    operation: F,
-) -> Result<Result<T, ScopeError>, ScopeError>
-where
-    M: UserScopeManager,
-    T: Send + 'static,
-    F: FnOnce(&M) -> Result<T, ScopeError> + Send + 'static,
-{
-    timed_manager_call_with_timeout(manager, MANAGER_OPERATION_TIMEOUT, operation)
-}
-
-fn timed_manager_call_with_timeout<M, T, F>(
-    manager: Arc<M>,
-    timeout: Duration,
-    operation: F,
-) -> Result<Result<T, ScopeError>, ScopeError>
-where
-    M: UserScopeManager,
-    T: Send + 'static,
-    F: FnOnce(&M) -> Result<T, ScopeError> + Send + 'static,
-{
-    let (sender, receiver) = mpsc::sync_channel(1);
-    std::thread::Builder::new()
-        .name("d2b-user-manager-op".to_owned())
-        .spawn(move || {
-            let _ = sender.send(operation(&manager));
-        })
-        .map_err(|_| ScopeError::UserManagerUnavailable)?;
-    receiver
-        .recv_timeout(timeout)
-        .map_err(|_| ScopeError::Timeout)
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -543,38 +493,7 @@ fn persist_ledger(path: &Path, ledger: &PersistedScopeLedger) -> Result<(), Runt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::environment::ManagerEnvironment;
     use d2b_contracts::unsafe_local_wire::ScopeIdentity;
-
-    #[derive(Clone)]
-    struct HangingManager;
-
-    impl UserScopeManager for HangingManager {
-        fn manager_environment(&self) -> Result<ManagerEnvironment, ScopeError> {
-            std::thread::sleep(Duration::from_millis(100));
-            Err(ScopeError::UserManagerUnavailable)
-        }
-
-        fn start_scope(
-            &self,
-            _supervisor_pid: u32,
-            _kind: HelperScopeKind,
-        ) -> Result<VerifiedScope, ScopeError> {
-            Err(ScopeError::CreateFailed)
-        }
-
-        fn inspect_scope(&self, _scope: &VerifiedScope) -> Result<ScopeInspection, ScopeError> {
-            Err(ScopeError::QueryFailed)
-        }
-
-        fn terminate_scope(&self, _scope: &VerifiedScope, _signal: i32) -> Result<(), ScopeError> {
-            Err(ScopeError::StopFailed)
-        }
-
-        fn stop_scope(&self, _scope: &VerifiedScope) -> Result<(), ScopeError> {
-            Err(ScopeError::StopFailed)
-        }
-    }
 
     #[test]
     fn persisted_scope_debug_hides_scope_identifiers() {
@@ -632,17 +551,5 @@ mod tests {
             kind: HelperScopeKind::LauncherApp,
         };
         assert!(!format!("{identity:?}").contains(canary));
-    }
-
-    #[test]
-    fn hung_user_manager_operation_times_out_without_blocking_caller() {
-        let started = Instant::now();
-        let result = timed_manager_call_with_timeout(
-            Arc::new(HangingManager),
-            Duration::from_millis(5),
-            UserScopeManager::manager_environment,
-        );
-        assert!(matches!(result, Err(ScopeError::Timeout)));
-        assert!(started.elapsed() < Duration::from_millis(50));
     }
 }

--- a/packages/d2b-unsafe-local-helper/src/runtime.rs
+++ b/packages/d2b-unsafe-local-helper/src/runtime.rs
@@ -1,0 +1,648 @@
+use crate::environment::EnvironmentError;
+use crate::systemd::{ScopeError, ScopeInspection, UserScopeManager, VerifiedScope};
+use d2b_contracts::unsafe_local_wire::{
+    HelperLaunchRequest, HelperOperationDisposition, HelperOperationResult, HelperScopeKind,
+    HelperScopeSnapshot, HelperScopeState, HelperSnapshot, MAX_HELPER_SNAPSHOT_SCOPES,
+};
+use d2b_core::workload_identity::WorkloadIdentity;
+use d2b_realm_core::ids::OperationId;
+use nix::libc;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::Duration;
+use std::time::Instant;
+use uzers::os::unix::UserExt;
+use uzers::{get_current_uid, get_user_by_uid};
+
+pub const MANAGER_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
+pub const SUPERVISOR_START_TIMEOUT: Duration = Duration::from_secs(5);
+pub const SNAPSHOT_RECONCILE_TIMEOUT: Duration = Duration::from_secs(20);
+const MAX_LEDGER_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeError {
+    InvalidIdentity,
+    UserManagerUnavailable,
+    EnvironmentInvalid,
+    ExecutableUnavailable,
+    ProxyUnavailable,
+    ScopeCreateFailed,
+    ScopeIdentityMismatch,
+    Timeout,
+    LedgerInvalid,
+    Internal,
+}
+
+impl From<EnvironmentError> for RuntimeError {
+    fn from(error: EnvironmentError) -> Self {
+        match error {
+            EnvironmentError::ExecutableUnavailable | EnvironmentError::PathMissing => {
+                Self::ExecutableUnavailable
+            }
+            EnvironmentError::ProxyUnavailable => Self::ProxyUnavailable,
+            _ => Self::EnvironmentInvalid,
+        }
+    }
+}
+
+impl From<ScopeError> for RuntimeError {
+    fn from(error: ScopeError) -> Self {
+        match error {
+            ScopeError::UserManagerUnavailable => Self::UserManagerUnavailable,
+            ScopeError::EnvironmentInvalid => Self::EnvironmentInvalid,
+            ScopeError::Timeout => Self::Timeout,
+            ScopeError::CreateFailed => Self::ScopeCreateFailed,
+            ScopeError::IdentityMismatch => Self::ScopeIdentityMismatch,
+            ScopeError::QueryFailed | ScopeError::StopFailed => Self::Internal,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PersistedScope {
+    operation_id: OperationId,
+    workload: WorkloadIdentity,
+    unit_name: String,
+    invocation_id: String,
+    control_group: String,
+    kind: HelperScopeKind,
+}
+
+impl fmt::Debug for PersistedScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PersistedScope")
+            .field("operation_id", &self.operation_id)
+            .field("workload", &self.workload)
+            .field("unit_name", &"<redacted>")
+            .field("invocation_id", &"<redacted>")
+            .field("control_group", &"<redacted>")
+            .field("kind", &self.kind)
+            .finish()
+    }
+}
+
+impl PersistedScope {
+    fn verified(&self) -> VerifiedScope {
+        VerifiedScope {
+            unit_name: self.unit_name.clone(),
+            invocation_id: self.invocation_id.clone(),
+            control_group: self.control_group.clone(),
+            kind: self.kind,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PersistedScopeLedger {
+    schema_version: u32,
+    scopes: Vec<PersistedScope>,
+}
+
+impl fmt::Debug for PersistedScopeLedger {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PersistedScopeLedger")
+            .field("schema_version", &self.schema_version)
+            .field("scope_count", &self.scopes.len())
+            .finish()
+    }
+}
+
+pub struct ScopeRuntime<M: UserScopeManager> {
+    manager: Arc<M>,
+    ledger_path: PathBuf,
+    ledger: Mutex<PersistedScopeLedger>,
+    user_home: PathBuf,
+}
+
+impl<M: UserScopeManager> fmt::Debug for ScopeRuntime<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScopeRuntime")
+            .field("ledger_path", &"<redacted>")
+            .field("user_home", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M: UserScopeManager> ScopeRuntime<M> {
+    pub fn new(manager: M) -> Result<Self, RuntimeError> {
+        let uid = get_current_uid();
+        if uid == 0 {
+            return Err(RuntimeError::InvalidIdentity);
+        }
+        let user = get_user_by_uid(uid).ok_or(RuntimeError::InvalidIdentity)?;
+        let user_home = user.home_dir().to_path_buf();
+        if !user_home.is_absolute() {
+            return Err(RuntimeError::InvalidIdentity);
+        }
+        let ledger_path = user_home.join(".local/state/d2b/unsafe-local-scopes.json");
+        Self::with_paths(manager, user_home, ledger_path)
+    }
+
+    pub fn with_paths(
+        manager: M,
+        user_home: PathBuf,
+        ledger_path: PathBuf,
+    ) -> Result<Self, RuntimeError> {
+        let ledger = load_ledger(&ledger_path)?;
+        Ok(Self {
+            manager: Arc::new(manager),
+            ledger_path,
+            ledger: Mutex::new(ledger),
+            user_home,
+        })
+    }
+
+    pub fn launch(
+        &self,
+        request: HelperLaunchRequest,
+    ) -> Result<HelperOperationResult, RuntimeError> {
+        let environment = timed_manager_call(Arc::clone(&self.manager), |manager| {
+            manager.manager_environment()
+        })??;
+        let argv = request.argv.as_slice();
+        let program = environment.resolve_program(&argv[0])?;
+        let child_environment = environment.child_entries(request.graphical, None)?;
+        let spec = SupervisorSpec {
+            program,
+            args: argv[1..].to_vec(),
+            environment: child_environment,
+            cwd: self.user_home.clone(),
+        };
+        let mut supervisor = BlockedSupervisor::spawn(&spec)?;
+        let supervisor_pid = supervisor.id();
+        let scope = match timed_manager_call(Arc::clone(&self.manager), move |manager| {
+            manager.start_scope(supervisor_pid, HelperScopeKind::LauncherApp)
+        }) {
+            Ok(Ok(scope)) => scope,
+            Ok(Err(error)) => {
+                supervisor.abort();
+                return Err(error.into());
+            }
+            Err(error) => {
+                supervisor.abort();
+                return Err(error.into());
+            }
+        };
+        let persisted = PersistedScope {
+            operation_id: request.operation_id.clone(),
+            workload: request.workload,
+            unit_name: scope.unit_name.clone(),
+            invocation_id: scope.invocation_id.clone(),
+            control_group: scope.control_group.clone(),
+            kind: scope.kind,
+        };
+        let persist_result = match self.ledger.lock() {
+            Ok(mut ledger) => {
+                ledger
+                    .scopes
+                    .retain(|entry| entry.operation_id != persisted.operation_id);
+                ledger.scopes.push(persisted);
+                if ledger.scopes.len() > MAX_HELPER_SNAPSHOT_SCOPES {
+                    Err(RuntimeError::LedgerInvalid)
+                } else {
+                    persist_ledger(&self.ledger_path, &ledger)
+                }
+            }
+            Err(_) => Err(RuntimeError::Internal),
+        };
+        if let Err(error) = persist_result {
+            supervisor.abort();
+            self.stop_failed_scope(&scope);
+            self.remove_scope_record(&request.operation_id);
+            return Err(error);
+        }
+        if let Err(error) = supervisor.release_and_wait_started() {
+            supervisor.abort();
+            self.stop_failed_scope(&scope);
+            self.remove_scope_record(&request.operation_id);
+            return Err(error);
+        }
+        supervisor.reap_in_background();
+
+        Ok(HelperOperationResult {
+            request_id: request.request_id,
+            operation_id: request.operation_id,
+            disposition: HelperOperationDisposition::Committed,
+            scope: Some(scope.wire_identity()),
+        })
+    }
+
+    fn stop_failed_scope(&self, scope: &VerifiedScope) {
+        let scope_for_kill = scope.clone();
+        let manager = Arc::clone(&self.manager);
+        let _ = timed_manager_call(manager, move |manager| {
+            manager.terminate_scope(&scope_for_kill, libc::SIGKILL)
+        });
+        let scope_for_stop = scope.clone();
+        let manager = Arc::clone(&self.manager);
+        let _ = timed_manager_call(manager, move |manager| manager.stop_scope(&scope_for_stop));
+    }
+
+    fn remove_scope_record(&self, operation_id: &OperationId) {
+        let Ok(mut ledger) = self.ledger.lock() else {
+            return;
+        };
+        ledger
+            .scopes
+            .retain(|entry| &entry.operation_id != operation_id);
+        let _ = persist_ledger(&self.ledger_path, &ledger);
+    }
+
+    pub fn snapshot(&self, generation: u64) -> Result<HelperSnapshot, RuntimeError> {
+        let entries = self
+            .ledger
+            .lock()
+            .map_err(|_| RuntimeError::Internal)?
+            .scopes
+            .clone();
+        if entries.len() > MAX_HELPER_SNAPSHOT_SCOPES {
+            return Err(RuntimeError::LedgerInvalid);
+        }
+
+        let mut scopes = Vec::with_capacity(entries.len());
+        let deadline = Instant::now() + SNAPSHOT_RECONCILE_TIMEOUT;
+        for entry in entries {
+            let state = if Instant::now() >= deadline {
+                HelperScopeState::Degraded
+            } else {
+                let verified = entry.verified();
+                let manager = Arc::clone(&self.manager);
+                let observed =
+                    timed_manager_call(manager, move |manager| manager.inspect_scope(&verified));
+                match observed {
+                    Ok(Ok(ScopeInspection {
+                        state,
+                        identity_matches: true,
+                    })) => state,
+                    _ => HelperScopeState::Degraded,
+                }
+            };
+            let scope = entry.verified().wire_identity();
+            scopes.push(HelperScopeSnapshot {
+                operation_id: entry.operation_id,
+                workload: entry.workload,
+                scope,
+                state,
+            });
+        }
+        Ok(HelperSnapshot { generation, scopes })
+    }
+}
+
+fn timed_manager_call<M, T, F>(
+    manager: Arc<M>,
+    operation: F,
+) -> Result<Result<T, ScopeError>, ScopeError>
+where
+    M: UserScopeManager,
+    T: Send + 'static,
+    F: FnOnce(&M) -> Result<T, ScopeError> + Send + 'static,
+{
+    timed_manager_call_with_timeout(manager, MANAGER_OPERATION_TIMEOUT, operation)
+}
+
+fn timed_manager_call_with_timeout<M, T, F>(
+    manager: Arc<M>,
+    timeout: Duration,
+    operation: F,
+) -> Result<Result<T, ScopeError>, ScopeError>
+where
+    M: UserScopeManager,
+    T: Send + 'static,
+    F: FnOnce(&M) -> Result<T, ScopeError> + Send + 'static,
+{
+    let (sender, receiver) = mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("d2b-user-manager-op".to_owned())
+        .spawn(move || {
+            let _ = sender.send(operation(&manager));
+        })
+        .map_err(|_| ScopeError::UserManagerUnavailable)?;
+    receiver
+        .recv_timeout(timeout)
+        .map_err(|_| ScopeError::Timeout)
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SupervisorSpec {
+    program: PathBuf,
+    args: Vec<String>,
+    environment: BTreeMap<String, String>,
+    cwd: PathBuf,
+}
+
+impl fmt::Debug for SupervisorSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SupervisorSpec")
+            .field("program", &"<redacted>")
+            .field("arg_count", &self.args.len())
+            .field("environment_count", &self.environment.len())
+            .field("cwd", &"<redacted>")
+            .finish()
+    }
+}
+
+struct BlockedSupervisor {
+    child: Option<Child>,
+    stdin: Option<std::process::ChildStdin>,
+    stdout: Option<std::process::ChildStdout>,
+}
+
+impl BlockedSupervisor {
+    fn spawn(spec: &SupervisorSpec) -> Result<Self, RuntimeError> {
+        let encoded = serde_json::to_vec(spec).map_err(|_| RuntimeError::Internal)?;
+        if encoded.len() > MAX_LEDGER_BYTES as usize {
+            return Err(RuntimeError::EnvironmentInvalid);
+        }
+        let executable = std::env::current_exe().map_err(|_| RuntimeError::Internal)?;
+        let mut child = Command::new(executable)
+            .arg("scope-supervisor")
+            .env_clear()
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| RuntimeError::ScopeCreateFailed)?;
+        let mut stdin = child.stdin.take().ok_or(RuntimeError::Internal)?;
+        let stdout = child.stdout.take().ok_or(RuntimeError::Internal)?;
+        let length = u32::try_from(encoded.len()).map_err(|_| RuntimeError::EnvironmentInvalid)?;
+        if stdin.write_all(&length.to_le_bytes()).is_err() || stdin.write_all(&encoded).is_err() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(RuntimeError::ScopeCreateFailed);
+        }
+        Ok(Self {
+            child: Some(child),
+            stdin: Some(stdin),
+            stdout: Some(stdout),
+        })
+    }
+
+    fn id(&self) -> u32 {
+        self.child.as_ref().expect("supervisor child present").id()
+    }
+
+    fn release_and_wait_started(&mut self) -> Result<(), RuntimeError> {
+        let mut stdin = self.stdin.take().ok_or(RuntimeError::Internal)?;
+        stdin
+            .write_all(&[1])
+            .map_err(|_| RuntimeError::ScopeCreateFailed)?;
+        drop(stdin);
+
+        let mut stdout = self.stdout.take().ok_or(RuntimeError::Internal)?;
+        let (sender, receiver) = mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("d2b-scope-start-ack".to_owned())
+            .spawn(move || {
+                let mut ack = [0u8; 1];
+                let result = stdout.read_exact(&mut ack).map(|()| ack[0]);
+                let _ = sender.send(result);
+            })
+            .map_err(|_| RuntimeError::Internal)?;
+        match receiver.recv_timeout(SUPERVISOR_START_TIMEOUT) {
+            Ok(Ok(1)) => Ok(()),
+            Ok(Ok(_)) | Ok(Err(_)) => Err(RuntimeError::ScopeCreateFailed),
+            Err(_) => Err(RuntimeError::Timeout),
+        }
+    }
+
+    fn abort(&mut self) {
+        self.stdin.take();
+        self.stdout.take();
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    fn reap_in_background(mut self) {
+        self.stdin.take();
+        self.stdout.take();
+        if let Some(mut child) = self.child.take() {
+            let _ = std::thread::Builder::new()
+                .name("d2b-scope-reaper".to_owned())
+                .spawn(move || {
+                    let _ = child.wait();
+                });
+        }
+    }
+}
+
+impl Drop for BlockedSupervisor {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            self.abort();
+        }
+    }
+}
+
+pub fn run_scope_supervisor() -> Result<(), RuntimeError> {
+    let mut length = [0u8; 4];
+    std::io::stdin()
+        .read_exact(&mut length)
+        .map_err(|_| RuntimeError::Internal)?;
+    let length = u32::from_le_bytes(length) as usize;
+    if length == 0 || length > MAX_LEDGER_BYTES as usize {
+        return Err(RuntimeError::EnvironmentInvalid);
+    }
+    let mut encoded = vec![0u8; length];
+    std::io::stdin()
+        .read_exact(&mut encoded)
+        .map_err(|_| RuntimeError::Internal)?;
+    let spec: SupervisorSpec =
+        serde_json::from_slice(&encoded).map_err(|_| RuntimeError::EnvironmentInvalid)?;
+    let mut release = [0u8; 1];
+    std::io::stdin()
+        .read_exact(&mut release)
+        .map_err(|_| RuntimeError::Internal)?;
+    if release != [1] {
+        return Err(RuntimeError::Internal);
+    }
+
+    let mut child = Command::new(&spec.program)
+        .args(&spec.args)
+        .env_clear()
+        .envs(&spec.environment)
+        .current_dir(&spec.cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| RuntimeError::ExecutableUnavailable)?;
+    std::io::stdout()
+        .write_all(&[1])
+        .map_err(|_| RuntimeError::Internal)?;
+    std::io::stdout()
+        .flush()
+        .map_err(|_| RuntimeError::Internal)?;
+    child.wait().map_err(|_| RuntimeError::Internal)?;
+    Ok(())
+}
+
+fn load_ledger(path: &Path) -> Result<PersistedScopeLedger, RuntimeError> {
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.len() > MAX_LEDGER_BYTES => {
+            return Err(RuntimeError::LedgerInvalid);
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(PersistedScopeLedger {
+                schema_version: 1,
+                scopes: Vec::new(),
+            });
+        }
+        Err(_) => return Err(RuntimeError::LedgerInvalid),
+    }
+    let encoded = fs::read(path).map_err(|_| RuntimeError::LedgerInvalid)?;
+    let ledger: PersistedScopeLedger =
+        serde_json::from_slice(&encoded).map_err(|_| RuntimeError::LedgerInvalid)?;
+    if ledger.schema_version != 1 || ledger.scopes.len() > MAX_HELPER_SNAPSHOT_SCOPES {
+        return Err(RuntimeError::LedgerInvalid);
+    }
+    Ok(ledger)
+}
+
+fn persist_ledger(path: &Path, ledger: &PersistedScopeLedger) -> Result<(), RuntimeError> {
+    let parent = path.parent().ok_or(RuntimeError::LedgerInvalid)?;
+    fs::create_dir_all(parent).map_err(|_| RuntimeError::LedgerInvalid)?;
+    fs::set_permissions(parent, fs::Permissions::from_mode(0o700))
+        .map_err(|_| RuntimeError::LedgerInvalid)?;
+    let encoded = serde_json::to_vec(ledger).map_err(|_| RuntimeError::LedgerInvalid)?;
+    if encoded.len() > MAX_LEDGER_BYTES as usize {
+        return Err(RuntimeError::LedgerInvalid);
+    }
+    let candidate = parent.join(format!(".unsafe-local-scopes.{}.new", std::process::id()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&candidate)
+        .map_err(|_| RuntimeError::LedgerInvalid)?;
+    let result = (|| {
+        file.write_all(&encoded)
+            .map_err(|_| RuntimeError::LedgerInvalid)?;
+        file.sync_all().map_err(|_| RuntimeError::LedgerInvalid)?;
+        fs::rename(&candidate, path).map_err(|_| RuntimeError::LedgerInvalid)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(candidate);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::environment::ManagerEnvironment;
+    use d2b_contracts::unsafe_local_wire::ScopeIdentity;
+
+    #[derive(Clone)]
+    struct HangingManager;
+
+    impl UserScopeManager for HangingManager {
+        fn manager_environment(&self) -> Result<ManagerEnvironment, ScopeError> {
+            std::thread::sleep(Duration::from_millis(100));
+            Err(ScopeError::UserManagerUnavailable)
+        }
+
+        fn start_scope(
+            &self,
+            _supervisor_pid: u32,
+            _kind: HelperScopeKind,
+        ) -> Result<VerifiedScope, ScopeError> {
+            Err(ScopeError::CreateFailed)
+        }
+
+        fn inspect_scope(&self, _scope: &VerifiedScope) -> Result<ScopeInspection, ScopeError> {
+            Err(ScopeError::QueryFailed)
+        }
+
+        fn terminate_scope(&self, _scope: &VerifiedScope, _signal: i32) -> Result<(), ScopeError> {
+            Err(ScopeError::StopFailed)
+        }
+
+        fn stop_scope(&self, _scope: &VerifiedScope) -> Result<(), ScopeError> {
+            Err(ScopeError::StopFailed)
+        }
+    }
+
+    #[test]
+    fn persisted_scope_debug_hides_scope_identifiers() {
+        let canary = "scope-private-canary";
+        let persisted = PersistedScope {
+            operation_id: OperationId::parse("op-1").unwrap(),
+            workload: serde_json::from_value(serde_json::json!({
+                "workloadId": "tools",
+                "realmId": "host",
+                "realmPath": ["host"],
+                "canonicalTarget": "tools.host.d2b"
+            }))
+            .unwrap(),
+            unit_name: canary.to_owned(),
+            invocation_id: canary.to_owned(),
+            control_group: format!("/{canary}"),
+            kind: HelperScopeKind::LauncherApp,
+        };
+        assert!(!format!("{persisted:?}").contains(canary));
+    }
+
+    #[test]
+    fn adoption_degrades_identity_ambiguity_without_stopping_scope() {
+        let inspection = ScopeInspection {
+            state: HelperScopeState::Active,
+            identity_matches: false,
+        };
+        let state = match inspection {
+            ScopeInspection {
+                state,
+                identity_matches: true,
+            } => state,
+            _ => HelperScopeState::Degraded,
+        };
+        assert_eq!(state, HelperScopeState::Degraded);
+    }
+
+    #[test]
+    fn supervisor_spec_debug_redacts_every_sensitive_surface() {
+        let canary = "runtime-private-canary";
+        let spec = SupervisorSpec {
+            program: PathBuf::from(format!("/{canary}")),
+            args: vec![canary.to_owned()],
+            environment: BTreeMap::from([("PRIVATE".to_owned(), canary.to_owned())]),
+            cwd: PathBuf::from(format!("/{canary}")),
+        };
+        assert!(!format!("{spec:?}").contains(canary));
+    }
+
+    #[test]
+    fn wire_scope_identity_remains_redacted() {
+        let canary = "invocation-private-canary";
+        let identity = ScopeIdentity {
+            invocation_id: canary.to_owned(),
+            kind: HelperScopeKind::LauncherApp,
+        };
+        assert!(!format!("{identity:?}").contains(canary));
+    }
+
+    #[test]
+    fn hung_user_manager_operation_times_out_without_blocking_caller() {
+        let started = Instant::now();
+        let result = timed_manager_call_with_timeout(
+            Arc::new(HangingManager),
+            Duration::from_millis(5),
+            UserScopeManager::manager_environment,
+        );
+        assert!(matches!(result, Err(ScopeError::Timeout)));
+        assert!(started.elapsed() < Duration::from_millis(50));
+    }
+}

--- a/packages/d2b-unsafe-local-helper/src/systemd.rs
+++ b/packages/d2b-unsafe-local-helper/src/systemd.rs
@@ -9,6 +9,7 @@ use zbus::zvariant::{OwnedObjectPath, Value};
 const SYSTEMD_DESTINATION: &str = "org.freedesktop.systemd1";
 const SYSTEMD_MANAGER_PATH: &str = "/org/freedesktop/systemd1";
 const SYSTEMD_MANAGER_INTERFACE: &str = "org.freedesktop.systemd1.Manager";
+const SYSTEMD_SCOPE_INTERFACE: &str = "org.freedesktop.systemd1.Scope";
 const SYSTEMD_UNIT_INTERFACE: &str = "org.freedesktop.systemd1.Unit";
 const SCOPE_IDENTITY_READY_TIMEOUT: Duration = Duration::from_secs(2);
 const SCOPE_IDENTITY_RETRY_INTERVAL: Duration = Duration::from_millis(20);
@@ -116,7 +117,14 @@ impl SystemdUserScopeManager {
         if invocation.len() != 16 {
             return Err(ScopeError::IdentityMismatch);
         }
-        let control_group: String = unit
+        let scope_unit = Proxy::new(
+            connection,
+            SYSTEMD_DESTINATION,
+            unit_path.as_str(),
+            SYSTEMD_SCOPE_INTERFACE,
+        )
+        .map_err(|_| ScopeError::QueryFailed)?;
+        let control_group: String = scope_unit
             .get_property("ControlGroup")
             .map_err(|_| ScopeError::QueryFailed)?;
         if !control_group_matches_unit(&control_group, unit_name) {

--- a/packages/d2b-unsafe-local-helper/src/systemd.rs
+++ b/packages/d2b-unsafe-local-helper/src/systemd.rs
@@ -2,8 +2,9 @@ use crate::environment::{EnvironmentError, ManagerEnvironment};
 use d2b_contracts::unsafe_local_wire::{HelperScopeKind, HelperScopeState, ScopeIdentity};
 use std::fmt;
 use std::path::Path;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
-use zbus::blocking::{Connection, Proxy};
+use zbus::blocking::{Connection, Proxy, connection};
 use zbus::zvariant::{OwnedObjectPath, Value};
 
 const SYSTEMD_DESTINATION: &str = "org.freedesktop.systemd1";
@@ -11,6 +12,7 @@ const SYSTEMD_MANAGER_PATH: &str = "/org/freedesktop/systemd1";
 const SYSTEMD_MANAGER_INTERFACE: &str = "org.freedesktop.systemd1.Manager";
 const SYSTEMD_SCOPE_INTERFACE: &str = "org.freedesktop.systemd1.Scope";
 const SYSTEMD_UNIT_INTERFACE: &str = "org.freedesktop.systemd1.Unit";
+const SYSTEMD_METHOD_TIMEOUT: Duration = Duration::from_secs(5);
 const SCOPE_IDENTITY_READY_TIMEOUT: Duration = Duration::from_secs(2);
 const SCOPE_IDENTITY_RETRY_INTERVAL: Duration = Duration::from_millis(20);
 
@@ -77,12 +79,33 @@ pub trait UserScopeManager: Send + Sync + 'static {
     fn stop_scope(&self, scope: &VerifiedScope) -> Result<(), ScopeError>;
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct SystemdUserScopeManager;
+#[derive(Debug, Default)]
+pub struct SystemdUserScopeManager {
+    connection: Mutex<Option<Connection>>,
+}
 
 impl SystemdUserScopeManager {
-    fn connection() -> Result<Connection, ScopeError> {
-        Connection::session().map_err(|_| ScopeError::UserManagerUnavailable)
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_connection<T>(
+        &self,
+        operation: impl FnOnce(&Connection) -> Result<T, ScopeError>,
+    ) -> Result<T, ScopeError> {
+        let mut cached = self
+            .connection
+            .lock()
+            .map_err(|_| ScopeError::UserManagerUnavailable)?;
+        if cached.is_none() {
+            let connection = connection::Builder::session()
+                .map_err(|_| ScopeError::UserManagerUnavailable)?
+                .method_timeout(SYSTEMD_METHOD_TIMEOUT)
+                .build()
+                .map_err(map_user_manager_error)?;
+            *cached = Some(connection);
+        }
+        operation(cached.as_ref().ok_or(ScopeError::UserManagerUnavailable)?)
     }
 
     fn manager_proxy(connection: &Connection) -> Result<Proxy<'_>, ScopeError> {
@@ -103,7 +126,7 @@ impl SystemdUserScopeManager {
         let manager = Self::manager_proxy(connection)?;
         let unit_path: OwnedObjectPath = manager
             .call("GetUnit", &(unit_name))
-            .map_err(|_| ScopeError::QueryFailed)?;
+            .map_err(map_query_error)?;
         let unit = Proxy::new(
             connection,
             SYSTEMD_DESTINATION,
@@ -111,9 +134,7 @@ impl SystemdUserScopeManager {
             SYSTEMD_UNIT_INTERFACE,
         )
         .map_err(|_| ScopeError::QueryFailed)?;
-        let invocation: Vec<u8> = unit
-            .get_property("InvocationID")
-            .map_err(|_| ScopeError::QueryFailed)?;
+        let invocation: Vec<u8> = unit.get_property("InvocationID").map_err(map_query_error)?;
         if invocation.len() != 16 {
             return Err(ScopeError::IdentityMismatch);
         }
@@ -126,13 +147,11 @@ impl SystemdUserScopeManager {
         .map_err(|_| ScopeError::QueryFailed)?;
         let control_group: String = scope_unit
             .get_property("ControlGroup")
-            .map_err(|_| ScopeError::QueryFailed)?;
+            .map_err(map_query_error)?;
         if !control_group_matches_unit(&control_group, unit_name) {
             return Err(ScopeError::IdentityMismatch);
         }
-        let active_state: String = unit
-            .get_property("ActiveState")
-            .map_err(|_| ScopeError::QueryFailed)?;
+        let active_state: String = unit.get_property("ActiveState").map_err(map_query_error)?;
         let state = match active_state.as_str() {
             "active" | "activating" | "reloading" => HelperScopeState::Active,
             "deactivating" => HelperScopeState::Stopping,
@@ -153,12 +172,13 @@ impl SystemdUserScopeManager {
 
 impl UserScopeManager for SystemdUserScopeManager {
     fn manager_environment(&self) -> Result<ManagerEnvironment, ScopeError> {
-        let connection = Self::connection()?;
-        let manager = Self::manager_proxy(&connection)?;
-        let environment: Vec<String> = manager
-            .get_property("Environment")
-            .map_err(|_| ScopeError::UserManagerUnavailable)?;
-        ManagerEnvironment::parse(environment).map_err(Into::into)
+        self.with_connection(|connection| {
+            let manager = Self::manager_proxy(connection)?;
+            let environment: Vec<String> = manager
+                .get_property("Environment")
+                .map_err(map_user_manager_error)?;
+            ManagerEnvironment::parse(environment).map_err(Into::into)
+        })
     }
 
     fn start_scope(
@@ -166,49 +186,51 @@ impl UserScopeManager for SystemdUserScopeManager {
         supervisor_pid: u32,
         kind: HelperScopeKind,
     ) -> Result<VerifiedScope, ScopeError> {
-        let connection = Self::connection()?;
-        let manager = Self::manager_proxy(&connection)?;
-        let unit_name = scope_unit_name(kind)?;
-        let properties = vec![
-            ("PIDs", Value::from(vec![supervisor_pid])),
-            (
-                "Description",
-                Value::from("d2b unsafe-local supervised process"),
-            ),
-            ("Slice", Value::from("app.slice")),
-            ("CollectMode", Value::from("inactive-or-failed")),
-            ("KillMode", Value::from("control-group")),
-        ];
-        let auxiliary: Vec<(&str, Vec<(&str, Value<'_>)>)> = Vec::new();
-        let _: OwnedObjectPath = manager
-            .call(
-                "StartTransientUnit",
-                &(unit_name.as_str(), "fail", properties, auxiliary),
-            )
-            .map_err(|_| ScopeError::CreateFailed)?;
+        self.with_connection(|connection| {
+            let manager = Self::manager_proxy(connection)?;
+            let unit_name = scope_unit_name(kind)?;
+            let properties = vec![
+                ("PIDs", Value::from(vec![supervisor_pid])),
+                (
+                    "Description",
+                    Value::from("d2b unsafe-local supervised process"),
+                ),
+                ("Slice", Value::from("app.slice")),
+                ("CollectMode", Value::from("inactive-or-failed")),
+                ("KillMode", Value::from("control-group")),
+            ];
+            let auxiliary: Vec<(&str, Vec<(&str, Value<'_>)>)> = Vec::new();
+            let _: OwnedObjectPath = manager
+                .call(
+                    "StartTransientUnit",
+                    &(unit_name.as_str(), "fail", properties, auxiliary),
+                )
+                .map_err(map_create_error)?;
 
-        await_scope_identity(
-            || Self::query_scope(&connection, &unit_name, kind),
-            SCOPE_IDENTITY_READY_TIMEOUT,
-            SCOPE_IDENTITY_RETRY_INTERVAL,
-        )
+            await_scope_identity(
+                || Self::query_scope(connection, &unit_name, kind),
+                SCOPE_IDENTITY_READY_TIMEOUT,
+                SCOPE_IDENTITY_RETRY_INTERVAL,
+            )
+        })
     }
 
     fn inspect_scope(&self, scope: &VerifiedScope) -> Result<ScopeInspection, ScopeError> {
-        let connection = Self::connection()?;
-        match Self::query_scope(&connection, &scope.unit_name, scope.kind) {
-            Ok((observed, state)) => Ok(ScopeInspection {
-                state,
-                identity_matches: observed.invocation_id == scope.invocation_id
-                    && observed.control_group == scope.control_group
-                    && observed.unit_name == scope.unit_name,
-            }),
-            Err(ScopeError::QueryFailed) => Ok(ScopeInspection {
-                state: HelperScopeState::Degraded,
-                identity_matches: false,
-            }),
-            Err(error) => Err(error),
-        }
+        self.with_connection(|connection| {
+            match Self::query_scope(connection, &scope.unit_name, scope.kind) {
+                Ok((observed, state)) => Ok(ScopeInspection {
+                    state,
+                    identity_matches: observed.invocation_id == scope.invocation_id
+                        && observed.control_group == scope.control_group
+                        && observed.unit_name == scope.unit_name,
+                }),
+                Err(ScopeError::QueryFailed) => Ok(ScopeInspection {
+                    state: HelperScopeState::Degraded,
+                    identity_matches: false,
+                }),
+                Err(error) => Err(error),
+            }
+        })
     }
 
     fn terminate_scope(&self, scope: &VerifiedScope, signal: i32) -> Result<(), ScopeError> {
@@ -216,12 +238,13 @@ impl UserScopeManager for SystemdUserScopeManager {
         if !inspection.identity_matches {
             return Err(ScopeError::IdentityMismatch);
         }
-        let connection = Self::connection()?;
-        let manager = Self::manager_proxy(&connection)?;
-        manager
-            .call_method("KillUnit", &(scope.unit_name.as_str(), "all", signal))
-            .map_err(|_| ScopeError::StopFailed)?;
-        Ok(())
+        self.with_connection(|connection| {
+            let manager = Self::manager_proxy(connection)?;
+            manager
+                .call_method("KillUnit", &(scope.unit_name.as_str(), "all", signal))
+                .map_err(map_stop_error)?;
+            Ok(())
+        })
     }
 
     fn stop_scope(&self, scope: &VerifiedScope) -> Result<(), ScopeError> {
@@ -229,13 +252,54 @@ impl UserScopeManager for SystemdUserScopeManager {
         if !inspection.identity_matches {
             return Err(ScopeError::IdentityMismatch);
         }
-        let connection = Self::connection()?;
-        let manager = Self::manager_proxy(&connection)?;
-        let _: OwnedObjectPath = manager
-            .call("StopUnit", &(scope.unit_name.as_str(), "replace"))
-            .map_err(|_| ScopeError::StopFailed)?;
-        Ok(())
+        self.with_connection(|connection| {
+            let manager = Self::manager_proxy(connection)?;
+            let _: OwnedObjectPath = manager
+                .call("StopUnit", &(scope.unit_name.as_str(), "replace"))
+                .map_err(map_stop_error)?;
+            Ok(())
+        })
     }
+}
+
+fn map_user_manager_error(error: zbus::Error) -> ScopeError {
+    if is_timeout(&error) {
+        ScopeError::Timeout
+    } else {
+        ScopeError::UserManagerUnavailable
+    }
+}
+
+fn map_create_error(error: zbus::Error) -> ScopeError {
+    if is_timeout(&error) {
+        ScopeError::Timeout
+    } else {
+        ScopeError::CreateFailed
+    }
+}
+
+fn map_query_error(error: zbus::Error) -> ScopeError {
+    if is_timeout(&error) {
+        ScopeError::Timeout
+    } else {
+        ScopeError::QueryFailed
+    }
+}
+
+fn map_stop_error(error: zbus::Error) -> ScopeError {
+    if is_timeout(&error) {
+        ScopeError::Timeout
+    } else {
+        ScopeError::StopFailed
+    }
+}
+
+fn is_timeout(error: &zbus::Error) -> bool {
+    matches!(
+        error,
+        zbus::Error::InputOutput(io_error)
+            if io_error.kind() == std::io::ErrorKind::TimedOut
+    )
 }
 
 fn await_scope_identity<F>(
@@ -349,5 +413,15 @@ mod tests {
 
         assert_eq!(observed, expected);
         assert_eq!(attempts, 2);
+    }
+
+    #[test]
+    fn dbus_method_timeouts_remain_typed() {
+        let error = zbus::Error::InputOutput(std::sync::Arc::new(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "timeout",
+        )));
+
+        assert_eq!(map_user_manager_error(error), ScopeError::Timeout);
     }
 }

--- a/packages/d2b-unsafe-local-helper/src/systemd.rs
+++ b/packages/d2b-unsafe-local-helper/src/systemd.rs
@@ -1,0 +1,289 @@
+use crate::environment::{EnvironmentError, ManagerEnvironment};
+use d2b_contracts::unsafe_local_wire::{HelperScopeKind, HelperScopeState, ScopeIdentity};
+use std::fmt;
+use std::path::Path;
+use zbus::blocking::{Connection, Proxy};
+use zbus::zvariant::{OwnedObjectPath, Value};
+
+const SYSTEMD_DESTINATION: &str = "org.freedesktop.systemd1";
+const SYSTEMD_MANAGER_PATH: &str = "/org/freedesktop/systemd1";
+const SYSTEMD_MANAGER_INTERFACE: &str = "org.freedesktop.systemd1.Manager";
+const SYSTEMD_UNIT_INTERFACE: &str = "org.freedesktop.systemd1.Unit";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeError {
+    UserManagerUnavailable,
+    EnvironmentInvalid,
+    Timeout,
+    CreateFailed,
+    IdentityMismatch,
+    QueryFailed,
+    StopFailed,
+}
+
+impl From<EnvironmentError> for ScopeError {
+    fn from(_: EnvironmentError) -> Self {
+        Self::EnvironmentInvalid
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct VerifiedScope {
+    pub unit_name: String,
+    pub invocation_id: String,
+    pub control_group: String,
+    pub kind: HelperScopeKind,
+}
+
+impl fmt::Debug for VerifiedScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerifiedScope")
+            .field("unit_name", &"<redacted>")
+            .field("invocation_id", &"<redacted>")
+            .field("control_group", &"<redacted>")
+            .field("kind", &self.kind)
+            .finish()
+    }
+}
+
+impl VerifiedScope {
+    pub fn wire_identity(&self) -> ScopeIdentity {
+        ScopeIdentity {
+            invocation_id: self.invocation_id.clone(),
+            kind: self.kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeInspection {
+    pub state: HelperScopeState,
+    pub identity_matches: bool,
+}
+
+pub trait UserScopeManager: Send + Sync + 'static {
+    fn manager_environment(&self) -> Result<ManagerEnvironment, ScopeError>;
+    fn start_scope(
+        &self,
+        supervisor_pid: u32,
+        kind: HelperScopeKind,
+    ) -> Result<VerifiedScope, ScopeError>;
+    fn inspect_scope(&self, scope: &VerifiedScope) -> Result<ScopeInspection, ScopeError>;
+    fn terminate_scope(&self, scope: &VerifiedScope, signal: i32) -> Result<(), ScopeError>;
+    fn stop_scope(&self, scope: &VerifiedScope) -> Result<(), ScopeError>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemdUserScopeManager;
+
+impl SystemdUserScopeManager {
+    fn connection() -> Result<Connection, ScopeError> {
+        Connection::session().map_err(|_| ScopeError::UserManagerUnavailable)
+    }
+
+    fn manager_proxy(connection: &Connection) -> Result<Proxy<'_>, ScopeError> {
+        Proxy::new(
+            connection,
+            SYSTEMD_DESTINATION,
+            SYSTEMD_MANAGER_PATH,
+            SYSTEMD_MANAGER_INTERFACE,
+        )
+        .map_err(|_| ScopeError::UserManagerUnavailable)
+    }
+
+    fn query_scope(
+        connection: &Connection,
+        unit_name: &str,
+        kind: HelperScopeKind,
+    ) -> Result<(VerifiedScope, HelperScopeState), ScopeError> {
+        let manager = Self::manager_proxy(connection)?;
+        let unit_path: OwnedObjectPath = manager
+            .call("GetUnit", &(unit_name))
+            .map_err(|_| ScopeError::QueryFailed)?;
+        let unit = Proxy::new(
+            connection,
+            SYSTEMD_DESTINATION,
+            unit_path.as_str(),
+            SYSTEMD_UNIT_INTERFACE,
+        )
+        .map_err(|_| ScopeError::QueryFailed)?;
+        let invocation: Vec<u8> = unit
+            .get_property("InvocationID")
+            .map_err(|_| ScopeError::QueryFailed)?;
+        if invocation.len() != 16 {
+            return Err(ScopeError::IdentityMismatch);
+        }
+        let control_group: String = unit
+            .get_property("ControlGroup")
+            .map_err(|_| ScopeError::QueryFailed)?;
+        if !control_group_matches_unit(&control_group, unit_name) {
+            return Err(ScopeError::IdentityMismatch);
+        }
+        let active_state: String = unit
+            .get_property("ActiveState")
+            .map_err(|_| ScopeError::QueryFailed)?;
+        let state = match active_state.as_str() {
+            "active" | "activating" | "reloading" => HelperScopeState::Active,
+            "deactivating" => HelperScopeState::Stopping,
+            "inactive" | "failed" => HelperScopeState::Exited,
+            _ => HelperScopeState::Degraded,
+        };
+        Ok((
+            VerifiedScope {
+                unit_name: unit_name.to_owned(),
+                invocation_id: hex(&invocation),
+                control_group,
+                kind,
+            },
+            state,
+        ))
+    }
+}
+
+impl UserScopeManager for SystemdUserScopeManager {
+    fn manager_environment(&self) -> Result<ManagerEnvironment, ScopeError> {
+        let connection = Self::connection()?;
+        let manager = Self::manager_proxy(&connection)?;
+        let environment: Vec<String> = manager
+            .get_property("Environment")
+            .map_err(|_| ScopeError::UserManagerUnavailable)?;
+        ManagerEnvironment::parse(environment).map_err(Into::into)
+    }
+
+    fn start_scope(
+        &self,
+        supervisor_pid: u32,
+        kind: HelperScopeKind,
+    ) -> Result<VerifiedScope, ScopeError> {
+        let connection = Self::connection()?;
+        let manager = Self::manager_proxy(&connection)?;
+        let unit_name = scope_unit_name(kind)?;
+        let properties = vec![
+            ("PIDs", Value::from(vec![supervisor_pid])),
+            (
+                "Description",
+                Value::from("d2b unsafe-local supervised process"),
+            ),
+            ("Slice", Value::from("app.slice")),
+            ("CollectMode", Value::from("inactive-or-failed")),
+            ("KillMode", Value::from("control-group")),
+        ];
+        let auxiliary: Vec<(&str, Vec<(&str, Value<'_>)>)> = Vec::new();
+        let _: OwnedObjectPath = manager
+            .call(
+                "StartTransientUnit",
+                &(unit_name.as_str(), "fail", properties, auxiliary),
+            )
+            .map_err(|_| ScopeError::CreateFailed)?;
+
+        let (scope, state) = Self::query_scope(&connection, &unit_name, kind)?;
+        if !matches!(state, HelperScopeState::Starting | HelperScopeState::Active) {
+            return Err(ScopeError::IdentityMismatch);
+        }
+        Ok(scope)
+    }
+
+    fn inspect_scope(&self, scope: &VerifiedScope) -> Result<ScopeInspection, ScopeError> {
+        let connection = Self::connection()?;
+        match Self::query_scope(&connection, &scope.unit_name, scope.kind) {
+            Ok((observed, state)) => Ok(ScopeInspection {
+                state,
+                identity_matches: observed.invocation_id == scope.invocation_id
+                    && observed.control_group == scope.control_group
+                    && observed.unit_name == scope.unit_name,
+            }),
+            Err(ScopeError::QueryFailed) => Ok(ScopeInspection {
+                state: HelperScopeState::Degraded,
+                identity_matches: false,
+            }),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn terminate_scope(&self, scope: &VerifiedScope, signal: i32) -> Result<(), ScopeError> {
+        let inspection = self.inspect_scope(scope)?;
+        if !inspection.identity_matches {
+            return Err(ScopeError::IdentityMismatch);
+        }
+        let connection = Self::connection()?;
+        let manager = Self::manager_proxy(&connection)?;
+        manager
+            .call_method("KillUnit", &(scope.unit_name.as_str(), "all", signal))
+            .map_err(|_| ScopeError::StopFailed)?;
+        Ok(())
+    }
+
+    fn stop_scope(&self, scope: &VerifiedScope) -> Result<(), ScopeError> {
+        let inspection = self.inspect_scope(scope)?;
+        if !inspection.identity_matches {
+            return Err(ScopeError::IdentityMismatch);
+        }
+        let connection = Self::connection()?;
+        let manager = Self::manager_proxy(&connection)?;
+        let _: OwnedObjectPath = manager
+            .call("StopUnit", &(scope.unit_name.as_str(), "replace"))
+            .map_err(|_| ScopeError::StopFailed)?;
+        Ok(())
+    }
+}
+
+fn scope_unit_name(kind: HelperScopeKind) -> Result<String, ScopeError> {
+    let prefix = match kind {
+        HelperScopeKind::LauncherApp => "app",
+        HelperScopeKind::WaylandProxy => "proxy",
+        HelperScopeKind::PersistentShell => "shell",
+    };
+    let mut random = [0u8; 16];
+    getrandom::getrandom(&mut random).map_err(|_| ScopeError::CreateFailed)?;
+    Ok(format!("d2b-unsafe-local-{prefix}-{}.scope", hex(&random)))
+}
+
+fn control_group_matches_unit(control_group: &str, unit_name: &str) -> bool {
+    !control_group.is_empty()
+        && control_group.starts_with('/')
+        && Path::new(control_group)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some(unit_name)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cgroup_identity_requires_exact_scope_leaf() {
+        let unit = "d2b-unsafe-local-app-0123456789abcdef.scope";
+        assert!(control_group_matches_unit(
+            &format!("/user.slice/user-1000.slice/user@1000.service/app.slice/{unit}"),
+            unit
+        ));
+        assert!(!control_group_matches_unit(
+            "/user.slice/user-1000.slice/user@1000.service/app.slice/foreign.scope",
+            unit
+        ));
+        assert!(!control_group_matches_unit("", unit));
+    }
+
+    #[test]
+    fn verified_scope_debug_redacts_all_manager_identity() {
+        let canary = "scope-identity-canary";
+        let scope = VerifiedScope {
+            unit_name: canary.to_owned(),
+            invocation_id: canary.to_owned(),
+            control_group: format!("/{canary}"),
+            kind: HelperScopeKind::LauncherApp,
+        };
+        assert!(!format!("{scope:?}").contains(canary));
+    }
+}

--- a/packages/d2b-unsafe-local-helper/src/systemd.rs
+++ b/packages/d2b-unsafe-local-helper/src/systemd.rs
@@ -2,6 +2,7 @@ use crate::environment::{EnvironmentError, ManagerEnvironment};
 use d2b_contracts::unsafe_local_wire::{HelperScopeKind, HelperScopeState, ScopeIdentity};
 use std::fmt;
 use std::path::Path;
+use std::time::{Duration, Instant};
 use zbus::blocking::{Connection, Proxy};
 use zbus::zvariant::{OwnedObjectPath, Value};
 
@@ -9,6 +10,8 @@ const SYSTEMD_DESTINATION: &str = "org.freedesktop.systemd1";
 const SYSTEMD_MANAGER_PATH: &str = "/org/freedesktop/systemd1";
 const SYSTEMD_MANAGER_INTERFACE: &str = "org.freedesktop.systemd1.Manager";
 const SYSTEMD_UNIT_INTERFACE: &str = "org.freedesktop.systemd1.Unit";
+const SCOPE_IDENTITY_READY_TIMEOUT: Duration = Duration::from_secs(2);
+const SCOPE_IDENTITY_RETRY_INTERVAL: Duration = Duration::from_millis(20);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScopeError {
@@ -176,11 +179,11 @@ impl UserScopeManager for SystemdUserScopeManager {
             )
             .map_err(|_| ScopeError::CreateFailed)?;
 
-        let (scope, state) = Self::query_scope(&connection, &unit_name, kind)?;
-        if !matches!(state, HelperScopeState::Starting | HelperScopeState::Active) {
-            return Err(ScopeError::IdentityMismatch);
-        }
-        Ok(scope)
+        await_scope_identity(
+            || Self::query_scope(&connection, &unit_name, kind),
+            SCOPE_IDENTITY_READY_TIMEOUT,
+            SCOPE_IDENTITY_RETRY_INTERVAL,
+        )
     }
 
     fn inspect_scope(&self, scope: &VerifiedScope) -> Result<ScopeInspection, ScopeError> {
@@ -224,6 +227,29 @@ impl UserScopeManager for SystemdUserScopeManager {
             .call("StopUnit", &(scope.unit_name.as_str(), "replace"))
             .map_err(|_| ScopeError::StopFailed)?;
         Ok(())
+    }
+}
+
+fn await_scope_identity<F>(
+    mut query: F,
+    timeout: Duration,
+    retry_interval: Duration,
+) -> Result<VerifiedScope, ScopeError>
+where
+    F: FnMut() -> Result<(VerifiedScope, HelperScopeState), ScopeError>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        match query() {
+            Ok((scope, HelperScopeState::Starting | HelperScopeState::Active)) => return Ok(scope),
+            Ok(_) => return Err(ScopeError::IdentityMismatch),
+            Err(ScopeError::QueryFailed | ScopeError::IdentityMismatch)
+                if Instant::now() < deadline =>
+            {
+                std::thread::sleep(retry_interval);
+            }
+            Err(error) => return Err(error),
+        }
     }
 }
 
@@ -285,5 +311,35 @@ mod tests {
             kind: HelperScopeKind::LauncherApp,
         };
         assert!(!format!("{scope:?}").contains(canary));
+    }
+
+    #[test]
+    fn scope_identity_waits_for_transient_unit_properties() {
+        let expected = VerifiedScope {
+            unit_name: "d2b-unsafe-local-app-test.scope".to_owned(),
+            invocation_id: "00112233445566778899aabbccddeeff".to_owned(),
+            control_group:
+                "/user.slice/user-1000.slice/user@1000.service/app.slice/d2b-unsafe-local-app-test.scope"
+                    .to_owned(),
+            kind: HelperScopeKind::LauncherApp,
+        };
+        let mut attempts = 0;
+
+        let observed = await_scope_identity(
+            || {
+                attempts += 1;
+                if attempts == 1 {
+                    Err(ScopeError::QueryFailed)
+                } else {
+                    Ok((expected.clone(), HelperScopeState::Active))
+                }
+            },
+            Duration::from_millis(50),
+            Duration::ZERO,
+        )
+        .unwrap();
+
+        assert_eq!(observed, expected);
+        assert_eq!(attempts, 2);
     }
 }

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -118,6 +118,7 @@ pub mod realm_access_resolver;
 pub mod supervisor;
 pub mod terminal_session;
 pub mod typed_error;
+pub mod unsafe_local_helper;
 pub mod wire;
 pub mod workload_target_index;
 use admission::{
@@ -342,6 +343,12 @@ pub struct DaemonConfig {
     pub daemon_group: String,
     pub public_socket_group: String,
     #[serde(default)]
+    pub unsafe_local_helper_socket_path: Option<PathBuf>,
+    #[serde(default)]
+    pub unsafe_local_helper_socket_group: Option<String>,
+    #[serde(default)]
+    pub unsafe_local_helper_users: Vec<String>,
+    #[serde(default)]
     pub launcher_users: Vec<String>,
     #[serde(default)]
     pub admin_users: Vec<String>,
@@ -404,6 +411,9 @@ impl Default for DaemonConfig {
             daemon_user: "d2bd".to_owned(),
             daemon_group: "d2bd".to_owned(),
             public_socket_group: "d2b".to_owned(),
+            unsafe_local_helper_socket_path: None,
+            unsafe_local_helper_socket_group: None,
+            unsafe_local_helper_users: Vec::new(),
             launcher_users: Vec::new(),
             admin_users: Vec::new(),
             server_version: default_server_version(),
@@ -524,6 +534,7 @@ struct RuntimeIdentity {
     daemon_uid: Uid,
     daemon_gid: Gid,
     public_socket_gid: Gid,
+    unsafe_local_helper_socket_gid: Option<Gid>,
     expect_root_owned_parent: bool,
 }
 
@@ -562,6 +573,8 @@ struct ServerState {
     /// until the daemon restarts or the VM stops.
     console_sessions: Arc<Mutex<console_session::ConsoleSessionTable>>,
     security_key_sessions: Arc<parking_lot::Mutex<security_key::SkSessionTable>>,
+    #[allow(dead_code)]
+    unsafe_local_helpers: Arc<unsafe_local_helper::HelperRegistry>,
 }
 
 struct GatewayDisplayRuntime {
@@ -1330,6 +1343,29 @@ pub async fn serve(options: ServeOptions) -> Result<(), TypedError> {
     ensure_locks_dir(&config.locks_dir, &runtime_identity)?;
     let _lock_file = acquire_state_lock(&config.state_lock_path, &runtime_identity)?;
     let listener = bind_public_socket(&config.public_socket_path, &runtime_identity)?;
+    let unsafe_local_helper_uids =
+        resolve_unsafe_local_helper_uids(&config, runtime_identity.daemon_uid)?;
+    let unsafe_local_helper_listener =
+        if let Some(path) = config.unsafe_local_helper_socket_path.as_deref() {
+            let socket_gid = runtime_identity
+                .unsafe_local_helper_socket_gid
+                .ok_or_else(|| TypedError::InternalConfig {
+                    detail: "unsafe-local helper socket path requires a socket group".to_owned(),
+                })?;
+            Some(
+                unsafe_local_helper::bind_helper_socket(
+                    path,
+                    socket_gid,
+                    runtime_identity.expect_root_owned_parent,
+                )
+                .map_err(|error| TypedError::InternalIo {
+                    context: "bind unsafe-local helper socket".to_owned(),
+                    detail: format!("{error:?}"),
+                })?,
+            )
+        } else {
+            None
+        };
 
     if options.drop_privileges {
         drop_privileges_if_root(&runtime_identity)?;
@@ -1404,6 +1440,10 @@ pub async fn serve(options: ServeOptions) -> Result<(), TypedError> {
         );
     }
 
+    let unsafe_local_helpers = Arc::new(unsafe_local_helper::HelperRegistry::new(
+        runtime_identity.daemon_uid.as_raw(),
+        unsafe_local_helper_uids,
+    ));
     let state = ServerState {
         daemon_uid: runtime_identity.daemon_uid.as_raw(),
         config,
@@ -1425,7 +1465,17 @@ pub async fn serve(options: ServeOptions) -> Result<(), TypedError> {
         security_key_sessions: Arc::new(parking_lot::Mutex::new(
             crate::security_key::SkSessionTable::default(),
         )),
+        unsafe_local_helpers: Arc::clone(&unsafe_local_helpers),
     };
+    if let Some(helper_listener) = unsafe_local_helper_listener {
+        std::thread::Builder::new()
+            .name("d2b-unsafe-local-listener".to_owned())
+            .spawn(move || unsafe_local_helpers.accept_loop(helper_listener))
+            .map_err(|error| TypedError::InternalIo {
+                context: "spawn unsafe-local helper listener".to_owned(),
+                detail: error.to_string(),
+            })?;
+    }
     refresh_activation_marker_metrics_on_startup(&state);
     refresh_broker_reap_log(&state, "startup");
 
@@ -2324,6 +2374,10 @@ fn resolve_runtime_identity(
             daemon_uid,
             daemon_gid,
             public_socket_gid: unistd::getgid(),
+            unsafe_local_helper_socket_gid: config
+                .unsafe_local_helper_socket_path
+                .as_ref()
+                .map(|_| unistd::getgid()),
             expect_root_owned_parent: false,
         });
     }
@@ -2345,12 +2399,56 @@ fn resolve_runtime_identity(
                 config.public_socket_group
             ),
         })?;
+    let unsafe_local_helper_socket_gid = match (
+        config.unsafe_local_helper_socket_path.as_ref(),
+        config.unsafe_local_helper_socket_group.as_ref(),
+    ) {
+        (Some(_), Some(group_name)) => Some(
+            Group::from_name(group_name)
+                .map_err(io_wrap("lookup unsafe-local helper socket group"))?
+                .ok_or_else(|| TypedError::InternalConfig {
+                    detail: format!("unsafe-local helper socket group {group_name} does not exist"),
+                })?
+                .gid,
+        ),
+        (None, None) => None,
+        _ => {
+            return Err(TypedError::InternalConfig {
+                detail: "unsafe-local helper socket path and group must be configured together"
+                    .to_owned(),
+            });
+        }
+    };
     Ok(RuntimeIdentity {
         daemon_uid: daemon_user.uid,
         daemon_gid: daemon_group.gid,
         public_socket_gid: public_group.gid,
+        unsafe_local_helper_socket_gid,
         expect_root_owned_parent: true,
     })
+}
+
+fn resolve_unsafe_local_helper_uids(
+    config: &DaemonConfig,
+    daemon_uid: Uid,
+) -> Result<Vec<u32>, TypedError> {
+    let mut uids = BTreeSet::new();
+    for username in &config.unsafe_local_helper_users {
+        let user = User::from_name(username)
+            .map_err(io_wrap("lookup unsafe-local helper user"))?
+            .ok_or_else(|| TypedError::InternalConfig {
+                detail: "configured unsafe-local helper user does not exist".to_owned(),
+            })?;
+        let uid = user.uid.as_raw();
+        if uid == 0 || uid == daemon_uid.as_raw() {
+            return Err(TypedError::InternalConfig {
+                detail: "unsafe-local helper users must be non-root and distinct from d2bd"
+                    .to_owned(),
+            });
+        }
+        uids.insert(uid);
+    }
+    Ok(uids.into_iter().collect())
 }
 
 fn validate_lock_parent(lock_path: &Path, identity: &RuntimeIdentity) -> Result<(), TypedError> {
@@ -17514,6 +17612,7 @@ mod public_status_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         };
         (state, dir)
     }
@@ -20114,6 +20213,7 @@ mod runtime_acl_tests {
             daemon_uid: unistd::getuid(),
             daemon_gid: unistd::getgid(),
             public_socket_gid: unistd::getgid(),
+            unsafe_local_helper_socket_gid: None,
             expect_root_owned_parent,
         }
     }
@@ -20179,6 +20279,7 @@ mod runtime_acl_tests {
             daemon_uid: unistd::getuid(),
             daemon_gid: unistd::getgid(),
             public_socket_gid: supp_gid,
+            unsafe_local_helper_socket_gid: None,
             expect_root_owned_parent: true,
         };
         let _socket = bind_public_socket(&socket_path, &identity).expect("bind public socket");
@@ -20420,6 +20521,7 @@ mod detached_exec_routing_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         }
     }
 
@@ -21090,6 +21192,7 @@ mod accept_loop_concurrency_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
             console_sessions: Arc::new(Mutex::new(
                 crate::console_session::ConsoleSessionTable::new(),
             )),
@@ -21625,6 +21728,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         }
     }
 
@@ -21662,6 +21766,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         }
     }
 
@@ -23753,6 +23858,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         };
         let server_socket_path = socket_path.clone();
         let broker = thread::spawn(move || {
@@ -23977,6 +24083,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         };
 
         let listener = socket(
@@ -24234,6 +24341,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         };
         let opener = RecordingOpener::new();
         adopt_orphaned_runners_on_startup_with(&state, &store, &FixedProcReader, &opener)
@@ -26127,6 +26235,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         };
 
         // Emit the same event that the timeout handler in
@@ -27036,6 +27145,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         };
 
         // Set a 0ms readiness timeout via the test-only config override so the
@@ -27160,6 +27270,7 @@ mod broker_dispatch_tests {
             security_key_sessions: Arc::new(parking_lot::Mutex::new(
                 crate::security_key::SkSessionTable::default(),
             )),
+            unsafe_local_helpers: Arc::new(crate::unsafe_local_helper::HelperRegistry::new(0, [])),
         };
 
         let response = dispatch_broker_vm_start(

--- a/packages/d2bd/src/unsafe_local_helper.rs
+++ b/packages/d2bd/src/unsafe_local_helper.rs
@@ -1,0 +1,1283 @@
+use d2b_contracts::unsafe_local_wire::{
+    DaemonToUnsafeLocalHelper, HELPER_SOCKET_BUFFER_REQUEST_BYTES, HelperFailureCode,
+    HelperHeartbeat, HelperHelloAccepted, HelperLaunchRequest, HelperOperationDisposition,
+    HelperOperationRejected, HelperOperationResult, HelperSnapshot, HelperTerminalReady,
+    MAX_COMPLETED_OPERATION_AGE_SECS, MAX_COMPLETED_OPERATIONS_PER_UID, MAX_HELPER_FRAME_SIZE,
+    MAX_HELPER_QUEUE_DEPTH, MAX_HELPER_SNAPSHOT_SCOPES, MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES,
+    UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION, UNSAFE_LOCAL_TERMINAL_FD_COUNT,
+    UNSAFE_LOCAL_TERMINAL_PROTOCOL_VERSION, UnsafeLocalHelperToDaemon,
+};
+use nix::cmsg_space;
+use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+use nix::sys::socket::{
+    ControlMessageOwned, MsgFlags, UnixAddr, getpeername, getsockopt, recvmsg, send,
+    sockopt::{AcceptConn, PeerCredentials, SockType as SocketTypeOpt},
+};
+use nix::unistd::{self, Gid};
+use parking_lot::Mutex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use socket2::{Domain, SockAddr, Socket, Type};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt;
+use std::fs;
+use std::io::IoSliceMut;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, mpsc};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+pub const HELPER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+pub const HELPER_STALE_AFTER: Duration = Duration::from_secs(15);
+pub const HELPER_OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
+const HELPER_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+const HELPER_LOOP_TICK: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelperRegistryError {
+    UnauthorizedPeer,
+    InvalidPeer,
+    SocketBufferTooSmall,
+    InvalidFrame,
+    FrameTooLarge,
+    ProtocolMismatch,
+    SnapshotTooLarge,
+    HelperUnavailable,
+    HelperStale,
+    QueueFull,
+    Timeout,
+    GenerationSuperseded,
+    RequestCorrelationMismatch,
+    OperationIdConflict,
+    OperationInProgress,
+    OperationRejected(HelperFailureCode),
+    InvalidTerminalFd,
+    Io,
+}
+
+pub enum HelperReply {
+    Operation(HelperOperationResult),
+    Rejected(HelperOperationRejected),
+    Terminal {
+        ready: HelperTerminalReady,
+        fd: OwnedFd,
+    },
+}
+
+impl fmt::Debug for HelperReply {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Operation(result) => f.debug_tuple("Operation").field(result).finish(),
+            Self::Rejected(rejected) => f.debug_tuple("Rejected").field(rejected).finish(),
+            Self::Terminal { ready, .. } => f
+                .debug_struct("Terminal")
+                .field("ready", ready)
+                .field("fd", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+struct PendingRequest {
+    operation_id: String,
+    sender: mpsc::SyncSender<Result<HelperReply, HelperRegistryError>>,
+}
+
+struct HelperConnection {
+    generation: u64,
+    socket: Arc<Socket>,
+    outbound: mpsc::SyncSender<DaemonToUnsafeLocalHelper>,
+    pending: Mutex<HashMap<u64, PendingRequest>>,
+    last_heartbeat_millis: AtomicU64,
+    connected_at: Instant,
+    closed: AtomicBool,
+}
+
+impl HelperConnection {
+    fn touch(&self) {
+        self.last_heartbeat_millis.store(
+            self.connected_at
+                .elapsed()
+                .as_millis()
+                .min(u128::from(u64::MAX)) as u64,
+            Ordering::Release,
+        );
+    }
+
+    fn is_stale(&self) -> bool {
+        let seen = self.last_heartbeat_millis.load(Ordering::Acquire);
+        self.connected_at
+            .elapsed()
+            .saturating_sub(Duration::from_millis(seen))
+            > HELPER_STALE_AFTER
+    }
+
+    fn close(&self, reason: HelperRegistryError) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let _ = self.socket.shutdown(std::net::Shutdown::Both);
+        let pending = std::mem::take(&mut *self.pending.lock());
+        for (_, request) in pending {
+            let _ = request.sender.try_send(Err(reason));
+        }
+    }
+}
+
+#[derive(Default)]
+struct RegistryState {
+    connections: HashMap<u32, Arc<HelperConnection>>,
+    snapshots: HashMap<u32, HelperSnapshot>,
+}
+
+pub struct HelperRegistry {
+    daemon_uid: u32,
+    allowed_uids: HashSet<u32>,
+    state: Mutex<RegistryState>,
+    operations: Mutex<OperationLedger>,
+}
+
+impl fmt::Debug for HelperRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock();
+        f.debug_struct("HelperRegistry")
+            .field("allowed_uid_count", &self.allowed_uids.len())
+            .field("active_helper_count", &state.connections.len())
+            .finish()
+    }
+}
+
+impl HelperRegistry {
+    pub fn new(daemon_uid: u32, allowed_uids: impl IntoIterator<Item = u32>) -> Self {
+        Self {
+            daemon_uid,
+            allowed_uids: allowed_uids.into_iter().collect(),
+            state: Mutex::new(RegistryState::default()),
+            operations: Mutex::new(OperationLedger::default()),
+        }
+    }
+
+    pub fn accept_loop(self: Arc<Self>, listener: Socket) {
+        loop {
+            match listener.accept() {
+                Ok((socket, _)) => {
+                    let registry = Arc::clone(&self);
+                    let _ = std::thread::Builder::new()
+                        .name("d2b-unsafe-local-helper".to_owned())
+                        .spawn(move || {
+                            if registry.handle_socket(socket).is_err() {
+                                tracing::warn!(
+                                    provider = "unsafe-local",
+                                    event_kind = "helper-register",
+                                    result = "rejected",
+                                    "unsafe-local helper connection rejected"
+                                );
+                            }
+                        });
+                }
+                Err(error) => {
+                    tracing::error!(
+                        provider = "unsafe-local",
+                        event_kind = "helper-accept",
+                        result = "failed",
+                        error_kind = ?error.kind(),
+                        "unsafe-local helper accept failed"
+                    );
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            }
+        }
+    }
+
+    pub fn active_generation(&self, uid: u32) -> Option<u64> {
+        self.state
+            .lock()
+            .connections
+            .get(&uid)
+            .filter(|connection| !connection.closed.load(Ordering::Acquire))
+            .map(|connection| connection.generation)
+    }
+
+    pub fn snapshot(&self, uid: u32) -> Option<HelperSnapshot> {
+        self.state.lock().snapshots.get(&uid).cloned()
+    }
+
+    pub fn dispatch_launch(
+        &self,
+        requester_uid: u32,
+        request: HelperLaunchRequest,
+    ) -> Result<HelperOperationResult, HelperRegistryError> {
+        let fingerprint = launch_fingerprint(&request)?;
+        let operation_key = request.operation_id.to_string();
+        let request_id = request.request_id;
+        match self.operations.lock().begin(
+            requester_uid,
+            operation_key.clone(),
+            fingerprint,
+            now_epoch_seconds(),
+        )? {
+            LedgerBegin::Completed(mut result) => {
+                result.request_id = request.request_id;
+                result.disposition = HelperOperationDisposition::AlreadyCommitted;
+                return Ok(result);
+            }
+            LedgerBegin::Rejected(code) => {
+                return Err(HelperRegistryError::OperationRejected(code));
+            }
+            LedgerBegin::Started => {}
+        }
+
+        let connection = match self.state.lock().connections.get(&requester_uid).cloned() {
+            Some(connection) => connection,
+            None => {
+                self.operations
+                    .lock()
+                    .abort_active(requester_uid, &operation_key);
+                return Err(HelperRegistryError::HelperUnavailable);
+            }
+        };
+        if connection.closed.load(Ordering::Acquire) {
+            self.operations
+                .lock()
+                .abort_active(requester_uid, &operation_key);
+            return Err(HelperRegistryError::HelperUnavailable);
+        }
+        if connection.is_stale() {
+            return Err(HelperRegistryError::HelperStale);
+        }
+        let (sender, receiver) = mpsc::sync_channel(1);
+        {
+            let mut pending = connection.pending.lock();
+            if pending.len() >= MAX_HELPER_QUEUE_DEPTH {
+                self.operations
+                    .lock()
+                    .abort_active(requester_uid, &operation_key);
+                return Err(HelperRegistryError::QueueFull);
+            }
+            if pending
+                .insert(
+                    request.request_id,
+                    PendingRequest {
+                        operation_id: operation_key.clone(),
+                        sender,
+                    },
+                )
+                .is_some()
+            {
+                self.operations
+                    .lock()
+                    .abort_active(requester_uid, &operation_key);
+                return Err(HelperRegistryError::RequestCorrelationMismatch);
+            }
+        }
+        if connection
+            .outbound
+            .try_send(DaemonToUnsafeLocalHelper::Launch(request))
+            .is_err()
+        {
+            connection.pending.lock().remove(&request_id);
+            self.operations
+                .lock()
+                .abort_active(requester_uid, &operation_key);
+            return Err(HelperRegistryError::QueueFull);
+        }
+
+        match receiver.recv_timeout(HELPER_OPERATION_TIMEOUT) {
+            Ok(Ok(HelperReply::Operation(result))) => {
+                self.operations.lock().complete(
+                    requester_uid,
+                    &operation_key,
+                    result.clone(),
+                    now_epoch_seconds(),
+                );
+                Ok(result)
+            }
+            Ok(Ok(HelperReply::Rejected(rejected))) => {
+                self.operations.lock().reject(
+                    requester_uid,
+                    &operation_key,
+                    rejected.code,
+                    now_epoch_seconds(),
+                );
+                Err(HelperRegistryError::OperationRejected(rejected.code))
+            }
+            Ok(Ok(HelperReply::Terminal { .. })) => {
+                Err(HelperRegistryError::RequestCorrelationMismatch)
+            }
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(HelperRegistryError::Timeout),
+        }
+    }
+
+    fn handle_socket(&self, socket: Socket) -> Result<(), HelperRegistryError> {
+        let peer =
+            getsockopt(&socket, PeerCredentials).map_err(|_| HelperRegistryError::InvalidPeer)?;
+        let uid = peer.uid() as u32;
+        if uid == 0 || uid == self.daemon_uid || !self.allowed_uids.contains(&uid) {
+            return Err(HelperRegistryError::UnauthorizedPeer);
+        }
+        configure_socket_buffers(&socket)?;
+        socket
+            .set_read_timeout(Some(HELPER_HANDSHAKE_TIMEOUT))
+            .map_err(|_| HelperRegistryError::Io)?;
+
+        let (hello, fds) = receive_frame::<UnsafeLocalHelperToDaemon>(&socket)?;
+        reject_unexpected_fds(fds)?;
+        let UnsafeLocalHelperToDaemon::Hello(hello) = hello else {
+            return Err(HelperRegistryError::ProtocolMismatch);
+        };
+        if hello.protocol_version != UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION || hello.generation == 0 {
+            return Err(HelperRegistryError::ProtocolMismatch);
+        }
+        send_frame(
+            &socket,
+            &DaemonToUnsafeLocalHelper::HelloAccepted(HelperHelloAccepted {
+                protocol_version: UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION,
+                generation: hello.generation,
+                heartbeat_interval_secs: HELPER_HEARTBEAT_INTERVAL.as_secs() as u32,
+                operation_timeout_secs: HELPER_OPERATION_TIMEOUT.as_secs() as u32,
+            }),
+        )?;
+        let (snapshot, fds) = receive_frame::<UnsafeLocalHelperToDaemon>(&socket)?;
+        reject_unexpected_fds(fds)?;
+        let UnsafeLocalHelperToDaemon::Snapshot(snapshot) = snapshot else {
+            return Err(HelperRegistryError::ProtocolMismatch);
+        };
+        if snapshot.generation != hello.generation {
+            return Err(HelperRegistryError::ProtocolMismatch);
+        }
+        if snapshot.scopes.len() > MAX_HELPER_SNAPSHOT_SCOPES {
+            return Err(HelperRegistryError::SnapshotTooLarge);
+        }
+
+        socket
+            .set_read_timeout(Some(HELPER_LOOP_TICK))
+            .map_err(|_| HelperRegistryError::Io)?;
+        let socket = Arc::new(socket);
+        let (outbound, outbound_rx) = mpsc::sync_channel(MAX_HELPER_QUEUE_DEPTH);
+        let connection = Arc::new(HelperConnection {
+            generation: hello.generation,
+            socket: Arc::clone(&socket),
+            outbound,
+            pending: Mutex::new(HashMap::new()),
+            last_heartbeat_millis: AtomicU64::new(0),
+            connected_at: Instant::now(),
+            closed: AtomicBool::new(false),
+        });
+        connection.touch();
+
+        let replaced = {
+            let mut state = self.state.lock();
+            state.snapshots.insert(uid, snapshot.clone());
+            state.connections.insert(uid, Arc::clone(&connection))
+        };
+        if let Some(replaced) = replaced {
+            replaced.close(HelperRegistryError::GenerationSuperseded);
+            tracing::info!(
+                provider = "unsafe-local",
+                event_kind = "helper-supersede",
+                result = "success",
+                "unsafe-local helper generation superseded"
+            );
+        } else {
+            tracing::info!(
+                provider = "unsafe-local",
+                event_kind = "helper-register",
+                result = "success",
+                "unsafe-local helper registered"
+            );
+        }
+        self.operations
+            .lock()
+            .adopt_snapshot(uid, &snapshot, now_epoch_seconds());
+
+        let result = self.connection_loop(uid, &connection, outbound_rx);
+        let mut state = self.state.lock();
+        if state
+            .connections
+            .get(&uid)
+            .is_some_and(|active| Arc::ptr_eq(active, &connection))
+        {
+            state.connections.remove(&uid);
+        }
+        drop(state);
+        connection.close(HelperRegistryError::HelperUnavailable);
+        result
+    }
+
+    fn connection_loop(
+        &self,
+        uid: u32,
+        connection: &Arc<HelperConnection>,
+        outbound: mpsc::Receiver<DaemonToUnsafeLocalHelper>,
+    ) -> Result<(), HelperRegistryError> {
+        let mut heartbeat_sequence = 0u64;
+        let mut next_heartbeat = Instant::now() + HELPER_HEARTBEAT_INTERVAL;
+        loop {
+            if connection.closed.load(Ordering::Acquire) {
+                return Err(HelperRegistryError::GenerationSuperseded);
+            }
+            while let Ok(frame) = outbound.try_recv() {
+                send_frame(&connection.socket, &frame)?;
+            }
+            if Instant::now() >= next_heartbeat {
+                heartbeat_sequence = heartbeat_sequence.wrapping_add(1);
+                send_frame(
+                    &connection.socket,
+                    &DaemonToUnsafeLocalHelper::Heartbeat(HelperHeartbeat {
+                        generation: connection.generation,
+                        sequence: heartbeat_sequence,
+                    }),
+                )?;
+                next_heartbeat = Instant::now() + HELPER_HEARTBEAT_INTERVAL;
+            }
+            if connection.is_stale() {
+                tracing::warn!(
+                    provider = "unsafe-local",
+                    event_kind = "helper-stale",
+                    result = "stale",
+                    "unsafe-local helper heartbeat stale"
+                );
+                return Err(HelperRegistryError::HelperStale);
+            }
+
+            match receive_frame::<UnsafeLocalHelperToDaemon>(&connection.socket) {
+                Ok((frame, fds)) => {
+                    if !self.is_active_generation(uid, connection) {
+                        close_raw_fds(fds);
+                        return Err(HelperRegistryError::GenerationSuperseded);
+                    }
+                    connection.touch();
+                    self.handle_incoming(connection, frame, fds)?;
+                }
+                Err(HelperRegistryError::Timeout) => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn is_active_generation(&self, uid: u32, connection: &Arc<HelperConnection>) -> bool {
+        self.state
+            .lock()
+            .connections
+            .get(&uid)
+            .is_some_and(|active| Arc::ptr_eq(active, connection))
+    }
+
+    fn handle_incoming(
+        &self,
+        connection: &HelperConnection,
+        frame: UnsafeLocalHelperToDaemon,
+        fds: Vec<RawFd>,
+    ) -> Result<(), HelperRegistryError> {
+        match frame {
+            UnsafeLocalHelperToDaemon::Heartbeat(heartbeat) => {
+                reject_unexpected_fds(fds)?;
+                if heartbeat.generation != connection.generation {
+                    return Err(HelperRegistryError::GenerationSuperseded);
+                }
+                Ok(())
+            }
+            UnsafeLocalHelperToDaemon::Operation(result) => {
+                reject_unexpected_fds(fds)?;
+                complete_pending(
+                    connection,
+                    result.request_id,
+                    result.operation_id.to_string(),
+                    HelperReply::Operation(result),
+                )
+            }
+            UnsafeLocalHelperToDaemon::Rejected(rejected) => {
+                reject_unexpected_fds(fds)?;
+                complete_pending(
+                    connection,
+                    rejected.request_id,
+                    rejected.operation_id.to_string(),
+                    HelperReply::Rejected(rejected),
+                )
+            }
+            UnsafeLocalHelperToDaemon::TerminalReady(ready) => {
+                let fd = validate_terminal_fd(&ready, fds)?;
+                complete_pending(
+                    connection,
+                    ready.request_id,
+                    ready.operation_id.to_string(),
+                    HelperReply::Terminal { ready, fd },
+                )
+            }
+            UnsafeLocalHelperToDaemon::Hello(_) | UnsafeLocalHelperToDaemon::Snapshot(_) => {
+                reject_unexpected_fds(fds)?;
+                Err(HelperRegistryError::ProtocolMismatch)
+            }
+        }
+    }
+}
+
+fn complete_pending(
+    connection: &HelperConnection,
+    request_id: u64,
+    operation_id: String,
+    reply: HelperReply,
+) -> Result<(), HelperRegistryError> {
+    let Some(pending) = connection.pending.lock().remove(&request_id) else {
+        return Err(HelperRegistryError::RequestCorrelationMismatch);
+    };
+    if pending.operation_id != operation_id {
+        let _ = pending
+            .sender
+            .try_send(Err(HelperRegistryError::RequestCorrelationMismatch));
+        return Err(HelperRegistryError::RequestCorrelationMismatch);
+    }
+    pending
+        .sender
+        .try_send(Ok(reply))
+        .map_err(|_| HelperRegistryError::RequestCorrelationMismatch)
+}
+
+pub fn bind_helper_socket(
+    path: &Path,
+    socket_gid: Gid,
+    set_group: bool,
+) -> Result<Socket, HelperRegistryError> {
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        if metadata.file_type().is_socket() {
+            fs::remove_file(path).map_err(|_| HelperRegistryError::Io)?;
+        } else {
+            return Err(HelperRegistryError::Io);
+        }
+    }
+    let socket = Socket::new(Domain::UNIX, Type::from(libc::SOCK_SEQPACKET), None)
+        .map_err(|_| HelperRegistryError::Io)?;
+    fcntl(socket.as_raw_fd(), FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))
+        .map_err(|_| HelperRegistryError::Io)?;
+    let address = SockAddr::unix(path).map_err(|_| HelperRegistryError::Io)?;
+    socket.bind(&address).map_err(|_| HelperRegistryError::Io)?;
+    socket.listen(128).map_err(|_| HelperRegistryError::Io)?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o660))
+        .map_err(|_| HelperRegistryError::Io)?;
+    if set_group {
+        unistd::chown(path, None, Some(socket_gid)).map_err(|_| HelperRegistryError::Io)?;
+    }
+    Ok(socket)
+}
+
+fn configure_socket_buffers(socket: &Socket) -> Result<(), HelperRegistryError> {
+    socket
+        .set_send_buffer_size(HELPER_SOCKET_BUFFER_REQUEST_BYTES)
+        .map_err(|_| HelperRegistryError::SocketBufferTooSmall)?;
+    socket
+        .set_recv_buffer_size(HELPER_SOCKET_BUFFER_REQUEST_BYTES)
+        .map_err(|_| HelperRegistryError::SocketBufferTooSmall)?;
+    let send = socket
+        .send_buffer_size()
+        .map_err(|_| HelperRegistryError::SocketBufferTooSmall)?;
+    let receive = socket
+        .recv_buffer_size()
+        .map_err(|_| HelperRegistryError::SocketBufferTooSmall)?;
+    if send < MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES
+        || receive < MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES
+    {
+        return Err(HelperRegistryError::SocketBufferTooSmall);
+    }
+    Ok(())
+}
+
+fn send_frame<T: Serialize>(socket: &Socket, frame: &T) -> Result<(), HelperRegistryError> {
+    let payload = serde_json::to_vec(frame).map_err(|_| HelperRegistryError::InvalidFrame)?;
+    if payload.len() > MAX_HELPER_FRAME_SIZE {
+        return Err(HelperRegistryError::FrameTooLarge);
+    }
+    let length = u32::try_from(payload.len()).map_err(|_| HelperRegistryError::FrameTooLarge)?;
+    let mut encoded = Vec::with_capacity(payload.len() + 4);
+    encoded.extend_from_slice(&length.to_le_bytes());
+    encoded.extend_from_slice(&payload);
+    let sent = send(socket.as_raw_fd(), &encoded, MsgFlags::MSG_NOSIGNAL)
+        .map_err(|_| HelperRegistryError::Io)?;
+    if sent != encoded.len() {
+        return Err(HelperRegistryError::InvalidFrame);
+    }
+    Ok(())
+}
+
+fn receive_frame<T: serde::de::DeserializeOwned>(
+    socket: &Socket,
+) -> Result<(T, Vec<RawFd>), HelperRegistryError> {
+    let mut encoded = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
+    let mut iov = [IoSliceMut::new(&mut encoded)];
+    let mut control = cmsg_space!([RawFd; 2]);
+    let message = match recvmsg::<UnixAddr>(
+        socket.as_raw_fd(),
+        &mut iov,
+        Some(&mut control),
+        MsgFlags::MSG_CMSG_CLOEXEC,
+    ) {
+        Ok(message) => message,
+        Err(nix::errno::Errno::EAGAIN) => return Err(HelperRegistryError::Timeout),
+        Err(_) => return Err(HelperRegistryError::Io),
+    };
+    let read = message.bytes;
+    if read == 0 {
+        return Err(HelperRegistryError::Io);
+    }
+    if message
+        .flags
+        .intersects(MsgFlags::MSG_TRUNC | MsgFlags::MSG_CTRUNC)
+    {
+        return Err(HelperRegistryError::FrameTooLarge);
+    }
+    let mut fds = Vec::new();
+    for control in message
+        .cmsgs()
+        .map_err(|_| HelperRegistryError::InvalidFrame)?
+    {
+        if let ControlMessageOwned::ScmRights(rights) = control {
+            fds.extend(rights);
+        }
+    }
+    if read < 4 {
+        close_raw_fds(fds);
+        return Err(HelperRegistryError::InvalidFrame);
+    }
+    let declared = u32::from_le_bytes(
+        encoded[..4]
+            .try_into()
+            .map_err(|_| HelperRegistryError::InvalidFrame)?,
+    ) as usize;
+    if declared > MAX_HELPER_FRAME_SIZE {
+        close_raw_fds(fds);
+        return Err(HelperRegistryError::FrameTooLarge);
+    }
+    if read != declared + 4 {
+        close_raw_fds(fds);
+        return Err(HelperRegistryError::InvalidFrame);
+    }
+    let frame = serde_json::from_slice(&encoded[4..read]).map_err(|_| {
+        close_raw_fds(fds.clone());
+        HelperRegistryError::InvalidFrame
+    })?;
+    Ok((frame, fds))
+}
+
+fn validate_terminal_fd(
+    ready: &HelperTerminalReady,
+    fds: Vec<RawFd>,
+) -> Result<OwnedFd, HelperRegistryError> {
+    if ready.terminal_protocol_version != UNSAFE_LOCAL_TERMINAL_PROTOCOL_VERSION
+        || fds.len() != UNSAFE_LOCAL_TERMINAL_FD_COUNT
+    {
+        close_raw_fds(fds);
+        return Err(HelperRegistryError::InvalidTerminalFd);
+    }
+    let raw = fds[0];
+    let duplicated = duplicate_received_fd(raw)?;
+    close_raw_fds(fds);
+    let flags = fcntl(duplicated.as_raw_fd(), FcntlArg::F_GETFD)
+        .map_err(|_| HelperRegistryError::InvalidTerminalFd)?;
+    if !FdFlag::from_bits_truncate(flags).contains(FdFlag::FD_CLOEXEC)
+        || getsockopt(&duplicated, SocketTypeOpt)
+            .map_err(|_| HelperRegistryError::InvalidTerminalFd)?
+            != nix::sys::socket::SockType::Stream
+        || getsockopt(&duplicated, AcceptConn)
+            .map_err(|_| HelperRegistryError::InvalidTerminalFd)?
+        || getpeername::<UnixAddr>(duplicated.as_raw_fd()).is_err()
+    {
+        return Err(HelperRegistryError::InvalidTerminalFd);
+    }
+    Ok(duplicated)
+}
+
+fn duplicate_received_fd(raw: RawFd) -> Result<OwnedFd, HelperRegistryError> {
+    let pid = rustix::process::Pid::from_raw(std::process::id() as i32)
+        .ok_or(HelperRegistryError::InvalidTerminalFd)?;
+    let pidfd = rustix::process::pidfd_open(pid, rustix::process::PidfdFlags::empty())
+        .map_err(|_| HelperRegistryError::InvalidTerminalFd)?;
+    let duplicated =
+        rustix::process::pidfd_getfd(&pidfd, raw, rustix::process::PidfdGetfdFlags::empty())
+            .map_err(|_| HelperRegistryError::InvalidTerminalFd)?;
+    fcntl(
+        duplicated.as_raw_fd(),
+        FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC),
+    )
+    .map_err(|_| HelperRegistryError::InvalidTerminalFd)?;
+    Ok(duplicated)
+}
+
+fn close_raw_fds(fds: Vec<RawFd>) {
+    for fd in fds {
+        let _ = unistd::close(fd);
+    }
+}
+
+fn reject_unexpected_fds(fds: Vec<RawFd>) -> Result<(), HelperRegistryError> {
+    let unexpected = !fds.is_empty();
+    close_raw_fds(fds);
+    if unexpected {
+        Err(HelperRegistryError::InvalidTerminalFd)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+enum LedgerState {
+    Active,
+    Completed {
+        result: HelperOperationResult,
+        completed_at: u64,
+    },
+    Rejected {
+        code: HelperFailureCode,
+        completed_at: u64,
+    },
+    Adopted {
+        completed_at: u64,
+    },
+}
+
+#[derive(Clone)]
+struct LedgerEntry {
+    fingerprint: Option<[u8; 32]>,
+    state: LedgerState,
+}
+
+#[derive(Default)]
+struct OperationLedger {
+    by_uid: BTreeMap<u32, HashMap<String, LedgerEntry>>,
+}
+
+enum LedgerBegin {
+    Started,
+    Completed(HelperOperationResult),
+    Rejected(HelperFailureCode),
+}
+
+impl OperationLedger {
+    fn begin(
+        &mut self,
+        uid: u32,
+        operation_id: String,
+        fingerprint: [u8; 32],
+        now: u64,
+    ) -> Result<LedgerBegin, HelperRegistryError> {
+        self.reap_uid(uid, now);
+        let entries = self.by_uid.entry(uid).or_default();
+        if let Some(entry) = entries.get(&operation_id) {
+            if entry.fingerprint != Some(fingerprint) {
+                return Err(HelperRegistryError::OperationIdConflict);
+            }
+            return match &entry.state {
+                LedgerState::Active => Err(HelperRegistryError::OperationInProgress),
+                LedgerState::Completed { result, .. } => Ok(LedgerBegin::Completed(result.clone())),
+                LedgerState::Rejected { code, .. } => Ok(LedgerBegin::Rejected(*code)),
+                LedgerState::Adopted { .. } => Err(HelperRegistryError::OperationIdConflict),
+            };
+        }
+        entries.insert(
+            operation_id,
+            LedgerEntry {
+                fingerprint: Some(fingerprint),
+                state: LedgerState::Active,
+            },
+        );
+        Ok(LedgerBegin::Started)
+    }
+
+    fn complete(&mut self, uid: u32, operation_id: &str, result: HelperOperationResult, now: u64) {
+        if let Some(entry) = self
+            .by_uid
+            .get_mut(&uid)
+            .and_then(|entries| entries.get_mut(operation_id))
+        {
+            entry.state = LedgerState::Completed {
+                result,
+                completed_at: now,
+            };
+        }
+        self.reap_uid(uid, now);
+    }
+
+    fn abort_active(&mut self, uid: u32, operation_id: &str) {
+        let Some(entries) = self.by_uid.get_mut(&uid) else {
+            return;
+        };
+        if entries
+            .get(operation_id)
+            .is_some_and(|entry| matches!(entry.state, LedgerState::Active))
+        {
+            entries.remove(operation_id);
+        }
+    }
+
+    fn reject(&mut self, uid: u32, operation_id: &str, code: HelperFailureCode, now: u64) {
+        if let Some(entry) = self
+            .by_uid
+            .get_mut(&uid)
+            .and_then(|entries| entries.get_mut(operation_id))
+        {
+            entry.state = LedgerState::Rejected {
+                code,
+                completed_at: now,
+            };
+        }
+        self.reap_uid(uid, now);
+    }
+
+    fn adopt_snapshot(&mut self, uid: u32, snapshot: &HelperSnapshot, now: u64) {
+        let entries = self.by_uid.entry(uid).or_default();
+        for scope in &snapshot.scopes {
+            let operation_id = scope.operation_id.to_string();
+            let adopted_result = HelperOperationResult {
+                request_id: 0,
+                operation_id: scope.operation_id.clone(),
+                disposition: HelperOperationDisposition::AlreadyCommitted,
+                scope: Some(scope.scope.clone()),
+            };
+            match entries.entry(operation_id) {
+                std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                    if matches!(occupied.get().state, LedgerState::Active) {
+                        occupied.get_mut().state = LedgerState::Completed {
+                            result: adopted_result,
+                            completed_at: now,
+                        };
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(vacant) => {
+                    vacant.insert(LedgerEntry {
+                        fingerprint: None,
+                        state: LedgerState::Adopted { completed_at: now },
+                    });
+                }
+            }
+        }
+        self.reap_uid(uid, now);
+    }
+
+    fn reap_uid(&mut self, uid: u32, now: u64) {
+        let Some(entries) = self.by_uid.get_mut(&uid) else {
+            return;
+        };
+        entries.retain(|_, entry| match &entry.state {
+            LedgerState::Active => true,
+            LedgerState::Completed { completed_at, .. }
+            | LedgerState::Rejected { completed_at, .. }
+            | LedgerState::Adopted { completed_at, .. } => {
+                now.saturating_sub(*completed_at) < MAX_COMPLETED_OPERATION_AGE_SECS
+            }
+        });
+        let mut completed: Vec<(String, u64)> = entries
+            .iter()
+            .filter_map(|(id, entry)| match &entry.state {
+                LedgerState::Active => None,
+                LedgerState::Completed { completed_at, .. }
+                | LedgerState::Rejected { completed_at, .. }
+                | LedgerState::Adopted { completed_at, .. } => Some((id.clone(), *completed_at)),
+            })
+            .collect();
+        if completed.len() > MAX_COMPLETED_OPERATIONS_PER_UID {
+            completed.sort_by_key(|(id, completed_at)| (*completed_at, id.clone()));
+            let excess = completed
+                .len()
+                .saturating_sub(MAX_COMPLETED_OPERATIONS_PER_UID);
+            for (id, _) in completed.into_iter().take(excess) {
+                entries.remove(&id);
+            }
+        }
+    }
+}
+
+fn launch_fingerprint(request: &HelperLaunchRequest) -> Result<[u8; 32], HelperRegistryError> {
+    let encoded = serde_json::to_vec(&(
+        &request.workload,
+        &request.item_id,
+        &request.argv,
+        request.graphical,
+    ))
+    .map_err(|_| HelperRegistryError::InvalidFrame)?;
+    Ok(Sha256::digest(encoded).into())
+}
+
+fn now_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use d2b_core::configured_argv::ConfiguredArgv;
+    use d2b_realm_core::{ids::OperationId, token::ProtocolToken};
+    use nix::sys::socket::{AddressFamily, SockFlag, socketpair};
+    use std::os::fd::OwnedFd;
+
+    fn launch(request_id: u64, operation_id: &str, arg: &str) -> HelperLaunchRequest {
+        HelperLaunchRequest {
+            request_id,
+            operation_id: OperationId::parse(operation_id).unwrap(),
+            workload: serde_json::from_value(serde_json::json!({
+                "workloadId": "tools",
+                "realmId": "host",
+                "realmPath": ["host"],
+                "canonicalTarget": "tools.host.d2b"
+            }))
+            .unwrap(),
+            item_id: ProtocolToken::parse("browser").unwrap(),
+            argv: ConfiguredArgv::new(vec![arg.to_owned()]).unwrap(),
+            graphical: false,
+        }
+    }
+
+    fn completed(request: &HelperLaunchRequest) -> HelperOperationResult {
+        HelperOperationResult {
+            request_id: request.request_id,
+            operation_id: request.operation_id.clone(),
+            disposition: HelperOperationDisposition::Committed,
+            scope: None,
+        }
+    }
+
+    #[test]
+    fn operation_ledger_rejects_reuse_with_new_fingerprint() {
+        let mut ledger = OperationLedger::default();
+        let first = launch(1, "op-1", "first");
+        assert!(matches!(
+            ledger
+                .begin(
+                    1000,
+                    "op-1".to_owned(),
+                    launch_fingerprint(&first).unwrap(),
+                    1
+                )
+                .unwrap(),
+            LedgerBegin::Started
+        ));
+        ledger.complete(1000, "op-1", completed(&first), 2);
+        let different = launch(2, "op-1", "different");
+        assert!(matches!(
+            ledger.begin(
+                1000,
+                "op-1".to_owned(),
+                launch_fingerprint(&different).unwrap(),
+                3
+            ),
+            Err(HelperRegistryError::OperationIdConflict)
+        ));
+    }
+
+    #[test]
+    fn operation_ledger_never_reaps_active_entries() {
+        let mut ledger = OperationLedger::default();
+        let active = launch(1, "active-op", "program");
+        ledger
+            .begin(
+                1000,
+                "active-op".to_owned(),
+                launch_fingerprint(&active).unwrap(),
+                0,
+            )
+            .unwrap();
+        for index in 0..=MAX_COMPLETED_OPERATIONS_PER_UID {
+            let request = launch(index as u64 + 2, &format!("done-{index}"), "program");
+            let key = request.operation_id.to_string();
+            ledger
+                .begin(
+                    1000,
+                    key.clone(),
+                    launch_fingerprint(&request).unwrap(),
+                    index as u64 + 1,
+                )
+                .unwrap();
+            ledger.complete(1000, &key, completed(&request), index as u64 + 1);
+        }
+        let entries = ledger.by_uid.get(&1000).unwrap();
+        assert!(matches!(
+            entries.get("active-op").map(|entry| &entry.state),
+            Some(LedgerState::Active)
+        ));
+        assert!(
+            entries
+                .values()
+                .filter(|entry| !matches!(entry.state, LedgerState::Active))
+                .count()
+                <= MAX_COMPLETED_OPERATIONS_PER_UID
+        );
+    }
+
+    #[test]
+    fn reconnect_snapshot_reconciles_an_ambiguous_active_launch() {
+        let mut ledger = OperationLedger::default();
+        let request = launch(1, "op-reconcile", "program");
+        let fingerprint = launch_fingerprint(&request).unwrap();
+        ledger
+            .begin(1000, "op-reconcile".to_owned(), fingerprint, 1)
+            .unwrap();
+        ledger.adopt_snapshot(
+            1000,
+            &HelperSnapshot {
+                generation: 2,
+                scopes: vec![d2b_contracts::unsafe_local_wire::HelperScopeSnapshot {
+                    operation_id: request.operation_id.clone(),
+                    workload: request.workload.clone(),
+                    scope: d2b_contracts::unsafe_local_wire::ScopeIdentity {
+                        invocation_id: "00112233445566778899aabbccddeeff".to_owned(),
+                        kind: d2b_contracts::unsafe_local_wire::HelperScopeKind::LauncherApp,
+                    },
+                    state: d2b_contracts::unsafe_local_wire::HelperScopeState::Active,
+                }],
+            },
+            2,
+        );
+        assert!(matches!(
+            ledger.begin(1000, "op-reconcile".to_owned(), fingerprint, 3),
+            Ok(LedgerBegin::Completed(HelperOperationResult {
+                disposition: HelperOperationDisposition::AlreadyCommitted,
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn registry_never_selects_a_different_uid_helper() {
+        let registry = HelperRegistry::new(42, [1000, 1001]);
+        assert!(registry.active_generation(1000).is_none());
+        assert!(registry.active_generation(1001).is_none());
+        assert!(!registry.allowed_uids.contains(&0));
+        assert!(!registry.allowed_uids.contains(&42));
+    }
+
+    #[test]
+    fn debug_surfaces_hide_uid_and_fingerprint_material() {
+        let registry = HelperRegistry::new(42, [1000]);
+        let debug = format!("{registry:?}");
+        assert!(!debug.contains("1000"));
+        assert!(!debug.contains("42"));
+        let request = launch(1, "op-1", "argv-private-canary");
+        let fingerprint = launch_fingerprint(&request).unwrap();
+        assert!(!format!("{fingerprint:?}").contains("argv-private-canary"));
+    }
+
+    #[test]
+    fn same_uid_helper_registers_and_reconnect_supersedes_generation() {
+        if unistd::getuid().is_root() {
+            return;
+        }
+        let uid = unistd::getuid().as_raw();
+        let registry = Arc::new(HelperRegistry::new(uid.wrapping_add(1), [uid]));
+        let first = register_helper(Arc::clone(&registry), 11);
+        assert_eq!(registry.active_generation(uid), Some(11));
+        let second = register_helper(Arc::clone(&registry), 12);
+        assert_eq!(registry.active_generation(uid), Some(12));
+        drop(first);
+        drop(second);
+    }
+
+    #[test]
+    fn helper_registration_rejects_uid_outside_eligibility_set() {
+        if unistd::getuid().is_root() {
+            return;
+        }
+        let uid = unistd::getuid().as_raw();
+        let registry = HelperRegistry::new(uid.wrapping_add(1), []);
+        let (server, client) = seqpacket_pair();
+        drop(client);
+        assert_eq!(
+            registry.handle_socket(server),
+            Err(HelperRegistryError::UnauthorizedPeer)
+        );
+    }
+
+    #[test]
+    fn registered_helper_dispatches_correlated_launch_without_uid_in_frame() {
+        if unistd::getuid().is_root() {
+            return;
+        }
+        let uid = unistd::getuid().as_raw();
+        let registry = Arc::new(HelperRegistry::new(uid.wrapping_add(1), [uid]));
+        let helper = register_helper(Arc::clone(&registry), 21);
+        let request = launch(91, "op-correlated", "/bin/true");
+        let expected_operation = request.operation_id.clone();
+        let dispatch_registry = Arc::clone(&registry);
+        let dispatch = std::thread::spawn(move || dispatch_registry.dispatch_launch(uid, request));
+
+        loop {
+            let (frame, fds) =
+                receive_frame::<DaemonToUnsafeLocalHelper>(&helper).expect("daemon request");
+            close_raw_fds(fds);
+            match frame {
+                DaemonToUnsafeLocalHelper::Launch(request) => {
+                    assert_eq!(request.request_id, 91);
+                    send_frame(
+                        &helper,
+                        &UnsafeLocalHelperToDaemon::Operation(HelperOperationResult {
+                            request_id: request.request_id,
+                            operation_id: request.operation_id,
+                            disposition: HelperOperationDisposition::Committed,
+                            scope: None,
+                        }),
+                    )
+                    .unwrap();
+                    break;
+                }
+                DaemonToUnsafeLocalHelper::Heartbeat(heartbeat) => {
+                    send_frame(&helper, &UnsafeLocalHelperToDaemon::Heartbeat(heartbeat)).unwrap();
+                }
+                other => panic!("unexpected daemon frame: {other:?}"),
+            }
+        }
+        let result = dispatch.join().unwrap().unwrap();
+        assert_eq!(result.operation_id, expected_operation);
+    }
+
+    #[test]
+    fn queue_saturation_does_not_leave_operation_replayable_as_active() {
+        if unistd::getuid().is_root() {
+            return;
+        }
+        let uid = unistd::getuid().as_raw();
+        let registry = HelperRegistry::new(uid.wrapping_add(1), [uid]);
+        let (socket, peer) = seqpacket_pair();
+        let (outbound, _outbound_rx) = mpsc::sync_channel(1);
+        outbound
+            .try_send(DaemonToUnsafeLocalHelper::Heartbeat(HelperHeartbeat {
+                generation: 1,
+                sequence: 1,
+            }))
+            .unwrap();
+        let connection = Arc::new(HelperConnection {
+            generation: 1,
+            socket: Arc::new(socket),
+            outbound,
+            pending: Mutex::new(HashMap::new()),
+            last_heartbeat_millis: AtomicU64::new(0),
+            connected_at: Instant::now(),
+            closed: AtomicBool::new(false),
+        });
+        registry.state.lock().connections.insert(uid, connection);
+        let request = launch(1, "queue-op", "/bin/true");
+        assert_eq!(
+            registry.dispatch_launch(uid, request.clone()),
+            Err(HelperRegistryError::QueueFull)
+        );
+        assert_eq!(
+            registry.dispatch_launch(uid, request),
+            Err(HelperRegistryError::QueueFull)
+        );
+        drop(peer);
+    }
+
+    #[test]
+    fn heartbeat_age_marks_helper_stale_without_global_cleanup() {
+        let (socket, peer) = seqpacket_pair();
+        let (outbound, _receiver) = mpsc::sync_channel(1);
+        let connection = HelperConnection {
+            generation: 1,
+            socket: Arc::new(socket),
+            outbound,
+            pending: Mutex::new(HashMap::new()),
+            last_heartbeat_millis: AtomicU64::new(0),
+            connected_at: Instant::now() - HELPER_STALE_AFTER - Duration::from_millis(1),
+            closed: AtomicBool::new(false),
+        };
+        assert!(connection.is_stale());
+        drop(peer);
+    }
+
+    #[test]
+    fn terminal_fd_validation_accepts_only_connected_cloexec_stream() {
+        let (stream, peer): (OwnedFd, OwnedFd) = socketpair(
+            AddressFamily::Unix,
+            nix::sys::socket::SockType::Stream,
+            None,
+            SockFlag::SOCK_CLOEXEC,
+        )
+        .unwrap();
+        let raw = unistd::dup(stream.as_raw_fd()).unwrap();
+        let ready = HelperTerminalReady {
+            request_id: 1,
+            operation_id: OperationId::parse("op-terminal").unwrap(),
+            terminal_protocol_version: UNSAFE_LOCAL_TERMINAL_PROTOCOL_VERSION,
+            transport:
+                d2b_contracts::unsafe_local_wire::HelperTerminalTransport::ConnectedUnixStream,
+            scope: d2b_contracts::unsafe_local_wire::ScopeIdentity {
+                invocation_id: "00112233445566778899aabbccddeeff".to_owned(),
+                kind: d2b_contracts::unsafe_local_wire::HelperScopeKind::PersistentShell,
+            },
+        };
+        let validated = validate_terminal_fd(&ready, vec![raw]).unwrap();
+        let flags = fcntl(validated.as_raw_fd(), FcntlArg::F_GETFD).unwrap();
+        assert!(FdFlag::from_bits_truncate(flags).contains(FdFlag::FD_CLOEXEC));
+        drop(peer);
+
+        let (datagram, datagram_peer): (OwnedFd, OwnedFd) = socketpair(
+            AddressFamily::Unix,
+            nix::sys::socket::SockType::Datagram,
+            None,
+            SockFlag::SOCK_CLOEXEC,
+        )
+        .unwrap();
+        let raw = unistd::dup(datagram.as_raw_fd()).unwrap();
+        assert!(matches!(
+            validate_terminal_fd(&ready, vec![raw]),
+            Err(HelperRegistryError::InvalidTerminalFd)
+        ));
+        drop(datagram_peer);
+    }
+
+    fn register_helper(registry: Arc<HelperRegistry>, generation: u64) -> Socket {
+        let uid = unistd::getuid().as_raw();
+        let (server, client) = seqpacket_pair();
+        let server_registry = Arc::clone(&registry);
+        std::thread::spawn(move || {
+            let _ = server_registry.handle_socket(server);
+        });
+        configure_socket_buffers(&client).unwrap();
+        send_frame(
+            &client,
+            &UnsafeLocalHelperToDaemon::Hello(d2b_contracts::unsafe_local_wire::HelperHello {
+                protocol_version: UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION,
+                generation,
+                features: Vec::new(),
+            }),
+        )
+        .unwrap();
+        let (accepted, fds) =
+            receive_frame::<DaemonToUnsafeLocalHelper>(&client).expect("hello accepted");
+        close_raw_fds(fds);
+        assert!(matches!(
+            accepted,
+            DaemonToUnsafeLocalHelper::HelloAccepted(HelperHelloAccepted {
+                generation: observed,
+                ..
+            }) if observed == generation
+        ));
+        send_frame(
+            &client,
+            &UnsafeLocalHelperToDaemon::Snapshot(HelperSnapshot {
+                generation,
+                scopes: Vec::new(),
+            }),
+        )
+        .unwrap();
+        for _ in 0..100 {
+            if registry.active_generation(uid) == Some(generation) {
+                return client;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        panic!("helper generation did not register");
+    }
+
+    fn seqpacket_pair() -> (Socket, Socket) {
+        let (left, right): (OwnedFd, OwnedFd) = socketpair(
+            AddressFamily::Unix,
+            nix::sys::socket::SockType::SeqPacket,
+            None,
+            SockFlag::SOCK_CLOEXEC,
+        )
+        .unwrap();
+        (Socket::from(left), Socket::from(right))
+    }
+}

--- a/packages/d2bd/src/unsafe_local_helper.rs
+++ b/packages/d2bd/src/unsafe_local_helper.rs
@@ -9,6 +9,7 @@ use d2b_contracts::unsafe_local_wire::{
 };
 use nix::cmsg_space;
 use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use nix::sys::socket::{
     ControlMessageOwned, MsgFlags, UnixAddr, getpeername, getsockopt, recvmsg, send,
     sockopt::{AcceptConn, PeerCredentials, SockType as SocketTypeOpt},
@@ -21,9 +22,10 @@ use socket2::{Domain, SockAddr, Socket, Type};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::fs;
-use std::io::IoSliceMut;
-use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::io::{IoSliceMut, Read, Write};
+use std::os::fd::{AsFd, AsRawFd, OwnedFd, RawFd};
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
@@ -89,6 +91,7 @@ struct HelperConnection {
     generation: u64,
     socket: Arc<Socket>,
     outbound: mpsc::SyncSender<DaemonToUnsafeLocalHelper>,
+    outbound_wakeup: Arc<UnixStream>,
     pending: Mutex<HashMap<u64, PendingRequest>>,
     last_heartbeat_millis: AtomicU64,
     connected_at: Instant,
@@ -123,6 +126,17 @@ impl HelperConnection {
         for (_, request) in pending {
             let _ = request.sender.try_send(Err(reason));
         }
+    }
+
+    fn queue_outbound(&self, frame: DaemonToUnsafeLocalHelper) -> Result<(), HelperRegistryError> {
+        self.outbound
+            .try_send(frame)
+            .map_err(|_| HelperRegistryError::QueueFull)?;
+        if signal_outbound(&self.outbound_wakeup).is_err() {
+            self.close(HelperRegistryError::Io);
+            return Err(HelperRegistryError::Io);
+        }
+        Ok(())
     }
 }
 
@@ -272,16 +286,12 @@ impl HelperRegistry {
                 return Err(HelperRegistryError::RequestCorrelationMismatch);
             }
         }
-        if connection
-            .outbound
-            .try_send(DaemonToUnsafeLocalHelper::Launch(request))
-            .is_err()
-        {
+        if let Err(error) = connection.queue_outbound(DaemonToUnsafeLocalHelper::Launch(request)) {
             connection.pending.lock().remove(&request_id);
             self.operations
                 .lock()
                 .abort_active(requester_uid, &operation_key);
-            return Err(HelperRegistryError::QueueFull);
+            return Err(error);
         }
 
         match receiver.recv_timeout(HELPER_OPERATION_TIMEOUT) {
@@ -320,10 +330,15 @@ impl HelperRegistry {
         }
         configure_socket_buffers(&socket)?;
         socket
+            .set_write_timeout(Some(HELPER_LOOP_TICK))
+            .map_err(|_| HelperRegistryError::Io)?;
+        socket
             .set_read_timeout(Some(HELPER_HANDSHAKE_TIMEOUT))
             .map_err(|_| HelperRegistryError::Io)?;
 
-        let (hello, fds) = receive_frame::<UnsafeLocalHelperToDaemon>(&socket)?;
+        let mut receive_buffer = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
+        let (hello, fds) =
+            receive_frame::<UnsafeLocalHelperToDaemon>(&socket, &mut receive_buffer)?;
         reject_unexpected_fds(fds)?;
         let UnsafeLocalHelperToDaemon::Hello(hello) = hello else {
             return Err(HelperRegistryError::ProtocolMismatch);
@@ -340,7 +355,8 @@ impl HelperRegistry {
                 operation_timeout_secs: HELPER_OPERATION_TIMEOUT.as_secs() as u32,
             }),
         )?;
-        let (snapshot, fds) = receive_frame::<UnsafeLocalHelperToDaemon>(&socket)?;
+        let (snapshot, fds) =
+            receive_frame::<UnsafeLocalHelperToDaemon>(&socket, &mut receive_buffer)?;
         reject_unexpected_fds(fds)?;
         let UnsafeLocalHelperToDaemon::Snapshot(snapshot) = snapshot else {
             return Err(HelperRegistryError::ProtocolMismatch);
@@ -353,14 +369,23 @@ impl HelperRegistry {
         }
 
         socket
-            .set_read_timeout(Some(HELPER_LOOP_TICK))
+            .set_read_timeout(None)
             .map_err(|_| HelperRegistryError::Io)?;
         let socket = Arc::new(socket);
         let (outbound, outbound_rx) = mpsc::sync_channel(MAX_HELPER_QUEUE_DEPTH);
+        let (outbound_wakeup_read, outbound_wakeup_write) =
+            UnixStream::pair().map_err(|_| HelperRegistryError::Io)?;
+        outbound_wakeup_read
+            .set_nonblocking(true)
+            .map_err(|_| HelperRegistryError::Io)?;
+        outbound_wakeup_write
+            .set_nonblocking(true)
+            .map_err(|_| HelperRegistryError::Io)?;
         let connection = Arc::new(HelperConnection {
             generation: hello.generation,
             socket: Arc::clone(&socket),
             outbound,
+            outbound_wakeup: Arc::new(outbound_wakeup_write),
             pending: Mutex::new(HashMap::new()),
             last_heartbeat_millis: AtomicU64::new(0),
             connected_at: Instant::now(),
@@ -393,7 +418,13 @@ impl HelperRegistry {
             .lock()
             .adopt_snapshot(uid, &snapshot, now_epoch_seconds());
 
-        let result = self.connection_loop(uid, &connection, outbound_rx);
+        let result = self.connection_loop(
+            uid,
+            &connection,
+            outbound_rx,
+            &outbound_wakeup_read,
+            &mut receive_buffer,
+        );
         let mut state = self.state.lock();
         if state
             .connections
@@ -412,6 +443,8 @@ impl HelperRegistry {
         uid: u32,
         connection: &Arc<HelperConnection>,
         outbound: mpsc::Receiver<DaemonToUnsafeLocalHelper>,
+        outbound_wakeup: &UnixStream,
+        receive_buffer: &mut [u8],
     ) -> Result<(), HelperRegistryError> {
         let mut heartbeat_sequence = 0u64;
         let mut next_heartbeat = Instant::now() + HELPER_HEARTBEAT_INTERVAL;
@@ -443,7 +476,12 @@ impl HelperRegistry {
                 return Err(HelperRegistryError::HelperStale);
             }
 
-            match receive_frame::<UnsafeLocalHelperToDaemon>(&connection.socket) {
+            match wait_for_connection_event(&connection.socket, outbound_wakeup)? {
+                ConnectionEvent::Outbound => continue,
+                ConnectionEvent::Tick => continue,
+                ConnectionEvent::Incoming => {}
+            }
+            match receive_frame::<UnsafeLocalHelperToDaemon>(&connection.socket, receive_buffer) {
                 Ok((frame, fds)) => {
                     if !self.is_active_generation(uid, connection) {
                         close_raw_fds(fds);
@@ -452,7 +490,6 @@ impl HelperRegistry {
                     connection.touch();
                     self.handle_incoming(connection, frame, fds)?;
                 }
-                Err(HelperRegistryError::Timeout) => {}
                 Err(error) => return Err(error),
             }
         }
@@ -548,10 +585,12 @@ pub fn bind_helper_socket(
             return Err(HelperRegistryError::Io);
         }
     }
-    let socket = Socket::new(Domain::UNIX, Type::from(libc::SOCK_SEQPACKET), None)
-        .map_err(|_| HelperRegistryError::Io)?;
-    fcntl(socket.as_raw_fd(), FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))
-        .map_err(|_| HelperRegistryError::Io)?;
+    let socket = Socket::new(
+        Domain::UNIX,
+        Type::from(libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC),
+        None,
+    )
+    .map_err(|_| HelperRegistryError::Io)?;
     let address = SockAddr::unix(path).map_err(|_| HelperRegistryError::Io)?;
     socket.bind(&address).map_err(|_| HelperRegistryError::Io)?;
     socket.listen(128).map_err(|_| HelperRegistryError::Io)?;
@@ -603,9 +642,12 @@ fn send_frame<T: Serialize>(socket: &Socket, frame: &T) -> Result<(), HelperRegi
 
 fn receive_frame<T: serde::de::DeserializeOwned>(
     socket: &Socket,
+    encoded: &mut [u8],
 ) -> Result<(T, Vec<RawFd>), HelperRegistryError> {
-    let mut encoded = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
-    let mut iov = [IoSliceMut::new(&mut encoded)];
+    if encoded.len() < MAX_HELPER_FRAME_SIZE + 5 {
+        return Err(HelperRegistryError::FrameTooLarge);
+    }
+    let mut iov = [IoSliceMut::new(encoded)];
     let mut control = cmsg_space!([RawFd; 2]);
     let message = match recvmsg::<UnixAddr>(
         socket.as_raw_fd(),
@@ -614,7 +656,6 @@ fn receive_frame<T: serde::de::DeserializeOwned>(
         MsgFlags::MSG_CMSG_CLOEXEC,
     ) {
         Ok(message) => message,
-        Err(nix::errno::Errno::EAGAIN) => return Err(HelperRegistryError::Timeout),
         Err(_) => return Err(HelperRegistryError::Io),
     };
     let read = message.bytes;
@@ -658,6 +699,77 @@ fn receive_frame<T: serde::de::DeserializeOwned>(
         HelperRegistryError::InvalidFrame
     })?;
     Ok((frame, fds))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionEvent {
+    Incoming,
+    Outbound,
+    Tick,
+}
+
+fn wait_for_connection_event(
+    socket: &Socket,
+    outbound_wakeup: &UnixStream,
+) -> Result<ConnectionEvent, HelperRegistryError> {
+    let interests = PollFlags::POLLIN | PollFlags::POLLERR | PollFlags::POLLHUP;
+    let mut fds = [
+        PollFd::new(socket.as_fd(), interests),
+        PollFd::new(outbound_wakeup.as_fd(), interests),
+    ];
+    let timeout = PollTimeout::try_from(HELPER_LOOP_TICK).map_err(|_| HelperRegistryError::Io)?;
+    loop {
+        match poll(&mut fds, timeout) {
+            Ok(0) => return Ok(ConnectionEvent::Tick),
+            Ok(_) => break,
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(_) => return Err(HelperRegistryError::Io),
+        }
+    }
+
+    let outbound_events = fds[1].revents().unwrap_or(PollFlags::empty());
+    if outbound_events.intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL) {
+        return Err(HelperRegistryError::Io);
+    }
+    if outbound_events.contains(PollFlags::POLLIN) {
+        drain_outbound_wakeup(outbound_wakeup)?;
+        return Ok(ConnectionEvent::Outbound);
+    }
+
+    let socket_events = fds[0].revents().unwrap_or(PollFlags::empty());
+    if socket_events.intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL) {
+        return Err(HelperRegistryError::Io);
+    }
+    if socket_events.contains(PollFlags::POLLIN) {
+        return Ok(ConnectionEvent::Incoming);
+    }
+    Err(HelperRegistryError::Io)
+}
+
+fn signal_outbound(outbound_wakeup: &UnixStream) -> Result<(), HelperRegistryError> {
+    let mut outbound_wakeup = outbound_wakeup;
+    loop {
+        match outbound_wakeup.write_all(&[1]) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => return Err(HelperRegistryError::Io),
+        }
+    }
+}
+
+fn drain_outbound_wakeup(outbound_wakeup: &UnixStream) -> Result<(), HelperRegistryError> {
+    let mut outbound_wakeup = outbound_wakeup;
+    let mut buffer = [0u8; MAX_HELPER_QUEUE_DEPTH];
+    loop {
+        match outbound_wakeup.read(&mut buffer) {
+            Ok(0) => return Err(HelperRegistryError::Io),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => return Err(HelperRegistryError::Io),
+        }
+    }
 }
 
 fn validate_terminal_fd(
@@ -940,6 +1052,31 @@ mod tests {
     }
 
     #[test]
+    fn queued_launch_wakes_idle_connection_loop() {
+        let (control, _peer) = seqpacket_pair();
+        let (wakeup_read, wakeup_write) = UnixStream::pair().unwrap();
+        wakeup_read.set_nonblocking(true).unwrap();
+        wakeup_write.set_nonblocking(true).unwrap();
+
+        signal_outbound(&wakeup_write).unwrap();
+
+        assert_eq!(
+            wait_for_connection_event(&control, &wakeup_read).unwrap(),
+            ConnectionEvent::Outbound
+        );
+    }
+
+    #[test]
+    fn bound_helper_listener_is_close_on_exec() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("helper.sock");
+        let socket = bind_helper_socket(&path, unistd::getgid(), false).unwrap();
+        let flags = fcntl(socket.as_raw_fd(), FcntlArg::F_GETFD).unwrap();
+
+        assert!(FdFlag::from_bits_truncate(flags).contains(FdFlag::FD_CLOEXEC));
+    }
+
+    #[test]
     fn operation_ledger_rejects_reuse_with_new_fingerprint() {
         let mut ledger = OperationLedger::default();
         let first = launch(1, "op-1", "first");
@@ -1101,10 +1238,12 @@ mod tests {
         let expected_operation = request.operation_id.clone();
         let dispatch_registry = Arc::clone(&registry);
         let dispatch = std::thread::spawn(move || dispatch_registry.dispatch_launch(uid, request));
+        let mut receive_buffer = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
 
         loop {
             let (frame, fds) =
-                receive_frame::<DaemonToUnsafeLocalHelper>(&helper).expect("daemon request");
+                receive_frame::<DaemonToUnsafeLocalHelper>(&helper, &mut receive_buffer)
+                    .expect("daemon request");
             close_raw_fds(fds);
             match frame {
                 DaemonToUnsafeLocalHelper::Launch(request) => {
@@ -1243,8 +1382,10 @@ mod tests {
             }),
         )
         .unwrap();
+        let mut receive_buffer = vec![0u8; MAX_HELPER_FRAME_SIZE + 5];
         let (accepted, fds) =
-            receive_frame::<DaemonToUnsafeLocalHelper>(&client).expect("hello accepted");
+            receive_frame::<DaemonToUnsafeLocalHelper>(&client, &mut receive_buffer)
+                .expect("hello accepted");
         close_raw_fds(fds);
         assert!(matches!(
             accepted,

--- a/packages/d2bd/src/unsafe_local_helper.rs
+++ b/packages/d2bd/src/unsafe_local_helper.rs
@@ -1279,6 +1279,7 @@ mod tests {
         let registry = HelperRegistry::new(uid.wrapping_add(1), [uid]);
         let (socket, peer) = seqpacket_pair();
         let (outbound, _outbound_rx) = mpsc::sync_channel(1);
+        let (_outbound_wakeup_read, outbound_wakeup_write) = UnixStream::pair().unwrap();
         outbound
             .try_send(DaemonToUnsafeLocalHelper::Heartbeat(HelperHeartbeat {
                 generation: 1,
@@ -1289,6 +1290,7 @@ mod tests {
             generation: 1,
             socket: Arc::new(socket),
             outbound,
+            outbound_wakeup: Arc::new(outbound_wakeup_write),
             pending: Mutex::new(HashMap::new()),
             last_heartbeat_millis: AtomicU64::new(0),
             connected_at: Instant::now(),
@@ -1311,10 +1313,12 @@ mod tests {
     fn heartbeat_age_marks_helper_stale_without_global_cleanup() {
         let (socket, peer) = seqpacket_pair();
         let (outbound, _receiver) = mpsc::sync_channel(1);
+        let (_outbound_wakeup_read, outbound_wakeup_write) = UnixStream::pair().unwrap();
         let connection = HelperConnection {
             generation: 1,
             socket: Arc::new(socket),
             outbound,
+            outbound_wakeup: Arc::new(outbound_wakeup_write),
             pending: Mutex::new(HashMap::new()),
             last_heartbeat_millis: AtomicU64::new(0),
             connected_at: Instant::now() - HELPER_STALE_AFTER - Duration::from_millis(1),

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -1,0 +1,243 @@
+{ pkgs, self }:
+
+let
+  d2bLib = import ./lib.nix {
+    inherit self;
+    inherit (pkgs) lib;
+  };
+in
+pkgs.testers.runNixOSTest {
+  name = "d2b-unsafe-local-helper";
+
+  nodes.machine = d2bLib.d2bDaemonNode {
+    extra = { pkgs, ... }: {
+      users.users.bob = {
+        isNormalUser = true;
+        uid = 1001;
+      };
+      d2b.realms.host = {
+        allowedUsers = [ "alice" ];
+        policy.allowUnsafeLocal = true;
+        workloads.tools = {
+          kind = "unsafe-local";
+          launcher.items.probe = {
+            type = "exec";
+            name = "Probe";
+            argv = [ "true" ];
+          };
+        };
+      };
+      environment.systemPackages = [ pkgs.jq pkgs.python3 ];
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("d2bd.service")
+    machine.wait_for_file("/run/d2b/unsafe-local-helper.sock", timeout=60)
+    machine.succeed("test \"$(stat -c %a /run/d2b/unsafe-local-helper.sock)\" = 660")
+    machine.succeed(
+        "test \"$(stat -c %G /run/d2b/unsafe-local-helper.sock)\" = d2b-unsafe-local"
+    )
+    machine.succeed("id -nG alice | tr ' ' '\\n' | grep -qx d2b-unsafe-local")
+    machine.fail("id -nG bob | tr ' ' '\\n' | grep -qx d2b-unsafe-local")
+
+    machine.succeed("systemctl start user@1000.service")
+    alice_user = (
+        "runuser -u alice -- env XDG_RUNTIME_DIR=/run/user/1000 "
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus "
+        "systemctl --user"
+    )
+    machine.wait_until_succeeds(
+        alice_user + " is-active d2b-unsafe-local-helper.service",
+        timeout=60,
+    )
+    machine.wait_until_succeeds(
+        "journalctl -u d2bd.service --no-pager | grep -q "
+        "'unsafe-local helper registered'",
+        timeout=60,
+    )
+    helper_pid = machine.succeed(
+        alice_user + " show -P MainPID d2b-unsafe-local-helper.service"
+    ).strip()
+    machine.succeed(
+        f"test \"$(readlink /proc/{helper_pid}/ns/net)\" = "
+        "\"$(readlink /proc/1/ns/net)\""
+    )
+
+    machine.succeed("systemctl start user@1001.service")
+    bob_user = (
+        "runuser -u bob -- env XDG_RUNTIME_DIR=/run/user/1001 "
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus "
+        "systemctl --user"
+    )
+    machine.wait_until_succeeds(
+        bob_user
+        + " show -P ConditionResult d2b-unsafe-local-helper.service | grep -qx no",
+        timeout=60,
+    )
+    machine.fail(bob_user + " is-active d2b-unsafe-local-helper.service")
+
+    machine.succeed("systemctl restart d2bd.service")
+    machine.wait_for_unit("d2bd.service")
+    machine.wait_for_file("/run/d2b/unsafe-local-helper.sock", timeout=60)
+    machine.wait_until_succeeds(
+        alice_user + " is-active d2b-unsafe-local-helper.service",
+        timeout=60,
+    )
+    machine.wait_until_succeeds(
+        "test \"$(journalctl -u d2bd.service --no-pager "
+        "| grep -c 'unsafe-local helper registered')\" -ge 2",
+        timeout=60,
+    )
+
+    machine.succeed("systemctl stop d2bd.service")
+    machine.succeed(alice_user + " stop d2b-unsafe-local-helper.service")
+    machine.succeed("rm -f /run/d2b/unsafe-local-helper.sock")
+    machine.succeed(
+        "cat > /run/d2b/helper-mock.py <<'PY'\n"
+        "import grp, json, os, socket, struct, time\n"
+        "path = '/run/d2b/unsafe-local-helper.sock'\n"
+        "def recv_frame(conn):\n"
+        "    data = conn.recv(262149)\n"
+        "    if len(data) < 4:\n"
+        "        raise RuntimeError('short frame')\n"
+        "    size = struct.unpack('<I', data[:4])[0]\n"
+        "    if size != len(data) - 4:\n"
+        "        raise RuntimeError('bad frame length')\n"
+        "    return json.loads(data[4:])\n"
+        "def send_frame(conn, value):\n"
+        "    data = json.dumps(value, separators=(',', ':')).encode()\n"
+        "    conn.sendall(struct.pack('<I', len(data)) + data)\n"
+        "def accept_helper(listener):\n"
+        "    conn, _ = listener.accept()\n"
+        "    hello = recv_frame(conn)\n"
+        "    generation = hello['payload']['generation']\n"
+        "    send_frame(conn, {'type':'helloAccepted','payload':{\n"
+        "        'protocolVersion':1,'generation':generation,\n"
+        "        'heartbeatIntervalSecs':5,'operationTimeoutSecs':30}})\n"
+        "    snapshot = recv_frame(conn)\n"
+        "    return conn, snapshot\n"
+        "listener = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)\n"
+        "listener.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 262144)\n"
+        "listener.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 262144)\n"
+        "listener.bind(path)\n"
+        "os.chmod(path, 0o660)\n"
+        "os.chown(path, -1, grp.getgrnam('d2b-unsafe-local').gr_gid)\n"
+        "listener.listen(8)\n"
+        "open('/run/d2b/helper-mock.ready', 'w').close()\n"
+        "conn, snapshot = accept_helper(listener)\n"
+        "open('/run/d2b/helper-snapshot-1.json', 'w').write(json.dumps(snapshot))\n"
+        "request = {'type':'launch','payload':{\n"
+        "  'requestId':41,'operationId':'op-host-scope-1',\n"
+        "  'workload':{'workloadId':'tools','realmId':'host',\n"
+        "    'realmPath':['host'],'canonicalTarget':'tools.host.d2b'},\n"
+        "  'itemId':'probe','argv':['sh','-c',\n"
+        "    'echo output-canary; echo error-canary >&2; '\n"
+        "    'test \"$D2B_MANAGER_CANARY\" = manager-canary && '\n"
+        "    'test \"$PWD\" = /home/alice && sleep 60'],\n"
+        "  'graphical':False}}\n"
+        "send_frame(conn, request)\n"
+        "response = recv_frame(conn)\n"
+        "open('/run/d2b/helper-launch-response.json', 'w').write(json.dumps(response))\n"
+        "conn.close()\n"
+        "conn, snapshot = accept_helper(listener)\n"
+        "open('/run/d2b/helper-snapshot-2.json', 'w').write(json.dumps(snapshot))\n"
+        "while os.path.exists('/run/d2b/keep-helper-connected'):\n"
+        "    send_frame(conn, {'type':'heartbeat','payload':{\n"
+        "      'generation':snapshot['payload']['generation'],'sequence':1}})\n"
+        "    try:\n"
+        "        recv_frame(conn)\n"
+        "    except Exception:\n"
+        "        break\n"
+        "    time.sleep(1)\n"
+        "conn.close()\n"
+        "conn, snapshot = accept_helper(listener)\n"
+        "send_frame(conn, {'type':'launch','payload':{\n"
+        "  'requestId':42,'operationId':'op-no-user-manager',\n"
+        "  'workload':{'workloadId':'tools','realmId':'host',\n"
+        "    'realmPath':['host'],'canonicalTarget':'tools.host.d2b'},\n"
+        "  'itemId':'probe','argv':['true'],'graphical':False}})\n"
+        "response = recv_frame(conn)\n"
+        "open('/run/d2b/helper-no-manager-response.json', 'w').write(json.dumps(response))\n"
+        "conn.close()\n"
+        "PY\n"
+        "chown d2bd:d2bd /run/d2b/helper-mock.py"
+    )
+    machine.succeed(
+        "runuser -u d2bd -- python3 /run/d2b/helper-mock.py "
+        ">/run/d2b/helper-mock.log 2>&1 & "
+        "echo $! > /run/d2b/helper-mock.pid"
+    )
+    machine.wait_for_file("/run/d2b/helper-mock.ready", timeout=60)
+    machine.succeed(
+        alice_user + " set-environment D2B_MANAGER_CANARY=manager-canary"
+    )
+    machine.succeed("touch /run/d2b/keep-helper-connected")
+    machine.succeed(alice_user + " start d2b-unsafe-local-helper.service")
+    machine.wait_for_file("/run/d2b/helper-launch-response.json", timeout=60)
+    machine.succeed(
+        "jq -e '.type == \"operation\" and "
+        ".payload.disposition == \"committed\" and "
+        ".payload.scope.kind == \"launcher-app\"' "
+        "/run/d2b/helper-launch-response.json"
+    )
+    invocation = machine.succeed(
+        "jq -r .payload.scope.invocationId /run/d2b/helper-launch-response.json"
+    ).strip()
+    scope = machine.succeed(
+        alice_user
+        + " list-units --state=active --plain --no-legend "
+        "'d2b-unsafe-local-app-*.scope' | awk 'NR == 1 {print $1}'"
+    ).strip()
+    assert scope.endswith(".scope"), f"unsafe-local app scope missing: {scope!r}"
+    machine.succeed(
+        alice_user + f" show -P InvocationID {scope} | grep -qx {invocation}"
+    )
+    control_group = machine.succeed(
+        alice_user + f" show -P ControlGroup {scope}"
+    ).strip()
+    app_pid = machine.succeed(
+        f"awk 'NR == 1 {{print $1}}' /sys/fs/cgroup{control_group}/cgroup.procs"
+    ).strip()
+    machine.succeed(f"test -d /proc/{app_pid}")
+    machine.fail(
+        "journalctl --no-pager | grep -E 'output-canary|error-canary'"
+    )
+
+    machine.wait_for_file("/run/d2b/helper-snapshot-2.json", timeout=60)
+    machine.succeed(
+        f"jq -e --arg invocation {invocation} "
+        "'.payload.scopes | any("
+        ".scope.invocationId == $invocation and .state == \"active\")' "
+        "/run/d2b/helper-snapshot-2.json"
+    )
+
+    machine.succeed("loginctl show-user alice -p Linger --value | grep -qx no")
+    machine.succeed("rm -f /run/d2b/keep-helper-connected")
+    machine.succeed("systemctl stop user@1000.service")
+    machine.wait_until_fails(f"test -d /proc/{app_pid}", timeout=60)
+
+    machine.succeed(
+        "runuser -u alice -- env "
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/missing "
+        "XDG_RUNTIME_DIR=/run/user/1000 "
+        "/run/current-system/sw/bin/d2b-unsafe-local-helper "
+        ">/run/d2b/no-manager-helper.log 2>&1 &"
+    )
+    machine.wait_for_file("/run/d2b/helper-no-manager-response.json", timeout=60)
+    machine.succeed(
+        "jq -e '.type == \"rejected\" and "
+        ".payload.code == \"user-manager-unavailable\"' "
+        "/run/d2b/helper-no-manager-response.json"
+    )
+
+    units = machine.succeed(
+        "systemctl list-unit-files --no-pager --no-legend "
+        "| awk '{print $1}' | grep -E '^(d2b|microvm)' | sort"
+    ).strip().split()
+    assert "d2b-unsafe-local-helper.service" not in units, (
+        "unsafe-local helper must be a user unit, not a fourth root unit"
+    )
+  '';
+}

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -196,7 +196,10 @@ pkgs.testers.runNixOSTest {
     machine.succeed(
         alice_user + f" show -P InvocationID {scope} | grep -qx {invocation}"
     )
-    machine.wait_for_file("/run/user/1000/d2b-helper-child-state", timeout=60)
+    machine.wait_until_succeeds(
+        "grep -qx 'cwd=/home/alice' /run/user/1000/d2b-helper-child-state",
+        timeout=60,
+    )
     machine.succeed(
         "grep -qx 'stdout=/dev/null' /run/user/1000/d2b-helper-child-state"
     )
@@ -205,9 +208,6 @@ pkgs.testers.runNixOSTest {
     )
     machine.succeed(
         "grep -qx 'env=manager-canary' /run/user/1000/d2b-helper-child-state"
-    )
-    machine.succeed(
-        "grep -qx 'cwd=/home/alice' /run/user/1000/d2b-helper-child-state"
     )
     control_group = machine.succeed(
         alice_user + f" show -P ControlGroup {scope}"

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -134,7 +134,7 @@ pkgs.testers.runNixOSTest {
         "    'realmPath':['host'],'canonicalTarget':'tools.host.d2b'},\n"
         "  'itemId':'probe','argv':['sh','-c',\n"
         "    'printf \"stdout=%s\\\\nstderr=%s\\\\nenv=%s\\\\ncwd=%s\\\\n\" '\n"
-        "    '\"$(readlink /proc/self/fd/1)\" \"$(readlink /proc/self/fd/2)\" '\n"
+        "    '\"$(readlink /proc/$$/fd/1)\" \"$(readlink /proc/$$/fd/2)\" '\n"
         "    '\"$D2B_MANAGER_CANARY\" \"$PWD\" '\n"
         "    '> /run/user/1000/d2b-helper-child-state; sleep 60'],\n"
         "  'graphical':False}}\n"

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -180,7 +180,8 @@ pkgs.testers.runNixOSTest {
         "jq -e '.type == \"operation\" and "
         ".payload.disposition == \"committed\" and "
         ".payload.scope.kind == \"launcher-app\"' "
-        "/run/d2b/helper-launch-response.json"
+        "/run/d2b/helper-launch-response.json "
+        "|| { cat /run/d2b/helper-launch-response.json >&2; exit 1; }"
     )
     invocation = machine.succeed(
         "jq -r .payload.scope.invocationId /run/d2b/helper-launch-response.json"

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -133,11 +133,10 @@ pkgs.testers.runNixOSTest {
         "  'workload':{'workloadId':'tools','realmId':'host',\n"
         "    'realmPath':['host'],'canonicalTarget':'tools.host.d2b'},\n"
         "  'itemId':'probe','argv':['sh','-c',\n"
-        "    'test \"$(readlink /proc/self/fd/1)\" = /dev/null && '\n"
-        "    'test \"$(readlink /proc/self/fd/2)\" = /dev/null && '\n"
-        "    'test \"$D2B_MANAGER_CANARY\" = manager-canary && '\n"
-        "    'test \"$PWD\" = /home/alice && '\n"
-        "    ': > /run/user/1000/d2b-helper-child-ok && sleep 60'],\n"
+        "    'printf \"stdout=%s\\\\nstderr=%s\\\\nenv=%s\\\\ncwd=%s\\\\n\" '\n"
+        "    '\"$(readlink /proc/self/fd/1)\" \"$(readlink /proc/self/fd/2)\" '\n"
+        "    '\"$D2B_MANAGER_CANARY\" \"$PWD\" '\n"
+        "    '> /run/user/1000/d2b-helper-child-state; sleep 60'],\n"
         "  'graphical':False}}\n"
         "send_frame(conn, request)\n"
         "response = recv_frame(conn)\n"
@@ -197,7 +196,19 @@ pkgs.testers.runNixOSTest {
     machine.succeed(
         alice_user + f" show -P InvocationID {scope} | grep -qx {invocation}"
     )
-    machine.wait_for_file("/run/user/1000/d2b-helper-child-ok", timeout=60)
+    machine.wait_for_file("/run/user/1000/d2b-helper-child-state", timeout=60)
+    machine.succeed(
+        "grep -qx 'stdout=/dev/null' /run/user/1000/d2b-helper-child-state"
+    )
+    machine.succeed(
+        "grep -qx 'stderr=/dev/null' /run/user/1000/d2b-helper-child-state"
+    )
+    machine.succeed(
+        "grep -qx 'env=manager-canary' /run/user/1000/d2b-helper-child-state"
+    )
+    machine.succeed(
+        "grep -qx 'cwd=/home/alice' /run/user/1000/d2b-helper-child-state"
+    )
     control_group = machine.succeed(
         alice_user + f" show -P ControlGroup {scope}"
     ).strip()

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -133,9 +133,11 @@ pkgs.testers.runNixOSTest {
         "  'workload':{'workloadId':'tools','realmId':'host',\n"
         "    'realmPath':['host'],'canonicalTarget':'tools.host.d2b'},\n"
         "  'itemId':'probe','argv':['sh','-c',\n"
-        "    'echo output-canary; echo error-canary >&2; '\n"
+        "    'test \"$(readlink /proc/self/fd/1)\" = /dev/null && '\n"
+        "    'test \"$(readlink /proc/self/fd/2)\" = /dev/null && '\n"
         "    'test \"$D2B_MANAGER_CANARY\" = manager-canary && '\n"
-        "    'test \"$PWD\" = /home/alice && sleep 60'],\n"
+        "    'test \"$PWD\" = /home/alice && '\n"
+        "    ': > /run/user/1000/d2b-helper-child-ok && sleep 60'],\n"
         "  'graphical':False}}\n"
         "send_frame(conn, request)\n"
         "response = recv_frame(conn)\n"
@@ -195,6 +197,7 @@ pkgs.testers.runNixOSTest {
     machine.succeed(
         alice_user + f" show -P InvocationID {scope} | grep -qx {invocation}"
     )
+    machine.wait_for_file("/run/user/1000/d2b-helper-child-ok", timeout=60)
     control_group = machine.succeed(
         alice_user + f" show -P ControlGroup {scope}"
     ).strip()
@@ -202,10 +205,6 @@ pkgs.testers.runNixOSTest {
         f"awk 'NR == 1 {{print $1}}' /sys/fs/cgroup{control_group}/cgroup.procs"
     ).strip()
     machine.succeed(f"test -d /proc/{app_pid}")
-    machine.fail(
-        "journalctl --no-pager | grep -E 'output-canary|error-canary'"
-    )
-
     machine.wait_for_file("/run/d2b/helper-snapshot-2.json", timeout=60)
     machine.succeed(
         f"jq -e --arg invocation {invocation} "

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -125,6 +125,8 @@ let
   workRealm = wlIndex.realms.byPath."work.home";
 
   unsafeLocalFixture = lib.recursiveUpdate hostBase {
+    users.users.bob = { isNormalUser = true; uid = 1001; };
+    d2b.daemonExperimental.enable = true;
     d2b.realms.host = {
       allowedUsers = [ "alice" ];
       policy.allowUnsafeLocal = true;
@@ -862,6 +864,50 @@ in
       defaultItemId = "browser";
       itemIds = [ "browser" "terminal" ];
       itemTypes = [ "exec" "shell" ];
+    };
+  };
+
+  "realm-workloads/unsafe-local-helper-user-service-and-eligibility" = {
+    expr =
+      let
+        service = unsafeCfg.systemd.user.services.d2b-unsafe-local-helper;
+        daemonConfig =
+          builtins.fromJSON unsafeCfg.environment.etc."d2b/daemon-config.json".text;
+        rootUnits =
+          lib.attrNames unsafeCfg.systemd.services
+          ++ lib.attrNames unsafeCfg.systemd.sockets;
+      in {
+        helperGroupDeclared = unsafeCfg.users.groups ? d2b-unsafe-local;
+        eligibleHasLifecycleGroup =
+          builtins.elem "d2b" unsafeCfg.users.users.alice.extraGroups;
+        eligibleHasHelperGroup =
+          builtins.elem "d2b-unsafe-local" unsafeCfg.users.users.alice.extraGroups;
+        ineligibleUserGroups = unsafeCfg.users.users.bob.extraGroups;
+        conditionGroup = service.unitConfig.ConditionGroup;
+        restart = service.serviceConfig.Restart;
+        execStartHasHelper =
+          lib.hasInfix "/bin/d2b-unsafe-local-helper" service.serviceConfig.ExecStart;
+        daemonSocketPath = daemonConfig.unsafeLocalHelperSocketPath;
+        daemonSocketGroup = daemonConfig.unsafeLocalHelperSocketGroup;
+        daemonAllowedUsers = daemonConfig.unsafeLocalHelperUsers;
+        helperRootUnitAbsent =
+          !(builtins.elem "d2b-unsafe-local-helper" rootUnits);
+        noHelperBrokerSocketUnit =
+          !(builtins.elem "d2b-unsafe-local-helper" (lib.attrNames unsafeCfg.systemd.sockets));
+      };
+    expected = {
+      helperGroupDeclared = true;
+      eligibleHasLifecycleGroup = true;
+      eligibleHasHelperGroup = true;
+      ineligibleUserGroups = [ ];
+      conditionGroup = "d2b-unsafe-local";
+      restart = "on-failure";
+      execStartHasHelper = true;
+      daemonSocketPath = "/run/d2b/unsafe-local-helper.sock";
+      daemonSocketGroup = "d2b-unsafe-local";
+      daemonAllowedUsers = [ "alice" ];
+      helperRootUnitAbsent = true;
+      noHelperBrokerSocketUnit = true;
     };
   };
 

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -644,6 +644,7 @@ realm-workloads/persistent-shell-compatibility-item
 realm-workloads/realm-row-workload-names
 realm-workloads/realm-with-no-workloads-empty-index
 realm-workloads/unsafe-local-artifacts-and-bundle-v10
+realm-workloads/unsafe-local-helper-user-service-and-eligibility
 realm-workloads/unsafe-local-index-posture-and-items
 realm-workloads/unsafe-local-omitted-from-launcher-v1
 realm-workloads/unsafe-local-private-artifact-carries-argv


### PR DESCRIPTION
## Change

- add the bounded, peer-authenticated unsafe-local helper channel owned by `d2bd`
- install the eligibility-gated global systemd user service
- run configured processes in verified same-UID transient scopes with persisted adoption state
- bound D-Bus methods, socket writes, queues, buffers, and poll wakeups
- preserve ambient user-manager environment while preventing graphical display fallback

## Validation

- `cargo test --locked -p d2b-unsafe-local-helper -p d2bd`
- KVM-backed `vmChecks.x86_64-linux.unsafe-local-helper`
- integrated `make check`

## Review

- Unanimous multidisciplinary Wave 1 review after transport, lifecycle, and test hardening.