### PR TITLE
unsafe-local: restore host shell profiles and release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ deprecations ship one minor release before removal.
   of depending on unrelated existing-image repair stages.
 - Made output-ring wake coverage observe data and EOF as separate valid
   notifications instead of racing both producer events into one read.
+- Made failed-fd-send coverage track the original pipe identity so concurrent
+  numeric fd reuse cannot produce a false leak report.
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,
   waking the supervisor accept loop so its owned listener unlinks before forced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ deprecations ship one minor release before removal.
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-12
+
 ### Added
 
-- Added proposed ADR 0045, defining parent-owned workload-hosted realm
+- Added ADR 0045, defining parent-owned workload-hosted realm
   controllers; explicit runtime, infrastructure, transport, substrate,
   credential, and display provider responsibilities; type-first sortable
   provider crates; generic Unix/vsock/direct/Azure-Relay byte transports;
@@ -29,7 +31,6 @@ deprecations ship one minor release before removal.
   of depending on unrelated existing-image repair stages.
 - Made output-ring wake coverage observe data and EOF as separate valid
   notifications instead of racing both producer events into one read.
-
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,
   waking the supervisor accept loop so its owned listener unlinks before forced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Fixed unsafe-local persistent shells inheriting `TERM=dumb` from the systemd
+  user manager by supplying a fixed true-color terminal baseline while
+  preserving the rest of the manager environment and login-shell startup.
+
 - Stabilized shell-supervisor teardown coverage by allowing its asynchronous
   socket cleanup the same bounded reconciliation horizon used by the runtime,
   waking the supervisor accept loop so its owned listener unlinks before forced

--- a/packages/d2b-unsafe-local-helper/src/environment.rs
+++ b/packages/d2b-unsafe-local-helper/src/environment.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 
 pub const MAX_MANAGER_ENVIRONMENT_ENTRIES: usize = 4096;
 pub const MAX_MANAGER_ENVIRONMENT_BYTES: usize = 256 * 1024;
+pub const PERSISTENT_SHELL_TERM: &str = "xterm-256color";
+pub const PERSISTENT_SHELL_COLORTERM: &str = "truecolor";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EnvironmentError {
@@ -82,6 +84,16 @@ impl ManagerEnvironment {
             entries.insert("WAYLAND_DISPLAY".to_owned(), display.to_owned());
         }
         Ok(entries)
+    }
+
+    pub fn persistent_shell_entries(&self) -> BTreeMap<String, String> {
+        let mut entries = self.entries.clone();
+        entries.insert("TERM".to_owned(), PERSISTENT_SHELL_TERM.to_owned());
+        entries.insert(
+            "COLORTERM".to_owned(),
+            PERSISTENT_SHELL_COLORTERM.to_owned(),
+        );
+        entries
     }
 
     pub fn path(&self) -> Result<&str, EnvironmentError> {
@@ -238,6 +250,36 @@ mod tests {
                 "{invalid:?}"
             );
         }
+    }
+
+    #[test]
+    fn persistent_shell_environment_overrides_non_terminal_manager_values_only() {
+        let environment = ManagerEnvironment::parse(vec![
+            "PATH=/run/current-system/sw/bin".to_owned(),
+            "PRIVATE_VALUE=preserved".to_owned(),
+            "TERM=dumb".to_owned(),
+            "COLORTERM=manager-value".to_owned(),
+        ])
+        .unwrap();
+
+        let child = environment.persistent_shell_entries();
+        assert_eq!(
+            child.get("TERM").map(String::as_str),
+            Some(PERSISTENT_SHELL_TERM)
+        );
+        assert_eq!(
+            child.get("COLORTERM").map(String::as_str),
+            Some(PERSISTENT_SHELL_COLORTERM)
+        );
+        assert_eq!(
+            child.get("PRIVATE_VALUE").map(String::as_str),
+            Some("preserved")
+        );
+        assert_eq!(
+            child.get("PATH").map(String::as_str),
+            Some("/run/current-system/sw/bin")
+        );
+        assert_eq!(child.len(), 4);
     }
 
     #[test]

--- a/packages/d2b-unsafe-local-helper/src/protocol.rs
+++ b/packages/d2b-unsafe-local-helper/src/protocol.rs
@@ -721,6 +721,8 @@ mod tests {
         let (payload_read, _payload_write) =
             rustix::pipe::pipe_with(rustix::pipe::PipeFlags::CLOEXEC).unwrap();
         let raw = payload_read.as_raw_fd();
+        let proc_path = std::path::PathBuf::from(format!("/proc/self/fd/{raw}"));
+        let original_identity = std::fs::read_link(&proc_path).unwrap();
         let result = send_queued_response(
             &sender,
             QueuedResponse {
@@ -729,6 +731,13 @@ mod tests {
             },
         );
         assert_eq!(result, Err(ProtocolError::ConnectFailed));
-        assert!(!std::path::Path::new(&format!("/proc/self/fd/{raw}")).exists());
+        match std::fs::read_link(&proc_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Ok(current_identity) => assert_ne!(
+                current_identity, original_identity,
+                "failed send retained ownership of the original fd"
+            ),
+            Err(error) => panic!("failed to inspect released fd: {error}"),
+        }
     }
 }

--- a/packages/d2b-unsafe-local-helper/src/shell_runtime.rs
+++ b/packages/d2b-unsafe-local-helper/src/shell_runtime.rs
@@ -412,7 +412,7 @@ fn create_and_attach<M: UserScopeManager>(
     if user.home_dir() != runtime.shell_home || !user.shell().is_absolute() {
         return Err(RuntimeError::InvalidIdentity);
     }
-    let child_environment = environment.child_entries(false, None)?;
+    let child_environment = environment.persistent_shell_entries();
     let supervisor_id = random_supervisor_id()?;
     supervisor_socket_path(&runtime_directory, &supervisor_id)
         .map_err(|_| RuntimeError::EnvironmentInvalid)?;

--- a/packages/d2b-unsafe-local-helper/tests/shell_supervisor.rs
+++ b/packages/d2b-unsafe-local-helper/tests/shell_supervisor.rs
@@ -400,6 +400,8 @@ fn exercise_helper_runtime_reconstruction(scratch: &Scratch, operation_suffix: &
         scratch.path.display().to_string(),
     );
     environment.insert("D2B_TEST_ENV".to_owned(), "manager-env-canary".to_owned());
+    environment.insert("TERM".to_owned(), "dumb".to_owned());
+    environment.insert("COLORTERM".to_owned(), "manager-value".to_owned());
     let manager = FakeScopeManager {
         environment: ManagerEnvironment::parse(
             environment
@@ -430,7 +432,7 @@ fn exercise_helper_runtime_reconstruction(scratch: &Scratch, operation_suffix: &
     terminal
         .set_read_timeout(Some(Duration::from_secs(2)))
         .unwrap();
-    let command = b"printf 'D2B_RUNTIME_ADOPT\\n'\n";
+    let command = b"printf 'D2B_RUNTIME_ENV:%s:%s\\n' \"$TERM\" \"$COLORTERM\"; if test -n \"$BASH_VERSION\"; then case $- in *i*) d2b_mode=interactive ;; *) d2b_mode=noninteractive ;; esac; if shopt -q login_shell; then d2b_login=login; else d2b_login=nonlogin; fi; printf 'D2B_RUNTIME_BASH:%s:%s\\n' \"$d2b_mode\" \"$d2b_login\"; fi\n";
     write_terminal_frame(
         &mut terminal,
         &HelperTerminalRequest::WriteStdin(HelperTerminalWriteStdin {
@@ -441,12 +443,27 @@ fn exercise_helper_runtime_reconstruction(scratch: &Scratch, operation_suffix: &
         }),
     );
     let _ = read_terminal_frame(&mut terminal);
-    let (_, output) = read_until(&mut terminal, 2, 0, b"D2B_RUNTIME_ADOPT");
+    let bash_login_shell = user.shell().file_name().and_then(|name| name.to_str()) == Some("bash");
+    let needle = if bash_login_shell {
+        b"D2B_RUNTIME_BASH:interactive:login".as_slice()
+    } else {
+        b"D2B_RUNTIME_ENV:xterm-256color:truecolor".as_slice()
+    };
+    let (_, output) = read_until(&mut terminal, 2, 0, needle);
     assert!(
         output
-            .windows(b"D2B_RUNTIME_ADOPT".len())
-            .any(|window| window == b"D2B_RUNTIME_ADOPT")
+            .windows(b"D2B_RUNTIME_ENV:xterm-256color:truecolor".len())
+            .any(|window| window == b"D2B_RUNTIME_ENV:xterm-256color:truecolor"),
+        "persistent shell inherited non-terminal manager TERM or COLORTERM"
     );
+    if bash_login_shell {
+        assert!(
+            output
+                .windows(b"D2B_RUNTIME_BASH:interactive:login".len())
+                .any(|window| window == b"D2B_RUNTIME_BASH:interactive:login"),
+            "Bash persistent shell was not interactive and login-mode"
+        );
+    }
     drop(terminal);
 
     let reconstructed = ScopeRuntime::with_paths_and_executable(


### PR DESCRIPTION
Fixes unsafe-local persistent shells inheriting TERM=dumb from the systemd user manager by supplying a trusted xterm-256color/truecolor baseline while preserving the full manager environment and login-shell startup. The branch also cuts d2b 1.4.1 from the current Unreleased section. Validation completed before the final main refresh: focused helper tests and Clippy, private NixOS build/switch, live Starship/profile/login/interactive/alias checks, and a tmux attach proof that remained active until timeout exit 124. The operator approved the terminal screenshot at https://github.com/vicondoa/d2b-ux-screenshot-review/tree/wlcontrol-host-shell-review. Final ten-role d2b panel returned unanimous signoff.