### PR TITLE
test: isolate parallel scratch and fd identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Made the mkfs diagnostic bound test exercise the formatter directly instead
+  of depending on unrelated existing-image repair stages.
+
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,
   waking the supervisor accept loop so its owned listener unlinks before forced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ deprecations ship one minor release before removal.
   of depending on unrelated existing-image repair stages.
 - Made output-ring wake coverage observe data and EOF as separate valid
   notifications instead of racing both producer events into one read.
+- Made disk-init test directories use exclusive process-local IDs so parallel
+  tests cannot silently share and remove each other's scratch state.
+- Made failed-fd-send coverage track the original pipe identity so concurrent
+  numeric fd reuse cannot produce a false leak report.
 
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ deprecations ship one minor release before removal.
 
 - Made the mkfs diagnostic bound test exercise the formatter directly instead
   of depending on unrelated existing-image repair stages.
+- Made output-ring wake coverage observe data and EOF as separate valid
+  notifications instead of racing both producer events into one read.
 
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,

--- a/packages/d2b-priv-broker/src/ops/disk_init.rs
+++ b/packages/d2b-priv-broker/src/ops/disk_init.rs
@@ -894,18 +894,22 @@ mod tests {
     use std::fs;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
 
     fn scratch_root() -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "d2b-disk-init-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        fs::create_dir_all(&dir).unwrap();
-        dir
+        for _ in 0..32 {
+            let id = NEXT_SCRATCH_ID.fetch_add(1, Ordering::Relaxed);
+            let dir =
+                std::env::temp_dir().join(format!("d2b-disk-init-{}-{id}", std::process::id()));
+            match fs::create_dir(&dir) {
+                Ok(()) => return dir,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => panic!("failed to create disk-init test directory: {error}"),
+            }
+        }
+        panic!("failed to reserve a unique disk-init test directory")
     }
 
     fn test_spec(path: PathBuf, size_bytes: u64, if_absent: bool) -> ResolvedDiskInitOp {

--- a/packages/d2b-priv-broker/src/ops/disk_init.rs
+++ b/packages/d2b-priv-broker/src/ops/disk_init.rs
@@ -1208,12 +1208,10 @@ mod tests {
         let scratch = scratch_root();
         let target = scratch.join("var.img");
         let file = create_regular_image(&target, 4096, 0o600);
-        drop(file);
-        let spec = test_spec(target.clone(), 4096, true);
         let stderr = format!("permission denied {}", "x".repeat(MKFS_STDERR_LIMIT * 2));
         let tool = failing_mkfs_tool(&scratch, &stderr);
 
-        let err = validate_or_repair_existing_with(&spec, &tool)
+        let err = run_mkfs_ext4_on_fd_with(&file, &target, &tool)
             .expect_err("failing mkfs must surface stderr");
         let rendered = err.to_string();
         assert!(rendered.contains("exit=Some(9)"));

--- a/packages/d2b-unsafe-local-helper/src/output_ring.rs
+++ b/packages/d2b-unsafe-local-helper/src/output_ring.rs
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn wait_wakes_for_output_and_eof() {
+    fn wait_wakes_for_output_then_eof() {
         let ring = Arc::new(OutputRing::new(32).unwrap());
         let producer = Arc::clone(&ring);
         let writer = std::thread::spawn(move || {
@@ -182,10 +182,17 @@ mod tests {
             producer.close();
         });
         let read = ring.read(0, 32, true, Duration::from_secs(1));
-        writer.join().unwrap();
         assert_eq!(read.data, b"ready");
-        assert!(read.eof);
         assert!(!read.timed_out);
+        let eof = if read.eof {
+            read
+        } else {
+            ring.read(read.next_cursor, 32, true, Duration::from_secs(1))
+        };
+        writer.join().unwrap();
+        assert!(eof.data.is_empty());
+        assert!(eof.eof);
+        assert!(!eof.timed_out);
     }
 
     #[test]

--- a/packages/d2b-unsafe-local-helper/src/output_ring.rs
+++ b/packages/d2b-unsafe-local-helper/src/output_ring.rs
@@ -184,11 +184,7 @@ mod tests {
         let read = ring.read(0, 32, true, Duration::from_secs(1));
         assert_eq!(read.data, b"ready");
         assert!(!read.timed_out);
-        let eof = if read.eof {
-            read
-        } else {
-            ring.read(read.next_cursor, 32, true, Duration::from_secs(1))
-        };
+        let eof = ring.read(read.next_cursor, 32, true, Duration::from_secs(1));
         writer.join().unwrap();
         assert!(eof.data.is_empty());
         assert!(eof.eof);

--- a/packages/d2b-unsafe-local-helper/src/protocol.rs
+++ b/packages/d2b-unsafe-local-helper/src/protocol.rs
@@ -721,6 +721,8 @@ mod tests {
         let (payload_read, _payload_write) =
             rustix::pipe::pipe_with(rustix::pipe::PipeFlags::CLOEXEC).unwrap();
         let raw = payload_read.as_raw_fd();
+        let proc_path = std::path::PathBuf::from(format!("/proc/self/fd/{raw}"));
+        let original_identity = std::fs::read_link(&proc_path).unwrap();
         let result = send_queued_response(
             &sender,
             QueuedResponse {
@@ -729,6 +731,13 @@ mod tests {
             },
         );
         assert_eq!(result, Err(ProtocolError::ConnectFailed));
-        assert!(!std::path::Path::new(&format!("/proc/self/fd/{raw}")).exists());
+        match std::fs::read_link(&proc_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Ok(current_identity) => assert_ne!(
+                current_identity, original_identity,
+                "failed send retained ownership of the original fd"
+            ),
+            Err(error) => panic!("failed to inspect released fd: {error}"),
+        }
     }
 }


### PR DESCRIPTION
Eliminates two process-shared test races: disk-init scratch directories now use process-local atomic IDs with exclusive create_dir, and failed-fd-send coverage tracks the original pipe identity instead of a reusable numeric fd. Validation: 20 disk suites at 32 threads, 50 protocol suites at 32 threads, 100 OutputRing stress runs, and make check all passed. Focused Rust, test, and kernel reviews returned unanimous signoff. This follows PR #300 and contains only the additional parallel-isolation changes.