### PR TITLE
test: isolate pinned Rust gates from developer artifacts

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -110,6 +110,7 @@ jobs:
             packages -> target
             packages/d2b-priv-broker -> target
           cache-directories: |
+            packages/.d2b-gate-targets
             packages/d2b-priv-broker/target-layer1
             packages/d2b-priv-broker/target-fakebackends
           prefix-key: "v0-rust"

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,11 @@ packages/*/t/
 # CI sccache local-disk backend (restored/saved by actions/cache in test-rust).
 .sccache/
 
+# Toolchain-scoped Cargo gate outputs. Developer Cargo commands continue to use
+# packages/target; tests/test-rust.sh uses these isolated dirs so artifacts from
+# another rustc version cannot poison the pinned gate.
+packages/.d2b-gate-targets/
+
 # Broker feature-pass target dirs (deterministic siblings of the broker target
 # dir, kept stable so sccache cache keys don't churn — see tests/test-rust.sh).
 packages/d2b-priv-broker/target-layer1/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ deprecations ship one minor release before removal.
   detection coverage while retaining the behavioral timeout check.
 - Isolated the pinned Rust gate's Cargo outputs by toolchain so developer builds
   from another compiler cannot poison doctest metadata.
+- Reused an already-installed pinned Rust toolchain before attempting a network
+  bootstrap.
 - Made the mkfs diagnostic bound test exercise the formatter directly instead
   of depending on unrelated existing-image repair stages.
 - Made output-ring wake coverage observe data and EOF as separate valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ deprecations ship one minor release before removal.
   isolated targets in CI caching.
 - Reused an already-installed pinned Rust toolchain before attempting a network
   bootstrap.
+- Made broker audit tests reserve exclusive process-local scratch directories
+  before opening their logs.
 
 ## [1.4.1] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Removed a scheduler-sensitive wall-clock assertion from zombie process
+  detection coverage while retaining the behavioral timeout check.
 - Made the mkfs diagnostic bound test exercise the formatter directly instead
   of depending on unrelated existing-image repair stages.
 - Made output-ring wake coverage observe data and EOF as separate valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ deprecations ship one minor release before removal.
 - Removed a scheduler-sensitive wall-clock assertion from zombie process
   detection coverage while retaining the behavioral timeout check.
 - Isolated the pinned Rust gate's Cargo outputs by toolchain so developer builds
-  from another compiler cannot poison doctest metadata.
+  from another compiler cannot poison doctest metadata, and included the
+  isolated targets in CI caching.
 - Reused an already-installed pinned Rust toolchain before attempting a network
   bootstrap.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ deprecations ship one minor release before removal.
 
 - Removed a scheduler-sensitive wall-clock assertion from zombie process
   detection coverage while retaining the behavioral timeout check.
+- Isolated the pinned Rust gate's Cargo outputs by toolchain so developer builds
+  from another compiler cannot poison doctest metadata.
 - Made the mkfs diagnostic bound test exercise the formatter directly instead
   of depending on unrelated existing-image repair stages.
 - Made output-ring wake coverage observe data and EOF as separate valid

--- a/packages/d2b-priv-broker/src/audit.rs
+++ b/packages/d2b-priv-broker/src/audit.rs
@@ -897,19 +897,25 @@ fn ts_at_least(line: &str, since: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
 
     fn target_scratch_root(prefix: &str) -> PathBuf {
         let base = std::env::var_os("CARGO_TARGET_TMPDIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"));
-        base.join(format!(
-            "{prefix}-{}-{}",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or_default()
-        ))
+        fs::create_dir_all(&base).expect("create audit test scratch root");
+        for _ in 0..1024 {
+            let id = NEXT_SCRATCH_ID.fetch_add(1, Ordering::Relaxed);
+            let path = base.join(format!("{prefix}-{}-{id}", std::process::id()));
+            match fs::create_dir(&path) {
+                Ok(()) => return path,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => panic!("create audit test directory {}: {error}", path.display()),
+            }
+        }
+        panic!("failed to reserve a unique audit test directory")
     }
 
     #[test]

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -13162,9 +13162,8 @@ mod wait_for_one_shot_exit_tests {
             .expect("spawn 'sleep 30'")
     }
 
-    // v1.2 asserts the zombie shortcut path: `wait_for_one_shot_exit`
-    // must return `Ok(())` immediately (≤100 ms) when the target is in
-    // state 'Z', without waiting for the full polling timeout.
+    // A zombie is already terminated, so the helper must return success
+    // instead of reaching the polling timeout.
     #[test]
     fn wait_for_one_shot_exit_returns_ok_on_zombie_child() {
         let mut child = spawn_zombie_child();
@@ -13177,19 +13176,13 @@ mod wait_for_one_shot_exit_tests {
         // and the original starttime; read it now.
         let start_ticks = read_start_time_ticks(pid);
 
-        let t0 = Instant::now();
         let result = wait_for_one_shot_exit(pid as i32, start_ticks, Duration::from_millis(500));
-        let elapsed = t0.elapsed();
 
         // Reap the zombie before asserting so it isn't left around on
         // a test failure.
         child.wait().expect("waitpid zombie child");
 
         assert_eq!(result, Ok(()), "expected Ok(()) for zombie child");
-        assert!(
-            elapsed <= Duration::from_millis(100),
-            "zombie shortcut must fire in ≤100 ms; took {elapsed:?}"
-        );
     }
 
     // v1.2 asserts the timeout path — `wait_for_one_shot_exit` must

--- a/packages/d2bd/src/lib.rs
+++ b/packages/d2bd/src/lib.rs
@@ -13185,9 +13185,8 @@ mod wait_for_one_shot_exit_tests {
         assert_eq!(result, Ok(()), "expected Ok(()) for zombie child");
     }
 
-    // v1.2 asserts the timeout path — `wait_for_one_shot_exit` must
-    // return `Err("oneshot-timeout:<pid>")` when the target stays alive
-    // through the full polling window.
+    // A process that remains alive through the polling window must return
+    // the stable timeout error.
     #[test]
     fn wait_for_one_shot_exit_times_out_on_alive_process() {
         let mut child = spawn_sleeping_child();

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -114,6 +114,25 @@ d2b_cargo_target_dir() {
   printf '%s\n' "$base"
 }
 
+d2b_cargo_gate_target_dir() {
+  local scope="${1:?d2b_cargo_gate_target_dir: missing scope}"
+  local toolchain="${2:?d2b_cargo_gate_target_dir: missing toolchain}"
+  case "$scope" in
+    workspace|broker|broker-layer1|broker-fakebackends|guest-shell-runner) ;;
+    *)
+      fail "unknown cargo gate target scope: $scope"
+      return 1
+      ;;
+  esac
+  case "$toolchain" in
+    ""|*[!A-Za-z0-9._-]*)
+      fail "unsafe cargo gate toolchain label: $toolchain"
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$(d2b_repo_root)/packages/.d2b-gate-targets/$toolchain/$scope"
+}
+
 d2b_cargo_bin_path() {
   local scope="$1" bin_name="$2" target_dir
   target_dir=$(d2b_cargo_target_dir "$scope") || return 1

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -147,9 +147,21 @@ d2b_prepend_path() {
 }
 
 d2b_activate_rust_toolchain_path() {
+  local channel="${1:-}"
   if [ -n "${D2B_RUST_TOOLCHAIN_PATH:-}" ]; then
     d2b_prepend_path "$D2B_RUST_TOOLCHAIN_PATH"
     return 0
+  fi
+  if [ -n "$channel" ]; then
+    local candidate
+    for candidate in "$HOME"/.rustup/toolchains/"$channel"-*/bin; do
+      if [ -x "$candidate/cargo" ] && [ -x "$candidate/rustc" ]; then
+        D2B_RUST_TOOLCHAIN_PATH="$candidate"
+        export D2B_RUST_TOOLCHAIN_PATH
+        d2b_prepend_path "$candidate"
+        return 0
+      fi
+    done
   fi
   return 1
 }

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -150,9 +150,6 @@ d2b_activate_rust_toolchain_path() {
   local channel="${1:-}"
   local required_tool
   if [ -n "${D2B_RUST_TOOLCHAIN_PATH:-}" ]; then
-    for required_tool in cargo rustc rustfmt cargo-fmt cargo-clippy clippy-driver; do
-      [ -x "$D2B_RUST_TOOLCHAIN_PATH/$required_tool" ] || return 1
-    done
     d2b_prepend_path "$D2B_RUST_TOOLCHAIN_PATH"
     return 0
   fi

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -148,19 +148,24 @@ d2b_prepend_path() {
 
 d2b_activate_rust_toolchain_path() {
   local channel="${1:-}"
+  local required_tool
   if [ -n "${D2B_RUST_TOOLCHAIN_PATH:-}" ]; then
+    for required_tool in cargo rustc rustfmt cargo-fmt cargo-clippy clippy-driver; do
+      [ -x "$D2B_RUST_TOOLCHAIN_PATH/$required_tool" ] || return 1
+    done
     d2b_prepend_path "$D2B_RUST_TOOLCHAIN_PATH"
     return 0
   fi
   if [ -n "$channel" ]; then
     local candidate
     for candidate in "$HOME"/.rustup/toolchains/"$channel"-*/bin; do
-      if [ -x "$candidate/cargo" ] && [ -x "$candidate/rustc" ]; then
-        D2B_RUST_TOOLCHAIN_PATH="$candidate"
-        export D2B_RUST_TOOLCHAIN_PATH
-        d2b_prepend_path "$candidate"
-        return 0
-      fi
+      for required_tool in cargo rustc rustfmt cargo-fmt cargo-clippy clippy-driver; do
+        [ -x "$candidate/$required_tool" ] || continue 2
+      done
+      D2B_RUST_TOOLCHAIN_PATH="$candidate"
+      export D2B_RUST_TOOLCHAIN_PATH
+      d2b_prepend_path "$candidate"
+      return 0
     done
   fi
   return 1

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -67,7 +67,11 @@ if command -v cargo >/dev/null 2>&1 \
   && command -v cargo-clippy >/dev/null 2>&1 \
   && command -v clippy-driver >/dev/null 2>&1 \
   && cargo --version | grep -Fq "$pinned_channel" \
-  && rustc --version | grep -Fq "$pinned_channel"; then
+  && rustc --version | grep -Fq "$pinned_channel" \
+  && rustfmt --version >/dev/null 2>&1 \
+  && cargo fmt --version >/dev/null 2>&1 \
+  && clippy-driver --version >/dev/null 2>&1 \
+  && cargo clippy --version >/dev/null 2>&1; then
   pinned_toolchain_active=1
 fi
 

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -56,10 +56,20 @@ guest_shell_runner_target_dir=$(d2b_cargo_gate_target_dir guest-shell-runner "$p
 # Full D2B_FIXTURES delivery to the sandbox/CI is a tracked W1 deliverable.
 workspace_test_excludes=(--exclude d2b-contract-tests)
 
-d2b_activate_rust_toolchain_path || true
+d2b_activate_rust_toolchain_path "$pinned_channel" || true
 export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-$pinned_channel}"
 
-if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] && ! command -v rustup >/dev/null 2>&1; then
+pinned_toolchain_active=0
+if command -v cargo >/dev/null 2>&1 \
+  && command -v rustc >/dev/null 2>&1 \
+  && cargo --version | grep -Fq "$pinned_channel" \
+  && rustc --version | grep -Fq "$pinned_channel"; then
+  pinned_toolchain_active=1
+fi
+
+if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] \
+  && [ "$pinned_toolchain_active" = 0 ] \
+  && ! command -v rustup >/dev/null 2>&1; then
   if ! command -v nix >/dev/null 2>&1; then
     fail "rustup not on PATH and nix is unavailable; rust gate cannot run pinned Rust $pinned_channel"
     exit 1
@@ -77,7 +87,9 @@ if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] && ! command -v rustup >/dev/null 2>
   exit $?
 fi
 
-if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] && command -v rustup >/dev/null 2>&1; then
+if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] \
+  && [ "$pinned_toolchain_active" = 0 ] \
+  && command -v rustup >/dev/null 2>&1; then
   export D2B_RUST_GATE_IN_NIX_SHELL=1
   export D2B_RUST_GATE_BOOTSTRAP_RUSTUP=1
   export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
@@ -85,7 +97,9 @@ if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] && command -v rustup >/dev/null 2>&1
   rustup toolchain install "$pinned_channel" --profile minimal --component rustfmt --component clippy
 fi
 
-if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] && ! command -v cargo >/dev/null 2>&1; then
+if [ -z "${D2B_RUST_GATE_IN_NIX_SHELL:-}" ] \
+  && [ "$pinned_toolchain_active" = 0 ] \
+  && ! command -v cargo >/dev/null 2>&1; then
   if ! command -v nix >/dev/null 2>&1; then
     fail "neither cargo nor nix is on PATH; rust gate cannot run"
     exit 1

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -41,18 +41,16 @@ if [ -z "$pinned_channel" ]; then
 fi
 export pinned_channel
 
-workspace_target_dir=$(d2b_cargo_target_dir workspace)
-# Separate target dirs for the broker's three concurrent feature passes so they
-# don't lock-contend. They are DETERMINISTIC siblings of the broker target dir
-# (not mktemp): sccache hashes the inherited CARGO_* environment, including
-# CARGO_TARGET_DIR, so a random per-run target dir would change the cache key
-# and defeat cross-run hits. Stable, distinct dirs keep the key stable (cache
-# hits) while still avoiding lock contention. They are gitignored and reused
-# across runs like the default broker/workspace target dirs.
-broker_target_dir=$(d2b_cargo_target_dir broker)
-broker_layer1_target_dir="${broker_target_dir%/}-layer1"
-broker_fakebackends_target_dir="${broker_target_dir%/}-fakebackends"
-guest_shell_runner_target_dir=$(d2b_cargo_target_dir guest-shell-runner)
+# Keep the pinned gate isolated from packages/target, where developers may have
+# built with a different rustc. Rust metadata is not cross-version compatible;
+# a shared target can make rustdoc load an rlib produced by the wrong compiler.
+# Stable per-toolchain dirs preserve incremental reuse and sccache hits without
+# allowing an unpinned Cargo invocation to poison the gate.
+workspace_target_dir=$(d2b_cargo_gate_target_dir workspace "$pinned_channel")
+broker_target_dir=$(d2b_cargo_gate_target_dir broker "$pinned_channel")
+broker_layer1_target_dir=$(d2b_cargo_gate_target_dir broker-layer1 "$pinned_channel")
+broker_fakebackends_target_dir=$(d2b_cargo_gate_target_dir broker-fakebackends "$pinned_channel")
+guest_shell_runner_target_dir=$(d2b_cargo_gate_target_dir guest-shell-runner "$pinned_channel")
 
 # Keep fixture-dependent contract crates out of generic workspace tests.
 # Full D2B_FIXTURES delivery to the sandbox/CI is a tracked W1 deliverable.

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -396,9 +396,13 @@ snapshot_schema_out() {
 }
 
 log "--> schema generation reproducibility"
-(cd "$ROOT/packages" && RUSTC_WRAPPER="" CARGO_BUILD_RUSTC_WRAPPER="" cargo xtask gen-schemas)
+(cd "$ROOT/packages" && \
+  RUSTC_WRAPPER="" CARGO_BUILD_RUSTC_WRAPPER="" \
+  CARGO_TARGET_DIR="$workspace_target_dir" cargo xtask gen-schemas)
 schema_snapshot_1=$(snapshot_schema_out)
-(cd "$ROOT/packages" && RUSTC_WRAPPER="" CARGO_BUILD_RUSTC_WRAPPER="" cargo xtask gen-schemas)
+(cd "$ROOT/packages" && \
+  RUSTC_WRAPPER="" CARGO_BUILD_RUSTC_WRAPPER="" \
+  CARGO_TARGET_DIR="$workspace_target_dir" cargo xtask gen-schemas)
 schema_snapshot_2=$(snapshot_schema_out)
 if [ "$schema_snapshot_1" != "$schema_snapshot_2" ]; then
   fail "schema generation reproducibility: cargo xtask gen-schemas output is not reproducible"
@@ -492,12 +496,15 @@ cargo_audit_check "broker workspace" "$broker_lock_file"
 cargo_audit_check "guest shell runner workspace" "$guest_shell_runner_lock_file" --ignore RUSTSEC-2024-0384
 
 log "--> tests/tools/stub-no-socket.sh"
-bash "$ROOT/tests/tools/stub-no-socket.sh"
+D2B_WORKSPACE_GATE_TARGET_DIR="$workspace_target_dir" \
+  bash "$ROOT/tests/tools/stub-no-socket.sh"
 ok "stub-no-socket"
 
 # Fail-closed Rust test inventory: every pinned workspace + broker test must
 # still exist (catches a silently-deleted test that would otherwise vanish from
 # coverage). The pinned set is committed under tests/golden/pinned/.
 log "--> tests/tools/assert-pinned-tests.sh"
-bash "$ROOT/tests/tools/assert-pinned-tests.sh"
+D2B_WORKSPACE_GATE_TARGET_DIR="$workspace_target_dir" \
+D2B_BROKER_GATE_TARGET_DIR="$broker_target_dir" \
+  bash "$ROOT/tests/tools/assert-pinned-tests.sh"
 ok "assert-pinned-tests"

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -62,6 +62,10 @@ export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-$pinned_channel}"
 pinned_toolchain_active=0
 if command -v cargo >/dev/null 2>&1 \
   && command -v rustc >/dev/null 2>&1 \
+  && command -v rustfmt >/dev/null 2>&1 \
+  && command -v cargo-fmt >/dev/null 2>&1 \
+  && command -v cargo-clippy >/dev/null 2>&1 \
+  && command -v clippy-driver >/dev/null 2>&1 \
   && cargo --version | grep -Fq "$pinned_channel" \
   && rustc --version | grep -Fq "$pinned_channel"; then
   pinned_toolchain_active=1

--- a/tests/tools/assert-pinned-tests.sh
+++ b/tests/tools/assert-pinned-tests.sh
@@ -5,6 +5,12 @@ HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=${ROOT:-$(cd "$HERE/../.." && pwd)}
 DEFAULT_PINNED_DIR="$ROOT/tests/golden/pinned"
 
+# shellcheck source=tests/lib.sh
+. "$ROOT/tests/lib.sh"
+
+workspace_target_dir=${D2B_WORKSPACE_GATE_TARGET_DIR:-$(d2b_cargo_target_dir workspace)}
+broker_target_dir=${D2B_BROKER_GATE_TARGET_DIR:-$(d2b_cargo_target_dir broker)}
+
 if ! command -v cargo >/dev/null 2>&1; then
   for candidate in "$HOME"/.rustup/toolchains/1.94.1-*/bin; do
     if [ -x "$candidate/cargo" ]; then
@@ -64,14 +70,16 @@ collect_present() {
 # Main workspace (packages/Cargo.toml).
 collect_present < <(
   cd "$ROOT/packages"
-  cargo nextest list --workspace --exclude d2b-contract-tests --message-format oneline
+  CARGO_TARGET_DIR="$workspace_target_dir" \
+    cargo nextest list --workspace --exclude d2b-contract-tests --message-format oneline
 )
 # Fixture contract tests are excluded from the default workspace test pass, but
 # test-rust.sh runs them with D2B_FIXTURES. Include their nextest
 # listing so retired shell gates can pin rendered-artifact contract successors.
 collect_present < <(
   cd "$ROOT/packages"
-  cargo nextest list -p d2b-contract-tests --message-format oneline
+  CARGO_TARGET_DIR="$workspace_target_dir" \
+    cargo nextest list -p d2b-contract-tests --message-format oneline
 )
 # Broker workspace (packages/d2b-priv-broker/Cargo.toml) is a SEPARATE
 # cargo workspace, excluded from the main one. Retired canaries pinned
@@ -109,7 +117,8 @@ collect_present < <(
   # (e.g. tests/pidfd_handoff_scm_rights.rs). test-rust.sh runs the
   # default, layer1-bootstrap, AND fake-backends broker test passes, so every
   # listed test is actually executed and can be guarded by the pinned gate.
-  cargo nextest list --workspace --features layer1-bootstrap,fake-backends --message-format oneline
+  CARGO_TARGET_DIR="$broker_target_dir" \
+    cargo nextest list --workspace --features layer1-bootstrap,fake-backends --message-format oneline
 )
 if [ -n "$broker_lock_backup" ]; then
   restore_broker_lock

--- a/tests/tools/layer1-jobs.py
+++ b/tests/tools/layer1-jobs.py
@@ -161,6 +161,7 @@ def rust_job(job: dict[str, Any]) -> str:
             packages -> target
             packages/d2b-priv-broker -> target
           cache-directories: |
+            packages/.d2b-gate-targets
             packages/d2b-priv-broker/target-layer1
             packages/d2b-priv-broker/target-fakebackends
           prefix-key: "v0-rust"

--- a/tests/tools/stub-no-socket.sh
+++ b/tests/tools/stub-no-socket.sh
@@ -12,7 +12,7 @@ ROOT=${ROOT:-$(cd "$HERE/../.." && pwd)}
 d2b_activate_rust_toolchain_path || true
 
 manifest="$ROOT/packages/Cargo.toml"
-workspace_target_dir=$(d2b_cargo_target_dir workspace)
+workspace_target_dir=${D2B_WORKSPACE_GATE_TARGET_DIR:-$(d2b_cargo_target_dir workspace)}
 if [ ! -f "$manifest" ]; then
   fail "missing Rust workspace manifest: $manifest"
   exit 1

--- a/tests/unit/gates/ci-rust-cache-sync.sh
+++ b/tests/unit/gates/ci-rust-cache-sync.sh
@@ -22,20 +22,14 @@ test_script="$ROOT/tests/test-rust.sh"
 
 rc=0
 
-# --- Build the set of target dirs that test-rust.sh actually uses ---
-# These are the paths that MUST be cached for warm CI builds.
-declared_dirs=(
-  "packages -> target"
-  "packages/d2b-priv-broker -> target"
-)
-# Broker parallel feature-pass target dirs: the script uses
-# ${broker_target_dir%/}-<suffix> where broker_target_dir resolves to
-# packages/d2b-priv-broker/target.
-while IFS= read -r suffix; do
-  declared_dirs+=("packages/d2b-priv-broker/target-${suffix}")
-done < <(
-  grep -oP '(?<=broker_target_dir%/\}-)[a-z0-9]+' "$test_script" | sort -u
-)
+# The pinned gate places every workspace and standalone feature pass below one
+# toolchain-scoped root. Cache that root rather than enumerating a channel or
+# each scope, so a toolchain bump does not require a workflow path rewrite.
+declared_dirs=("packages/.d2b-gate-targets")
+if ! grep -q 'd2b_cargo_gate_target_dir' "$test_script"; then
+  log "FAIL: test-rust.sh does not use the toolchain-scoped target helper"
+  rc=1
+fi
 
 # --- Extract cached dirs from CI workflow (simple grep) ---
 # The workflow's Swatinem/rust-cache step declares paths in `workspaces:`


### PR DESCRIPTION
## Summary

- remove the scheduler-sensitive wall-clock assertion from zombie detection while retaining the behavioral timeout check
- isolate pinned Rust gate artifacts by toolchain and propagate that target through schema generation and nested Rust test helpers
- reuse an installed pinned toolchain before attempting a network bootstrap

## Testing checklist (mandatory)

- [ ] **`make check` passes locally**: final-base run delegated to PR CI at operator direction so independent shards run in parallel.
- [x] **`make test-integration` passes on the host before PR creation**, or N/A: test-infrastructure-only change with no daemon, broker, NixOS module, runtime, network, or generated-artifact behavior change.
- [x] **`make test-host-integration` passes on the host before PR creation**, or N/A: test-infrastructure-only change with no host/runtime behavior change.
- [x] **Manual `make test-hardware` run**, or N/A: no device, passthrough, or microVM behavior changed.
- [x] **New/changed tests are wired into a `make` target**: existing `make test-rust` and `make check` paths are updated; no new test ID was added.
- [x] **Docs + CI updated in lockstep**: CHANGELOG updated; no workflow topology or shipped documentation changed.

## Validation evidence

- targeted zombie wait test passed
- `D2B_SKIP_FIXTURE_BUILD=1 make test-rust` passed while `packages/target` remained deliberately polluted by Rust 1.95 artifacts; the pinned gate used Rust 1.94.1 under `packages/.d2b-gate-targets/1.94.1`
- `make check-tier0` passed
- focused code review returned no findings

## Notes

No runtime contract or migration-ledger entry changed.
