### PR TITLE
shell: reject mismatched local VM shell declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ deprecations ship one minor release before removal.
 - Rejected local-VM realm workloads that advertise persistent shells while the
   referenced guest has shell support disabled, preventing desktop clients from
   exposing a terminal action that can only fail at runtime.
+- Made exec-runner drain tests tolerate saturated CI scheduling while
+  preserving clean-EOF and leaked-pipe coverage.
 - Made unsafe-local helper FD cleanup tests track the original kernel object so
   concurrent numeric descriptor reuse cannot report a false leak.
 - Removed a scheduler-sensitive wall-clock assertion from zombie process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ deprecations ship one minor release before removal.
 
 ### Fixed
 
+- Rejected local-VM realm workloads that advertise persistent shells while the
+  referenced guest has shell support disabled, preventing desktop clients from
+  exposing a terminal action that can only fail at runtime.
 - Made unsafe-local helper FD cleanup tests track the original kernel object so
   concurrent numeric descriptor reuse cannot report a false leak.
 - Removed a scheduler-sensitive wall-clock assertion from zombie process

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -716,6 +716,11 @@ let
                   (row: builtins.elem row.item.type [ "exec" "shell" ])
                   itemRows);
               unsafeLocal = workload.kind == "unsafe-local";
+              linkedLocalVm =
+                workload.enable
+                && workload.kind == "local-vm"
+                && workload.legacyVmName != null
+                && builtins.hasAttr workload.legacyVmName cfg.vms;
               configuredLocalVm =
                 workload.enable
                 && workload.kind == "local-vm"
@@ -829,6 +834,18 @@ let
                 message = ''
                   ${path} declares a shell launcher item but shell.enable is
                   false.
+                '';
+              }
+              {
+                assertion =
+                  !linkedLocalVm
+                  || !workload.shell.enable
+                  || cfg.vms.${workload.legacyVmName}.guest.shell.enable;
+                message = ''
+                  ${path}.shell.enable is true, but its referenced local VM
+                  d2b.vms.${workload.legacyVmName}.guest.shell.enable is false.
+                  Enable persistent shells in the guest before advertising the
+                  workload as shell-capable.
                 '';
               }
             ]

--- a/nixos-modules/options-realms-workloads.nix
+++ b/nixos-modules/options-realms-workloads.nix
@@ -281,7 +281,11 @@ let
           enable = lib.mkOption {
             type = lib.types.bool;
             default = false;
-            description = "Enable persistent-shell semantics for this workload.";
+            description = ''
+              Enable persistent-shell semantics for this workload. A local-vm
+              workload that references an existing VM through `legacyVmName`
+              also requires `d2b.vms.<name>.guest.shell.enable = true`.
+            '';
           };
 
           defaultName = lib.mkOption {

--- a/packages/d2b-exec-runner/src/service_mode.rs
+++ b/packages/d2b-exec-runner/src/service_mode.rs
@@ -1471,6 +1471,10 @@ ControlGroup=/d2b.slice/d2b-exec.slice/d2b-exec-03.service
             stderr: b"hello stderr".to_vec(),
             fail: false,
         };
+        let cfg = SuperviseConfig {
+            grace: Duration::from_secs(60),
+            ..fast_cfg()
+        };
         let result = supervise(
             &spec("/bin/true", 0),
             &paths,
@@ -1484,7 +1488,7 @@ ControlGroup=/d2b.slice/d2b-exec.slice/d2b-exec-03.service
             Arc::new(FlagCancel {
                 flag: Arc::new(AtomicBool::new(false)),
             }),
-            &fast_cfg(),
+            &cfg,
         );
         assert_eq!(result, RunnerResult::Done);
         assert_eq!(read_phase(&paths), StatusPhase::Exited(7));
@@ -1777,7 +1781,6 @@ ControlGroup=/d2b.slice/d2b-exec.slice/d2b-exec-03.service
             proc: Arc::clone(&proc),
             read_fd: StdMutex::new(Some(read_fd)),
         };
-        let start = std::time::Instant::now();
         let result = supervise(
             &spec("/bin/true", 0),
             &paths,
@@ -1793,12 +1796,8 @@ ControlGroup=/d2b.slice/d2b-exec.slice/d2b-exec-03.service
             }),
             &fast_cfg(),
         );
-        // The bounded drain wait must let supervise return promptly even though
-        // the pipe write-end is still held open.
-        assert!(
-            start.elapsed() < Duration::from_secs(30),
-            "supervise hung on a lingering pipe holder"
-        );
+        // Returning while the pipe write-end is still held proves the drain
+        // wait is bounded without depending on host scheduler latency.
         assert_eq!(result, RunnerResult::Done);
         assert_eq!(read_phase(&paths), StatusPhase::Exited(0));
         // Releasing the write end lets the detached drain thread finish cleanly.

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -5,6 +5,7 @@ let
     inherit self;
     inherit (pkgs) lib;
   };
+  waylandProxy = self.packages.${pkgs.stdenv.hostPlatform.system}.d2b-wayland-proxy;
 in
 pkgs.testers.runNixOSTest {
   name = "d2b-unsafe-local-helper";
@@ -412,6 +413,7 @@ PY
         "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/missing "
         "XDG_RUNTIME_DIR=/run/user/1000 "
         "setsid -f /run/current-system/sw/bin/d2b-unsafe-local-helper "
+        "--wayland-proxy ${waylandProxy}/bin/d2b-wayland-proxy "
         "</dev/null >/run/d2b/no-manager-helper.log 2>&1"
     )
     machine.wait_until_succeeds(

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -1362,6 +1362,11 @@ in
         cfg = (mkEval [
           (lib.recursiveUpdate workloadFixture {
             d2b.realms.work.workloads.corp-laptop.shell.enable = true;
+            d2b.vms.corpbox.guest = {
+              control.enable = true;
+              exec.enable = true;
+              shell.enable = true;
+            };
           })
         ]).config;
         row = lib.findFirst
@@ -1379,6 +1384,20 @@ in
       id = "terminal";
       capabilities = [ "persistent-shell" "pty" ];
     };
+  };
+
+  "realm-workloads/local-vm-shell-requires-guest-shell" = {
+    expr = hasMessage
+      [
+        "workloads.corp-laptop.shell.enable is true"
+        "d2b.vms.corpbox.guest.shell.enable is false"
+      ]
+      (failureMessages [
+        (lib.recursiveUpdate workloadFixture {
+          d2b.realms.work.workloads.corp-laptop.shell.enable = true;
+        })
+      ]);
+    expected = true;
   };
 
   # ── cross-realm vsock CID collision: assertion fires ─────────────────────────

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -647,6 +647,7 @@ realm-workloads/launcher-json-shape
 realm-workloads/launcher-json-workload-id-field
 realm-workloads/launcher-v2-public-metadata-hides-argv
 realm-workloads/local-vm-private-items-filter-unsupported-kinds
+realm-workloads/local-vm-shell-requires-guest-shell
 realm-workloads/persistent-shell-compatibility-item
 realm-workloads/private-configured-workload-bounds
 realm-workloads/realm-row-workload-names


### PR DESCRIPTION
## Change
- fail evaluation when a realm local-VM workload advertises persistent shells but its referenced guest has shell support disabled
- document the required workload/guest capability pairing and add positive/negative nix-unit coverage
- repair the unsafe-local host check so its no-user-manager helper receives the mandatory immutable Wayland proxy path
- remove scheduler-sensitive wall-clock assumptions from exec-runner pipe-drain tests while retaining EOF and leaked-writer behavior coverage

## Validation
- `make test-nix-unit`
- `make check-tier0`
- `make check`
- `make test-integration`
- `make test-host-integration`
- `nix build .#vmChecks.x86_64-linux.unsafe-local-helper -L`
- `cargo test --locked -p d2b-exec-runner`

## Review
- full ten-role panel completed with unanimous 10/10 signoff and no findings
