### PR TITLE
test: stabilize mkfs and output-ring assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Made the mkfs diagnostic bound test exercise the formatter directly instead
+  of depending on unrelated existing-image repair stages.
+
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,
   waking the supervisor accept loop so its owned listener unlinks before forced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ deprecations ship one minor release before removal.
 
 - Made the mkfs diagnostic bound test exercise the formatter directly instead
   of depending on unrelated existing-image repair stages.
+- Made output-ring wake coverage observe data and EOF as separate valid
+  notifications instead of racing both producer events into one read.
 
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,

--- a/packages/d2b-priv-broker/src/ops/disk_init.rs
+++ b/packages/d2b-priv-broker/src/ops/disk_init.rs
@@ -1208,12 +1208,10 @@ mod tests {
         let scratch = scratch_root();
         let target = scratch.join("var.img");
         let file = create_regular_image(&target, 4096, 0o600);
-        drop(file);
-        let spec = test_spec(target.clone(), 4096, true);
         let stderr = format!("permission denied {}", "x".repeat(MKFS_STDERR_LIMIT * 2));
         let tool = failing_mkfs_tool(&scratch, &stderr);
 
-        let err = validate_or_repair_existing_with(&spec, &tool)
+        let err = run_mkfs_ext4_on_fd_with(&file, &target, &tool)
             .expect_err("failing mkfs must surface stderr");
         let rendered = err.to_string();
         assert!(rendered.contains("exit=Some(9)"));

--- a/packages/d2b-unsafe-local-helper/src/output_ring.rs
+++ b/packages/d2b-unsafe-local-helper/src/output_ring.rs
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn wait_wakes_for_output_and_eof() {
+    fn wait_wakes_for_output_then_eof() {
         let ring = Arc::new(OutputRing::new(32).unwrap());
         let producer = Arc::clone(&ring);
         let writer = std::thread::spawn(move || {
@@ -182,10 +182,17 @@ mod tests {
             producer.close();
         });
         let read = ring.read(0, 32, true, Duration::from_secs(1));
-        writer.join().unwrap();
         assert_eq!(read.data, b"ready");
-        assert!(read.eof);
         assert!(!read.timed_out);
+        let eof = if read.eof {
+            read
+        } else {
+            ring.read(read.next_cursor, 32, true, Duration::from_secs(1))
+        };
+        writer.join().unwrap();
+        assert!(eof.data.is_empty());
+        assert!(eof.eof);
+        assert!(!eof.timed_out);
     }
 
     #[test]

--- a/packages/d2b-unsafe-local-helper/src/output_ring.rs
+++ b/packages/d2b-unsafe-local-helper/src/output_ring.rs
@@ -184,11 +184,7 @@ mod tests {
         let read = ring.read(0, 32, true, Duration::from_secs(1));
         assert_eq!(read.data, b"ready");
         assert!(!read.timed_out);
-        let eof = if read.eof {
-            read
-        } else {
-            ring.read(read.next_cursor, 32, true, Duration::from_secs(1))
-        };
+        let eof = ring.read(read.next_cursor, 32, true, Duration::from_secs(1));
         writer.join().unwrap();
         assert!(eof.data.is_empty());
         assert!(eof.eof);


### PR DESCRIPTION
Makes the mkfs diagnostic-bound test exercise the formatter directly and makes OutputRing coverage observe data and EOF at separate valid cursor reads. Validation: mkfs test repeated 30 times, OutputRing test repeated 100 times, and make check passed. Final ten-role d2b panel reviewed this branch together with the terminal fix and returned unanimous signoff.