### PR TITLE
test: allow bounded shell socket cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+### Fixed
+
+- Stabilized shell-supervisor teardown coverage by allowing its asynchronous
+  socket cleanup the same bounded reconciliation horizon used by the runtime.
+
 ## [1.4.0] - 2026-07-12
 
 ### Added

--- a/packages/d2b-unsafe-local-helper/tests/shell_supervisor.rs
+++ b/packages/d2b-unsafe-local-helper/tests/shell_supervisor.rs
@@ -469,11 +469,14 @@ fn helper_runtime_creates_persists_and_reconstructs_real_supervisor() {
         killed.into_parts().0,
         UnsafeLocalHelperToDaemon::Shell(_)
     ));
-    let deadline = Instant::now() + Duration::from_secs(2);
+    let deadline = Instant::now() + Duration::from_secs(5);
     while has_shell_socket(&scratch.path) && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(10));
     }
-    assert!(!has_shell_socket(&scratch.path));
+    assert!(
+        !has_shell_socket(&scratch.path),
+        "shell supervisor socket survived the cleanup deadline"
+    );
 }
 
 fn workload() -> WorkloadIdentity {


### PR DESCRIPTION
Aligns the shell-supervisor integration test cleanup wait with the runtime five-second reconciliation horizon and adds an explicit cleanup-deadline diagnostic. Validation: the failing test passed 20 consecutive runs, followed by a successful make check. This addresses the only failed check observed on the generated v1.4.0 prebuilt-manifest PR.