### PR TITLE
contracts: define unsafe-local persistent shell wire v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Prepared unsafe-local persistent shells with private helper protocol v2,
+  correlated management results, bounded dedicated terminal-stream frames,
+  restart snapshot metadata, typed shell failures, and the public
+  `unsafe-local-shell-v1` feature token. Runtime dispatch remains unavailable.
+
 - Added proposed ADR 0045, defining parent-owned workload-hosted realm
   controllers, explicit runtime/infrastructure/relay provider responsibilities,
   type-first sortable provider crate names with mandatory standard interfaces

--- a/docs/reference/daemon-api.md
+++ b/docs/reference/daemon-api.md
@@ -77,15 +77,15 @@ compatibility surface.
 | --- | --- | --- | --- |
 | `FeatureFlag` | struct | [`FeatureFlag`](../../packages/d2b-contracts/src/lib.rs#L100) | empty struct |
 | `GuestCapability` | enum | [`GuestCapability`](../../packages/d2b-contracts/src/guest_wire.rs#L351) | `Health`; `Capabilities`; `ExecAttached`; `ExecDetached`; `ExecTty`; `ExecLogs`; `TtyResize`; `Signals`; `ReadGuestFile`; `UsbipImport`; `ShellAttached`; `ShellManagement`; `ShellForceAttach`; `UsbipStatus`; `SystemActivation`; `AudioStatus`; `AudioSet` |
-| `Hello` | struct | [`Hello`](../../packages/d2b-contracts/src/lib.rs#L181) | struct { `client_version`: `SemverRange`; `supported_features`: `Vec<FeatureFlag>` } |
-| `HelloOk` | struct | [`HelloOk`](../../packages/d2b-contracts/src/lib.rs#L189) | struct { `server_version`: `Version`; `selected_version`: `Version`; `capabilities`: `Vec<FeatureFlag>` } |
-| `HelloRejected` | struct | [`HelloRejected`](../../packages/d2b-contracts/src/lib.rs#L197) | struct { `reason`: `HelloRejectedReason` } |
-| `HelloRejectedReason` | enum | [`HelloRejectedReason`](../../packages/d2b-contracts/src/lib.rs#L203) | `VersionMismatch`; `CapabilityNegotiationFailed`; `InternalError` |
+| `Hello` | struct | [`Hello`](../../packages/d2b-contracts/src/lib.rs#L184) | struct { `client_version`: `SemverRange`; `supported_features`: `Vec<FeatureFlag>` } |
+| `HelloOk` | struct | [`HelloOk`](../../packages/d2b-contracts/src/lib.rs#L192) | struct { `server_version`: `Version`; `selected_version`: `Version`; `capabilities`: `Vec<FeatureFlag>` } |
+| `HelloRejected` | struct | [`HelloRejected`](../../packages/d2b-contracts/src/lib.rs#L200) | struct { `reason`: `HelloRejectedReason` } |
+| `HelloRejectedReason` | enum | [`HelloRejectedReason`](../../packages/d2b-contracts/src/lib.rs#L206) | `VersionMismatch`; `CapabilityNegotiationFailed`; `InternalError` |
 | `HelloRequest` | struct | [`HelloRequest`](../../packages/d2b-contracts/src/broker_wire.rs#L494) | struct { `client_version`: `String`; `supported_features`: `Vec<String>` } |
 | `HelloRequest` | struct | [`HelloRequest`](../../packages/d2b-contracts/src/guest_wire.rs#L581) | struct { `metadata`: `GuestRequestMetadata`; `host_nonce`: `GuestNonce`; `transcript_version`: `u32` } |
 | `HelloResponse` | struct | [`HelloResponse`](../../packages/d2b-contracts/src/broker_wire.rs#L584) | struct { `server_version`: `String`; `selected_version`: `String`; `capabilities`: `Vec<String>` } |
 | `HelloResponse` | struct | [`HelloResponse`](../../packages/d2b-contracts/src/guest_wire.rs#L589) | struct { `guest_nonce`: `GuestNonce`; `guest_boot_id`: `GuestBootId`; `protocol_version`: `u32` } |
-| `KnownFeatureFlag` | enum | [`KnownFeatureFlag`](../../packages/d2b-contracts/src/lib.rs#L153) | `TypedErrors`; `ManifestV04`; `StatusCheckBridges`; `ExportBrokerAudit`; `ConfiguredLaunchV1`; `UnsafeLocalProviderV1` |
+| `KnownFeatureFlag` | enum | [`KnownFeatureFlag`](../../packages/d2b-contracts/src/lib.rs#L154) | `TypedErrors`; `ManifestV04`; `StatusCheckBridges`; `ExportBrokerAudit`; `ConfiguredLaunchV1`; `UnsafeLocalProviderV1`; `UnsafeLocalShellV1` |
 <!-- END AUTO-GENERATED: handshake-types -->
 
 ## Public socket
@@ -502,7 +502,7 @@ running live guest activation.
 | `TerminalStatus` | enum | [`TerminalStatus`](../../packages/d2b-contracts/src/guest_wire.rs#L1454) | `ExitCode` — struct { `exit_code`: `i32` }; `Signal` — struct { `signal`: `u32` }; `StatusCode` — struct { `status_code`: `i32` }; `Error` — struct { `error`: `GuestControlErrorKind` } |
 | `SignalTarget` | enum | [`SignalTarget`](../../packages/d2b-contracts/src/guest_wire.rs#L1473) | `ForegroundProcessGroup`; `ProcessTree` |
 | `ExecCancelReason` | enum | [`ExecCancelReason`](../../packages/d2b-contracts/src/guest_wire.rs#L1480) | `ClientDisconnect`; `UserRequested`; `SlowConsumer`; `ProtocolError` |
-| `KnownFeatureFlag` | enum | [`KnownFeatureFlag`](../../packages/d2b-contracts/src/lib.rs#L153) | `TypedErrors`; `ManifestV04`; `StatusCheckBridges`; `ExportBrokerAudit`; `ConfiguredLaunchV1`; `UnsafeLocalProviderV1` |
+| `KnownFeatureFlag` | enum | [`KnownFeatureFlag`](../../packages/d2b-contracts/src/lib.rs#L154) | `TypedErrors`; `ManifestV04`; `StatusCheckBridges`; `ExportBrokerAudit`; `ConfiguredLaunchV1`; `UnsafeLocalProviderV1`; `UnsafeLocalShellV1` |
 | `WorkloadOp` | enum | [`WorkloadOp`](../../packages/d2b-contracts/src/public_wire.rs#L202) | `List` — (WorkloadListArgs); `Status` — (WorkloadStatusArgs); `LauncherExec` — (LauncherExecArgs) |
 | `WorkloadAvailability` | enum | [`WorkloadAvailability`](../../packages/d2b-contracts/src/public_wire.rs#L242) | `Ready`; `HelperUnavailable`; `HelperStale`; `UserManagerUnavailable`; `GraphicalSessionInactive`; `WaylandUnavailable`; `ProxyUnavailable`; `Degraded` |
 | `GraphicalLaunchPosture` | enum | [`GraphicalLaunchPosture`](../../packages/d2b-contracts/src/public_wire.rs#L256) | `Proxied`; `NotApplicable`; `GraphicalSessionInactive`; `WaylandUnavailable`; `ProxyUnavailable` |
@@ -544,13 +544,13 @@ running live guest activation.
 | `TerminalStream` | enum | [`TerminalStream`](../../packages/d2b-contracts/src/terminal_wire.rs#L19) | `Stdout`; `Stderr` |
 | `TerminalStatus` | enum | [`TerminalStatus`](../../packages/d2b-contracts/src/terminal_wire.rs#L197) | `Exited` — struct { `code`: `i32` }; `Signaled` — struct { `signal`: `u32` }; `Error` — struct { `slug`: `String` } |
 | `PathClass` | enum | [`PathClass`](../../packages/d2b-contracts/src/types.rs#L171) | `Vm`; `Runtime` |
-| `HelperScopeKind` | enum | [`HelperScopeKind`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L53) | `LauncherApp`; `WaylandProxy`; `PersistentShell` |
-| `HelperScopeState` | enum | [`HelperScopeState`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L77) | `Starting`; `Active`; `Stopping`; `Exited`; `Degraded` |
-| `HelperFailureCode` | enum | [`HelperFailureCode`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L196) | `InvalidRequest`; `OperationIdConflict`; `QueueFull`; `Timeout`; `UserManagerUnavailable`; `EnvironmentInvalid`; `ExecutableUnavailable`; `ScopeCreateFailed`; `ScopeIdentityMismatch`; `GraphicalSessionInactive`; `WaylandUnavailable`; `ProxyUnavailable`; `FirstClientTimeout`; `ShellUnavailable`; `Internal` |
-| `HelperOperationDisposition` | enum | [`HelperOperationDisposition`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L216) | `Committed`; `AlreadyCommitted`; `Completed` |
-| `HelperTerminalTransport` | enum | [`HelperTerminalTransport`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L245) | `ConnectedUnixStream` |
-| `DaemonToUnsafeLocalHelper` | enum | [`DaemonToUnsafeLocalHelper`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L264) | `HelloAccepted` — (HelperHelloAccepted); `Heartbeat` — (HelperHeartbeat); `Launch` — (HelperLaunchRequest); `Shell` — (HelperShellRequest) |
-| `UnsafeLocalHelperToDaemon` | enum | [`UnsafeLocalHelperToDaemon`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L273) | `Hello` — (HelperHello); `Snapshot` — (HelperSnapshot); `Heartbeat` — (HelperHeartbeat); `Operation` — (HelperOperationResult); `TerminalReady` — (HelperTerminalReady); `Rejected` — (HelperOperationRejected) |
+| `HelperScopeKind` | enum | [`HelperScopeKind`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L123) | `LauncherApp`; `WaylandProxy`; `PersistentShell` |
+| `HelperScopeState` | enum | [`HelperScopeState`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L147) | `Starting`; `Active`; `Stopping`; `Exited`; `Degraded` |
+| `HelperFailureCode` | enum | [`HelperFailureCode`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L402) | `InvalidRequest`; `OperationIdConflict`; `QueueFull`; `Timeout`; `UserManagerUnavailable`; `EnvironmentInvalid`; `ExecutableUnavailable`; `ScopeCreateFailed`; `ScopeIdentityMismatch`; `GraphicalSessionInactive`; `WaylandUnavailable`; `ProxyUnavailable`; `FirstClientTimeout`; `ShellUnavailable`; `ShellNotFound`; `ShellAlreadyAttached`; `TerminalOutputGap`; `TerminalOffsetMismatch`; `TerminalClosed`; `InvalidTerminalSize`; `Internal` |
+| `HelperOperationDisposition` | enum | [`HelperOperationDisposition`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L428) | `Committed`; `AlreadyCommitted`; `Completed` |
+| `HelperTerminalTransport` | enum | [`HelperTerminalTransport`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L471) | `ConnectedUnixStream` |
+| `DaemonToUnsafeLocalHelper` | enum | [`DaemonToUnsafeLocalHelper`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L873) | `HelloAccepted` — (HelperHelloAccepted); `Heartbeat` — (HelperHeartbeat); `Launch` — (HelperLaunchRequest); `Shell` — (HelperShellRequest) |
+| `UnsafeLocalHelperToDaemon` | enum | [`UnsafeLocalHelperToDaemon`](../../packages/d2b-contracts/src/unsafe_local_wire.rs#L882) | `Hello` — (HelperHello); `Snapshot` — (HelperSnapshot); `Heartbeat` — (HelperHeartbeat); `Operation` — (HelperOperationResult); `TerminalReady` — (HelperTerminalReady); `Shell` — (HelperShellResponse); `Rejected` — (HelperOperationRejected) |
 | `UsbipClaimSource` | enum | [`UsbipClaimSource`](../../packages/d2b-contracts/src/usbip.rs#L99) | `Declared` — struct { `firewall_ref`: `String`; `bind_ref`: `String` }; `Explicit` |
 <!-- END AUTO-GENERATED: enum-variants -->
 

--- a/docs/reference/schemas/v2/unsafe-local-helper-wire.json
+++ b/docs/reference/schemas/v2/unsafe-local-helper-wire.json
@@ -6,7 +6,9 @@
     "daemonToHelper",
     "helperToDaemon",
     "protocolVersion",
-    "terminalProtocolVersion"
+    "terminalProtocolVersion",
+    "terminalRequest",
+    "terminalResponse"
   ],
   "properties": {
     "daemonToHelper": {
@@ -24,6 +26,12 @@
       "type": "integer",
       "format": "uint32",
       "minimum": 0.0
+    },
+    "terminalRequest": {
+      "$ref": "#/definitions/HelperTerminalRequest"
+    },
+    "terminalResponse": {
+      "$ref": "#/definitions/HelperTerminalResponse"
     }
   },
   "additionalProperties": false,
@@ -128,6 +136,12 @@
         "proxy-unavailable",
         "first-client-timeout",
         "shell-unavailable",
+        "shell-not-found",
+        "shell-already-attached",
+        "terminal-output-gap",
+        "terminal-offset-mismatch",
+        "terminal-closed",
+        "invalid-terminal-size",
         "internal"
       ]
     },
@@ -309,6 +323,30 @@
       },
       "additionalProperties": false
     },
+    "HelperPersistentShellSnapshot": {
+      "type": "object",
+      "required": [
+        "attached",
+        "name",
+        "state",
+        "supervisorId"
+      ],
+      "properties": {
+        "attached": {
+          "type": "boolean"
+        },
+        "name": {
+          "$ref": "#/definitions/ShellName"
+        },
+        "state": {
+          "$ref": "#/definitions/ShellSessionState"
+        },
+        "supervisorId": {
+          "$ref": "#/definitions/HelperSupervisorId"
+        }
+      },
+      "additionalProperties": false
+    },
     "HelperScopeKind": {
       "type": "string",
       "enum": [
@@ -328,6 +366,16 @@
       "properties": {
         "operationId": {
           "$ref": "#/definitions/OperationId"
+        },
+        "persistentShell": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HelperPersistentShellSnapshot"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "scope": {
           "$ref": "#/definitions/ScopeIdentity"
@@ -351,6 +399,92 @@
         "degraded"
       ]
     },
+    "HelperShellAttachResult": {
+      "type": "object",
+      "required": [
+        "resolvedName",
+        "state"
+      ],
+      "properties": {
+        "forceEvicted": {
+          "default": false,
+          "type": "boolean"
+        },
+        "resolvedName": {
+          "$ref": "#/definitions/ShellName"
+        },
+        "state": {
+          "$ref": "#/definitions/ShellSessionState"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperShellDetachResponse": {
+      "type": "object",
+      "required": [
+        "operationId",
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "operationId": {
+          "$ref": "#/definitions/OperationId"
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/ShellDetachResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperShellKillResponse": {
+      "type": "object",
+      "required": [
+        "operationId",
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "operationId": {
+          "$ref": "#/definitions/OperationId"
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/ShellKillResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperShellListResponse": {
+      "type": "object",
+      "required": [
+        "operationId",
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "operationId": {
+          "$ref": "#/definitions/OperationId"
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/ShellListResult"
+        }
+      },
+      "additionalProperties": false
+    },
     "HelperShellRequest": {
       "oneOf": [
         {
@@ -363,11 +497,15 @@
             "args": {
               "type": "object",
               "required": [
-                "request_id",
+                "operationId",
+                "requestId",
                 "workload"
               ],
               "properties": {
-                "request_id": {
+                "operationId": {
+                  "$ref": "#/definitions/OperationId"
+                },
+                "requestId": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0
@@ -375,7 +513,8 @@
                 "workload": {
                   "$ref": "#/definitions/WorkloadIdentity"
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "op": {
               "type": "string",
@@ -383,7 +522,8 @@
                 "list"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -395,12 +535,38 @@
             "args": {
               "type": "object",
               "required": [
-                "operation_id",
-                "request_id",
-                "tty",
+                "initialTerminalSize",
+                "operationId",
+                "requestId",
                 "workload"
               ],
               "properties": {
+                "force": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "initialTerminalSize": {
+                  "type": "object",
+                  "required": [
+                    "cols",
+                    "rows"
+                  ],
+                  "properties": {
+                    "cols": {
+                      "type": "integer",
+                      "format": "uint32",
+                      "maximum": 65535.0,
+                      "minimum": 1.0
+                    },
+                    "rows": {
+                      "type": "integer",
+                      "format": "uint32",
+                      "maximum": 65535.0,
+                      "minimum": 1.0
+                    }
+                  },
+                  "additionalProperties": false
+                },
                 "name": {
                   "anyOf": [
                     {
@@ -411,21 +577,19 @@
                     }
                   ]
                 },
-                "operation_id": {
+                "operationId": {
                   "$ref": "#/definitions/OperationId"
                 },
-                "request_id": {
+                "requestId": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0
                 },
-                "tty": {
-                  "type": "boolean"
-                },
                 "workload": {
                   "$ref": "#/definitions/WorkloadIdentity"
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "op": {
               "type": "string",
@@ -433,7 +597,8 @@
                 "attach"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -446,18 +611,18 @@
               "type": "object",
               "required": [
                 "name",
-                "operation_id",
-                "request_id",
+                "operationId",
+                "requestId",
                 "workload"
               ],
               "properties": {
                 "name": {
                   "$ref": "#/definitions/ShellName"
                 },
-                "operation_id": {
+                "operationId": {
                   "$ref": "#/definitions/OperationId"
                 },
-                "request_id": {
+                "requestId": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0
@@ -465,7 +630,8 @@
                 "workload": {
                   "$ref": "#/definitions/WorkloadIdentity"
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "op": {
               "type": "string",
@@ -473,7 +639,8 @@
                 "detach"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -486,18 +653,18 @@
               "type": "object",
               "required": [
                 "name",
-                "operation_id",
-                "request_id",
+                "operationId",
+                "requestId",
                 "workload"
               ],
               "properties": {
                 "name": {
                   "$ref": "#/definitions/ShellName"
                 },
-                "operation_id": {
+                "operationId": {
                   "$ref": "#/definitions/OperationId"
                 },
-                "request_id": {
+                "requestId": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0
@@ -505,7 +672,8 @@
                 "workload": {
                   "$ref": "#/definitions/WorkloadIdentity"
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "op": {
               "type": "string",
@@ -513,7 +681,69 @@
                 "kill"
               ]
             }
-          }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "HelperShellResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "list"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperShellListResponse"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "detach"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperShellDetachResponse"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "kill"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperShellKillResponse"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -538,11 +768,272 @@
       },
       "additionalProperties": false
     },
+    "HelperSupervisorId": {
+      "description": "Opaque persistent-shell supervisor identity.",
+      "type": "string",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "HelperTerminalAttachmentClosed": {
+      "type": "object",
+      "required": [
+        "detached"
+      ],
+      "properties": {
+        "cause": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ShellCloseCause"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "detached": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalChunkBase64": {
+      "description": "Bounded standard padded base64 terminal bytes.",
+      "type": "string",
+      "maxLength": 87384,
+      "minLength": 0,
+      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+    },
+    "HelperTerminalControl": {
+      "type": "object",
+      "required": [
+        "controlSequence",
+        "requestId"
+      ],
+      "properties": {
+        "controlSequence": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalControlResponse_for_HelperTerminalAttachmentClosed": {
+      "type": "object",
+      "required": [
+        "controlSequence",
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "controlSequence": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/HelperTerminalAttachmentClosed"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalControlResponse_for_TerminalCloseResult": {
+      "type": "object",
+      "required": [
+        "controlSequence",
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "controlSequence": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/TerminalCloseResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalControlResponse_for_TerminalControlResult": {
+      "type": "object",
+      "required": [
+        "controlSequence",
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "controlSequence": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/TerminalControlResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalOperationResult_for_HelperTerminalReadOutputResult": {
+      "type": "object",
+      "required": [
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/HelperTerminalReadOutputResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalOperationResult_for_TerminalWaitResult": {
+      "type": "object",
+      "required": [
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/TerminalWaitResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalOperationResult_for_TerminalWriteStdinResult": {
+      "type": "object",
+      "required": [
+        "requestId",
+        "result"
+      ],
+      "properties": {
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/TerminalWriteStdinResult"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalReadOutput": {
+      "type": "object",
+      "required": [
+        "cursor",
+        "maxLen",
+        "requestId",
+        "stream"
+      ],
+      "properties": {
+        "cursor": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "maxLen": {
+          "type": "integer",
+          "format": "uint64",
+          "maximum": 65536.0,
+          "minimum": 1.0
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "stream": {
+          "$ref": "#/definitions/TerminalStream"
+        },
+        "timeoutMs": {
+          "default": 0,
+          "type": "integer",
+          "format": "uint64",
+          "maximum": 1000.0,
+          "minimum": 0.0
+        },
+        "wait": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalReadOutputResult": {
+      "type": "object",
+      "required": [
+        "dataBase64",
+        "nextCursor"
+      ],
+      "properties": {
+        "dataBase64": {
+          "$ref": "#/definitions/HelperTerminalChunkBase64"
+        },
+        "droppedBytes": {
+          "default": 0,
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "eof": {
+          "default": false,
+          "type": "boolean"
+        },
+        "nextCursor": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "timedOut": {
+          "default": false,
+          "type": "boolean"
+        },
+        "truncated": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "HelperTerminalReady": {
       "type": "object",
       "required": [
         "operationId",
         "requestId",
+        "result",
         "scope",
         "terminalProtocolVersion",
         "transport"
@@ -555,6 +1046,9 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        },
+        "result": {
+          "$ref": "#/definitions/HelperShellAttachResult"
         },
         "scope": {
           "$ref": "#/definitions/ScopeIdentity"
@@ -570,6 +1064,313 @@
       },
       "additionalProperties": false
     },
+    "HelperTerminalRejected": {
+      "type": "object",
+      "required": [
+        "code",
+        "requestId"
+      ],
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/HelperFailureCode"
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalRequest": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "op"
+          ],
+          "properties": {
+            "args": {
+              "$ref": "#/definitions/HelperTerminalWriteStdin"
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "writeStdin"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "op"
+          ],
+          "properties": {
+            "args": {
+              "$ref": "#/definitions/HelperTerminalReadOutput"
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "readOutput"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "op"
+          ],
+          "properties": {
+            "args": {
+              "$ref": "#/definitions/HelperTerminalResize"
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "resize"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "op"
+          ],
+          "properties": {
+            "args": {
+              "$ref": "#/definitions/HelperTerminalWait"
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "wait"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "op"
+          ],
+          "properties": {
+            "args": {
+              "$ref": "#/definitions/HelperTerminalControl"
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "closeStdin"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "op"
+          ],
+          "properties": {
+            "args": {
+              "$ref": "#/definitions/HelperTerminalControl"
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "closeAttachment"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "HelperTerminalResize": {
+      "type": "object",
+      "required": [
+        "cols",
+        "controlSequence",
+        "requestId",
+        "rows"
+      ],
+      "properties": {
+        "cols": {
+          "type": "integer",
+          "format": "uint32",
+          "maximum": 65535.0,
+          "minimum": 1.0
+        },
+        "controlSequence": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "rows": {
+          "type": "integer",
+          "format": "uint32",
+          "maximum": 65535.0,
+          "minimum": 1.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "writeStdin"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperTerminalOperationResult_for_TerminalWriteStdinResult"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "readOutput"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperTerminalOperationResult_for_HelperTerminalReadOutputResult"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "resize"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperTerminalControlResponse_for_TerminalControlResult"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "wait"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperTerminalOperationResult_for_TerminalWaitResult"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "closeStdin"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperTerminalControlResponse_for_TerminalCloseResult"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "closeAttachment"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperTerminalControlResponse_for_HelperTerminalAttachmentClosed"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "op",
+            "result"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "rejected"
+              ]
+            },
+            "result": {
+              "$ref": "#/definitions/HelperTerminalRejected"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "HelperTerminalTransport": {
       "description": "Transport represented by the single fd attached to a terminal-ready frame.",
       "oneOf": [
@@ -581,6 +1382,55 @@
           ]
         }
       ]
+    },
+    "HelperTerminalWait": {
+      "type": "object",
+      "required": [
+        "requestId"
+      ],
+      "properties": {
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "timeoutMs": {
+          "default": 0,
+          "type": "integer",
+          "format": "uint64",
+          "maximum": 1000.0,
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "HelperTerminalWriteStdin": {
+      "type": "object",
+      "required": [
+        "chunkBase64",
+        "offset",
+        "requestId"
+      ],
+      "properties": {
+        "chunkBase64": {
+          "$ref": "#/definitions/HelperTerminalChunkBase64"
+        },
+        "eof": {
+          "default": false,
+          "type": "boolean"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
     },
     "OperationId": {
       "type": "string",
@@ -622,12 +1472,283 @@
       },
       "additionalProperties": false
     },
+    "ShellCloseCause": {
+      "type": "string",
+      "enum": [
+        "client-detach",
+        "evicted-by-force",
+        "evicted-by-admin-detach",
+        "killed-by-admin",
+        "pool-unavailable",
+        "output-gap"
+      ]
+    },
+    "ShellDetachResult": {
+      "type": "object",
+      "required": [
+        "detached",
+        "resolvedName"
+      ],
+      "properties": {
+        "cause": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ShellCloseCause"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "detached": {
+          "type": "boolean"
+        },
+        "resolvedName": {
+          "$ref": "#/definitions/ShellName"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ShellKillResult": {
+      "type": "object",
+      "required": [
+        "killed",
+        "name",
+        "state"
+      ],
+      "properties": {
+        "killed": {
+          "type": "boolean"
+        },
+        "name": {
+          "$ref": "#/definitions/ShellName"
+        },
+        "state": {
+          "$ref": "#/definitions/ShellSessionState"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ShellListEntry": {
+      "type": "object",
+      "required": [
+        "name",
+        "state"
+      ],
+      "properties": {
+        "attached": {
+          "default": false,
+          "type": "boolean"
+        },
+        "isDefault": {
+          "default": false,
+          "type": "boolean"
+        },
+        "name": {
+          "$ref": "#/definitions/ShellName"
+        },
+        "state": {
+          "$ref": "#/definitions/ShellSessionState"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ShellListResult": {
+      "type": "object",
+      "required": [
+        "defaultName",
+        "sessions"
+      ],
+      "properties": {
+        "defaultName": {
+          "$ref": "#/definitions/ShellName"
+        },
+        "sessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ShellListEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "ShellName": {
       "description": "Persistent shell session name.",
       "type": "string",
       "maxLength": 64,
       "minLength": 1,
       "pattern": "^[A-Za-z0-9_][A-Za-z0-9._-]{0,63}$"
+    },
+    "ShellSessionState": {
+      "type": "string",
+      "enum": [
+        "attached",
+        "detached",
+        "killed",
+        "pool-unavailable",
+        "feature-disabled",
+        "output-gap"
+      ]
+    },
+    "TerminalCloseResult": {
+      "type": "object",
+      "properties": {
+        "stdinClosed": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TerminalControlResult": {
+      "type": "object",
+      "properties": {
+        "delivered": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TerminalStatus": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "exited"
+              ]
+            },
+            "value": {
+              "type": "object",
+              "required": [
+                "code"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "signaled"
+              ]
+            },
+            "value": {
+              "type": "object",
+              "required": [
+                "signal"
+              ],
+              "properties": {
+                "signal": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "value": {
+              "type": "object",
+              "required": [
+                "slug"
+              ],
+              "properties": {
+                "slug": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "TerminalStream": {
+      "type": "string",
+      "enum": [
+        "stdout",
+        "stderr"
+      ]
+    },
+    "TerminalWaitResult": {
+      "type": "object",
+      "properties": {
+        "running": {
+          "default": false,
+          "type": "boolean"
+        },
+        "terminalStatus": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TerminalStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TerminalWriteStdinResult": {
+      "type": "object",
+      "required": [
+        "acceptedLen",
+        "nextOffset"
+      ],
+      "properties": {
+        "acceptedLen": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "backpressured": {
+          "default": false,
+          "type": "boolean"
+        },
+        "nextOffset": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "stdinClosed": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
     },
     "UnsafeLocalHelperToDaemon": {
       "oneOf": [
@@ -717,6 +1838,24 @@
               "type": "string",
               "enum": [
                 "terminalReady"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "payload",
+            "type"
+          ],
+          "properties": {
+            "payload": {
+              "$ref": "#/definitions/HelperShellResponse"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "shell"
               ]
             }
           }

--- a/docs/reference/schemas/v2/unsafe-local-helper-wire.md
+++ b/docs/reference/schemas/v2/unsafe-local-helper-wire.md
@@ -2,14 +2,30 @@
 
 Schema: [`unsafe-local-helper-wire.json`](./unsafe-local-helper-wire.json)
 
-This schema captures private helper protocol version 1 between `d2bd` and the
-same-UID unsafe-local user helper. Peer credentials, not payload fields,
-establish execution identity.
+This schema captures private helper protocol version 2 between `d2bd` and the
+same-UID unsafe-local user helper. It is an install-together contract with no
+version-1 fallback. Peer credentials, not payload fields, establish execution
+identity. The dedicated terminal stream remains terminal protocol version 1.
 
 ## Contract notes
 
 - Control frames use bounded `AF_UNIX` `SOCK_SEQPACKET` messages.
 - Terminal readiness transfers exactly one connected `AF_UNIX` `SOCK_STREAM`.
+- Shell management requests and responses correlate both request and operation
+  ids. List, detach, and kill results map directly to the public shell result
+  DTOs.
+- The connected terminal stream is bound to one attachment. Its frames use a
+  four-byte little-endian JSON-body length prefix, contain no client-supplied
+  session handle, and cover bounded stdin writes, output reads, resize, wait,
+  stdin close, attachment close, and typed rejection.
+- Terminal JSON frames are limited to 128 KiB, decoded chunks to 64 KiB,
+  per-stream output rings to 8 MiB, and long polls to 1000 ms.
+- Persistent-shell snapshots carry only a redacted shell name, state/attachment
+  posture, and a bounded opaque supervisor id in addition to common scope
+  identity.
 - Socket and received descriptors use the frozen CLOEXEC requirements.
-- Requests contain no uid, environment, cwd, compositor path, or
-  public-supplied argv.
+- Shell and terminal requests contain no uid, argv, environment, cwd, host
+  path, transcript, PID, unit name, compositor data, or terminal session
+  handle.
+- These are contract definitions only. Unsafe-local persistent-shell runtime
+  dispatch remains unavailable until its daemon and helper backend lands.

--- a/docs/reference/unsafe-local-provider.md
+++ b/docs/reference/unsafe-local-provider.md
@@ -88,9 +88,11 @@ The closed unsafe-local posture is:
 | `executionIdentity` | `authenticated-requester-uid` |
 | `sessionPersistence` | `user-manager-lifetime` |
 
-`configured-launch-v1` and `unsafe-local-provider-v1` are additive protocol-v3
-feature flags. Clients must hide or refuse unsupported operations; they must
-never fall back to unsafe-local.
+`configured-launch-v1`, `unsafe-local-provider-v1`, and
+`unsafe-local-shell-v1` are additive protocol-v3 feature flags. The shell token
+identifies contract support only until the later runtime slices enable
+dispatch. Clients must hide or refuse unsupported operations; they must never
+fall back to unsafe-local.
 
 Availability values are directly actionable: `helper-unavailable` and
 `helper-stale` require restarting the caller's user helper;
@@ -117,10 +119,12 @@ host-local Unix binding. The helper lookup is keyed by the requester's
 remote, stale-helper, cross-UID, direct-compositor, root, SSH, and arbitrary
 command fallbacks are not available.
 
-The separate helper protocol is version 1 on the daemon-owned
+The separate helper protocol is version 2 on the daemon-owned
 `/run/d2b/unsafe-local-helper.sock` `SOCK_SEQPACKET` endpoint. Peer credentials,
-not a uid field, establish identity. Frames contain no uid, environment, cwd,
-or public-supplied command. Both peers request at least 256 KiB for
+not a uid field, establish identity. Version 1 is rejected without a
+compatibility fallback because the daemon and helper are installed together.
+Frames contain no uid, environment, cwd, or public-supplied command. Both peers
+request at least 256 KiB for
 `SO_SNDBUF` and `SO_RCVBUF` before exchanging frames and verify that Linux
 reports effective buffers of at least 512 KiB. A smaller effective buffer makes
 the helper unavailable rather than allowing a valid 256 KiB frame to fail with
@@ -159,7 +163,14 @@ and multiple fds are rejected. The receiver requires
 `getsockopt(SO_TYPE) == SOCK_STREAM`, `getsockopt(SO_ACCEPTCONN) == 0`, and a
 successful `getpeername`, then verifies the authenticated helper generation,
 request correlation, and terminal protocol version before accepting the fd.
-Terminal bytes do not share the helper control queue.
+Terminal protocol version 1 uses bounded JSON frames with a four-byte
+little-endian body-length prefix for stdin writes, output reads, resize, wait,
+stdin close, attachment close, and typed rejections. The connected socket binds
+one attachment, so these frames never accept a client-supplied session handle.
+Frames are limited to 128 KiB, decoded chunks to 64 KiB, per-stream output rings
+to 8 MiB, and waits to 1000 ms.
+Terminal bytes do not share the helper control queue. This contract does not
+make unsafe-local persistent-shell runtime dispatch available yet.
 
 Every socket is created with `SOCK_CLOEXEC`, every other control or PTY fd uses
 `O_CLOEXEC`, and rights are received with `MSG_CMSG_CLOEXEC`. Only descriptors

--- a/docs/reference/unsafe-local-provider.md
+++ b/docs/reference/unsafe-local-provider.md
@@ -89,10 +89,10 @@ The closed unsafe-local posture is:
 | `sessionPersistence` | `user-manager-lifetime` |
 
 `configured-launch-v1`, `unsafe-local-provider-v1`, and
-`unsafe-local-shell-v1` are additive protocol-v3 feature flags. The shell token
-identifies contract support only until the later runtime slices enable
-dispatch. Clients must hide or refuse unsupported operations; they must never
-fall back to unsafe-local.
+`unsafe-local-shell-v1` are additive protocol-v3 feature flags. Clients may
+recognize the shell token with this contract revision, but `d2bd` does not
+advertise it until runtime dispatch is enabled. Clients must hide or refuse
+unsupported operations; they must never fall back to unsafe-local.
 
 Availability values are directly actionable: `helper-unavailable` and
 `helper-stale` require restarting the caller's user helper;

--- a/packages/d2b-contract-tests/tests/realm_workload_schema_contract.rs
+++ b/packages/d2b-contract-tests/tests/realm_workload_schema_contract.rs
@@ -442,6 +442,72 @@ fn generated_unsafe_local_schemas_are_closed_and_argv_is_private() {
 }
 
 #[test]
+fn helper_shell_schema_is_correlated_bounded_and_authority_free() {
+    let helper_schema = read_repo_file("docs/reference/schemas/v2/unsafe-local-helper-wire.json");
+    let helper_schema: serde_json::Value = serde_json::from_str(&helper_schema).unwrap();
+    for root_field in [
+        "daemonToHelper",
+        "helperToDaemon",
+        "protocolVersion",
+        "terminalProtocolVersion",
+        "terminalRequest",
+        "terminalResponse",
+    ] {
+        assert!(
+            helper_schema["required"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|field| field == root_field),
+            "helper schema must require {root_field}"
+        );
+    }
+
+    let definitions = helper_schema["definitions"].as_object().unwrap();
+    let shell_request = serde_json::to_string(&definitions["HelperShellRequest"]).unwrap();
+    for field in ["requestId", "operationId", "initialTerminalSize"] {
+        assert!(
+            shell_request.contains(field),
+            "helper shell request schema must use wire field {field}"
+        );
+    }
+    for forbidden in ["request_id", "operation_id", "initial_terminal_size"] {
+        assert!(
+            !shell_request.contains(forbidden),
+            "helper shell request schema must not expose Rust field {forbidden}"
+        );
+    }
+
+    let shell_and_terminal = definitions
+        .iter()
+        .filter(|(name, _)| {
+            name.starts_with("HelperShell")
+                || name.starts_with("HelperTerminal")
+                || *name == "HelperPersistentShellSnapshot"
+        })
+        .map(|(_, definition)| definition)
+        .collect::<Vec<_>>();
+    let shell_and_terminal = serde_json::to_string(&shell_and_terminal).unwrap();
+    for forbidden in [
+        "\"uid\"",
+        "\"argv\"",
+        "\"environment\"",
+        "\"cwd\"",
+        "\"path\"",
+        "\"transcript\"",
+        "\"pid\"",
+        "\"unitName\"",
+        "\"compositor\"",
+        "\"session\"",
+    ] {
+        assert!(
+            !shell_and_terminal.contains(forbidden),
+            "helper shell/terminal schema must not contain {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn rendered_launcher_metadata_hides_argv_and_private_bundle_resolves_it() {
     let Some(dir) = env::var_os("D2B_FIXTURES").map(std::path::PathBuf::from) else {
         eprintln!("  (skipping rendered unsafe-local contracts; D2B_FIXTURES unset)");

--- a/packages/d2b-contracts/src/lib.rs
+++ b/packages/d2b-contracts/src/lib.rs
@@ -124,6 +124,7 @@ impl FeatureFlag {
             "export-broker-audit" => Some(KnownFeatureFlag::ExportBrokerAudit),
             "configured-launch-v1" => Some(KnownFeatureFlag::ConfiguredLaunchV1),
             "unsafe-local-provider-v1" => Some(KnownFeatureFlag::UnsafeLocalProviderV1),
+            "unsafe-local-shell-v1" => Some(KnownFeatureFlag::UnsafeLocalShellV1),
             _ => None,
         }
     }
@@ -157,6 +158,7 @@ pub enum KnownFeatureFlag {
     ExportBrokerAudit,
     ConfiguredLaunchV1,
     UnsafeLocalProviderV1,
+    UnsafeLocalShellV1,
 }
 
 impl KnownFeatureFlag {
@@ -168,6 +170,7 @@ impl KnownFeatureFlag {
             Self::ExportBrokerAudit => "export-broker-audit",
             Self::ConfiguredLaunchV1 => "configured-launch-v1",
             Self::UnsafeLocalProviderV1 => "unsafe-local-provider-v1",
+            Self::UnsafeLocalShellV1 => "unsafe-local-shell-v1",
         }
     }
 
@@ -424,6 +427,17 @@ mod tests {
             reply.capabilities,
             vec![KnownFeatureFlag::TypedErrors.wire_value()]
         );
+    }
+
+    #[test]
+    fn unsafe_local_shell_feature_is_known_without_changing_public_protocol() {
+        let feature = FeatureFlag::new("unsafe-local-shell-v1").expect("valid feature");
+        assert_eq!(feature.known(), Some(KnownFeatureFlag::UnsafeLocalShellV1));
+        assert_eq!(KnownFeatureFlag::UnsafeLocalShellV1.wire_value(), feature);
+        assert_eq!(PROTOCOL_VERSION, 3);
+
+        let unknown = FeatureFlag::new("unsafe-local-shell-v2").expect("valid future feature");
+        assert_eq!(unknown.known(), None);
     }
 
     #[test]

--- a/packages/d2b-contracts/src/unsafe_local_wire.rs
+++ b/packages/d2b-contracts/src/unsafe_local_wire.rs
@@ -3,18 +3,48 @@
 //! The authenticated Unix peer credential is the execution identity. No frame
 //! carries a uid, environment, cwd, compositor path, or arbitrary public argv.
 
-use crate::public_wire::ShellName;
+use crate::{
+    public_wire::{
+        EXEC_MAX_CHUNK_BYTES, ShellCloseCause, ShellDetachResult, ShellKillResult, ShellListResult,
+        ShellName, ShellSessionState,
+    },
+    terminal_wire::{
+        TerminalCloseResult, TerminalControlResult, TerminalReadOutputChunk, TerminalSize,
+        TerminalStream, TerminalWaitResult, TerminalWriteStdinResult,
+    },
+};
 use d2b_core::{configured_argv::ConfiguredArgv, workload_identity::WorkloadIdentity};
 use d2b_realm_core::{ids::OperationId, token::ProtocolToken};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use schemars::{
+    JsonSchema,
+    r#gen::SchemaGenerator,
+    schema::{InstanceType, Metadata, Schema, SchemaObject, SingleOrVec, StringValidation},
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::fmt;
 
-pub const UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION: u32 = 1;
+pub const UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION: u32 = 2;
 pub const UNSAFE_LOCAL_TERMINAL_PROTOCOL_VERSION: u32 = 1;
 /// Every terminal-ready frame carries exactly one connected Unix stream fd.
 pub const UNSAFE_LOCAL_TERMINAL_FD_COUNT: usize = 1;
 pub const MAX_HELPER_FRAME_SIZE: usize = 256 * 1024;
+/// Maximum length-prefixed JSON frame on one attached terminal stream.
+pub const MAX_UNSAFE_LOCAL_TERMINAL_FRAME_SIZE: usize = 128 * 1024;
+pub const UNSAFE_LOCAL_TERMINAL_LENGTH_PREFIX_BYTES: usize = 4;
+/// Maximum decoded terminal input or output chunk.
+pub const MAX_UNSAFE_LOCAL_TERMINAL_CHUNK_BYTES: u64 = EXEC_MAX_CHUNK_BYTES;
+/// Maximum standard padded base64 envelope for one terminal chunk.
+pub const MAX_UNSAFE_LOCAL_TERMINAL_BASE64_BYTES: usize =
+    (MAX_UNSAFE_LOCAL_TERMINAL_CHUNK_BYTES as usize).div_ceil(3) * 4;
+/// Maximum retained output per persistent shell stream.
+pub const MAX_UNSAFE_LOCAL_TERMINAL_OUTPUT_RING_BYTES: u64 = 8 * 1024 * 1024;
+/// Maximum duration of one terminal long-poll.
+pub const MAX_UNSAFE_LOCAL_TERMINAL_WAIT_TIMEOUT_MS: u64 = 1_000;
+pub const MAX_UNSAFE_LOCAL_TERMINAL_ROWS: u32 = 65_535;
+pub const MAX_UNSAFE_LOCAL_TERMINAL_COLS: u32 = 65_535;
+pub const MAX_HELPER_SUPERVISOR_ID_BYTES: usize = 128;
+const _: () =
+    assert!(MAX_UNSAFE_LOCAL_TERMINAL_BASE64_BYTES + 1024 < MAX_UNSAFE_LOCAL_TERMINAL_FRAME_SIZE);
 /// Value requested through `SO_SNDBUF` and `SO_RCVBUF` on both control peers.
 pub const HELPER_SOCKET_BUFFER_REQUEST_BYTES: usize = MAX_HELPER_FRAME_SIZE;
 /// Minimum value that `getsockopt` must report after Linux doubles the request.
@@ -23,6 +53,46 @@ pub const MAX_HELPER_QUEUE_DEPTH: usize = 128;
 pub const MAX_HELPER_SNAPSHOT_SCOPES: usize = 1024;
 pub const MAX_COMPLETED_OPERATIONS_PER_UID: usize = 1024;
 pub const MAX_COMPLETED_OPERATION_AGE_SECS: u64 = 24 * 60 * 60;
+
+pub const fn unsafe_local_helper_protocol_supported(version: u32) -> bool {
+    version == UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION
+}
+
+pub fn encode_unsafe_local_terminal_frame<T>(message: &T) -> Result<Vec<u8>, HelperFailureCode>
+where
+    T: Serialize,
+{
+    let body = serde_json::to_vec(message).map_err(|_| HelperFailureCode::InvalidRequest)?;
+    if body.len() > MAX_UNSAFE_LOCAL_TERMINAL_FRAME_SIZE {
+        return Err(HelperFailureCode::InvalidRequest);
+    }
+    let mut frame = Vec::with_capacity(UNSAFE_LOCAL_TERMINAL_LENGTH_PREFIX_BYTES + body.len());
+    frame.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    frame.extend_from_slice(&body);
+    Ok(frame)
+}
+
+pub fn decode_unsafe_local_terminal_frame<T>(frame: &[u8]) -> Result<T, HelperFailureCode>
+where
+    T: DeserializeOwned,
+{
+    if frame.len() < UNSAFE_LOCAL_TERMINAL_LENGTH_PREFIX_BYTES {
+        return Err(HelperFailureCode::InvalidRequest);
+    }
+    let declared_length = u32::from_le_bytes(
+        frame[..UNSAFE_LOCAL_TERMINAL_LENGTH_PREFIX_BYTES]
+            .try_into()
+            .map_err(|_| HelperFailureCode::InvalidRequest)?,
+    ) as usize;
+    if declared_length > MAX_UNSAFE_LOCAL_TERMINAL_FRAME_SIZE
+        || frame.len() != UNSAFE_LOCAL_TERMINAL_LENGTH_PREFIX_BYTES + declared_length
+    {
+        return Err(HelperFailureCode::InvalidRequest);
+    }
+    serde_json::from_slice(&frame[UNSAFE_LOCAL_TERMINAL_LENGTH_PREFIX_BYTES..])
+        .map_err(|_| HelperFailureCode::InvalidRequest)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct HelperHello {
@@ -82,6 +152,83 @@ pub enum HelperScopeState {
     Degraded,
 }
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct HelperSupervisorId(String);
+
+impl HelperSupervisorId {
+    pub fn new(value: impl Into<String>) -> Result<Self, HelperFailureCode> {
+        let value = value.into();
+        let valid = !value.is_empty()
+            && value.len() <= MAX_HELPER_SUPERVISOR_ID_BYTES
+            && value.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-')
+            });
+        valid
+            .then_some(Self(value))
+            .ok_or(HelperFailureCode::InvalidRequest)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for HelperSupervisorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("HelperSupervisorId(<redacted>)")
+    }
+}
+
+impl<'de> Deserialize<'de> for HelperSupervisorId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(|_| {
+            serde::de::Error::custom(
+                "helper supervisor id must be 1..=128 bytes of [A-Za-z0-9._:-]",
+            )
+        })
+    }
+}
+
+impl JsonSchema for HelperSupervisorId {
+    fn schema_name() -> String {
+        "HelperSupervisorId".to_owned()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        bounded_string_schema(
+            1,
+            MAX_HELPER_SUPERVISOR_ID_BYTES as u32,
+            "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+            "Opaque persistent-shell supervisor identity.",
+        )
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperPersistentShellSnapshot {
+    pub name: ShellName,
+    pub state: ShellSessionState,
+    pub attached: bool,
+    pub supervisor_id: HelperSupervisorId,
+}
+
+impl fmt::Debug for HelperPersistentShellSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperPersistentShellSnapshot")
+            .field("name", &"<redacted>")
+            .field("state", &self.state)
+            .field("attached", &self.attached)
+            .field("supervisor_id", &"<redacted>")
+            .finish()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct HelperScopeSnapshot {
@@ -89,6 +236,8 @@ pub struct HelperScopeSnapshot {
     pub workload: WorkloadIdentity,
     pub scope: ScopeIdentity,
     pub state: HelperScopeState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persistent_shell: Option<HelperPersistentShellSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -110,28 +259,49 @@ pub struct HelperLaunchRequest {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "op", content = "args", rename_all = "camelCase")]
+#[serde(
+    tag = "op",
+    content = "args",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
 pub enum HelperShellRequest {
     List {
+        #[schemars(rename = "requestId")]
         request_id: u64,
+        #[schemars(rename = "operationId")]
+        operation_id: OperationId,
         workload: WorkloadIdentity,
     },
     Attach {
+        #[schemars(rename = "requestId")]
         request_id: u64,
+        #[schemars(rename = "operationId")]
         operation_id: OperationId,
         workload: WorkloadIdentity,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         name: Option<ShellName>,
-        tty: bool,
+        #[serde(default)]
+        force: bool,
+        #[schemars(
+            rename = "initialTerminalSize",
+            schema_with = "bounded_terminal_size_schema"
+        )]
+        initial_terminal_size: TerminalSize,
     },
     Detach {
+        #[schemars(rename = "requestId")]
         request_id: u64,
+        #[schemars(rename = "operationId")]
         operation_id: OperationId,
         workload: WorkloadIdentity,
         name: ShellName,
     },
     Kill {
+        #[schemars(rename = "requestId")]
         request_id: u64,
+        #[schemars(rename = "operationId")]
         operation_id: OperationId,
         workload: WorkloadIdentity,
         name: ShellName,
@@ -143,10 +313,12 @@ impl fmt::Debug for HelperShellRequest {
         match self {
             Self::List {
                 request_id,
+                operation_id,
                 workload,
             } => f
                 .debug_struct("HelperShellRequest::List")
                 .field("request_id", request_id)
+                .field("operation_id", operation_id)
                 .field("workload", workload)
                 .finish(),
             Self::Attach {
@@ -154,14 +326,16 @@ impl fmt::Debug for HelperShellRequest {
                 operation_id,
                 workload,
                 name,
-                tty,
+                force,
+                initial_terminal_size,
             } => f
                 .debug_struct("HelperShellRequest::Attach")
                 .field("request_id", request_id)
                 .field("operation_id", operation_id)
                 .field("workload", workload)
                 .field("name", &name.as_ref().map(|_| "<redacted>"))
-                .field("tty", tty)
+                .field("force", force)
+                .field("initial_terminal_size", initial_terminal_size)
                 .finish(),
             Self::Detach {
                 request_id,
@@ -191,6 +365,38 @@ impl fmt::Debug for HelperShellRequest {
     }
 }
 
+impl HelperShellRequest {
+    pub fn request_id(&self) -> u64 {
+        match self {
+            Self::List { request_id, .. }
+            | Self::Attach { request_id, .. }
+            | Self::Detach { request_id, .. }
+            | Self::Kill { request_id, .. } => *request_id,
+        }
+    }
+
+    pub fn operation_id(&self) -> &OperationId {
+        match self {
+            Self::List { operation_id, .. }
+            | Self::Attach { operation_id, .. }
+            | Self::Detach { operation_id, .. }
+            | Self::Kill { operation_id, .. } => operation_id,
+        }
+    }
+
+    pub fn validate_bounds(&self) -> Result<(), HelperFailureCode> {
+        match self {
+            Self::Attach {
+                initial_terminal_size,
+                ..
+            } if !terminal_size_valid(*initial_terminal_size) => {
+                Err(HelperFailureCode::InvalidTerminalSize)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum HelperFailureCode {
@@ -208,6 +414,12 @@ pub enum HelperFailureCode {
     ProxyUnavailable,
     FirstClientTimeout,
     ShellUnavailable,
+    ShellNotFound,
+    ShellAlreadyAttached,
+    TerminalOutputGap,
+    TerminalOffsetMismatch,
+    TerminalClosed,
+    InvalidTerminalSize,
     Internal,
 }
 
@@ -229,7 +441,7 @@ pub struct HelperOperationResult {
     pub scope: Option<ScopeIdentity>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct HelperTerminalReady {
     pub request_id: u64,
@@ -237,6 +449,20 @@ pub struct HelperTerminalReady {
     pub terminal_protocol_version: u32,
     pub transport: HelperTerminalTransport,
     pub scope: ScopeIdentity,
+    pub result: HelperShellAttachResult,
+}
+
+impl fmt::Debug for HelperTerminalReady {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperTerminalReady")
+            .field("request_id", &self.request_id)
+            .field("operation_id", &self.operation_id)
+            .field("terminal_protocol_version", &self.terminal_protocol_version)
+            .field("transport", &self.transport)
+            .field("scope", &self.scope)
+            .field("result", &self.result)
+            .finish()
+    }
 }
 
 /// Transport represented by the single fd attached to a terminal-ready frame.
@@ -259,6 +485,389 @@ pub struct HelperOperationRejected {
     pub code: HelperFailureCode,
 }
 
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperShellAttachResult {
+    pub resolved_name: ShellName,
+    pub state: ShellSessionState,
+    #[serde(default)]
+    pub force_evicted: bool,
+}
+
+impl fmt::Debug for HelperShellAttachResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperShellAttachResult")
+            .field("resolved_name", &"<redacted>")
+            .field("state", &self.state)
+            .field("force_evicted", &self.force_evicted)
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperShellListResponse {
+    pub request_id: u64,
+    pub operation_id: OperationId,
+    pub result: ShellListResult,
+}
+
+impl fmt::Debug for HelperShellListResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperShellListResponse")
+            .field("request_id", &self.request_id)
+            .field("operation_id", &self.operation_id)
+            .field("result", &self.result)
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperShellDetachResponse {
+    pub request_id: u64,
+    pub operation_id: OperationId,
+    pub result: ShellDetachResult,
+}
+
+impl fmt::Debug for HelperShellDetachResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperShellDetachResponse")
+            .field("request_id", &self.request_id)
+            .field("operation_id", &self.operation_id)
+            .field("result", &self.result)
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperShellKillResponse {
+    pub request_id: u64,
+    pub operation_id: OperationId,
+    pub result: ShellKillResult,
+}
+
+impl fmt::Debug for HelperShellKillResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperShellKillResponse")
+            .field("request_id", &self.request_id)
+            .field("operation_id", &self.operation_id)
+            .field("result", &self.result)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    tag = "op",
+    content = "result",
+    rename_all = "camelCase",
+    deny_unknown_fields
+)]
+pub enum HelperShellResponse {
+    List(HelperShellListResponse),
+    Detach(HelperShellDetachResponse),
+    Kill(HelperShellKillResponse),
+}
+
+impl HelperShellResponse {
+    pub fn request_id(&self) -> u64 {
+        match self {
+            Self::List(response) => response.request_id,
+            Self::Detach(response) => response.request_id,
+            Self::Kill(response) => response.request_id,
+        }
+    }
+
+    pub fn operation_id(&self) -> &OperationId {
+        match self {
+            Self::List(response) => &response.operation_id,
+            Self::Detach(response) => &response.operation_id,
+            Self::Kill(response) => &response.operation_id,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct HelperTerminalChunkBase64(String);
+
+impl HelperTerminalChunkBase64 {
+    pub fn new(value: impl Into<String>) -> Result<Self, HelperFailureCode> {
+        let value = value.into();
+        valid_base64_chunk(&value)
+            .then_some(Self(value))
+            .ok_or(HelperFailureCode::InvalidRequest)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn decoded_len(&self) -> usize {
+        decoded_base64_len(&self.0).unwrap_or(0)
+    }
+}
+
+impl fmt::Debug for HelperTerminalChunkBase64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperTerminalChunkBase64")
+            .field("encoded_len", &self.0.len())
+            .field("decoded_len", &self.decoded_len())
+            .finish()
+    }
+}
+
+impl<'de> Deserialize<'de> for HelperTerminalChunkBase64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(|_| {
+            serde::de::Error::custom("terminal chunk must be bounded standard padded base64")
+        })
+    }
+}
+
+impl JsonSchema for HelperTerminalChunkBase64 {
+    fn schema_name() -> String {
+        "HelperTerminalChunkBase64".to_owned()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        bounded_string_schema(
+            0,
+            MAX_UNSAFE_LOCAL_TERMINAL_BASE64_BYTES as u32,
+            "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "Bounded standard padded base64 terminal bytes.",
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalWriteStdin {
+    pub request_id: u64,
+    pub offset: u64,
+    pub chunk_base64: HelperTerminalChunkBase64,
+    #[serde(default)]
+    pub eof: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalReadOutput {
+    pub request_id: u64,
+    pub stream: TerminalStream,
+    pub cursor: u64,
+    #[schemars(range(min = 1, max = 65536))]
+    pub max_len: u64,
+    #[serde(default)]
+    pub wait: bool,
+    #[serde(default)]
+    #[schemars(range(max = 1000))]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalResize {
+    pub request_id: u64,
+    pub control_sequence: u64,
+    #[schemars(range(min = 1, max = 65535))]
+    pub rows: u32,
+    #[schemars(range(min = 1, max = 65535))]
+    pub cols: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalWait {
+    pub request_id: u64,
+    #[serde(default)]
+    #[schemars(range(max = 1000))]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalControl {
+    pub request_id: u64,
+    pub control_sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    tag = "op",
+    content = "args",
+    rename_all = "camelCase",
+    deny_unknown_fields
+)]
+pub enum HelperTerminalRequest {
+    WriteStdin(HelperTerminalWriteStdin),
+    ReadOutput(HelperTerminalReadOutput),
+    Resize(HelperTerminalResize),
+    Wait(HelperTerminalWait),
+    CloseStdin(HelperTerminalControl),
+    CloseAttachment(HelperTerminalControl),
+}
+
+impl HelperTerminalRequest {
+    pub fn request_id(&self) -> u64 {
+        match self {
+            Self::WriteStdin(request) => request.request_id,
+            Self::ReadOutput(request) => request.request_id,
+            Self::Resize(request) => request.request_id,
+            Self::Wait(request) => request.request_id,
+            Self::CloseStdin(request) | Self::CloseAttachment(request) => request.request_id,
+        }
+    }
+
+    pub fn validate_bounds(&self) -> Result<(), HelperFailureCode> {
+        match self {
+            Self::ReadOutput(request)
+                if request.max_len > MAX_UNSAFE_LOCAL_TERMINAL_CHUNK_BYTES
+                    || request.timeout_ms > MAX_UNSAFE_LOCAL_TERMINAL_WAIT_TIMEOUT_MS =>
+            {
+                Err(HelperFailureCode::InvalidRequest)
+            }
+            Self::Resize(request)
+                if !terminal_size_valid(TerminalSize {
+                    rows: request.rows,
+                    cols: request.cols,
+                }) =>
+            {
+                Err(HelperFailureCode::InvalidTerminalSize)
+            }
+            Self::Wait(request)
+                if request.timeout_ms > MAX_UNSAFE_LOCAL_TERMINAL_WAIT_TIMEOUT_MS =>
+            {
+                Err(HelperFailureCode::InvalidRequest)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalReadOutputResult {
+    pub data_base64: HelperTerminalChunkBase64,
+    pub next_cursor: u64,
+    #[serde(default)]
+    pub eof: bool,
+    #[serde(default)]
+    pub dropped_bytes: u64,
+    #[serde(default)]
+    pub truncated: bool,
+    #[serde(default)]
+    pub timed_out: bool,
+}
+
+impl fmt::Debug for HelperTerminalReadOutputResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelperTerminalReadOutputResult")
+            .field("data_base64_len", &self.data_base64.as_str().len())
+            .field("next_cursor", &self.next_cursor)
+            .field("eof", &self.eof)
+            .field("dropped_bytes", &self.dropped_bytes)
+            .field("truncated", &self.truncated)
+            .field("timed_out", &self.timed_out)
+            .finish()
+    }
+}
+
+impl TryFrom<TerminalReadOutputChunk> for HelperTerminalReadOutputResult {
+    type Error = HelperFailureCode;
+
+    fn try_from(value: TerminalReadOutputChunk) -> Result<Self, Self::Error> {
+        Ok(Self {
+            data_base64: HelperTerminalChunkBase64::new(value.data_base64)?,
+            next_cursor: value.next_offset,
+            eof: value.eof,
+            dropped_bytes: value.dropped_bytes,
+            truncated: value.truncated,
+            timed_out: value.timed_out,
+        })
+    }
+}
+
+impl From<HelperTerminalReadOutputResult> for TerminalReadOutputChunk {
+    fn from(value: HelperTerminalReadOutputResult) -> Self {
+        Self {
+            data_base64: value.data_base64.0,
+            next_offset: value.next_cursor,
+            eof: value.eof,
+            dropped_bytes: value.dropped_bytes,
+            truncated: value.truncated,
+            timed_out: value.timed_out,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalOperationResult<T> {
+    pub request_id: u64,
+    pub result: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalControlResponse<T> {
+    pub request_id: u64,
+    pub control_sequence: u64,
+    pub result: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalAttachmentClosed {
+    pub detached: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cause: Option<ShellCloseCause>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperTerminalRejected {
+    pub request_id: u64,
+    pub code: HelperFailureCode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    tag = "op",
+    content = "result",
+    rename_all = "camelCase",
+    deny_unknown_fields
+)]
+pub enum HelperTerminalResponse {
+    WriteStdin(HelperTerminalOperationResult<TerminalWriteStdinResult>),
+    ReadOutput(HelperTerminalOperationResult<HelperTerminalReadOutputResult>),
+    Resize(HelperTerminalControlResponse<TerminalControlResult>),
+    Wait(HelperTerminalOperationResult<TerminalWaitResult>),
+    CloseStdin(HelperTerminalControlResponse<TerminalCloseResult>),
+    CloseAttachment(HelperTerminalControlResponse<HelperTerminalAttachmentClosed>),
+    Rejected(HelperTerminalRejected),
+}
+
+impl HelperTerminalResponse {
+    pub fn request_id(&self) -> u64 {
+        match self {
+            Self::WriteStdin(response) => response.request_id,
+            Self::ReadOutput(response) => response.request_id,
+            Self::Resize(response) => response.request_id,
+            Self::Wait(response) => response.request_id,
+            Self::CloseStdin(response) => response.request_id,
+            Self::CloseAttachment(response) => response.request_id,
+            Self::Rejected(response) => response.request_id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", content = "payload", rename_all = "camelCase")]
 pub enum DaemonToUnsafeLocalHelper {
@@ -276,6 +885,7 @@ pub enum UnsafeLocalHelperToDaemon {
     Heartbeat(HelperHeartbeat),
     Operation(HelperOperationResult),
     TerminalReady(HelperTerminalReady),
+    Shell(HelperShellResponse),
     Rejected(HelperOperationRejected),
 }
 
@@ -286,76 +896,498 @@ pub struct UnsafeLocalHelperWireSchema {
     pub terminal_protocol_version: u32,
     pub daemon_to_helper: DaemonToUnsafeLocalHelper,
     pub helper_to_daemon: UnsafeLocalHelperToDaemon,
+    pub terminal_request: HelperTerminalRequest,
+    pub terminal_response: HelperTerminalResponse,
+}
+
+fn terminal_size_valid(size: TerminalSize) -> bool {
+    (1..=MAX_UNSAFE_LOCAL_TERMINAL_ROWS).contains(&size.rows)
+        && (1..=MAX_UNSAFE_LOCAL_TERMINAL_COLS).contains(&size.cols)
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[allow(dead_code)]
+struct BoundedTerminalSizeSchema {
+    #[schemars(range(min = 1, max = 65535))]
+    rows: u32,
+    #[schemars(range(min = 1, max = 65535))]
+    cols: u32,
+}
+
+fn bounded_terminal_size_schema(r#gen: &mut SchemaGenerator) -> Schema {
+    BoundedTerminalSizeSchema::json_schema(r#gen)
+}
+
+fn decoded_base64_len(value: &str) -> Option<usize> {
+    if !value.len().is_multiple_of(4) {
+        return None;
+    }
+    let padding = value.bytes().rev().take_while(|byte| *byte == b'=').count();
+    if padding > 2 {
+        return None;
+    }
+    value
+        .len()
+        .checked_div(4)?
+        .checked_mul(3)?
+        .checked_sub(padding)
+}
+
+fn valid_base64_chunk(value: &str) -> bool {
+    if value.len() > MAX_UNSAFE_LOCAL_TERMINAL_BASE64_BYTES {
+        return false;
+    }
+    let padding_start = value.find('=').unwrap_or(value.len());
+    if value[..padding_start]
+        .bytes()
+        .any(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/')))
+        || value[padding_start..].bytes().any(|byte| byte != b'=')
+    {
+        return false;
+    }
+    decoded_base64_len(value)
+        .is_some_and(|len| len <= MAX_UNSAFE_LOCAL_TERMINAL_CHUNK_BYTES as usize)
+}
+
+fn bounded_string_schema(
+    min_length: u32,
+    max_length: u32,
+    pattern: &str,
+    description: &str,
+) -> Schema {
+    let mut object = SchemaObject {
+        instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
+        string: Some(Box::new(StringValidation {
+            min_length: Some(min_length),
+            max_length: Some(max_length),
+            pattern: Some(pattern.to_owned()),
+        })),
+        ..Default::default()
+    };
+    object.metadata = Some(Box::new(Metadata {
+        description: Some(description.to_owned()),
+        ..Default::default()
+    }));
+    Schema::Object(object)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::public_wire::{ShellKillResult, ShellListEntry, ShellSessionState};
+    use serde::de::DeserializeOwned;
 
-    #[test]
-    fn argv_is_bounded_and_debug_redacted() {
-        let canary = "private-canary-argv";
-        let argv = ConfiguredArgv::new(vec!["firefox".to_owned(), canary.to_owned()]).unwrap();
-        let debug = format!("{argv:?}");
-        assert!(!debug.contains(canary));
-        assert!(!debug.contains("firefox"));
-        assert!(debug.contains("argc"));
-        assert!(ConfiguredArgv::new(Vec::new()).is_err());
-        assert!(ConfiguredArgv::new(vec!["x\0y".to_owned()]).is_err());
+    fn workload() -> WorkloadIdentity {
+        serde_json::from_value(serde_json::json!({
+            "workloadId": "tools",
+            "realmId": "host",
+            "realmPath": ["host"],
+            "canonicalTarget": "tools.host.d2b"
+        }))
+        .unwrap()
+    }
+
+    fn operation(value: &str) -> OperationId {
+        OperationId::parse(value).unwrap()
+    }
+
+    fn shell_name(value: &str) -> ShellName {
+        ShellName::new(value).unwrap()
+    }
+
+    fn round_trip<T>(value: &T)
+    where
+        T: Serialize + DeserializeOwned + PartialEq + fmt::Debug,
+    {
+        let encoded = serde_json::to_vec(value).unwrap();
+        let decoded: T = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(&decoded, value);
+    }
+
+    fn terminal_round_trip<T>(value: &T)
+    where
+        T: Serialize + DeserializeOwned + PartialEq + fmt::Debug,
+    {
+        let frame = encode_unsafe_local_terminal_frame(value).unwrap();
+        let decoded: T = decode_unsafe_local_terminal_frame(&frame).unwrap();
+        assert_eq!(&decoded, value);
     }
 
     #[test]
-    fn helper_frames_reject_uid_environment_and_cwd_fields() {
-        let frame = r#"{
-          "type":"hello",
-          "payload":{"protocolVersion":1,"generation":1,"features":[],"uid":1000}
-        }"#;
-        assert!(serde_json::from_str::<UnsafeLocalHelperToDaemon>(frame).is_err());
+    fn management_request_variants_round_trip_and_correlate() {
+        let requests = [
+            HelperShellRequest::List {
+                request_id: 1,
+                operation_id: operation("op-list"),
+                workload: workload(),
+            },
+            HelperShellRequest::Attach {
+                request_id: 2,
+                operation_id: operation("op-attach"),
+                workload: workload(),
+                name: Some(shell_name("primary")),
+                force: true,
+                initial_terminal_size: TerminalSize { rows: 24, cols: 80 },
+            },
+            HelperShellRequest::Detach {
+                request_id: 3,
+                operation_id: operation("op-detach"),
+                workload: workload(),
+                name: shell_name("primary"),
+            },
+            HelperShellRequest::Kill {
+                request_id: 4,
+                operation_id: operation("op-kill"),
+                workload: workload(),
+                name: shell_name("primary"),
+            },
+        ];
 
-        let launch = r#"{
-          "requestId":1,
-          "operationId":"op-1",
-          "workload":{
-            "workloadId":"tools",
-            "realmId":"host",
-            "realmPath":["host"],
-            "canonicalTarget":"tools.host.d2b"
-          },
-          "itemId":"browser",
-          "argv":["firefox"],
-          "graphical":true,
-          "cwd":"/tmp"
-        }"#;
-        assert!(serde_json::from_str::<HelperLaunchRequest>(launch).is_err());
+        for (index, request) in requests.iter().enumerate() {
+            round_trip(request);
+            let encoded = serde_json::to_string(request).unwrap();
+            assert!(!encoded.contains("request_id"));
+            assert!(!encoded.contains("operation_id"));
+            assert!(!encoded.contains("initial_terminal_size"));
+            assert_eq!(request.request_id(), index as u64 + 1);
+            assert_eq!(
+                request.operation_id().as_str(),
+                ["op-list", "op-attach", "op-detach", "op-kill"][index]
+            );
+            assert_eq!(request.validate_bounds(), Ok(()));
+        }
     }
 
     #[test]
-    fn scope_identity_debug_hides_invocation_id() {
-        let canary = "private-canary-invocation";
-        let scope = ScopeIdentity {
-            invocation_id: canary.to_owned(),
-            kind: HelperScopeKind::LauncherApp,
+    fn management_response_variants_round_trip_and_correlate() {
+        let responses = [
+            HelperShellResponse::List(HelperShellListResponse {
+                request_id: 1,
+                operation_id: operation("op-list"),
+                result: ShellListResult {
+                    default_name: shell_name("primary"),
+                    sessions: vec![ShellListEntry {
+                        name: shell_name("primary"),
+                        state: ShellSessionState::Detached,
+                        attached: false,
+                        is_default: true,
+                    }],
+                },
+            }),
+            HelperShellResponse::Detach(HelperShellDetachResponse {
+                request_id: 2,
+                operation_id: operation("op-detach"),
+                result: ShellDetachResult {
+                    resolved_name: shell_name("primary"),
+                    detached: true,
+                    cause: Some(ShellCloseCause::EvictedByAdminDetach),
+                },
+            }),
+            HelperShellResponse::Kill(HelperShellKillResponse {
+                request_id: 3,
+                operation_id: operation("op-kill"),
+                result: ShellKillResult {
+                    name: shell_name("primary"),
+                    killed: true,
+                    state: ShellSessionState::Killed,
+                },
+            }),
+        ];
+
+        for (index, response) in responses.iter().enumerate() {
+            round_trip(response);
+            assert_eq!(response.request_id(), index as u64 + 1);
+            assert_eq!(
+                response.operation_id().as_str(),
+                ["op-list", "op-detach", "op-kill"][index]
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_request_variants_round_trip_and_correlate() {
+        let requests = [
+            HelperTerminalRequest::WriteStdin(HelperTerminalWriteStdin {
+                request_id: 1,
+                offset: 0,
+                chunk_base64: HelperTerminalChunkBase64::new("aGVsbG8=").unwrap(),
+                eof: false,
+            }),
+            HelperTerminalRequest::ReadOutput(HelperTerminalReadOutput {
+                request_id: 2,
+                stream: TerminalStream::Stdout,
+                cursor: 0,
+                max_len: 4096,
+                wait: true,
+                timeout_ms: 250,
+            }),
+            HelperTerminalRequest::Resize(HelperTerminalResize {
+                request_id: 3,
+                control_sequence: 7,
+                rows: 40,
+                cols: 120,
+            }),
+            HelperTerminalRequest::Wait(HelperTerminalWait {
+                request_id: 4,
+                timeout_ms: 500,
+            }),
+            HelperTerminalRequest::CloseStdin(HelperTerminalControl {
+                request_id: 5,
+                control_sequence: 8,
+            }),
+            HelperTerminalRequest::CloseAttachment(HelperTerminalControl {
+                request_id: 6,
+                control_sequence: 9,
+            }),
+        ];
+
+        for (index, request) in requests.iter().enumerate() {
+            round_trip(request);
+            terminal_round_trip(request);
+            assert_eq!(request.request_id(), index as u64 + 1);
+            assert_eq!(request.validate_bounds(), Ok(()));
+            let encoded = serde_json::to_vec(request).unwrap();
+            assert!(encoded.len() <= MAX_UNSAFE_LOCAL_TERMINAL_FRAME_SIZE);
+            assert!(!encoded.windows(11).any(|window| window == b"\"session\":"));
+        }
+    }
+
+    #[test]
+    fn terminal_response_variants_round_trip_and_correlate() {
+        let responses = [
+            HelperTerminalResponse::WriteStdin(HelperTerminalOperationResult {
+                request_id: 1,
+                result: TerminalWriteStdinResult {
+                    accepted_len: 5,
+                    next_offset: 5,
+                    backpressured: false,
+                    stdin_closed: false,
+                },
+            }),
+            HelperTerminalResponse::ReadOutput(HelperTerminalOperationResult {
+                request_id: 2,
+                result: HelperTerminalReadOutputResult {
+                    data_base64: HelperTerminalChunkBase64::new("aGVsbG8=").unwrap(),
+                    next_cursor: 5,
+                    eof: false,
+                    dropped_bytes: 0,
+                    truncated: false,
+                    timed_out: false,
+                },
+            }),
+            HelperTerminalResponse::Resize(HelperTerminalControlResponse {
+                request_id: 3,
+                control_sequence: 7,
+                result: TerminalControlResult { delivered: true },
+            }),
+            HelperTerminalResponse::Wait(HelperTerminalOperationResult {
+                request_id: 4,
+                result: TerminalWaitResult {
+                    running: true,
+                    terminal_status: None,
+                },
+            }),
+            HelperTerminalResponse::CloseStdin(HelperTerminalControlResponse {
+                request_id: 5,
+                control_sequence: 8,
+                result: TerminalCloseResult { stdin_closed: true },
+            }),
+            HelperTerminalResponse::CloseAttachment(HelperTerminalControlResponse {
+                request_id: 6,
+                control_sequence: 9,
+                result: HelperTerminalAttachmentClosed {
+                    detached: true,
+                    cause: Some(ShellCloseCause::ClientDetach),
+                },
+            }),
+            HelperTerminalResponse::Rejected(HelperTerminalRejected {
+                request_id: 7,
+                code: HelperFailureCode::TerminalOffsetMismatch,
+            }),
+        ];
+
+        for (index, response) in responses.iter().enumerate() {
+            round_trip(response);
+            terminal_round_trip(response);
+            assert_eq!(response.request_id(), index as u64 + 1);
+        }
+
+        let shared = TerminalReadOutputChunk {
+            data_base64: "aGVsbG8=".to_owned(),
+            next_offset: 5,
+            eof: false,
+            dropped_bytes: 0,
+            truncated: false,
+            timed_out: false,
         };
-        assert!(!format!("{scope:?}").contains(canary));
+        let helper = HelperTerminalReadOutputResult::try_from(shared.clone()).unwrap();
+        assert_eq!(TerminalReadOutputChunk::from(helper), shared);
     }
 
     #[test]
-    fn shell_request_debug_hides_shell_name() {
-        let canary = "private-shell-name-canary";
+    fn helper_frames_reject_unknown_and_forbidden_fields() {
+        let hello = r#"{
+          "type":"hello",
+          "payload":{"protocolVersion":2,"generation":1,"features":[],"uid":1000}
+        }"#;
+        assert!(serde_json::from_str::<UnsafeLocalHelperToDaemon>(hello).is_err());
+
+        let shell = serde_json::json!({
+            "op": "list",
+            "args": {
+                "requestId": 1,
+                "operationId": "op-list",
+                "workload": serde_json::to_value(workload()).unwrap(),
+                "cwd": "/forbidden"
+            }
+        });
+        assert!(serde_json::from_value::<HelperShellRequest>(shell).is_err());
+
+        let terminal = serde_json::json!({
+            "op": "wait",
+            "args": {"requestId": 1, "timeoutMs": 1, "session": "forbidden"}
+        });
+        assert!(serde_json::from_value::<HelperTerminalRequest>(terminal).is_err());
+
+        let response = serde_json::json!({
+            "op": "rejected",
+            "result": {
+                "requestId": 1,
+                "code": "terminal-closed",
+                "message": "forbidden"
+            }
+        });
+        assert!(serde_json::from_value::<HelperTerminalResponse>(response).is_err());
+    }
+
+    #[test]
+    fn terminal_and_geometry_bounds_are_closed() {
+        assert_eq!(MAX_UNSAFE_LOCAL_TERMINAL_CHUNK_BYTES, EXEC_MAX_CHUNK_BYTES);
+        assert_eq!(MAX_UNSAFE_LOCAL_TERMINAL_OUTPUT_RING_BYTES, 8 * 1024 * 1024);
+        assert_eq!(UNSAFE_LOCAL_TERMINAL_LENGTH_PREFIX_BYTES, 4);
+
+        let maximum = format!(
+            "{}==",
+            "A".repeat(MAX_UNSAFE_LOCAL_TERMINAL_BASE64_BYTES - 2)
+        );
+        assert!(HelperTerminalChunkBase64::new(maximum).is_ok());
+        let oversized = "A".repeat(MAX_UNSAFE_LOCAL_TERMINAL_BASE64_BYTES + 4);
+        assert!(HelperTerminalChunkBase64::new(oversized).is_err());
+        assert!(HelperTerminalChunkBase64::new("not padded").is_err());
+
+        let oversized_read = HelperTerminalRequest::ReadOutput(HelperTerminalReadOutput {
+            request_id: 1,
+            stream: TerminalStream::Stdout,
+            cursor: 0,
+            max_len: MAX_UNSAFE_LOCAL_TERMINAL_CHUNK_BYTES + 1,
+            wait: true,
+            timeout_ms: MAX_UNSAFE_LOCAL_TERMINAL_WAIT_TIMEOUT_MS + 1,
+        });
+        assert_eq!(
+            oversized_read.validate_bounds(),
+            Err(HelperFailureCode::InvalidRequest)
+        );
+
+        let invalid_resize = HelperTerminalRequest::Resize(HelperTerminalResize {
+            request_id: 1,
+            control_sequence: 1,
+            rows: 0,
+            cols: 80,
+        });
+        assert_eq!(
+            invalid_resize.validate_bounds(),
+            Err(HelperFailureCode::InvalidTerminalSize)
+        );
+
+        assert_eq!(
+            decode_unsafe_local_terminal_frame::<HelperTerminalRequest>(&[0, 0, 0]),
+            Err(HelperFailureCode::InvalidRequest)
+        );
+        let oversized_prefix = ((MAX_UNSAFE_LOCAL_TERMINAL_FRAME_SIZE + 1) as u32).to_le_bytes();
+        assert_eq!(
+            decode_unsafe_local_terminal_frame::<HelperTerminalRequest>(&oversized_prefix),
+            Err(HelperFailureCode::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn debug_redacts_names_terminal_bytes_and_supervisor_identity() {
+        let shell_canary = "private-shell-name-canary";
         let request = HelperShellRequest::Attach {
             request_id: 1,
-            operation_id: OperationId::parse("op-1").unwrap(),
-            workload: serde_json::from_value(serde_json::json!({
-                "workloadId": "tools",
-                "realmId": "host",
-                "realmPath": ["host"],
-                "canonicalTarget": "tools.host.d2b"
-            }))
-            .unwrap(),
-            name: Some(ShellName::new(canary).unwrap()),
-            tty: true,
+            operation_id: operation("op-1"),
+            workload: workload(),
+            name: Some(shell_name(shell_canary)),
+            force: true,
+            initial_terminal_size: TerminalSize { rows: 24, cols: 80 },
         };
-        assert!(!format!("{request:?}").contains(canary));
+        assert!(!format!("{request:?}").contains(shell_canary));
+
+        let bytes_canary = "cHJpdmF0ZS10ZXJtaW5hbC1jYW5hcnk=";
+        let output = HelperTerminalReadOutputResult {
+            data_base64: HelperTerminalChunkBase64::new(bytes_canary).unwrap(),
+            next_cursor: 24,
+            eof: false,
+            dropped_bytes: 0,
+            truncated: false,
+            timed_out: false,
+        };
+        assert!(!format!("{output:?}").contains(bytes_canary));
+
+        let supervisor_canary = "private-supervisor-canary";
+        let snapshot = HelperPersistentShellSnapshot {
+            name: shell_name(shell_canary),
+            state: ShellSessionState::Detached,
+            attached: false,
+            supervisor_id: HelperSupervisorId::new(supervisor_canary).unwrap(),
+        };
+        let debug = format!("{snapshot:?}");
+        assert!(!debug.contains(shell_canary));
+        assert!(!debug.contains(supervisor_canary));
+        assert!(HelperSupervisorId::new("x".repeat(MAX_HELPER_SUPERVISOR_ID_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn generated_shell_and_terminal_schema_excludes_authority_fields() {
+        let schema = serde_json::to_value(schemars::schema_for!(UnsafeLocalHelperWireSchema))
+            .expect("schema serializes");
+        let definitions = schema["definitions"].as_object().unwrap();
+        let selected = definitions
+            .iter()
+            .filter(|(name, _)| {
+                name.starts_with("HelperShell")
+                    || name.starts_with("HelperTerminal")
+                    || *name == "HelperPersistentShellSnapshot"
+            })
+            .map(|(_, definition)| definition)
+            .collect::<Vec<_>>();
+        let selected = serde_json::to_string(&selected).unwrap();
+        for forbidden in [
+            "\"uid\"",
+            "\"argv\"",
+            "\"environment\"",
+            "\"cwd\"",
+            "\"path\"",
+            "\"transcript\"",
+            "\"pid\"",
+            "\"unitName\"",
+            "\"compositor\"",
+            "\"session\"",
+        ] {
+            assert!(
+                !selected.contains(forbidden),
+                "private shell/terminal schema contains forbidden field {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn helper_v1_is_rejected_while_terminal_v1_is_preserved() {
+        assert_eq!(UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION, 2);
+        assert!(!unsafe_local_helper_protocol_supported(1));
+        assert!(unsafe_local_helper_protocol_supported(2));
+        assert_eq!(UNSAFE_LOCAL_TERMINAL_PROTOCOL_VERSION, 1);
     }
 
     #[test]
@@ -368,21 +1400,23 @@ mod tests {
         );
         let ready = HelperTerminalReady {
             request_id: 1,
-            operation_id: OperationId::parse("op-1").unwrap(),
+            operation_id: operation("op-1"),
             terminal_protocol_version: UNSAFE_LOCAL_TERMINAL_PROTOCOL_VERSION,
             transport: HelperTerminalTransport::ConnectedUnixStream,
             scope: ScopeIdentity {
                 invocation_id: "opaque".to_owned(),
                 kind: HelperScopeKind::PersistentShell,
             },
+            result: HelperShellAttachResult {
+                resolved_name: shell_name("primary"),
+                state: ShellSessionState::Attached,
+                force_evicted: false,
+            },
         };
+        round_trip(&ready);
         let json = serde_json::to_string(&ready).unwrap();
         assert!(json.contains("\"transport\":\"connected-unix-stream\""));
-        assert!(
-            serde_json::from_str::<HelperTerminalReady>(
-                r#"{"requestId":1,"operationId":"op-1","terminalProtocolVersion":1,"transport":"unix-datagram","scope":{"invocationId":"opaque","kind":"persistent-shell"}}"#
-            )
-            .is_err()
-        );
+        let invalid = json.replace("connected-unix-stream", "unix-datagram");
+        assert!(serde_json::from_str::<HelperTerminalReady>(&invalid).is_err());
     }
 }

--- a/packages/d2b-unsafe-local-helper/src/protocol.rs
+++ b/packages/d2b-unsafe-local-helper/src/protocol.rs
@@ -6,6 +6,7 @@ use d2b_contracts::unsafe_local_wire::{
     HelperHeartbeat, HelperHello, HelperOperationRejected, MAX_HELPER_FRAME_SIZE,
     MAX_HELPER_QUEUE_DEPTH, MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES,
     UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION, UnsafeLocalHelperToDaemon,
+    unsafe_local_helper_protocol_supported,
 };
 use d2b_realm_core::ids::OperationId;
 use nix::cmsg_space;
@@ -103,7 +104,7 @@ impl<M: UserScopeManager> HelperClient<M> {
         let accepted: DaemonToUnsafeLocalHelper = receive_frame(&socket, &mut receive_buffer)?;
         match accepted {
             DaemonToUnsafeLocalHelper::HelloAccepted(accepted)
-                if accepted.protocol_version == UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION
+                if unsafe_local_helper_protocol_supported(accepted.protocol_version)
                     && accepted.generation == generation => {}
             DaemonToUnsafeLocalHelper::HelloAccepted(_) => {
                 return Err(ProtocolError::GenerationMismatch);
@@ -432,8 +433,12 @@ fn shell_operation_identity(
 ) -> Option<(u64, OperationId)> {
     use d2b_contracts::unsafe_local_wire::HelperShellRequest;
     match request {
-        HelperShellRequest::List { .. } => None,
-        HelperShellRequest::Attach {
+        HelperShellRequest::List {
+            request_id,
+            operation_id,
+            ..
+        }
+        | HelperShellRequest::Attach {
             request_id,
             operation_id,
             ..

--- a/packages/d2b-unsafe-local-helper/src/runtime.rs
+++ b/packages/d2b-unsafe-local-helper/src/runtime.rs
@@ -404,6 +404,7 @@ impl<M: UserScopeManager> ScopeRuntime<M> {
                 workload: entry.workload,
                 scope,
                 state,
+                persistent_shell: None,
             });
         }
         Ok(HelperSnapshot { generation, scopes })

--- a/packages/d2b/src/lib.rs
+++ b/packages/d2b/src/lib.rs
@@ -1598,6 +1598,7 @@ fn daemon_supported_features() -> Vec<d2b_contracts::FeatureFlag> {
         KnownFeatureFlag::ExportBrokerAudit.wire_value(),
         KnownFeatureFlag::ConfiguredLaunchV1.wire_value(),
         KnownFeatureFlag::UnsafeLocalProviderV1.wire_value(),
+        KnownFeatureFlag::UnsafeLocalShellV1.wire_value(),
     ]
 }
 

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -2942,7 +2942,6 @@ fn handle_connection_authorized(
         KnownFeatureFlag::ExportBrokerAudit.wire_value(),
         KnownFeatureFlag::ConfiguredLaunchV1.wire_value(),
         KnownFeatureFlag::UnsafeLocalProviderV1.wire_value(),
-        KnownFeatureFlag::UnsafeLocalShellV1.wire_value(),
     ];
     let capabilities = advertised_capabilities
         .into_iter()

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -2942,6 +2942,7 @@ fn handle_connection_authorized(
         KnownFeatureFlag::ExportBrokerAudit.wire_value(),
         KnownFeatureFlag::ConfiguredLaunchV1.wire_value(),
         KnownFeatureFlag::UnsafeLocalProviderV1.wire_value(),
+        KnownFeatureFlag::UnsafeLocalShellV1.wire_value(),
     ];
     let capabilities = advertised_capabilities
         .into_iter()

--- a/packages/d2bd/src/unsafe_local_helper.rs
+++ b/packages/d2bd/src/unsafe_local_helper.rs
@@ -6,6 +6,7 @@ use d2b_contracts::unsafe_local_wire::{
     MAX_HELPER_QUEUE_DEPTH, MAX_HELPER_SNAPSHOT_SCOPES, MIN_EFFECTIVE_HELPER_SOCKET_BUFFER_BYTES,
     UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION, UNSAFE_LOCAL_TERMINAL_FD_COUNT,
     UNSAFE_LOCAL_TERMINAL_PROTOCOL_VERSION, UnsafeLocalHelperToDaemon,
+    unsafe_local_helper_protocol_supported,
 };
 use nix::cmsg_space;
 use nix::fcntl::{FcntlArg, FdFlag, fcntl};
@@ -444,7 +445,8 @@ impl HelperRegistry {
         let UnsafeLocalHelperToDaemon::Hello(hello) = hello else {
             return Err(HelperRegistryError::ProtocolMismatch);
         };
-        if hello.protocol_version != UNSAFE_LOCAL_HELPER_PROTOCOL_VERSION || hello.generation == 0 {
+        if !unsafe_local_helper_protocol_supported(hello.protocol_version) || hello.generation == 0
+        {
             return Err(HelperRegistryError::ProtocolMismatch);
         }
         send_frame(
@@ -667,6 +669,10 @@ impl HelperRegistry {
                     HelperReply::Terminal { ready, fd },
                 )
                 .map(|_| ())
+            }
+            UnsafeLocalHelperToDaemon::Shell(_) => {
+                reject_unexpected_fds(fds)?;
+                Err(HelperRegistryError::ProtocolMismatch)
             }
             UnsafeLocalHelperToDaemon::Hello(_) | UnsafeLocalHelperToDaemon::Snapshot(_) => {
                 reject_unexpected_fds(fds)?;
@@ -1435,6 +1441,7 @@ mod tests {
                         kind: d2b_contracts::unsafe_local_wire::HelperScopeKind::LauncherApp,
                     },
                     state: d2b_contracts::unsafe_local_wire::HelperScopeState::Active,
+                    persistent_shell: None,
                 }],
             },
             2,
@@ -1647,6 +1654,11 @@ mod tests {
                 invocation_id: "00112233445566778899aabbccddeeff".to_owned(),
                 kind: d2b_contracts::unsafe_local_wire::HelperScopeKind::PersistentShell,
             },
+            result: d2b_contracts::unsafe_local_wire::HelperShellAttachResult {
+                resolved_name: d2b_contracts::public_wire::ShellName::new("default").unwrap(),
+                state: d2b_contracts::public_wire::ShellSessionState::Attached,
+                force_evicted: false,
+            },
         };
         let validated = validate_terminal_fd(&ready, vec![ReceivedFd(raw)]).unwrap();
         let flags = fcntl(validated.as_raw_fd(), FcntlArg::F_GETFD).unwrap();
@@ -1688,6 +1700,11 @@ mod tests {
             scope: d2b_contracts::unsafe_local_wire::ScopeIdentity {
                 invocation_id: "00112233445566778899aabbccddeeff".to_owned(),
                 kind: d2b_contracts::unsafe_local_wire::HelperScopeKind::PersistentShell,
+            },
+            result: d2b_contracts::unsafe_local_wire::HelperShellAttachResult {
+                resolved_name: d2b_contracts::public_wire::ShellName::new("default").unwrap(),
+                state: d2b_contracts::public_wire::ShellSessionState::Attached,
+                force_evicted: false,
             },
         };
 


### PR DESCRIPTION
## Change
- bump the private same-UID helper protocol to v2 while keeping public protocol 3 and terminal protocol v1
- add correlated shell management results and bounded dedicated terminal-stream request/response frames
- add redacted restart snapshot metadata and closed shell failure codes
- add the additive `unsafe-local-shell-v1` feature token without advertising runtime support yet
- regenerate private schemas and update reference documentation

## Validation
- `make check`
- focused d2b-contracts, d2b-core, contract-schema, formatting, Clippy, and drift checks

## Stack
- base contracts slice for the ADR 0044 Wave 3 helper-runtime and daemon-integration PRs