### PR TITLE
ADR-0045 W8: freeze generated state and lock authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Added the W8 generated state/lock authority: runtime lock acquisition now
+  consumes trusted storage/sync inventories, binds exact lock and protected
+  resource identities, uses guarded atomic state access, and reconciles lock
+  files durably through the broker.
 - Split W8's remaining integration work at real file/contract boundaries so
   nine dependency-ready components can implement concurrently: secrets
   transactions, helper backend, shell client, gateway core, provider parity,

--- a/docs/reference/schemas/v2/storage-lifecycle-report.json
+++ b/docs/reference/schemas/v2/storage-lifecycle-report.json
@@ -227,6 +227,7 @@
         "ofd-lock-missing-cloexec",
         "fd-passing-missing-lease-transfer-record",
         "duplicate-acquire-order",
+        "lock-missing-protected-resource-id",
         "unclassified"
       ]
     }

--- a/docs/reference/schemas/v2/storage-lifecycle-report.md
+++ b/docs/reference/schemas/v2/storage-lifecycle-report.md
@@ -1,0 +1,89 @@
+# `storage-lifecycle-report.json` schema (`v2`)
+
+Schema: [`storage-lifecycle-report.json`](./storage-lifecycle-report.json)
+
+`storage-lifecycle-report.json` is the host-local daemon startup report on
+storage/restart/sync contract posture, written by `d2bd` (`packages/d2bd/src/
+storage_lifecycle.rs`) to `/var/lib/d2b/daemon-state/storage-lifecycle-report.json`.
+See [`docs/reference/storage-lifecycle-report.md`](../../storage-lifecycle-report.md)
+for the operator-facing description of the artifact's role, location, and
+diagnostic-only authority. This page documents the generated schema itself.
+
+## Top-level fields
+
+- `schemaVersion` — schema version for this artifact (currently `"v2"`).
+- `storageContractPresent` / `syncContractPresent` — whether the active
+  bundle carried a `storage.json` / `sync.json` contract at all.
+- `pathCount` / `lockCount` / `restartPolicyCount` — counts from the parsed
+  contracts, for quick doctor/status summaries.
+- `issues` — the closed `StorageLifecycleIssue` taxonomy below; empty when
+  the daemon's read-only contract check found no problems.
+
+## `StorageLifecycleIssue` kinds
+
+A closed, tagged-union `kind` taxonomy. Every variant is fully bounded —
+never a raw managed path, only bundle-scoped ids and closed reason slugs:
+
+- `missing-storage-contract` / `missing-sync-contract` — the active bundle
+  did not carry the corresponding contract at all.
+- `legacy-bundle-contracts-unavailable` (`bundleVersion`) — the bundle
+  predates the contracts this report validates.
+- `bundle-resolver-unavailable` — the daemon could not resolve a bundle to
+  check in the first place.
+- `storage-contract-invalid` (`contractId`, `reason`, optional `offendingId`)
+  — `reason` is a `StorageContractValidationReason` slug.
+- `sync-contract-invalid` (`contractId`, `reason`, optional `offendingId`) —
+  `reason` is a `SyncContractValidationReason` slug.
+- `missing-restart-policy` / `adoptable-missing-cgroup-leaf` (`roleId`, `vm`)
+  — restart/adoption posture gaps for a specific VM/role.
+
+## `SyncContractValidationReason`
+
+Closed reason slugs for a `sync-contract-invalid` issue:
+
+- `duplicate-lock-id` — the same lock id appears more than once in
+  `sync.json`.
+- `ofd-lock-missing-cloexec` — a lock row declares `cloexecRequired: false`
+  (or omits it), which the generated-row acquisition bridge
+  (`d2b_state::LockSet::acquire_from_generated`, documented in
+  [`sync.md`](./sync.md)) always fails closed on.
+- `fd-passing-missing-lease-transfer-record` — a lock declares an fd-passing
+  mechanism (`ScmRights`/`ExplicitFdMapping`) without the paired
+  inheritance-policy record the mechanism requires.
+- `duplicate-acquire-order` — two locks resolve to the same total-order rank
+  under `SyncJson::global_order_rank`.
+- `lock-missing-protected-resource-id` — a lock row's `resourceId` (the
+  *protected state* resource this lock guards — see the `resourceId`
+  contract note in [`sync.md`](./sync.md)) is null, or does not resolve to
+  exactly one row in the paired `storage.json`. Every generated lock must
+  authorize a real, uniquely identified protected resource before the
+  generated-row runtime bridge can drive it; a lock that fails this check has
+  no runtime-acquirable protected-resource identity at all, and is
+  classified under this reason rather than falling through to
+  `unclassified`.
+- `unclassified` — a validation failure the classifier could not attribute
+  to a more specific reason above. Any newly detected failure mode gets its
+  own named reason instead of silently accumulating under `unclassified`.
+
+## `StorageContractValidationReason`
+
+Closed reason slugs for a `storage-contract-invalid` issue:
+
+- `duplicate-storage-path-id` — the same storage path id appears more than
+  once in `storage.json`.
+- `duplicate-restart-policy` — the same restart policy key appears more than
+  once.
+- `duplicate-degraded-reason` — the same degraded-state reason slug appears
+  more than once.
+- `unclassified` — as above, a fallback that new failure modes must not
+  accumulate under.
+
+## Schema-version compatibility
+
+Adding `lock-missing-protected-resource-id` to `SyncContractValidationReason`
+is an additive, backward-compatible change: it is a new enum member, not a
+renamed or removed one, and `schemaVersion` remains `"v2"`. Older readers that
+do not recognize the new slug still parse every other field; only doctor/CLI
+surfaces that exhaustively match on `SyncContractValidationReason` (see
+`packages/d2b/src/doctor.rs`) needed a corresponding non-breaking update to
+render it distinctly instead of panicking or silently dropping it.

--- a/docs/reference/schemas/v2/sync.md
+++ b/docs/reference/schemas/v2/sync.md
@@ -36,33 +36,54 @@ degraded-state handling.
 `d2b_core::sync::LockSpec` (this schema's Rust type) is consumed directly by
 `d2b-state`'s `LockSet::acquire_from_generated` / `acquire_from_generated_with_clock`
 (`packages/d2b-state/src/lock.rs`) — a single canonical adapter, not a
-per-consumer reinterpretation. The adapter opens/acquires the paired storage
-row's real lock file (resolved through
-`AnchoredResource::resolve_generated`, `packages/d2b-state/src/path.rs`) and
-returns a `LockGuard` whose fields are *exactly* derived from the generated
-contract, with no invented defaults:
+per-consumer reinterpretation. The adapter never invents a row: it takes the
+*whole* trusted `sync.json` (`&SyncJson`) and `storage.json` (`&StorageJson`)
+documents plus opaque `ContractId`s (`lock_id`, and the caller's requested
+`protected_resource_ids`), looks up the exactly-one matching lock/storage rows
+itself (`find_unique_lock`/`find_unique_storage_row` — a missing *or*
+duplicate id fails closed with `InvalidSchema`), and only then resolves the
+generated resource. There is no detached `LockSpec`/`StoragePathSpec` row
+parameter for a caller to substitute a same-id-but-different row into, and no
+caller-supplied `AnchoredResource` for a caller to pair with the wrong row:
 
 | Generated field | Runtime derivation | Invention avoided |
 | --- | --- | --- |
-| `id`, `resourceId`, protected resource ids (from `allowedHolders`'s implied scope + the paired storage row) | Encoded via a deterministic, collision-checked charset bridge (`ContractId` → `d2b_contracts::v2_state::ResourceId`); any collision or unrepresentable byte fails closed (`InvalidSchema`). | No array-index-by-id hack; no silent lowercasing that could collide. |
+| `id`, `resourceId` (the lock file's own paired storage row, looked up internally — never caller-supplied) | Encoded via a deterministic, collision-checked charset bridge (`ContractId` → `d2b_contracts::v2_state::ResourceId`); any collision or unrepresentable byte fails closed (`InvalidSchema`). | No array-index-by-id hack; no silent lowercasing that could collide; no caller-substitutable row. |
+| Protected resource ids | Caller-supplied `&[ContractId]`, deduplicated and each resolved to exactly one `RegularFile` row in the trusted `storage.json`; distinct from the lock file's own `resourceId` (a lock protects state, it is not itself the protected state). Stored on the guard as `protected_resources()`. | No inferred parent/path protection; no silent reuse of the lock file's own id as "the" protected resource. |
 | Total order | `SyncJson::global_order_rank(&lock.id)` — the unique `(scopeClass, anchoredRoot, normalizedPath, lockId)` sort key across every declared lock, converted to a 0-based rank. | No synthetic `global_order` field invented; no fabricated `acquire_after` edges — none exist in the generated contract, so none are processed. |
 | `ownerProcess` / `releaseAuthority` | Rendered to `(ActorKind, name)` via `render_authority`, covering only `RealmController`/`RealmBroker` (the only authorities the current generator emits); every other `AuthorityRef` variant fails closed. Symmetry (`ownerProcess == releaseAuthority`) is required and verified, never assumed. | No default/first-holder guess when the two diverge. |
-| `timeoutPolicy` | `FailFast`/`NoWait` require `timeoutMs == null` and produce no deadline; `BoundedWait` requires `timeoutMs` in `1..=300000` and produces that exact `Duration`. | No synthetic 1ms deadline; extraneous `timeoutMs` on a fail-fast lock fails closed instead of being silently ignored. |
+| `timeoutPolicy` | `FailFast`/`NoWait` require `timeoutMs == null`, perform no sleep, and produce no deadline. `BoundedWait` requires `timeoutMs` in `1..=300000`; the acquire loop computes one absolute monotonic deadline up front (`Clock::now() + timeoutMs`) and, on each contended poll, sleeps `min(remaining, MAX_LOCK_POLL_BACKOFF)` via `poll_backoff_or_deadline` — never an invented fixed backoff, and never a sleep that would overshoot the deadline. | No synthetic 1ms deadline; extraneous `timeoutMs` on a fail-fast lock fails closed instead of being silently ignored; no unconditional max-backoff sleep once less than the cap remains. |
 | Cancellation | Honored unconditionally in the acquire loop (the generated contract carries no distinct cancellation-policy field). | Documented as the strictly-safer default, not a fabricated policy value. |
 | `stalePolicy`, `adoptionPolicy`, `degradeScope` | Passed through byte-for-byte onto the returned `LockGuard` (`generated_stale_policy()`, `generated_adoption_policy()`, `generated_degrade_scope()` accessors) for the caller's own reconciliation, never reinterpreted inside the adapter. | No stale/adoption heuristic baked into `d2b-state`. |
 | `fdPassingPolicy` | Mapped losslessly by name to `d2b_contracts::v2_state::FdTransferPolicy` (`None → Never`, `ScmRights → ScmRightsLeaseHandoff`, `ExplicitFdMapping → ExplicitFdMapping`); `inheritancePolicy` is cross-checked for the one valid pairing per mechanism. | No default transfer mechanism. |
 | `cloexecRequired` | Verified `true` (fails closed otherwise) and independently re-checked via `fcntl(F_GETFD)` on the held fd after open. | Never assumed from the declared policy alone. |
-| Storage row (`path`, `mode`, `mode`/owner metadata) | Resolved through the caller's trusted anchor + `AnchoredResource::resolve_generated` (`openat2` `BENEATH|NO_SYMLINKS|NO_MAGICLINKS`), never a separately-probed inode; cross-checked against `pathTemplate`/`scope`/`kind` on the lock spec itself. | No pairing by array position; no trust of a caller-supplied resource id that doesn't match the row the guard actually opened. |
+| Storage row (`path`, `mode`, owner metadata) | Resolved through the caller's trusted anchor + the crate-private `GeneratedResource::resolve` (`openat2` `BENEATH|NO_SYMLINKS|NO_MAGICLINKS`), never a separately-probed inode; cross-checked against the row's own declared `mode`/owner metadata. The lock file itself is only ever **opened** (`O_RDWR`), never created: a missing lock file fails closed and the caller must route through broker reconciliation to (re-)create it, instead of the generated adapter silently materializing broker-owned state. | No pairing by array position; no `O_CREAT`/`O_EXCL` in the generated-row acquisition path; no trust of a caller-supplied resource id that doesn't match the row the guard actually opened. |
 
-The returned `LockGuard` exposes the held fd's *exact* `(dev, ino)` identity
-via `fd_identity()` (a fresh `fstat` of the held fd on every call — immune to
-a path being replaced after acquisition) and `verify_binding()`, which
-rejects a resource whose id matches but whose containing directory's
-`(dev, ino)` has since changed. A resolved `AnchoredResource` cannot be
-constructed by pairing an arbitrary trusted root with an arbitrary resource
-id: `resolve_generated` walks from the caller's anchor using the generated
-absolute path only, and binds the resource to whichever guard subsequently
-holds it.
+The returned `LockGuard` exposes the held lock file's *exact* `(dev, ino)`
+identity via `fd_identity()` (a fresh `fstat` of the held fd on every call —
+immune to a path being replaced after acquisition), its `lock_file_resource_id()`,
+and its `protected_resources()`. `validate_state_binding(lock_id, resource_id,
+owner, ownership_epoch)` authorizes a *protected* resource — it checks
+`resource_id` for **membership** in `protected_resources`, not equality
+against the lock file's own id — so `AtomicWrite` (`atomic.rs`, unchanged by
+this bridge) can keep calling it with the id of the state it is writing, not
+the id of the lock file guarding that state.
+
+To actually open the protected resource under the guard's authority, callers
+use `LockGuard::bind_protected_resource(storage, resource_id, anchor,
+anchor_path, metadata)`: it re-validates the row against the trusted
+`storage.json`, requires `resource_id` to be a member of this exact guard's
+`protected_resources`, and only then resolves a fresh, non-forgeable
+`GeneratedResource` the same way the lock file itself was resolved — a
+resolved resource is never a clone of anything the caller supplied, and a
+guard that has been released (`release`/`release_in_place`) rejects every
+subsequent bind with `LockReleased`. The crate-private `GeneratedResource`
+capability itself is fully opaque outside `d2b-state`: its resource id,
+directory descriptor, leaf name, and re-derived directory identity are
+private fields with no public constructor, field mutation, or clone that
+would let a resolved resource outlive the guard/anchor that produced it;
+public code only ever receives the legacy `AnchoredResource` shape via
+`into_anchored_resource()`.
 
 This bridge is additive: existing callers of `LockSet::acquire`/
 `acquire_with_clock` (the pre-existing scratch-`LockSpec` API) are

--- a/docs/reference/schemas/v2/sync.md
+++ b/docs/reference/schemas/v2/sync.md
@@ -25,11 +25,15 @@ degraded-state handling.
 - Every host-mutable lock surface has one repair owner. New locks must be
   represented by a generated sync row and reconciled through that owner instead
   of through side-channel lock files or cleanup scripts.
-- Every rendered `LockSpec.resourceId` MUST reference a real generated
-  `storage.json` row (a regular-file lock resource, e.g. the per-realm
-  `keys.lock`/`state.lock`/`audit.lock` rows). A lock with no `resourceId` has
-  no runtime-acquirable identity and cannot be driven by the generated-row
-  runtime bridge below.
+- Every rendered `LockSpec.resourceId` MUST be non-null and MUST reference a
+  real generated `storage.json` row — the *protected state* resource this lock
+  guards (its schema-intended semantic), never the lock file's own row. The
+  lock file's own row is a distinct concept, discovered internally (never by a
+  second id field) as the unique regular-file `storage.json` row whose
+  `pathTemplate` exactly equals this lock's own `pathTemplate` (e.g. the
+  per-realm `keys.lock`/`state.lock`/`audit.lock` rows). A lock with no
+  `resourceId` or no `pathTemplate` has no runtime-acquirable identity and
+  cannot be driven by the generated-row runtime bridge below.
 
 ## Runtime bridge: `d2b_state::LockSet::acquire_from_generated`
 
@@ -38,18 +42,21 @@ degraded-state handling.
 (`packages/d2b-state/src/lock.rs`) — a single canonical adapter, not a
 per-consumer reinterpretation. The adapter never invents a row: it takes the
 *whole* trusted `sync.json` (`&SyncJson`) and `storage.json` (`&StorageJson`)
-documents plus opaque `ContractId`s (`lock_id`, and the caller's requested
-`protected_resource_ids`), looks up the exactly-one matching lock/storage rows
-itself (`find_unique_lock`/`find_unique_storage_row` — a missing *or*
-duplicate id fails closed with `InvalidSchema`), and only then resolves the
-generated resource. There is no detached `LockSpec`/`StoragePathSpec` row
-parameter for a caller to substitute a same-id-but-different row into, and no
-caller-supplied `AnchoredResource` for a caller to pair with the wrong row:
+documents plus one opaque `ContractId` (`lock_id`), looks up the exactly-one
+matching lock row itself (`find_unique_lock` — a missing *or* duplicate id
+fails closed with `InvalidSchema`), and derives both the protected resource and
+the lock file's own row exclusively from that lock's own fields — never from
+any caller-supplied resource selection. There is no detached `LockSpec`/
+`StoragePathSpec` row parameter for a caller to substitute a same-id-but-
+different row into, no caller-supplied protected-resource parameter of any
+kind, and no caller-supplied `AnchoredResource` for a caller to pair with the
+wrong row:
 
 | Generated field | Runtime derivation | Invention avoided |
 | --- | --- | --- |
-| `id`, `resourceId` (the lock file's own paired storage row, looked up internally — never caller-supplied) | Encoded via a deterministic, collision-checked charset bridge (`ContractId` → `d2b_contracts::v2_state::ResourceId`); any collision or unrepresentable byte fails closed (`InvalidSchema`). | No array-index-by-id hack; no silent lowercasing that could collide; no caller-substitutable row. |
-| Protected resource ids | Caller-supplied `&[ContractId]`, deduplicated and each resolved to exactly one `RegularFile` row in the trusted `storage.json`; distinct from the lock file's own `resourceId` (a lock protects state, it is not itself the protected state). Stored on the guard as `protected_resources()`. | No inferred parent/path protection; no silent reuse of the lock file's own id as "the" protected resource. |
+| `id` | Encoded via a deterministic, collision-checked charset bridge (`ContractId` → `d2b_contracts::v2_state::ResourceId`); any collision or unrepresentable byte fails closed (`InvalidSchema`). | No array-index-by-id hack; no silent lowercasing that could collide. |
+| `resourceId` (the *protected state* resource this lock guards) | Required non-null (`InvalidSchema` if absent) and resolved to exactly one row in the trusted `storage.json` via `find_unique_storage_row` (a missing or duplicate id fails closed); the row must share the lock's own `scope`. Stored on the guard as `protected_resources()` (always exactly the one, schema-declared element — never a caller-selected set). | No caller-supplied protected-resource parameter of any kind; no inferred parent/path protection; no silent reuse of the lock file's own row as "the" protected resource. |
+| Lock file's own storage row (a distinct concept from `resourceId` — see above) | Resolved internally via `find_unique_lock_file_row`: the unique row in `storage.json` whose `pathTemplate` exactly equals this lock's own (mandatory) `pathTemplate`. That row must be a `RegularFile` sharing the lock's `scope`, must declare an owner (`owner.value`) matching `ownerProcess.value`, and must declare both the `no-symlink` and `no-magic-link` invariants. Stored on the guard as `lock_file_resource_id()`. | No second schema field for the lock-file row; no caller-suppliable row of any kind; a path-template collision (more than one match) or a scope/owner/invariant mismatch fails closed rather than guessing. |
 | Total order | `SyncJson::global_order_rank(&lock.id)` — the unique `(scopeClass, anchoredRoot, normalizedPath, lockId)` sort key across every declared lock, converted to a 0-based rank. | No synthetic `global_order` field invented; no fabricated `acquire_after` edges — none exist in the generated contract, so none are processed. |
 | `ownerProcess` / `releaseAuthority` | Rendered to `(ActorKind, name)` via `render_authority`, covering only `RealmController`/`RealmBroker` (the only authorities the current generator emits); every other `AuthorityRef` variant fails closed. Symmetry (`ownerProcess == releaseAuthority`) is required and verified, never assumed. | No default/first-holder guess when the two diverge. |
 | `timeoutPolicy` | `FailFast`/`NoWait` require `timeoutMs == null`, perform no sleep, and produce no deadline. `BoundedWait` requires `timeoutMs` in `1..=300000`; the acquire loop computes one absolute monotonic deadline up front (`Clock::now() + timeoutMs`) and, on each contended poll, sleeps `min(remaining, MAX_LOCK_POLL_BACKOFF)` via `poll_backoff_or_deadline` — never an invented fixed backoff, and never a sleep that would overshoot the deadline. | No synthetic 1ms deadline; extraneous `timeoutMs` on a fail-fast lock fails closed instead of being silently ignored; no unconditional max-backoff sleep once less than the cap remains. |
@@ -57,36 +64,41 @@ caller-supplied `AnchoredResource` for a caller to pair with the wrong row:
 | `stalePolicy`, `adoptionPolicy`, `degradeScope` | Passed through byte-for-byte onto the returned `LockGuard` (`generated_stale_policy()`, `generated_adoption_policy()`, `generated_degrade_scope()` accessors) for the caller's own reconciliation, never reinterpreted inside the adapter. | No stale/adoption heuristic baked into `d2b-state`. |
 | `fdPassingPolicy` | Mapped losslessly by name to `d2b_contracts::v2_state::FdTransferPolicy` (`None → Never`, `ScmRights → ScmRightsLeaseHandoff`, `ExplicitFdMapping → ExplicitFdMapping`); `inheritancePolicy` is cross-checked for the one valid pairing per mechanism. | No default transfer mechanism. |
 | `cloexecRequired` | Verified `true` (fails closed otherwise) and independently re-checked via `fcntl(F_GETFD)` on the held fd after open. | Never assumed from the declared policy alone. |
-| Storage row (`path`, `mode`, owner metadata) | Resolved through the caller's trusted anchor + the crate-private `GeneratedResource::resolve` (`openat2` `BENEATH|NO_SYMLINKS|NO_MAGICLINKS`), never a separately-probed inode; cross-checked against the row's own declared `mode`/owner metadata. The lock file itself is only ever **opened** (`O_RDWR`), never created: a missing lock file fails closed and the caller must route through broker reconciliation to (re-)create it, instead of the generated adapter silently materializing broker-owned state. | No pairing by array position; no `O_CREAT`/`O_EXCL` in the generated-row acquisition path; no trust of a caller-supplied resource id that doesn't match the row the guard actually opened. |
+| Lock-file row (`path`, `mode`, owner metadata) | Resolved through the caller's trusted anchor + the crate-private `GeneratedResource::resolve` (`openat2` `BENEATH|NO_SYMLINKS|NO_MAGICLINKS`), never a separately-probed inode; cross-checked against the row's own declared `mode`/owner metadata. The lock file itself is only ever **opened** (`O_RDWR`), never created: a missing lock file fails closed and the caller must route through broker reconciliation to (re-)create it, instead of the generated adapter silently materializing broker-owned state. | No pairing by array position; no `O_CREAT`/`O_EXCL` in the generated-row acquisition path; no trust of a caller-supplied resource id that doesn't match the row the guard actually opened. |
 
 The returned `LockGuard` exposes the held lock file's *exact* `(dev, ino)`
 identity via `fd_identity()` (a fresh `fstat` of the held fd on every call —
 immune to a path being replaced after acquisition), its `lock_file_resource_id()`,
-and its `protected_resources()`. `validate_state_binding(lock_id, resource_id,
-owner, ownership_epoch)` authorizes a *protected* resource — it checks
-`resource_id` for **membership** in `protected_resources`, not equality
-against the lock file's own id — so `AtomicWrite` (`atomic.rs`, unchanged by
-this bridge) can keep calling it with the id of the state it is writing, not
-the id of the lock file guarding that state.
+and its `protected_resources()` (always exactly one element: the schema's own
+`resourceId`, encoded). `validate_state_binding(lock_id, resource_id, owner,
+ownership_epoch)` authorizes the *protected* resource — it checks `resource_id`
+against `protected_resources` (by construction, always the single
+schema-declared protected resource, never the lock file's own id) — so
+`AtomicWrite` (`atomic.rs`, unchanged by this bridge) can keep calling it with
+the id of the state it is writing, not the id of the lock file guarding that
+state.
 
 To actually open the protected resource under the guard's authority, callers
-use `LockGuard::bind_protected_resource(storage, resource_id, anchor,
-anchor_path, metadata)`: it re-validates the row against the trusted
-`storage.json`, requires `resource_id` to be a member of this exact guard's
-`protected_resources`, and only then resolves a fresh, non-forgeable
-`GeneratedResource` the same way the lock file itself was resolved — a
-resolved resource is never a clone of anything the caller supplied, and a
-guard that has been released (`release`/`release_in_place`) rejects every
-subsequent bind with `LockReleased`. The crate-private `GeneratedResource`
-capability itself is fully opaque outside `d2b-state`: its resource id,
-directory descriptor, leaf name, and re-derived directory identity are
-private fields with no public constructor, field mutation, or clone that
-would let a resolved resource outlive the guard/anchor that produced it;
-public code only ever receives the legacy `AnchoredResource` shape via
-`into_anchored_resource()`.
+use `LockGuard::bind_protected_resource(storage, anchor, anchor_path,
+metadata)`: there is no caller-supplied resource-id parameter — the resource
+resolved is always exactly the one this guard's generated lock declared via
+`resourceId`, re-validated against the trusted `storage.json`. It then resolves
+a fresh, non-forgeable `GeneratedResource` the same way the lock file itself
+was resolved — a resolved resource is never a clone of anything the caller
+supplied, and a guard that has been released (`release`/`release_in_place`)
+rejects every subsequent bind with `LockReleased`. The crate-private
+`GeneratedResource` capability itself is fully opaque outside `d2b-state`: its
+resource id, directory descriptor, leaf name, and re-derived directory
+identity are private fields with no public constructor, field mutation, or
+clone that would let a resolved resource outlive the guard/anchor that
+produced it; public code only ever receives the legacy `AnchoredResource` shape
+via `into_anchored_resource()`.
 
 This bridge is additive: existing callers of `LockSet::acquire`/
 `acquire_with_clock` (the pre-existing scratch-`LockSpec` API) are
 unaffected, and no field was added to `d2b_core::sync::LockSpec` or its
 nested types — the generated schema (`sync.json`) is unchanged by this
-bridge; only `d2b-state`'s runtime consumption of it is new.
+bridge; only `d2b-state`'s runtime consumption of it is new. In particular,
+`resourceId`'s runtime meaning (the protected state resource, not the lock
+file's own row) is this bridge's semantic reading of an existing field, not a
+schema change.

--- a/docs/reference/schemas/v2/sync.md
+++ b/docs/reference/schemas/v2/sync.md
@@ -59,12 +59,12 @@ wrong row:
 | Lock file's own storage row (a distinct concept from `resourceId` — see above) | Resolved internally via `find_unique_lock_file_row`: the unique row in `storage.json` whose `pathTemplate` exactly equals this lock's own (mandatory) `pathTemplate`. That row must be a `RegularFile` sharing the lock's `scope`, must declare an owner (`owner.value`) matching `ownerProcess.value`, and must declare both the `no-symlink` and `no-magic-link` invariants. Stored on the guard as `lock_file_resource_id()`. | No second schema field for the lock-file row; no caller-suppliable row of any kind; a path-template collision (more than one match) or a scope/owner/invariant mismatch fails closed rather than guessing. |
 | Total order | `SyncJson::global_order_rank(&lock.id)` — the unique `(scopeClass, anchoredRoot, normalizedPath, lockId)` sort key across every declared lock, converted to a 0-based rank. | No synthetic `global_order` field invented; no fabricated `acquire_after` edges — none exist in the generated contract, so none are processed. |
 | `ownerProcess` / `releaseAuthority` | Rendered to `(ActorKind, name)` via `render_authority`, covering only `RealmController`/`RealmBroker` (the only authorities the current generator emits); every other `AuthorityRef` variant fails closed. Symmetry (`ownerProcess == releaseAuthority`) is required and verified, never assumed. | No default/first-holder guess when the two diverge. |
-| `timeoutPolicy` | `FailFast`/`NoWait` require `timeoutMs == null`, perform no sleep, and produce no deadline. `BoundedWait` requires `timeoutMs` in `1..=300000`; the acquire loop computes one absolute monotonic deadline up front (`Clock::now() + timeoutMs`) and, on each contended poll, sleeps `min(remaining, MAX_LOCK_POLL_BACKOFF)` via `poll_backoff_or_deadline` — never an invented fixed backoff, and never a sleep that would overshoot the deadline. | No synthetic 1ms deadline; extraneous `timeoutMs` on a fail-fast lock fails closed instead of being silently ignored; no unconditional max-backoff sleep once less than the cap remains. |
+| `timeoutPolicy` | `FailFast`/`NoWait` require `timeoutMs == null`, perform no sleep, and produce no deadline. `BoundedWait` requires `timeoutMs` in `1..=300000`; the acquire loop computes one absolute monotonic deadline up front (`Clock::now() + timeoutMs`) and, on each contended poll, sleeps `min(remaining, MAX_LOCK_POLL_BACKOFF)` via `poll_backoff_or_deadline` — never an invented fixed backoff, and never a sleep that would overshoot the deadline. Before every retry attempt after the first — including immediately after any sleep — the loop re-checks the same absolute deadline (`deadline_elapsed`) and fails closed on a late wakeup rather than issuing one more `set_ofd_lock` attempt past the deadline. | No synthetic 1ms deadline; extraneous `timeoutMs` on a fail-fast lock fails closed instead of being silently ignored; no unconditional max-backoff sleep once less than the cap remains; no acquisition past the deadline due to OS scheduling delay after a sleep returns. |
 | Cancellation | Honored unconditionally in the acquire loop (the generated contract carries no distinct cancellation-policy field). | Documented as the strictly-safer default, not a fabricated policy value. |
 | `stalePolicy`, `adoptionPolicy`, `degradeScope` | Passed through byte-for-byte onto the returned `LockGuard` (`generated_stale_policy()`, `generated_adoption_policy()`, `generated_degrade_scope()` accessors) for the caller's own reconciliation, never reinterpreted inside the adapter. | No stale/adoption heuristic baked into `d2b-state`. |
 | `fdPassingPolicy` | Mapped losslessly by name to `d2b_contracts::v2_state::FdTransferPolicy` (`None → Never`, `ScmRights → ScmRightsLeaseHandoff`, `ExplicitFdMapping → ExplicitFdMapping`); `inheritancePolicy` is cross-checked for the one valid pairing per mechanism. | No default transfer mechanism. |
 | `cloexecRequired` | Verified `true` (fails closed otherwise) and independently re-checked via `fcntl(F_GETFD)` on the held fd after open. | Never assumed from the declared policy alone. |
-| Lock-file row (`path`, `mode`, owner metadata) | Resolved through the caller's trusted anchor + the crate-private `GeneratedResource::resolve` (`openat2` `BENEATH|NO_SYMLINKS|NO_MAGICLINKS`), never a separately-probed inode; cross-checked against the row's own declared `mode`/owner metadata. The lock file itself is only ever **opened** (`O_RDWR`), never created: a missing lock file fails closed and the caller must route through broker reconciliation to (re-)create it, instead of the generated adapter silently materializing broker-owned state. | No pairing by array position; no `O_CREAT`/`O_EXCL` in the generated-row acquisition path; no trust of a caller-supplied resource id that doesn't match the row the guard actually opened. |
+| Lock-file row (`path`, `mode`, owner metadata) | Resolved through the caller's trusted anchor + the crate-private `GeneratedResource::resolve` (`openat2` `BENEATH|NO_SYMLINKS|NO_MAGICLINKS`), never a separately-probed inode; cross-checked against the row's own declared `mode`/owner metadata. The lock file itself is only ever **opened** (`O_RDWR`), never created by the holder: a missing lock file fails closed and the caller must route through broker reconciliation to (re-)create it. Broker-side reconciliation (`d2b-priv-broker`'s `reconcile_storage_scope`) creates a missing generated regular-file lock row anchored/`O_NOFOLLOW`, with `O_CREAT\|O_EXCL\|O_CLOEXEC`, the row's exact declared owner/group/mode, `fsync`s the new file then its parent directory, and on `EEXIST` validates the existing file's type/owner/mode/link-count and `fsync`s the parent before reporting success — never a holder-side create and never an arbitrary-path regular-file creation. | No pairing by array position; no `O_CREAT`/`O_EXCL` in the generated-row acquisition path; no trust of a caller-supplied resource id that doesn't match the row the guard actually opened. |
 
 The returned `LockGuard` exposes the held lock file's *exact* `(dev, ino)`
 identity via `fd_identity()` (a fresh `fstat` of the held fd on every call —
@@ -78,21 +78,44 @@ schema-declared protected resource, never the lock file's own id) — so
 the id of the state it is writing, not the id of the lock file guarding that
 state.
 
-To actually open the protected resource under the guard's authority, callers
-use `LockGuard::bind_protected_resource(storage, anchor, anchor_path,
-metadata)`: there is no caller-supplied resource-id parameter — the resource
-resolved is always exactly the one this guard's generated lock declared via
-`resourceId`, re-validated against the trusted `storage.json`. It then resolves
-a fresh, non-forgeable `GeneratedResource` the same way the lock file itself
-was resolved — a resolved resource is never a clone of anything the caller
-supplied, and a guard that has been released (`release`/`release_in_place`)
-rejects every subsequent bind with `LockReleased`. The crate-private
-`GeneratedResource` capability itself is fully opaque outside `d2b-state`: its
-resource id, directory descriptor, leaf name, and re-derived directory
-identity are private fields with no public constructor, field mutation, or
-clone that would let a resolved resource outlive the guard/anchor that
-produced it; public code only ever receives the legacy `AnchoredResource` shape
-via `into_anchored_resource()`.
+To actually use the protected resource under the guard's authority, callers
+call `LockGuard::protected_resource(resource_id)` — a no-argument (besides the
+opaque id it is asserting, purely for a fail-closed identity check), no-storage,
+no-anchor, no-metadata borrow of a capability the guard already resolved and
+retained *once*, at generated-lock acquisition time (`acquire_from_generated_with_clock`),
+from the same trusted `storage.json` + anchor that call was given. There is no
+way to hand the guard a new inventory, a new anchor, or a "same id, different
+row" substitute after acquisition: the `GeneratedResource` it resolved is
+retained on the guard for its entire lifetime and is never re-resolved. Passing
+any `resource_id` other than the guard's own single protected resource (for
+example, the lock file's own `lock_file_resource_id()`) is rejected with
+`LockMismatch`, as is any call after `release`/`release_in_place`
+(`LockReleased`).
+
+`protected_resource` returns a `GuardedResource<'guard>` — a non-cloneable,
+non-`Debug` capability borrowed from (and lifetime-tied to) `&LockGuard`. It
+cannot be constructed, mutated, or cloned by public code; it exposes only
+`resource_id()` (the resolved resource's own id, for a fail-closed identity
+check — never a caller-supplied override) and `verify_live_identity()` (a
+fresh `fstat` of the bound directory, re-checked against the identity captured
+once at resolution time, so a resolved binding can never silently authorize
+access through a since-replaced directory). The underlying crate-private
+`GeneratedResource` capability itself remains fully opaque outside
+`d2b-state`: its resource id, directory descriptor, leaf name, and captured
+directory identity are private fields with no public constructor, field
+mutation, or clone that would let a resolved resource outlive the guard that
+produced it.
+
+`d2b-state`'s `AtomicWrite<RealAtomicFilesystem>` exposes two generated/guarded
+entry points built on this capability — `write_guarded(guard, resource_id,
+payload, policy)` and `read_guarded::<T>(guard, resource_id, policy)` — which
+resolve the `GuardedResource`, re-verify its live identity, and perform the
+durable write/read, returning only the plain `AtomicWriteReceipt`/
+`DurableState<T>` result: the filesystem handle and the `GuardedResource`
+itself never escape these calls. The pre-existing `AtomicWrite::write`/`read`
+APIs (`atomic.rs`, otherwise unchanged by this bridge) remain available for
+callers still driving a plain `AnchoredResource`; the guarded entry points are
+the non-forgeable authority seam for callers consuming generated locks.
 
 This bridge is additive: existing callers of `LockSet::acquire`/
 `acquire_with_clock` (the pre-existing scratch-`LockSpec` API) are

--- a/docs/reference/schemas/v2/sync.md
+++ b/docs/reference/schemas/v2/sync.md
@@ -25,3 +25,47 @@ degraded-state handling.
 - Every host-mutable lock surface has one repair owner. New locks must be
   represented by a generated sync row and reconciled through that owner instead
   of through side-channel lock files or cleanup scripts.
+- Every rendered `LockSpec.resourceId` MUST reference a real generated
+  `storage.json` row (a regular-file lock resource, e.g. the per-realm
+  `keys.lock`/`state.lock`/`audit.lock` rows). A lock with no `resourceId` has
+  no runtime-acquirable identity and cannot be driven by the generated-row
+  runtime bridge below.
+
+## Runtime bridge: `d2b_state::LockSet::acquire_from_generated`
+
+`d2b_core::sync::LockSpec` (this schema's Rust type) is consumed directly by
+`d2b-state`'s `LockSet::acquire_from_generated` / `acquire_from_generated_with_clock`
+(`packages/d2b-state/src/lock.rs`) — a single canonical adapter, not a
+per-consumer reinterpretation. The adapter opens/acquires the paired storage
+row's real lock file (resolved through
+`AnchoredResource::resolve_generated`, `packages/d2b-state/src/path.rs`) and
+returns a `LockGuard` whose fields are *exactly* derived from the generated
+contract, with no invented defaults:
+
+| Generated field | Runtime derivation | Invention avoided |
+| --- | --- | --- |
+| `id`, `resourceId`, protected resource ids (from `allowedHolders`'s implied scope + the paired storage row) | Encoded via a deterministic, collision-checked charset bridge (`ContractId` → `d2b_contracts::v2_state::ResourceId`); any collision or unrepresentable byte fails closed (`InvalidSchema`). | No array-index-by-id hack; no silent lowercasing that could collide. |
+| Total order | `SyncJson::global_order_rank(&lock.id)` — the unique `(scopeClass, anchoredRoot, normalizedPath, lockId)` sort key across every declared lock, converted to a 0-based rank. | No synthetic `global_order` field invented; no fabricated `acquire_after` edges — none exist in the generated contract, so none are processed. |
+| `ownerProcess` / `releaseAuthority` | Rendered to `(ActorKind, name)` via `render_authority`, covering only `RealmController`/`RealmBroker` (the only authorities the current generator emits); every other `AuthorityRef` variant fails closed. Symmetry (`ownerProcess == releaseAuthority`) is required and verified, never assumed. | No default/first-holder guess when the two diverge. |
+| `timeoutPolicy` | `FailFast`/`NoWait` require `timeoutMs == null` and produce no deadline; `BoundedWait` requires `timeoutMs` in `1..=300000` and produces that exact `Duration`. | No synthetic 1ms deadline; extraneous `timeoutMs` on a fail-fast lock fails closed instead of being silently ignored. |
+| Cancellation | Honored unconditionally in the acquire loop (the generated contract carries no distinct cancellation-policy field). | Documented as the strictly-safer default, not a fabricated policy value. |
+| `stalePolicy`, `adoptionPolicy`, `degradeScope` | Passed through byte-for-byte onto the returned `LockGuard` (`generated_stale_policy()`, `generated_adoption_policy()`, `generated_degrade_scope()` accessors) for the caller's own reconciliation, never reinterpreted inside the adapter. | No stale/adoption heuristic baked into `d2b-state`. |
+| `fdPassingPolicy` | Mapped losslessly by name to `d2b_contracts::v2_state::FdTransferPolicy` (`None → Never`, `ScmRights → ScmRightsLeaseHandoff`, `ExplicitFdMapping → ExplicitFdMapping`); `inheritancePolicy` is cross-checked for the one valid pairing per mechanism. | No default transfer mechanism. |
+| `cloexecRequired` | Verified `true` (fails closed otherwise) and independently re-checked via `fcntl(F_GETFD)` on the held fd after open. | Never assumed from the declared policy alone. |
+| Storage row (`path`, `mode`, `mode`/owner metadata) | Resolved through the caller's trusted anchor + `AnchoredResource::resolve_generated` (`openat2` `BENEATH|NO_SYMLINKS|NO_MAGICLINKS`), never a separately-probed inode; cross-checked against `pathTemplate`/`scope`/`kind` on the lock spec itself. | No pairing by array position; no trust of a caller-supplied resource id that doesn't match the row the guard actually opened. |
+
+The returned `LockGuard` exposes the held fd's *exact* `(dev, ino)` identity
+via `fd_identity()` (a fresh `fstat` of the held fd on every call — immune to
+a path being replaced after acquisition) and `verify_binding()`, which
+rejects a resource whose id matches but whose containing directory's
+`(dev, ino)` has since changed. A resolved `AnchoredResource` cannot be
+constructed by pairing an arbitrary trusted root with an arbitrary resource
+id: `resolve_generated` walks from the caller's anchor using the generated
+absolute path only, and binds the resource to whichever guard subsequently
+holds it.
+
+This bridge is additive: existing callers of `LockSet::acquire`/
+`acquire_with_clock` (the pre-existing scratch-`LockSpec` API) are
+unaffected, and no field was added to `d2b_core::sync::LockSpec` or its
+nested types — the generated schema (`sync.json`) is unchanged by this
+bridge; only `d2b-state`'s runtime consumption of it is new.

--- a/nixos-modules/realm-storage-rows.nix
+++ b/nixos-modules/realm-storage-rows.nix
@@ -575,7 +575,13 @@ let
           inherit scope realmId;
           path = "${stateRoot}/store-view/sync.lock";
           normalizedPath = "r/${realmId}/w/${workloadId}/store-view/sync.lock";
-          resourceId = (normalized "workload-store-view-live").resourceId;
+          # Protects the aggregate store-view directory (covering the
+          # live/meta/state/gcroots leaves beneath it), not just one leaf:
+          # this lock's whole mutation domain is the aggregate, so its
+          # protected resource must be too. See the hand-authored
+          # "path:workload-store-view:${workloadId}" row above, not a
+          # `normalized "workload-store-view-*"` single-leaf lookup.
+          resourceId = "path:workload-store-view:${workloadId}";
         })
         (mkOfdLock {
           id = "lock:workload-keys:${workloadId}";

--- a/nixos-modules/realm-storage-rows.nix
+++ b/nixos-modules/realm-storage-rows.nix
@@ -111,10 +111,14 @@ let
       path,
       realmId,
       normalizedPath,
-      # The storage-row id of the regular-file this OFD lock is taken on.
-      # Mandatory (no default/null): every generated lock MUST be paired
-      # with the exact storage row for its lock file so a runtime consumer
-      # can resolve/open/create it without inventing a resource identity.
+      # The storage-row id of the protected state resource this OFD lock
+      # guards (e.g. the state/store-view/keys directory it serializes
+      # access to) -- NOT the lock file's own storage row. Mandatory (no
+      # default/null): every generated lock MUST declare exactly which
+      # resource it protects so a runtime consumer never invents that
+      # binding. The lock file's own storage row is resolved separately,
+      # internally, by exact pathTemplate match against this lock's
+      # `path`, so it needs no id here.
       resourceId,
       owner ? brokerActor realmId,
     }:
@@ -563,7 +567,7 @@ let
           inherit scope realmId;
           path = "${stateRoot}/state/state.lock";
           normalizedPath = "r/${realmId}/w/${workloadId}/state/state.lock";
-          resourceId = "path:workload-state-lock:${workloadId}";
+          resourceId = (normalized "workload-state-data").resourceId;
           owner = controllerActor realmId;
         })
         (mkOfdLock {
@@ -571,14 +575,14 @@ let
           inherit scope realmId;
           path = "${stateRoot}/store-view/sync.lock";
           normalizedPath = "r/${realmId}/w/${workloadId}/store-view/sync.lock";
-          resourceId = "path:workload-store-lock:${workloadId}";
+          resourceId = (normalized "workload-store-view-live").resourceId;
         })
         (mkOfdLock {
           id = "lock:workload-keys:${workloadId}";
           inherit scope realmId;
           path = "${stateRoot}/keys/keys.lock";
           normalizedPath = "r/${realmId}/w/${workloadId}/keys/keys.lock";
-          resourceId = "path:workload-keys-lock:${workloadId}";
+          resourceId = (normalized "workload-keys").resourceId;
         })
       ];
     in
@@ -799,7 +803,7 @@ let
           inherit scope realmId;
           path = "${stateRoot}/controller/state.lock";
           normalizedPath = "r/${realmId}/controller/state.lock";
-          resourceId = "path:realm-controller-lock:${realmId}";
+          resourceId = (normalized "realm-controller-state").resourceId;
           owner = controllerActor realmId;
         })
         (mkOfdLock {
@@ -807,14 +811,14 @@ let
           inherit scope realmId;
           path = "${stateRoot}/broker/state.lock";
           normalizedPath = "r/${realmId}/broker/state.lock";
-          resourceId = "path:realm-broker-lock:${realmId}";
+          resourceId = (normalized "realm-broker-state").resourceId;
         })
         (mkOfdLock {
           id = "lock:realm-audit:${realmId}";
           inherit scope realmId;
           path = "${stateRoot}/audit/audit.lock";
           normalizedPath = "r/${realmId}/audit/audit.lock";
-          resourceId = "path:realm-audit-lock:${realmId}";
+          resourceId = (normalized "realm-audit").resourceId;
         })
       ] ++ lib.flatten (map (workload: workload.locks) workloads);
       providers = map

--- a/nixos-modules/realm-storage-rows.nix
+++ b/nixos-modules/realm-storage-rows.nix
@@ -111,12 +111,16 @@ let
       path,
       realmId,
       normalizedPath,
+      # The storage-row id of the regular-file this OFD lock is taken on.
+      # Mandatory (no default/null): every generated lock MUST be paired
+      # with the exact storage row for its lock file so a runtime consumer
+      # can resolve/open/create it without inventing a resource identity.
+      resourceId,
       owner ? brokerActor realmId,
     }:
     {
-      inherit id scope;
+      inherit id scope resourceId;
       pathTemplate = path;
-      resourceId = null;
       kind = "ofd";
       ownerProcess = owner;
       allowedHolders = [ owner ];
@@ -297,6 +301,15 @@ let
           writers = [ (controllerActor realmId) (brokerActor realmId) ];
         })
         (mkPath {
+          id = "path:workload-state-lock:${workloadId}";
+          inherit scope realmId;
+          path = "${stateRoot}/state/state.lock";
+          kind = "regular-file";
+          mode = "0600";
+          owner = controllerUser realmId;
+          readers = [ (controllerActor realmId) ];
+        })
+        (mkPath {
           id = (normalized "workload-disks").resourceId;
           inherit scope realmId;
           path = (normalized "workload-disks").path;
@@ -440,6 +453,16 @@ let
           sensitivity = "secret-adjacent";
         })
         (mkPath {
+          id = "path:workload-keys-lock:${workloadId}";
+          inherit scope realmId;
+          path = "${stateRoot}/keys/keys.lock";
+          kind = "regular-file";
+          mode = "0600";
+          owner = brokerUser realmId;
+          readers = [ (brokerActor realmId) ];
+          sensitivity = "secret-adjacent";
+        })
+        (mkPath {
           id = "path:workload-audit:${workloadId}";
           inherit scope realmId;
           path = auditRoot;
@@ -540,6 +563,7 @@ let
           inherit scope realmId;
           path = "${stateRoot}/state/state.lock";
           normalizedPath = "r/${realmId}/w/${workloadId}/state/state.lock";
+          resourceId = "path:workload-state-lock:${workloadId}";
           owner = controllerActor realmId;
         })
         (mkOfdLock {
@@ -547,12 +571,14 @@ let
           inherit scope realmId;
           path = "${stateRoot}/store-view/sync.lock";
           normalizedPath = "r/${realmId}/w/${workloadId}/store-view/sync.lock";
+          resourceId = "path:workload-store-lock:${workloadId}";
         })
         (mkOfdLock {
           id = "lock:workload-keys:${workloadId}";
           inherit scope realmId;
           path = "${stateRoot}/keys/keys.lock";
           normalizedPath = "r/${realmId}/w/${workloadId}/keys/keys.lock";
+          resourceId = "path:workload-keys-lock:${workloadId}";
         })
       ];
     in
@@ -652,6 +678,15 @@ let
           writers = [ (controllerActor realmId) (brokerActor realmId) ];
         })
         (mkPath {
+          id = "path:realm-controller-lock:${realmId}";
+          inherit scope realmId;
+          path = "${stateRoot}/controller/state.lock";
+          kind = "regular-file";
+          mode = "0600";
+          owner = controllerUser realmId;
+          readers = [ (controllerActor realmId) ];
+        })
+        (mkPath {
           id = "path:realm-controller-keys:${realmId}";
           inherit scope realmId;
           path = "${stateRoot}/controller/keys";
@@ -668,11 +703,30 @@ let
           readers = [ (brokerActor realmId) ];
         })
         (mkPath {
+          id = "path:realm-broker-lock:${realmId}";
+          inherit scope realmId;
+          path = "${stateRoot}/broker/state.lock";
+          kind = "regular-file";
+          mode = "0600";
+          owner = brokerUser realmId;
+          readers = [ (brokerActor realmId) ];
+        })
+        (mkPath {
           id = (normalized "realm-audit").resourceId;
           inherit scope realmId;
           path = (normalized "realm-audit").path;
           owner = brokerUser realmId;
           writers = [ (brokerActor realmId) ];
+          sensitivity = "audit";
+        })
+        (mkPath {
+          id = "path:realm-audit-lock:${realmId}";
+          inherit scope realmId;
+          path = "${stateRoot}/audit/audit.lock";
+          kind = "regular-file";
+          mode = "0600";
+          owner = brokerUser realmId;
+          readers = [ (brokerActor realmId) ];
           sensitivity = "audit";
         })
         (mkPath {
@@ -745,6 +799,7 @@ let
           inherit scope realmId;
           path = "${stateRoot}/controller/state.lock";
           normalizedPath = "r/${realmId}/controller/state.lock";
+          resourceId = "path:realm-controller-lock:${realmId}";
           owner = controllerActor realmId;
         })
         (mkOfdLock {
@@ -752,12 +807,14 @@ let
           inherit scope realmId;
           path = "${stateRoot}/broker/state.lock";
           normalizedPath = "r/${realmId}/broker/state.lock";
+          resourceId = "path:realm-broker-lock:${realmId}";
         })
         (mkOfdLock {
           id = "lock:realm-audit:${realmId}";
           inherit scope realmId;
           path = "${stateRoot}/audit/audit.lock";
           normalizedPath = "r/${realmId}/audit/audit.lock";
+          resourceId = "path:realm-audit-lock:${realmId}";
         })
       ] ++ lib.flatten (map (workload: workload.locks) workloads);
       providers = map

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1671,6 +1671,7 @@ name = "d2b-state"
 version = "2.0.0"
 dependencies = [
  "d2b-contracts",
+ "d2b-core",
  "nix 0.29.0",
  "rustix 0.38.44",
  "serde",

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -13,6 +13,7 @@ use d2b_core::{
         ActorKind, PrincipalKind, RepairPolicy, SensitivityClass, StorageInvariant, StorageJson,
         StoragePathKind,
     },
+    storage_lifecycle::{StorageContractValidationReason, SyncContractValidationReason},
     sync::{LockKind, SyncJson},
 };
 use regex::Regex;
@@ -402,6 +403,89 @@ fn storage_lifecycle_report_schema_and_reference_are_committed() {
     assert!(reference.contains("/var/lib/d2b/daemon-state/storage-lifecycle-report.json"));
     assert!(reference.contains("./schemas/v2/storage-lifecycle-report.json"));
     assert!(xtask.contains("\"storage-lifecycle-report.json\""));
+}
+
+/// A real drift/round-trip check for the new `lock-missing-protected-resource-id`
+/// `SyncContractValidationReason` member: it walks *every* variant of the
+/// actual `d2b_core::storage_lifecycle::SyncContractValidationReason` (and its
+/// `StorageContractValidationReason` sibling) Rust enum, serializes each with
+/// `serde_json` (the exact same serializer `schemars`/`xtask gen-schemas`
+/// renders the committed schema from), and asserts the resulting slug set is
+/// *exactly* — neither a subset nor a superset of — the committed schema's
+/// enum array. This catches both a schema/Rust drift in either direction: a
+/// new Rust variant left undeclared in the schema, or a stale schema slug
+/// whose Rust variant was removed/renamed.
+#[test]
+fn storage_lifecycle_report_schema_reason_enums_round_trip_every_rust_variant() {
+    let schema = read_repo_file("docs/reference/schemas/v2/storage-lifecycle-report.json");
+    let schema: serde_json::Value =
+        serde_json::from_str(&schema).expect("storage lifecycle report schema parses as JSON");
+    let companion_doc = read_repo_file("docs/reference/schemas/v2/storage-lifecycle-report.md");
+
+    let sync_reasons = [
+        SyncContractValidationReason::DuplicateLockId,
+        SyncContractValidationReason::OfdLockMissingCloexec,
+        SyncContractValidationReason::FdPassingMissingLeaseTransferRecord,
+        SyncContractValidationReason::DuplicateAcquireOrder,
+        SyncContractValidationReason::LockMissingProtectedResourceId,
+        SyncContractValidationReason::Unclassified,
+    ];
+    let rendered_sync_reasons: BTreeSet<String> = sync_reasons
+        .iter()
+        .map(|reason| {
+            serde_json::to_value(reason)
+                .expect("SyncContractValidationReason serializes")
+                .as_str()
+                .expect("serializes to a plain string")
+                .to_owned()
+        })
+        .collect();
+    let schema_sync_reasons: BTreeSet<String> =
+        schema["definitions"]["SyncContractValidationReason"]["enum"]
+            .as_array()
+            .expect("SyncContractValidationReason enum array")
+            .iter()
+            .map(|value| value.as_str().expect("enum values are strings").to_owned())
+            .collect();
+    assert_eq!(
+        rendered_sync_reasons, schema_sync_reasons,
+        "every SyncContractValidationReason Rust variant must have exactly one \
+         matching committed schema enum slug, and vice versa"
+    );
+    assert!(rendered_sync_reasons.contains("lock-missing-protected-resource-id"));
+
+    let storage_reasons = [
+        StorageContractValidationReason::DuplicateStoragePathId,
+        StorageContractValidationReason::DuplicateRestartPolicy,
+        StorageContractValidationReason::DuplicateDegradedReason,
+        StorageContractValidationReason::Unclassified,
+    ];
+    let rendered_storage_reasons: BTreeSet<String> = storage_reasons
+        .iter()
+        .map(|reason| {
+            serde_json::to_value(reason)
+                .expect("StorageContractValidationReason serializes")
+                .as_str()
+                .expect("serializes to a plain string")
+                .to_owned()
+        })
+        .collect();
+    let schema_storage_reasons: BTreeSet<String> =
+        schema["definitions"]["StorageContractValidationReason"]["enum"]
+            .as_array()
+            .expect("StorageContractValidationReason enum array")
+            .iter()
+            .map(|value| value.as_str().expect("enum values are strings").to_owned())
+            .collect();
+    assert_eq!(rendered_storage_reasons, schema_storage_reasons);
+
+    // The companion doc must document the new slug and stay cross-referenced
+    // with both the schema it describes and the sync-contract reference it
+    // borrows the `resourceId` semantics from.
+    assert!(companion_doc.contains("lock-missing-protected-resource-id"));
+    assert!(companion_doc.contains("./storage-lifecycle-report.json"));
+    assert!(companion_doc.contains("./sync.md"));
+    assert!(companion_doc.contains("schemaVersion"));
 }
 
 #[test]
@@ -866,6 +950,70 @@ fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_availabl
                 lock.id.as_str()
             );
         }
+
+        // Every `lock:workload-store:*` lock's resourceId must resolve to
+        // the aggregate `path:workload-store-view:*` resource — the
+        // directory covering the live/meta/state/gcroots leaves beneath it
+        // — never to a single leaf such as `workload-store-view-live`. The
+        // lock's whole mutation domain is that aggregate, so its protected
+        // resource must cover the same domain, not one narrower slice of
+        // it that would leave the rest unprotected.
+        let workload_store_locks: Vec<_> = sync
+            .locks
+            .iter()
+            .filter(|lock| lock.id.as_str().starts_with("lock:workload-store:"))
+            .collect();
+        assert!(
+            !workload_store_locks.is_empty(),
+            "{fixture_name} sync.json must include a workload-store lock"
+        );
+        for lock in &workload_store_locks {
+            let protected_id = lock.resource_id.as_ref().unwrap_or_else(|| {
+                panic!("{fixture_name} lock {} has no resourceId", lock.id.as_str())
+            });
+            assert!(
+                protected_id
+                    .as_str()
+                    .starts_with("path:workload-store-view:"),
+                "{fixture_name} workload-store lock {} must protect the aggregate \
+                 path:workload-store-view:* resource, not a single leaf (got {})",
+                lock.id.as_str(),
+                protected_id.as_str()
+            );
+            let protected_row = rows_by_id.get(protected_id.as_str()).unwrap_or_else(|| {
+                panic!(
+                    "{fixture_name} lock {} resourceId {} has no matching storage.json row",
+                    lock.id.as_str(),
+                    protected_id.as_str()
+                )
+            });
+            assert_eq!(protected_row.kind, StoragePathKind::Directory);
+            let aggregate_path = protected_row.path_template.as_str();
+            // Every one of this exact workload's live/meta/state/gcroots
+            // leaf rows must live strictly beneath the aggregate path this
+            // lock protects — scoped by path prefix (not by id substring,
+            // which would risk matching a sibling workload's identically
+            // suffixed leaf id under a multi-workload fixture).
+            let leaf_suffixes = [
+                "/store-view/live",
+                "/store-view/meta",
+                "/store-view/state",
+                "/store-view/gcroots",
+            ];
+            for suffix in leaf_suffixes {
+                let matched = storage.paths.iter().any(|row| {
+                    let path = row.path_template.as_str();
+                    path.starts_with(aggregate_path) && path.ends_with(suffix)
+                });
+                assert!(
+                    matched,
+                    "{fixture_name} workload-store lock {}'s aggregate protected resource {} \
+                     must have a real storage.json row for its {suffix} leaf beneath it",
+                    lock.id.as_str(),
+                    aggregate_path
+                );
+            }
+        }
     }
 }
 
@@ -1162,6 +1310,10 @@ fn registered_host_mutation_sources() -> BTreeMap<&'static str, &'static str> {
         (
             "packages/d2b-priv-broker/src/ops/media.rs",
             "storage paths:qemu-media registry/runtime index",
+        ),
+        (
+            "packages/d2b-priv-broker/src/ops/storage_contract.rs",
+            "broker reconciles generated regular-file lock rows anchored/nofollow",
         ),
         (
             "packages/d2b-priv-broker/src/ops/store_sync.rs",

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -10,7 +10,8 @@ use d2b_core::{
     processes::ProcessesJson,
     realm_controller_config::{RealmControllerRuntimeState, RealmControllersJson},
     storage::{
-        ActorKind, PrincipalKind, RepairPolicy, StorageInvariant, StorageJson, StoragePathKind,
+        ActorKind, PrincipalKind, RepairPolicy, SensitivityClass, StorageInvariant, StorageJson,
+        StoragePathKind,
     },
     sync::{LockKind, SyncJson},
 };
@@ -593,6 +594,178 @@ fn rendered_storage_contract_covers_process_writable_paths_when_fixture_availabl
                     "{fixture_name} observability storage rows must use a broker repair policy"
                 );
             }
+        }
+    }
+}
+
+/// Every rendered lock in `sync.json` must carry a non-null `resourceId`
+/// that pairs, without invention, to a real generated `storage.json` row
+/// which the shared `d2b-state` runtime bridge
+/// (`LockSet::acquire_from_generated`) will actually open. This is a
+/// schema/JSON-level contract test (this crate does not depend on
+/// `d2b-state`): it proves the *generated fixtures* carry every field the
+/// runtime bridge requires, not that the bridge itself behaves correctly
+/// (that is covered by `d2b-state`'s own unit tests in `lock.rs`/`path.rs`).
+#[test]
+fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_available() {
+    let fixture_dirs: Vec<_> = ["D2B_FIXTURES", "D2B_FIXTURES_FULL"]
+        .into_iter()
+        .filter_map(|name| env::var_os(name).map(|dir| (name, PathBuf::from(dir))))
+        .collect();
+    if fixture_dirs.is_empty() {
+        eprintln!("  (skipping rendered sync/storage pairing check; D2B_FIXTURES unset)");
+        return;
+    }
+
+    for (fixture_name, dir) in fixture_dirs {
+        let storage: StorageJson = read_json(&dir, "storage.json");
+        let sync: SyncJson = read_json(&dir, "sync.json");
+
+        let rows_by_id: BTreeMap<&str, _> = storage
+            .paths
+            .iter()
+            .map(|row| (row.id.as_str(), row))
+            .collect();
+
+        assert!(
+            !sync.locks.is_empty(),
+            "{fixture_name} sync.json must render at least one lock"
+        );
+
+        // Every lock must carry a resourceId, and it must resolve to a real
+        // regular-file storage row that the runtime bridge can actually
+        // open/acquire against — never a dangling or absent id.
+        for lock in &sync.locks {
+            let resource_id = lock.resource_id.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "{fixture_name} lock {} has no resourceId; the shared runtime bridge cannot \
+                     acquire it without inventing a resource identity",
+                    lock.id.as_str()
+                )
+            });
+            let row = rows_by_id.get(resource_id.as_str()).unwrap_or_else(|| {
+                panic!(
+                    "{fixture_name} lock {} resourceId {} has no matching storage.json row",
+                    lock.id.as_str(),
+                    resource_id.as_str()
+                )
+            });
+            assert_eq!(
+                row.kind,
+                StoragePathKind::RegularFile,
+                "{fixture_name} lock {} resourceId {} must pair with a regular-file row",
+                lock.id.as_str(),
+                resource_id.as_str()
+            );
+            assert!(
+                row.no_follow,
+                "{fixture_name} lock-file row {} must be noFollow",
+                row.id.as_str()
+            );
+            assert!(
+                !row.recursive,
+                "{fixture_name} lock-file row {} must not be recursive",
+                row.id.as_str()
+            );
+            if let Some(path_template) = &lock.path_template {
+                assert_eq!(
+                    path_template.as_str(),
+                    row.path_template.as_str(),
+                    "{fixture_name} lock {} pathTemplate must match its paired storage row",
+                    lock.id.as_str()
+                );
+            }
+            assert_eq!(
+                lock.scope.as_str(),
+                row.scope.as_str(),
+                "{fixture_name} lock {} scope must match its paired storage row's scope",
+                lock.id.as_str()
+            );
+            // Every generated lock is CLOEXEC OFD, close-on-exec inheritance,
+            // and fail-fast with no fd-passing mechanism today: assert the
+            // exact uniform policy so a silent drift is caught, not papered
+            // over by a permissive adapter.
+            assert_eq!(lock.kind, LockKind::Ofd);
+            assert!(lock.cloexec_required);
+        }
+
+        // Global total order: `SyncJson::global_order_rank` must assign a
+        // strict bijection onto `0..locks.len()` — no duplicate or missing
+        // rank, proving the total order is well-defined across every
+        // rendered lock without any fabricated `acquire_after` edge.
+        let mut ranks: Vec<usize> = sync
+            .locks
+            .iter()
+            .map(|lock| {
+                sync.global_order_rank(&lock.id).unwrap_or_else(|| {
+                    panic!(
+                        "{fixture_name} lock {} missing from its own global order",
+                        lock.id.as_str()
+                    )
+                })
+            })
+            .collect();
+        ranks.sort_unstable();
+        let expected: Vec<usize> = (0..sync.locks.len()).collect();
+        assert_eq!(
+            ranks, expected,
+            "{fixture_name} global_order_rank must be a strict bijection over every rendered lock"
+        );
+
+        // The per-workload `keys.lock` row (task requirement: every OFD lock
+        // file that currently lacks a storage row, especially workload keys)
+        // must exist, be broker-owned/secret-adjacent/mode-0600, and pair
+        // with exactly one lock whose owner/allowedHolders match the row's
+        // broker owner.
+        let keys_lock_rows: Vec<_> = storage
+            .paths
+            .iter()
+            .filter(|row| row.id.as_str().starts_with("path:workload-keys-lock:"))
+            .collect();
+        assert!(
+            !keys_lock_rows.is_empty(),
+            "{fixture_name} storage.json must include a workload keys.lock row"
+        );
+        for row in &keys_lock_rows {
+            assert_eq!(row.kind, StoragePathKind::RegularFile);
+            assert_eq!(row.mode, "0600");
+            assert_eq!(row.sensitivity, SensitivityClass::SecretAdjacent);
+            assert_eq!(row.creator.kind, ActorKind::Broker);
+            assert_eq!(row.owner.kind, PrincipalKind::User);
+            assert!(row.owner.value.as_str().starts_with("d2bbr-r-"));
+            assert!(
+                matches!(
+                    row.repair_policy,
+                    RepairPolicy::BrokerReconcile | RepairPolicy::BrokerFailClosed
+                ),
+                "{fixture_name} keys.lock row {} must use a broker repair policy",
+                row.id.as_str()
+            );
+            assert!(row.invariants.contains(&StorageInvariant::NoSymlink));
+            assert!(row.invariants.contains(&StorageInvariant::NoMagicLink));
+
+            let paired_lock = sync
+                .locks
+                .iter()
+                .find(|lock| {
+                    lock.resource_id.as_ref().map(|id| id.as_str()) == Some(row.id.as_str())
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{fixture_name} keys.lock row {} has no paired lock in sync.json",
+                        row.id.as_str()
+                    )
+                });
+            assert_eq!(paired_lock.owner_process.kind, ActorKind::Broker);
+            assert_eq!(
+                paired_lock.owner_process.value.as_str(),
+                row.owner.value.as_str()
+            );
+            assert_eq!(
+                paired_lock.release_authority.value.as_str(),
+                row.owner.value.as_str(),
+                "{fixture_name} keys.lock owner/release authority must be symmetric"
+            );
         }
     }
 }

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -767,6 +767,53 @@ fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_availabl
                 "{fixture_name} keys.lock owner/release authority must be symmetric"
             );
         }
+
+        // The generated adapter's `protected_resource_ids` are a distinct
+        // concept from a lock's own `resourceId` (the lock *file*): a lock
+        // protects some other piece of state, it is not itself that state.
+        // Prove the real fixture actually carries, for every generated
+        // workload-state lock, at least one storage row that (a) shares the
+        // lock's scope (the same invariant `bind_protected_resource`
+        // enforces) and (b) is genuinely distinct from the lock file's own
+        // paired `resourceId` row — the real `workload-state-data` row from
+        // `nixos-modules/realm-storage-rows.nix`, discovered by scope
+        // rather than a guessed id string, never a fabricated row.
+        let workload_state_locks: Vec<_> = sync
+            .locks
+            .iter()
+            .filter(|lock| lock.id.as_str().starts_with("lock:workload-state:"))
+            .collect();
+        assert!(
+            !workload_state_locks.is_empty(),
+            "{fixture_name} sync.json must include a workload-state lock"
+        );
+        for lock in &workload_state_locks {
+            let lock_file_id = lock.resource_id.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "{fixture_name} lock {} has no resourceId",
+                    lock.id.as_str()
+                )
+            });
+            let candidate_protected_rows: Vec<_> = storage
+                .paths
+                .iter()
+                .filter(|row| {
+                    row.scope.as_str() == lock.scope.as_str()
+                        && row.id.as_str() != lock_file_id.as_str()
+                        && row.kind == StoragePathKind::RegularFile
+                })
+                .collect();
+            assert!(
+                !candidate_protected_rows.is_empty(),
+                "{fixture_name} expected at least one regular-file storage row sharing scope {} \
+                 with lock {} that is distinct from the lock file's own resourceId {} — the \
+                 runtime bridge's caller-supplied protected_resource_ids needs a real, \
+                 non-lock-file row to bind",
+                lock.scope.as_str(),
+                lock.id.as_str(),
+                lock_file_id.as_str()
+            );
+        }
     }
 }
 

--- a/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
+++ b/packages/d2b-contract-tests/tests/storage_sync_contracts.rs
@@ -599,13 +599,16 @@ fn rendered_storage_contract_covers_process_writable_paths_when_fixture_availabl
 }
 
 /// Every rendered lock in `sync.json` must carry a non-null `resourceId`
-/// that pairs, without invention, to a real generated `storage.json` row
-/// which the shared `d2b-state` runtime bridge
-/// (`LockSet::acquire_from_generated`) will actually open. This is a
-/// schema/JSON-level contract test (this crate does not depend on
-/// `d2b-state`): it proves the *generated fixtures* carry every field the
-/// runtime bridge requires, not that the bridge itself behaves correctly
-/// (that is covered by `d2b-state`'s own unit tests in `lock.rs`/`path.rs`).
+/// naming the *protected state* resource it guards (its schema-intended
+/// semantic), and a `pathTemplate` that resolves, without invention, to
+/// exactly one real generated regular-file `storage.json` row — the lock
+/// file's own row, paired internally by the shared `d2b-state` runtime
+/// bridge (`LockSet::acquire_from_generated`) via exact `pathTemplate`
+/// match rather than a second id field. This is a schema/JSON-level
+/// contract test (this crate does not depend on `d2b-state`): it proves
+/// the *generated fixtures* carry every field the runtime bridge requires,
+/// not that the bridge itself behaves correctly (that is covered by
+/// `d2b-state`'s own unit tests in `lock.rs`/`path.rs`).
 #[test]
 fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_available() {
     let fixture_dirs: Vec<_> = ["D2B_FIXTURES", "D2B_FIXTURES_FULL"]
@@ -632,54 +635,101 @@ fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_availabl
             "{fixture_name} sync.json must render at least one lock"
         );
 
-        // Every lock must carry a resourceId, and it must resolve to a real
-        // regular-file storage row that the runtime bridge can actually
-        // open/acquire against — never a dangling or absent id.
+        // Every lock must carry a non-null resourceId naming its protected
+        // state resource, and a pathTemplate that resolves to exactly one
+        // real regular-file storage row — the lock file's own row, never
+        // caller-selected or guessed by id.
         for lock in &sync.locks {
-            let resource_id = lock.resource_id.as_ref().unwrap_or_else(|| {
+            let protected_id = lock.resource_id.as_ref().unwrap_or_else(|| {
                 panic!(
                     "{fixture_name} lock {} has no resourceId; the shared runtime bridge cannot \
-                     acquire it without inventing a resource identity",
+                     resolve the protected resource it guards without inventing an identity",
                     lock.id.as_str()
                 )
             });
-            let row = rows_by_id.get(resource_id.as_str()).unwrap_or_else(|| {
+            let protected_row = rows_by_id.get(protected_id.as_str()).unwrap_or_else(|| {
                 panic!(
                     "{fixture_name} lock {} resourceId {} has no matching storage.json row",
                     lock.id.as_str(),
-                    resource_id.as_str()
+                    protected_id.as_str()
                 )
             });
             assert_eq!(
-                row.kind,
-                StoragePathKind::RegularFile,
-                "{fixture_name} lock {} resourceId {} must pair with a regular-file row",
-                lock.id.as_str(),
-                resource_id.as_str()
+                lock.scope.as_str(),
+                protected_row.scope.as_str(),
+                "{fixture_name} lock {} scope must match its protected resource row's scope",
+                lock.id.as_str()
             );
-            assert!(
-                row.no_follow,
-                "{fixture_name} lock-file row {} must be noFollow",
-                row.id.as_str()
-            );
-            assert!(
-                !row.recursive,
-                "{fixture_name} lock-file row {} must not be recursive",
-                row.id.as_str()
-            );
-            if let Some(path_template) = &lock.path_template {
-                assert_eq!(
-                    path_template.as_str(),
-                    row.path_template.as_str(),
-                    "{fixture_name} lock {} pathTemplate must match its paired storage row",
+
+            let path_template = lock.path_template.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "{fixture_name} lock {} has no pathTemplate; the shared runtime bridge \
+                     cannot resolve the paired lock-file row without inventing a match",
                     lock.id.as_str()
-                );
-            }
+                )
+            });
+            let lock_file_rows: Vec<_> = storage
+                .paths
+                .iter()
+                .filter(|row| row.path_template.as_str() == path_template.as_str())
+                .collect();
+            assert_eq!(
+                lock_file_rows.len(),
+                1,
+                "{fixture_name} lock {} pathTemplate {} must match exactly one storage.json row \
+                 (found {}); an ambiguous or missing match cannot be resolved without invention",
+                lock.id.as_str(),
+                path_template.as_str(),
+                lock_file_rows.len()
+            );
+            let lock_row = lock_file_rows[0];
+            assert_eq!(
+                lock_row.kind,
+                StoragePathKind::RegularFile,
+                "{fixture_name} lock {} pathTemplate {} must pair with a regular-file row",
+                lock.id.as_str(),
+                path_template.as_str()
+            );
             assert_eq!(
                 lock.scope.as_str(),
-                row.scope.as_str(),
-                "{fixture_name} lock {} scope must match its paired storage row's scope",
+                lock_row.scope.as_str(),
+                "{fixture_name} lock {} scope must match its paired lock-file row's scope",
                 lock.id.as_str()
+            );
+            assert_eq!(
+                lock.owner_process.value.as_str(),
+                lock_row.owner.value.as_str(),
+                "{fixture_name} lock {} owner must match its paired lock-file row's owner",
+                lock.id.as_str()
+            );
+            assert!(
+                lock_row.invariants.contains(&StorageInvariant::NoSymlink),
+                "{fixture_name} lock-file row {} must declare no-symlink",
+                lock_row.id.as_str()
+            );
+            assert!(
+                lock_row.invariants.contains(&StorageInvariant::NoMagicLink),
+                "{fixture_name} lock-file row {} must declare no-magic-link",
+                lock_row.id.as_str()
+            );
+            assert!(
+                lock_row.no_follow,
+                "{fixture_name} lock-file row {} must be noFollow",
+                lock_row.id.as_str()
+            );
+            assert!(
+                !lock_row.recursive,
+                "{fixture_name} lock-file row {} must not be recursive",
+                lock_row.id.as_str()
+            );
+            assert_ne!(
+                protected_row.id.as_str(),
+                lock_row.id.as_str(),
+                "{fixture_name} lock {} protected resource {} must be distinct from its own \
+                 lock-file row {} — a lock never protects itself",
+                lock.id.as_str(),
+                protected_id.as_str(),
+                lock_row.id.as_str()
             );
             // Every generated lock is CLOEXEC OFD, close-on-exec inheritance,
             // and fail-fast with no fd-passing mechanism today: assert the
@@ -715,8 +765,8 @@ fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_availabl
         // The per-workload `keys.lock` row (task requirement: every OFD lock
         // file that currently lacks a storage row, especially workload keys)
         // must exist, be broker-owned/secret-adjacent/mode-0600, and pair
-        // with exactly one lock whose owner/allowedHolders match the row's
-        // broker owner.
+        // — by exact pathTemplate match, never by resourceId — with exactly
+        // one lock whose owner/allowedHolders match the row's broker owner.
         let keys_lock_rows: Vec<_> = storage
             .paths
             .iter()
@@ -744,18 +794,25 @@ fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_availabl
             assert!(row.invariants.contains(&StorageInvariant::NoSymlink));
             assert!(row.invariants.contains(&StorageInvariant::NoMagicLink));
 
-            let paired_lock = sync
+            let paired_locks: Vec<_> = sync
                 .locks
                 .iter()
-                .find(|lock| {
-                    lock.resource_id.as_ref().map(|id| id.as_str()) == Some(row.id.as_str())
+                .filter(|lock| {
+                    lock.path_template
+                        .as_ref()
+                        .map(|template| template.as_str())
+                        == Some(row.path_template.as_str())
                 })
-                .unwrap_or_else(|| {
-                    panic!(
-                        "{fixture_name} keys.lock row {} has no paired lock in sync.json",
-                        row.id.as_str()
-                    )
-                });
+                .collect();
+            assert_eq!(
+                paired_locks.len(),
+                1,
+                "{fixture_name} keys.lock row {} must pair with exactly one lock by pathTemplate \
+                 (found {})",
+                row.id.as_str(),
+                paired_locks.len()
+            );
+            let paired_lock = paired_locks[0];
             assert_eq!(paired_lock.owner_process.kind, ActorKind::Broker);
             assert_eq!(
                 paired_lock.owner_process.value.as_str(),
@@ -766,18 +823,22 @@ fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_availabl
                 row.owner.value.as_str(),
                 "{fixture_name} keys.lock owner/release authority must be symmetric"
             );
+            // The lock's own resourceId names the protected `workload-keys`
+            // resource, never this lock-file row itself.
+            let protected_id = paired_lock.resource_id.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "{fixture_name} keys lock {} has no resourceId",
+                    paired_lock.id.as_str()
+                )
+            });
+            assert_ne!(protected_id.as_str(), row.id.as_str());
         }
 
-        // The generated adapter's `protected_resource_ids` are a distinct
-        // concept from a lock's own `resourceId` (the lock *file*): a lock
-        // protects some other piece of state, it is not itself that state.
-        // Prove the real fixture actually carries, for every generated
-        // workload-state lock, at least one storage row that (a) shares the
-        // lock's scope (the same invariant `bind_protected_resource`
-        // enforces) and (b) is genuinely distinct from the lock file's own
-        // paired `resourceId` row — the real `workload-state-data` row from
-        // `nixos-modules/realm-storage-rows.nix`, discovered by scope
-        // rather than a guessed id string, never a fabricated row.
+        // Every `lock:workload-state:*` lock's resourceId must resolve to
+        // the real `workload-state-data` resource — a directory, not the
+        // lock file — proving the protected resource is schema-derived and
+        // genuinely distinct from the lock file's own row, never a
+        // fabricated or guessed id.
         let workload_state_locks: Vec<_> = sync
             .locks
             .iter()
@@ -788,30 +849,21 @@ fn rendered_sync_locks_pair_exactly_with_real_storage_rows_when_fixture_availabl
             "{fixture_name} sync.json must include a workload-state lock"
         );
         for lock in &workload_state_locks {
-            let lock_file_id = lock.resource_id.as_ref().unwrap_or_else(|| {
+            let protected_id = lock.resource_id.as_ref().unwrap_or_else(|| {
+                panic!("{fixture_name} lock {} has no resourceId", lock.id.as_str())
+            });
+            let protected_row = rows_by_id.get(protected_id.as_str()).unwrap_or_else(|| {
                 panic!(
-                    "{fixture_name} lock {} has no resourceId",
-                    lock.id.as_str()
+                    "{fixture_name} lock {} resourceId {} has no matching storage.json row",
+                    lock.id.as_str(),
+                    protected_id.as_str()
                 )
             });
-            let candidate_protected_rows: Vec<_> = storage
-                .paths
-                .iter()
-                .filter(|row| {
-                    row.scope.as_str() == lock.scope.as_str()
-                        && row.id.as_str() != lock_file_id.as_str()
-                        && row.kind == StoragePathKind::RegularFile
-                })
-                .collect();
-            assert!(
-                !candidate_protected_rows.is_empty(),
-                "{fixture_name} expected at least one regular-file storage row sharing scope {} \
-                 with lock {} that is distinct from the lock file's own resourceId {} — the \
-                 runtime bridge's caller-supplied protected_resource_ids needs a real, \
-                 non-lock-file row to bind",
+            assert_eq!(
+                protected_row.scope.as_str(),
                 lock.scope.as_str(),
-                lock.id.as_str(),
-                lock_file_id.as_str()
+                "{fixture_name} workload-state lock {} protected resource must share its scope",
+                lock.id.as_str()
             );
         }
     }

--- a/packages/d2b-core/src/storage_lifecycle.rs
+++ b/packages/d2b-core/src/storage_lifecycle.rs
@@ -110,6 +110,7 @@ pub enum SyncContractValidationReason {
     OfdLockMissingCloexec,
     FdPassingMissingLeaseTransferRecord,
     DuplicateAcquireOrder,
+    LockMissingProtectedResourceId,
     Unclassified,
 }
 
@@ -146,6 +147,8 @@ pub fn classify_sync_validation_reason(detail: &str) -> SyncContractValidationRe
         && detail.ends_with(" must require a lease transfer record")
     {
         SyncContractValidationReason::FdPassingMissingLeaseTransferRecord
+    } else if detail.ends_with(" must be paired with a storage resourceId") {
+        SyncContractValidationReason::LockMissingProtectedResourceId
     } else if detail.starts_with("lock ") && detail.contains(" shares acquire order key with ") {
         SyncContractValidationReason::DuplicateAcquireOrder
     } else {
@@ -165,6 +168,15 @@ pub fn sync_validation_offending_id(detail: &str) -> Option<String> {
     } else if let Some(rest) = detail.strip_prefix("lock ") {
         rest.split_once(" shares acquire order key with ")
             .and_then(|(id, _)| bounded_contract_detail(id))
+    } else if let Some(prefixed) = detail.strip_suffix(" must be paired with a storage resourceId")
+    {
+        // Message shape is "<LockKind Debug> lock <lock_id>"; the kind name
+        // never contains the literal " lock " separator, so splitting on its
+        // first occurrence isolates the lock id regardless of which lock
+        // kind (Ofd/FileRecord) produced the message.
+        prefixed
+            .split_once(" lock ")
+            .and_then(|(_, id)| bounded_contract_detail(id))
     } else {
         None
     }
@@ -249,6 +261,62 @@ mod tests {
                 "reason": "duplicate-storage-path-id",
                 "offendingId": "path:run-root"
             })
+        );
+
+        let missing_protected_resource =
+            serde_json::to_value(StorageLifecycleIssue::SyncContractInvalid {
+                contract_id: "sync.json".to_owned(),
+                reason: SyncContractValidationReason::LockMissingProtectedResourceId,
+                offending_id: Some("lock:daemon".to_owned()),
+            })
+            .expect("serialize missing protected resource issue");
+        assert_eq!(
+            missing_protected_resource,
+            json!({
+                "kind": "sync-contract-invalid",
+                "contractId": "sync.json",
+                "reason": "lock-missing-protected-resource-id",
+                "offendingId": "lock:daemon"
+            })
+        );
+    }
+
+    #[test]
+    fn classifies_missing_protected_resource_id_for_every_paired_lock_kind() {
+        assert_eq!(
+            classify_sync_validation_reason(
+                "Ofd lock lock:daemon must be paired with a storage resourceId"
+            ),
+            SyncContractValidationReason::LockMissingProtectedResourceId,
+        );
+        assert_eq!(
+            classify_sync_validation_reason(
+                "FileRecord lock lock:workload-keys must be paired with a storage resourceId"
+            ),
+            SyncContractValidationReason::LockMissingProtectedResourceId,
+        );
+        assert_eq!(
+            sync_validation_offending_id(
+                "Ofd lock lock:daemon must be paired with a storage resourceId"
+            )
+            .as_deref(),
+            Some("lock:daemon"),
+        );
+        assert_eq!(
+            sync_validation_offending_id(
+                "FileRecord lock lock:workload-keys must be paired with a storage resourceId"
+            )
+            .as_deref(),
+            Some("lock:workload-keys"),
+        );
+        // A raw path in the offending-id position must never leak; the
+        // bounded-detail charset check rejects it and the caller instead
+        // gets a redacted `None` rather than a raw storage path.
+        assert_eq!(
+            sync_validation_offending_id(
+                "Ofd lock /run/d2b/daemon.lock must be paired with a storage resourceId"
+            ),
+            None,
         );
     }
 

--- a/packages/d2b-core/src/sync.rs
+++ b/packages/d2b-core/src/sync.rs
@@ -145,6 +145,14 @@ impl SyncJson {
             if lock.kind == LockKind::Ofd && !lock.cloexec_required {
                 return Err(format!("OFD lock {} must require O_CLOEXEC", lock.id));
             }
+            if matches!(lock.kind, LockKind::Ofd | LockKind::FileRecord)
+                && lock.resource_id.is_none()
+            {
+                return Err(format!(
+                    "{:?} lock {} must be paired with a storage resourceId",
+                    lock.kind, lock.id
+                ));
+            }
             if lock.fd_passing_policy.mechanism != FdPassingMechanism::None
                 && !lock.fd_passing_policy.lease_transfer_record_required
             {
@@ -167,6 +175,41 @@ impl SyncJson {
             }
         }
         Ok(())
+    }
+
+    /// Deterministic global total-order rank for `lock_id`.
+    ///
+    /// The generated contract has no separate stored `global_order` field:
+    /// [`validate_lock_order`] already enforces that every lock's
+    /// `(scope_class, anchored_root, normalized_path, lock_id)` acquire-order
+    /// key is unique across the whole `SyncJson`. Sorting the full lock set
+    /// by that key yields a strict, reproducible total order; this method
+    /// returns the 0-based position of `lock_id` in that order, or `None` if
+    /// `lock_id` is absent. A runtime that only ever acquires locks in
+    /// non-decreasing rank order (never a lower rank while holding a guard
+    /// with an equal-or-greater rank) satisfies acquire-after ordering for
+    /// every lock, which is a strict superset of any partial-order DAG:
+    /// today's generated locks declare no cross-lock dependency, so the
+    /// total order is the entire ordering contract there is to enforce.
+    pub fn global_order_rank(&self, lock_id: &ContractId) -> Option<usize> {
+        type OrderKey<'a> = (LockScopeClass, &'a str, &'a str, &'a str);
+        let mut keyed: Vec<(OrderKey<'_>, &ContractId)> = self
+            .locks
+            .iter()
+            .map(|lock| {
+                (
+                    (
+                        lock.acquire_order.scope_class,
+                        lock.acquire_order.anchored_root.as_str(),
+                        lock.acquire_order.normalized_path.as_str(),
+                        lock.acquire_order.lock_id.as_str(),
+                    ),
+                    &lock.id,
+                )
+            })
+            .collect();
+        keyed.sort_by(|left, right| left.0.cmp(&right.0));
+        keyed.iter().position(|(_, id)| *id == lock_id)
     }
 }
 
@@ -191,13 +234,14 @@ mod tests {
         }
     }
 
-    #[test]
-    fn ofd_locks_require_cloexec() {
-        let lock = LockSpec {
-            id: ContractId::parse("lock:daemon").unwrap(),
+    /// A schema-valid, fully-paired OFD lock baseline for `id`, so individual
+    /// tests only need to override the single field they're exercising.
+    fn valid_lock(id: &str) -> LockSpec {
+        LockSpec {
+            id: ContractId::parse(id).unwrap(),
             scope: ContractId::parse("host").unwrap(),
-            path_template: Some(PathTemplate::parse("/run/d2b/daemon.lock").unwrap()),
-            resource_id: None,
+            path_template: Some(PathTemplate::parse(format!("/run/d2b/{id}.lock")).unwrap()),
+            resource_id: Some(ContractId::parse(format!("path:{id}")).unwrap()),
             kind: LockKind::Ofd,
             owner_process: actor(ActorKind::Daemon, "d2bd"),
             allowed_holders: vec![actor(ActorKind::Daemon, "d2bd")],
@@ -206,7 +250,7 @@ mod tests {
                 mechanism: FdPassingMechanism::None,
                 lease_transfer_record_required: false,
             },
-            acquire_order: order("lock:daemon"),
+            acquire_order: order(id),
             timeout_policy: LockTimeoutPolicy {
                 kind: LockTimeoutKind::FailFast,
                 timeout_ms: None,
@@ -218,8 +262,14 @@ mod tests {
             adoption_policy: LockAdoptionPolicy::ReacquireAfterProof,
             degrade_scope: DegradeScope::Host,
             release_authority: actor(ActorKind::Daemon, "d2bd"),
-            cloexec_required: false,
-        };
+            cloexec_required: true,
+        }
+    }
+
+    #[test]
+    fn ofd_locks_require_cloexec() {
+        let mut lock = valid_lock("lock:daemon");
+        lock.cloexec_required = false;
         assert!(
             SyncJson {
                 schema_version: "v2".to_owned(),
@@ -227,6 +277,58 @@ mod tests {
             }
             .validate_lock_order()
             .is_err()
+        );
+    }
+
+    #[test]
+    fn ofd_locks_require_resource_id() {
+        let mut lock = valid_lock("lock:daemon");
+        lock.resource_id = None;
+        let err = SyncJson {
+            schema_version: "v2".to_owned(),
+            locks: vec![lock],
+        }
+        .validate_lock_order()
+        .unwrap_err();
+        assert!(err.contains("resourceId"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn valid_paired_lock_passes() {
+        let lock = valid_lock("lock:daemon");
+        assert!(
+            SyncJson {
+                schema_version: "v2".to_owned(),
+                locks: vec![lock],
+            }
+            .validate_lock_order()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn global_order_rank_is_deterministic_and_unique() {
+        // Deliberately inserted out of natural sort order to prove the rank
+        // is derived from the acquire-order key, not from array position.
+        let locks = vec![
+            valid_lock("lock:zebra"),
+            valid_lock("lock:apple"),
+            valid_lock("lock:mango"),
+        ];
+        let doc = SyncJson {
+            schema_version: "v2".to_owned(),
+            locks,
+        };
+        assert!(doc.validate_lock_order().is_ok());
+        let apple = doc.global_order_rank(&ContractId::parse("lock:apple").unwrap());
+        let mango = doc.global_order_rank(&ContractId::parse("lock:mango").unwrap());
+        let zebra = doc.global_order_rank(&ContractId::parse("lock:zebra").unwrap());
+        assert_eq!(apple, Some(0));
+        assert_eq!(mango, Some(1));
+        assert_eq!(zebra, Some(2));
+        assert_eq!(
+            doc.global_order_rank(&ContractId::parse("lock:missing").unwrap()),
+            None
         );
     }
 }

--- a/packages/d2b-priv-broker/src/ops/storage_contract.rs
+++ b/packages/d2b-priv-broker/src/ops/storage_contract.rs
@@ -188,10 +188,12 @@ fn is_generated_lock_file_row(resolver: &BundleResolver, spec: &StoragePathSpec)
 /// path string handed to the kernel outside that anchored walk. A
 /// pre-existing file is validated (regular, exact owner/mode, single hard
 /// link) rather than silently trusted or blindly re-created, and the
-/// parent directory entry is `fsync`ed before reporting success on both
-/// the fresh-create and the already-exists path, so a caller observing a
-/// successful reconcile can trust the file is durably present under its
-/// final name.
+/// file itself is `fsync`ed, then the parent directory entry is `fsync`ed,
+/// before reporting success on both the fresh-create and the
+/// already-exists path - so a caller observing a successful reconcile can
+/// trust both the file's contents/metadata and its directory entry are
+/// durably present under its final name, even if the file being reused
+/// was left by a prior invocation whose own fsyncs were interrupted.
 fn reconcile_lock_file_row(
     spec: &StoragePathSpec,
     storage_ref: &BundleOpId,
@@ -266,8 +268,12 @@ fn reconcile_lock_file_row(
 /// opened (still anchored/nofollow) and validated to actually be the
 /// regular file this row describes (type, hard-link count, owner, mode)
 /// rather than assumed. Both the fresh-create and the validated-EEXIST
-/// paths `fsync` the parent directory entry before returning success, so
-/// a durable listing is guaranteed either way.
+/// paths `fsync` the file itself before `fsync`ing the parent directory
+/// entry and returning success, so any owner/mode metadata this call just
+/// wrote (or just validated on a reused file) is durable before the
+/// caller is told the reconcile succeeded - even if the reused file was
+/// left behind by a prior invocation that was interrupted before its own
+/// fsyncs landed.
 fn create_or_validate_lock_file(
     parent_fd: &OwnedFd,
     name: &str,
@@ -275,6 +281,45 @@ fn create_or_validate_lock_file(
     uid: Uid,
     gid: Gid,
     path_hash: &str,
+) -> Result<StorageReconcileStatus, StorageContractError> {
+    create_or_validate_lock_file_with_sync(
+        parent_fd,
+        name,
+        mode,
+        uid,
+        gid,
+        path_hash,
+        &RealLockFileSync,
+    )
+}
+
+/// Seam over the `fsync(2)` calls inside
+/// [`create_or_validate_lock_file_with_sync`], letting tests inject a
+/// fault on a specific call (e.g. the reused-file `fsync` on the EEXIST
+/// path) without touching real filesystem behaviour. Production code
+/// always uses [`RealLockFileSync`].
+trait LockFileSync {
+    fn fsync(&self, fd: std::os::fd::BorrowedFd<'_>) -> nix::Result<()>;
+}
+
+/// The real `fsync(2)` syscall, used by every non-test caller of
+/// [`create_or_validate_lock_file`].
+struct RealLockFileSync;
+
+impl LockFileSync for RealLockFileSync {
+    fn fsync(&self, fd: std::os::fd::BorrowedFd<'_>) -> nix::Result<()> {
+        nix::unistd::fsync(fd.as_raw_fd())
+    }
+}
+
+fn create_or_validate_lock_file_with_sync(
+    parent_fd: &OwnedFd,
+    name: &str,
+    mode: u32,
+    uid: Uid,
+    gid: Gid,
+    path_hash: &str,
+    sync: &dyn LockFileSync,
 ) -> Result<StorageReconcileStatus, StorageContractError> {
     let io_err = |err: std::io::Error| StorageContractError::Io {
         path_hash: path_hash.to_owned(),
@@ -290,14 +335,16 @@ fn create_or_validate_lock_file(
             crate::sys::path_safe::fchmod(fd.as_fd(), mode).map_err(io_err)?;
             crate::sys::path_safe::fchown(fd.as_fd(), Some(uid.as_raw()), Some(gid.as_raw()))
                 .map_err(io_err)?;
-            nix::unistd::fsync(fd.as_raw_fd()).map_err(|err| StorageContractError::Io {
-                path_hash: path_hash.to_owned(),
-                detail: format!("fsync lock file: {err}"),
-            })?;
-            nix::unistd::fsync(parent_fd.as_raw_fd()).map_err(|err| StorageContractError::Io {
-                path_hash: path_hash.to_owned(),
-                detail: format!("fsync lock file parent: {err}"),
-            })?;
+            sync.fsync(fd.as_fd())
+                .map_err(|err| StorageContractError::Io {
+                    path_hash: path_hash.to_owned(),
+                    detail: format!("fsync lock file: {err}"),
+                })?;
+            sync.fsync(parent_fd.as_fd())
+                .map_err(|err| StorageContractError::Io {
+                    path_hash: path_hash.to_owned(),
+                    detail: format!("fsync lock file parent: {err}"),
+                })?;
             Ok(StorageReconcileStatus::Created)
         }
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -328,10 +375,21 @@ fn create_or_validate_lock_file(
                     reason: "lock-file-existing-mode-mismatch".to_owned(),
                 });
             }
-            nix::unistd::fsync(parent_fd.as_raw_fd()).map_err(|err| StorageContractError::Io {
-                path_hash: path_hash.to_owned(),
-                detail: format!("fsync lock file parent: {err}"),
-            })?;
+            // The validated existing file may have been created (and its
+            // owner/mode set) by a prior invocation whose own fsyncs were
+            // interrupted before landing durably - re-fsync the file itself
+            // here, ahead of the parent, so the metadata this call just
+            // validated is guaranteed durable before reporting `Reused`.
+            sync.fsync(fd.as_fd())
+                .map_err(|err| StorageContractError::Io {
+                    path_hash: path_hash.to_owned(),
+                    detail: format!("fsync lock file: {err}"),
+                })?;
+            sync.fsync(parent_fd.as_fd())
+                .map_err(|err| StorageContractError::Io {
+                    path_hash: path_hash.to_owned(),
+                    detail: format!("fsync lock file parent: {err}"),
+                })?;
             Ok(StorageReconcileStatus::Reused)
         }
         Err(err) => Err(io_err(err)),
@@ -666,6 +724,91 @@ mod tests {
         let reused = create_or_validate_lock_file(&parent_fd, "keys.lock", 0o640, uid, gid, "hash")
             .expect("second call validates and reuses the same file");
         assert_eq!(reused, StorageReconcileStatus::Reused);
+    }
+
+    /// A [`LockFileSync`] that fails the `call_to_fail`th `fsync` call
+    /// this instance sees (1-indexed, counted from when the instance is
+    /// constructed), then delegates every other call to the real
+    /// syscall.
+    struct FailAtCallSync {
+        calls: std::cell::Cell<u32>,
+        call_to_fail: u32,
+    }
+
+    impl LockFileSync for FailAtCallSync {
+        fn fsync(&self, fd: std::os::fd::BorrowedFd<'_>) -> nix::Result<()> {
+            let call = self.calls.get() + 1;
+            self.calls.set(call);
+            if call == self.call_to_fail {
+                return Err(nix::Error::EIO);
+            }
+            nix::unistd::fsync(fd.as_raw_fd())
+        }
+    }
+
+    #[test]
+    fn create_or_validate_lock_file_propagates_a_failed_reuse_path_fsync_and_is_retryable() {
+        let scratch = project_scratch("create-or-validate-lock-file-reuse-fsync-fault");
+        let parent_fd = crate::sys::path_safe::open_dir_path_safe(scratch.path()).unwrap();
+        let uid = current_uid();
+        let gid = current_gid();
+
+        // First call: real sync, creates the file (2 fsyncs: file, parent).
+        let created = create_or_validate_lock_file_with_sync(
+            &parent_fd,
+            "keys.lock",
+            0o640,
+            uid,
+            gid,
+            "hash",
+            &RealLockFileSync,
+        )
+        .expect("first call creates the lock file");
+        assert_eq!(created, StorageReconcileStatus::Created);
+
+        // Second call hits the EEXIST/reuse path, which validates the
+        // existing file and then re-fsyncs it (the 1st fsync call this
+        // fresh `FailAtCallSync` instance sees) before fsyncing the
+        // parent (the 2nd) and returning `Reused`. Fail exactly that 1st
+        // call - the reused file's own fsync, ahead of the parent - and
+        // assert the fault propagates as an error rather than being
+        // swallowed into a silent `Reused`, and that the parent fsync
+        // (call 2) never happens because the file fsync failure
+        // short-circuits it.
+        let faulting = FailAtCallSync {
+            calls: std::cell::Cell::new(0),
+            call_to_fail: 1,
+        };
+        let err = create_or_validate_lock_file_with_sync(
+            &parent_fd,
+            "keys.lock",
+            0o640,
+            uid,
+            gid,
+            "hash",
+            &faulting,
+        )
+        .expect_err("a failed reused-file fsync must not be reported as success");
+        match err {
+            StorageContractError::Io { detail, .. } => {
+                assert!(detail.contains("fsync lock file:"), "{detail}");
+            }
+            other => panic!("expected Io error, got {other:?}"),
+        }
+        assert_eq!(
+            faulting.calls.get(),
+            1,
+            "the parent fsync must never run once the file fsync fails"
+        );
+
+        // A retry with a healthy sync mechanism must still succeed and
+        // observe the same file as `Reused`: the earlier fault must not
+        // have left the lock file (or the reconcile step) in a state
+        // that requires anything other than a plain retry.
+        let retried =
+            create_or_validate_lock_file(&parent_fd, "keys.lock", 0o640, uid, gid, "hash")
+                .expect("retry after a transient fsync fault must succeed");
+        assert_eq!(retried, StorageReconcileStatus::Reused);
     }
 
     #[test]

--- a/packages/d2b-priv-broker/src/ops/storage_contract.rs
+++ b/packages/d2b-priv-broker/src/ops/storage_contract.rs
@@ -5,6 +5,7 @@
 //! opaque bundle ids from the daemon and resolve every path/owner/mode from
 //! the broker's trusted bundle copy.
 
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 
 use d2b_contracts::broker_wire::{
@@ -12,7 +13,10 @@ use d2b_contracts::broker_wire::{
 };
 use d2b_contracts::types::BundleOpId;
 use d2b_core::bundle_resolver::BundleResolver;
-use d2b_core::storage::{PrincipalKind, PrincipalRef, StoragePathKind};
+use d2b_core::storage::{
+    PrincipalKind, PrincipalRef, StorageInvariant, StoragePathKind, StoragePathSpec,
+};
+use nix::libc;
 use nix::unistd::{Gid, Group, Uid, User};
 
 use super::hosts::stable_hash_str;
@@ -134,6 +138,9 @@ pub fn reconcile_storage_scope(
                 })
             }
         }
+        StoragePathKind::RegularFile if is_generated_lock_file_row(resolver, spec) => {
+            reconcile_lock_file_row(spec, storage_ref, &path_buf, path_hash, apply)
+        }
         _ if apply => Err(StorageContractError::Refused {
             subject: storage_ref.as_str().to_owned(),
             reason: "storage-apply-supported-for-directory-only".to_owned(),
@@ -146,6 +153,188 @@ pub fn reconcile_storage_scope(
             applied: false,
             path_hash,
         }),
+    }
+}
+
+/// True exactly when some `sync.json` lock's own `pathTemplate` names this
+/// storage row (matched on `pathTemplate` + `scope`) - i.e. this regular
+/// file row exists solely to BE a generated OFD lock file, never an
+/// arbitrary broker-created regular file. `reconcile_storage_scope` only
+/// creates regular files for rows this returns `true` for; every other
+/// `RegularFile` row remains check-only via the existing
+/// `storage-apply-supported-for-directory-only` refusal.
+fn is_generated_lock_file_row(resolver: &BundleResolver, spec: &StoragePathSpec) -> bool {
+    resolver.sync.as_ref().is_some_and(|sync| {
+        sync.locks.iter().any(|lock| {
+            lock.path_template.as_ref() == Some(&spec.path_template) && lock.scope == spec.scope
+        })
+    })
+}
+
+/// Reconciles a generated regular-file storage row that is exclusively a
+/// lock file (see [`is_generated_lock_file_row`]). This is the only
+/// regular-file shape `reconcile_storage_scope` may create; holders never
+/// create the lock file themselves (see
+/// `d2b_state::LockGuard::acquire_from_generated`'s open-only contract) -
+/// only this broker path may, and a missing file fails the holder closed
+/// with a "reconcile first" error rather than silently creating it under
+/// lock-acquisition pressure.
+///
+/// Creation is anchored/nofollow `O_CREAT|O_EXCL`+`O_CLOEXEC` beneath the
+/// parent directory (opened via
+/// [`crate::sys::path_safe::open_dir_path_safe`], itself symlink-/
+/// magic-link-/mount-escape-free component-by-component from the
+/// filesystem root) - never a raw absolute-path `open(2)` and never a
+/// path string handed to the kernel outside that anchored walk. A
+/// pre-existing file is validated (regular, exact owner/mode, single hard
+/// link) rather than silently trusted or blindly re-created, and the
+/// parent directory entry is `fsync`ed before reporting success on both
+/// the fresh-create and the already-exists path, so a caller observing a
+/// successful reconcile can trust the file is durably present under its
+/// final name.
+fn reconcile_lock_file_row(
+    spec: &StoragePathSpec,
+    storage_ref: &BundleOpId,
+    path_buf: &Path,
+    path_hash: String,
+    apply: bool,
+) -> Result<ReconcileStorageScopeResponse, StorageContractError> {
+    if !apply {
+        let status = if path_buf.exists() {
+            StorageReconcileStatus::Clean
+        } else {
+            StorageReconcileStatus::CheckedOnly
+        };
+        return Ok(ReconcileStorageScopeResponse {
+            storage_ref: storage_ref.clone(),
+            scope: spec.scope.as_str().to_owned(),
+            kind: format!("{:?}", spec.kind),
+            status,
+            applied: false,
+            path_hash,
+        });
+    }
+    if !spec.no_follow
+        || !spec.invariants.contains(&StorageInvariant::NoSymlink)
+        || !spec.invariants.contains(&StorageInvariant::NoMagicLink)
+    {
+        return Err(StorageContractError::Invalid {
+            subject: storage_ref.as_str().to_owned(),
+            detail: "lock-file-row-missing-no-symlink-invariant".to_owned(),
+        });
+    }
+    let mode = parse_mode(&spec.mode, storage_ref.as_str())?;
+    let uid = resolve_uid(&spec.owner)?;
+    let gid = resolve_gid(&spec.group)?;
+
+    let parent = path_buf
+        .parent()
+        .ok_or_else(|| StorageContractError::Refused {
+            subject: storage_ref.as_str().to_owned(),
+            reason: "storage-path-has-no-parent".to_owned(),
+        })?;
+    let name = path_buf
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| StorageContractError::Refused {
+            subject: storage_ref.as_str().to_owned(),
+            reason: "storage-path-has-no-leaf".to_owned(),
+        })?;
+
+    let parent_fd = crate::sys::path_safe::open_dir_path_safe(parent).map_err(|err| {
+        StorageContractError::Io {
+            path_hash: path_hash.clone(),
+            detail: err.to_string(),
+        }
+    })?;
+
+    let status = create_or_validate_lock_file(&parent_fd, name, mode, uid, gid, &path_hash)?;
+
+    Ok(ReconcileStorageScopeResponse {
+        storage_ref: storage_ref.clone(),
+        scope: spec.scope.as_str().to_owned(),
+        kind: format!("{:?}", spec.kind),
+        status,
+        applied: true,
+        path_hash,
+    })
+}
+
+/// The anchored create-or-validate step behind [`reconcile_lock_file_row`].
+/// `O_CREAT|O_EXCL` beneath `parent_fd` either wins the create race
+/// outright, or hits `EEXIST` - in which case the existing entry is
+/// opened (still anchored/nofollow) and validated to actually be the
+/// regular file this row describes (type, hard-link count, owner, mode)
+/// rather than assumed. Both the fresh-create and the validated-EEXIST
+/// paths `fsync` the parent directory entry before returning success, so
+/// a durable listing is guaranteed either way.
+fn create_or_validate_lock_file(
+    parent_fd: &OwnedFd,
+    name: &str,
+    mode: u32,
+    uid: Uid,
+    gid: Gid,
+    path_hash: &str,
+) -> Result<StorageReconcileStatus, StorageContractError> {
+    let io_err = |err: std::io::Error| StorageContractError::Io {
+        path_hash: path_hash.to_owned(),
+        detail: err.to_string(),
+    };
+    match crate::sys::path_safe::create_file_at_safe(
+        parent_fd,
+        name,
+        libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL,
+        mode,
+    ) {
+        Ok(fd) => {
+            crate::sys::path_safe::fchmod(fd.as_fd(), mode).map_err(io_err)?;
+            crate::sys::path_safe::fchown(fd.as_fd(), Some(uid.as_raw()), Some(gid.as_raw()))
+                .map_err(io_err)?;
+            nix::unistd::fsync(fd.as_raw_fd()).map_err(|err| StorageContractError::Io {
+                path_hash: path_hash.to_owned(),
+                detail: format!("fsync lock file: {err}"),
+            })?;
+            nix::unistd::fsync(parent_fd.as_raw_fd()).map_err(|err| StorageContractError::Io {
+                path_hash: path_hash.to_owned(),
+                detail: format!("fsync lock file parent: {err}"),
+            })?;
+            Ok(StorageReconcileStatus::Created)
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            let fd = crate::sys::path_safe::open_file_at_safe(parent_fd, name, libc::O_RDONLY)
+                .map_err(io_err)?;
+            let stat = crate::sys::path_safe::fstat_fd(fd.as_fd()).map_err(io_err)?;
+            if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
+                return Err(StorageContractError::Refused {
+                    subject: name.to_owned(),
+                    reason: "lock-file-existing-not-regular".to_owned(),
+                });
+            }
+            if stat.st_nlink != 1 {
+                return Err(StorageContractError::Refused {
+                    subject: name.to_owned(),
+                    reason: "lock-file-existing-hardlinked".to_owned(),
+                });
+            }
+            if stat.st_uid != uid.as_raw() || stat.st_gid != gid.as_raw() {
+                return Err(StorageContractError::Refused {
+                    subject: name.to_owned(),
+                    reason: "lock-file-existing-owner-mismatch".to_owned(),
+                });
+            }
+            if stat.st_mode & 0o7777 != mode {
+                return Err(StorageContractError::Refused {
+                    subject: name.to_owned(),
+                    reason: "lock-file-existing-mode-mismatch".to_owned(),
+                });
+            }
+            nix::unistd::fsync(parent_fd.as_raw_fd()).map_err(|err| StorageContractError::Io {
+                path_hash: path_hash.to_owned(),
+                detail: format!("fsync lock file parent: {err}"),
+            })?;
+            Ok(StorageReconcileStatus::Reused)
+        }
+        Err(err) => Err(io_err(err)),
     }
 }
 
@@ -431,6 +620,219 @@ mod tests {
         let err = reconcile_storage_scope(&resolver, &BundleOpId::new("path:regular-file"), true)
             .expect_err("regular files are check-only in broker reconcile");
         assert_refused_reason(Err(err), "storage-apply-supported-for-directory-only");
+    }
+
+    #[test]
+    fn generated_lock_file_row_detection_matches_on_path_template_and_scope() {
+        let resolver = resolver_with_storage_path(
+            "path:lock-file",
+            "/run/d2b/daemon.lock",
+            StoragePathKind::RegularFile,
+            sync_with_lock(lock("lock:daemon", true, FdPassingMechanism::None, false)),
+        );
+        let spec = resolver.find_storage_path_spec("path:lock-file").unwrap();
+        assert!(is_generated_lock_file_row(&resolver, spec));
+
+        let unmatched = resolver_with_storage_path(
+            "path:regular-file",
+            "/var/lib/d2b/storage-contract-regular-file",
+            StoragePathKind::RegularFile,
+            sync_with_lock(lock("lock:daemon", true, FdPassingMechanism::None, false)),
+        );
+        let unmatched_spec = unmatched
+            .find_storage_path_spec("path:regular-file")
+            .unwrap();
+        assert!(!is_generated_lock_file_row(&unmatched, unmatched_spec));
+    }
+
+    #[test]
+    fn create_or_validate_lock_file_creates_and_reuses_matching_file() {
+        let scratch = project_scratch("create-or-validate-lock-file-creates-and-reuses");
+        let parent_fd = crate::sys::path_safe::open_dir_path_safe(scratch.path()).unwrap();
+        let uid = current_uid();
+        let gid = current_gid();
+
+        let created =
+            create_or_validate_lock_file(&parent_fd, "keys.lock", 0o640, uid, gid, "hash")
+                .expect("first call creates the lock file");
+        assert_eq!(created, StorageReconcileStatus::Created);
+        let metadata = std::fs::metadata(scratch.path().join("keys.lock")).unwrap();
+        assert!(metadata.is_file());
+        assert_eq!(
+            std::os::unix::fs::PermissionsExt::mode(&metadata.permissions()) & 0o7777,
+            0o640
+        );
+
+        let reused = create_or_validate_lock_file(&parent_fd, "keys.lock", 0o640, uid, gid, "hash")
+            .expect("second call validates and reuses the same file");
+        assert_eq!(reused, StorageReconcileStatus::Reused);
+    }
+
+    #[test]
+    fn create_or_validate_lock_file_rejects_existing_directory() {
+        let scratch = project_scratch("create-or-validate-lock-file-rejects-directory");
+        std::fs::create_dir(scratch.path().join("keys.lock")).unwrap();
+        let parent_fd = crate::sys::path_safe::open_dir_path_safe(scratch.path()).unwrap();
+
+        let err = create_or_validate_lock_file(
+            &parent_fd,
+            "keys.lock",
+            0o640,
+            current_uid(),
+            current_gid(),
+            "hash",
+        )
+        .expect_err("a directory in place of the lock file must be refused");
+        assert_refused_reason(Err(err), "lock-file-existing-not-regular");
+    }
+
+    #[test]
+    fn create_or_validate_lock_file_rejects_mode_drift() {
+        let scratch = project_scratch("create-or-validate-lock-file-rejects-mode-drift");
+        let parent_fd = crate::sys::path_safe::open_dir_path_safe(scratch.path()).unwrap();
+        create_or_validate_lock_file(
+            &parent_fd,
+            "keys.lock",
+            0o640,
+            current_uid(),
+            current_gid(),
+            "hash",
+        )
+        .expect("first call creates the lock file");
+
+        let err = create_or_validate_lock_file(
+            &parent_fd,
+            "keys.lock",
+            0o600,
+            current_uid(),
+            current_gid(),
+            "hash",
+        )
+        .expect_err("a mode-drifted existing lock file must be refused");
+        assert_refused_reason(Err(err), "lock-file-existing-mode-mismatch");
+    }
+
+    #[test]
+    fn create_or_validate_lock_file_rejects_extra_hard_link() {
+        let scratch = project_scratch("create-or-validate-lock-file-rejects-hard-link");
+        let parent_fd = crate::sys::path_safe::open_dir_path_safe(scratch.path()).unwrap();
+        create_or_validate_lock_file(
+            &parent_fd,
+            "keys.lock",
+            0o640,
+            current_uid(),
+            current_gid(),
+            "hash",
+        )
+        .expect("first call creates the lock file");
+        std::fs::hard_link(
+            scratch.path().join("keys.lock"),
+            scratch.path().join("keys.lock.alias"),
+        )
+        .unwrap();
+
+        let err = create_or_validate_lock_file(
+            &parent_fd,
+            "keys.lock",
+            0o640,
+            current_uid(),
+            current_gid(),
+            "hash",
+        )
+        .expect_err("an extra hard link on the existing lock file must be refused");
+        assert_refused_reason(Err(err), "lock-file-existing-hardlinked");
+    }
+
+    #[test]
+    fn reconcile_lock_file_row_requires_no_symlink_and_no_magiclink_invariants() {
+        let scratch = project_scratch("reconcile-lock-file-row-requires-invariants");
+        let path_buf = scratch.path().join("keys.lock");
+        let spec = lock_file_storage_spec(&path_buf, vec![StorageInvariant::NoSymlink]);
+
+        let err = reconcile_lock_file_row(
+            &spec,
+            &BundleOpId::new("path:keys-lock"),
+            &path_buf,
+            "hash".to_owned(),
+            true,
+        )
+        .expect_err("a lock-file row missing NoMagicLink must be rejected");
+        match err {
+            StorageContractError::Invalid { detail, .. } => {
+                assert_eq!(detail, "lock-file-row-missing-no-symlink-invariant");
+            }
+            other => panic!("expected invalid detail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_lock_file_row_creates_and_reports_checked_only_without_apply() {
+        let scratch = project_scratch("reconcile-lock-file-row-checked-only-without-apply");
+        let path_buf = scratch.path().join("keys.lock");
+        let spec = lock_file_storage_spec(
+            &path_buf,
+            vec![StorageInvariant::NoSymlink, StorageInvariant::NoMagicLink],
+        );
+
+        let checked = reconcile_lock_file_row(
+            &spec,
+            &BundleOpId::new("path:keys-lock"),
+            &path_buf,
+            "hash".to_owned(),
+            false,
+        )
+        .expect("check-only reconcile does not touch the filesystem");
+        assert_eq!(checked.status, StorageReconcileStatus::CheckedOnly);
+        assert!(!checked.applied);
+        assert!(!path_buf.exists());
+
+        let created = reconcile_lock_file_row(
+            &spec,
+            &BundleOpId::new("path:keys-lock"),
+            &path_buf,
+            "hash".to_owned(),
+            true,
+        )
+        .expect("apply=true creates the lock file");
+        assert_eq!(created.status, StorageReconcileStatus::Created);
+        assert!(created.applied);
+        assert!(path_buf.is_file());
+    }
+
+    fn current_uid() -> Uid {
+        nix::unistd::getuid()
+    }
+
+    fn current_gid() -> Gid {
+        nix::unistd::getgid()
+    }
+
+    fn lock_file_storage_spec(path: &Path, invariants: Vec<StorageInvariant>) -> StoragePathSpec {
+        StoragePathSpec {
+            id: ContractId::parse("path:keys-lock").unwrap(),
+            scope: ContractId::parse("host").unwrap(),
+            path_template: PathTemplate::parse(path.to_str().unwrap()).unwrap(),
+            kind: StoragePathKind::RegularFile,
+            lifecycle: StorageLifecycle::BootScopedReadoptable,
+            persistence: StoragePersistence::BootScoped,
+            owner: principal(PrincipalKind::Uid, &current_uid().as_raw().to_string()),
+            group: principal(PrincipalKind::Gid, &current_gid().as_raw().to_string()),
+            mode: "0640".to_owned(),
+            access_acl: Vec::new(),
+            default_acl: Vec::new(),
+            creator: actor(ActorKind::Broker, "d2b-priv-broker"),
+            writers: vec![actor(ActorKind::Broker, "d2b-priv-broker")],
+            readers: vec![actor(ActorKind::Daemon, "d2bd")],
+            cleanup_policy: CleanupPolicy::Boot,
+            repair_policy: RepairPolicy::BrokerReconcile,
+            restart_policy: StorageRestartPolicy::PreserveAcrossDaemonRestart,
+            adoption_policy: StorageAdoptionPolicy::AdoptWithLiveOwnerProof,
+            lease_class: LeaseClass::None,
+            sensitivity: SensitivityClass::Private,
+            no_follow: true,
+            recursive: false,
+            invariants,
+        }
     }
 
     #[test]

--- a/packages/d2b-state/Cargo.toml
+++ b/packages/d2b-state/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 default = []
 host-fs = [
     "dep:d2b-contracts",
+    "dep:d2b-core",
     "dep:nix",
     "dep:rustix",
     "dep:serde",
@@ -22,6 +23,11 @@ tokio = ["host-fs", "dep:tokio"]
 
 [dependencies]
 d2b-contracts = { workspace = true, default-features = false, features = ["v2-state"], optional = true }
+# Optional, host-fs-gated: bridges the generated d2b-core sync/storage
+# contract (Nix-rendered LockSpec/StoragePathSpec rows) into this crate's
+# runtime LockSet/LockGuard/AnchoredResource without inventing mapping data.
+# d2b-core intentionally does NOT depend back on d2b-state or d2b-contracts.
+d2b-core = { workspace = true, optional = true }
 nix = { workspace = true, features = ["fs"], optional = true }
 rustix = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/packages/d2b-state/src/atomic.rs
+++ b/packages/d2b-state/src/atomic.rs
@@ -452,6 +452,70 @@ impl<F: AtomicFilesystem> AtomicWrite<F> {
     }
 }
 
+impl AtomicWrite<RealAtomicFilesystem> {
+    /// Reads exactly the resource `guard` acquired protection for at
+    /// generated-lock acquisition time, identified by `resource_id`.
+    ///
+    /// Never accepts a caller-supplied [`AnchoredResource`] or storage
+    /// inventory: the only resolution consulted is
+    /// [`LockGuard::protected_resource`]'s acquisition-time-bound
+    /// [`GuardedResource`](crate::path::GuardedResource) borrow, which is
+    /// re-verified against its live directory identity (detecting a
+    /// replacement race between acquisition and this call) before any
+    /// filesystem access. The temporary [`RealAtomicFilesystem`] built
+    /// from that borrow is used and dropped entirely inside this call —
+    /// only the plain [`DurableState<T>`] result is returned, never the
+    /// filesystem handle or the guarded borrow itself.
+    pub fn read_guarded<T>(
+        guard: &LockGuard,
+        resource_id: &d2b_contracts::v2_state::ResourceId,
+        policy: &ReadPolicy,
+    ) -> Result<DurableState<T>>
+    where
+        T: DeserializeOwned + Serialize + PartialEq,
+    {
+        let resource = guard.protected_resource(resource_id)?;
+        // `protected_resource` already validates `resource_id` against the
+        // guard's own acquisition-time-bound resource id before returning
+        // this capability; re-asserting it here is a belt-and-suspenders
+        // check against the exact opaque identity carried by the
+        // capability itself, never a re-derivation from caller input.
+        debug_assert_eq!(resource.resource_id(), resource_id);
+        resource.verify_live_identity()?;
+        let mut atomic =
+            AtomicWrite::new(RealAtomicFilesystem::new(resource.to_anchored_resource()));
+        atomic.read::<T>(policy)
+    }
+
+    /// Writes `payload` to exactly the resource `guard` acquired
+    /// protection for at generated-lock acquisition time, identified by
+    /// `resource_id`.
+    ///
+    /// Same non-forgeable resolution and live-identity re-verification as
+    /// [`Self::read_guarded`]. `policy.lock_id` and `guard` still flow
+    /// through the unchanged [`Self::validate_lock`]/
+    /// [`LockGuard::validate_state_binding`] check that every legacy
+    /// `write` call already goes through — this guarded entry point adds
+    /// the non-forgeable resource resolution on top of, not instead of,
+    /// that existing authority check.
+    pub fn write_guarded<T>(
+        guard: &LockGuard,
+        resource_id: &d2b_contracts::v2_state::ResourceId,
+        payload: &T,
+        policy: &WritePolicy,
+    ) -> Result<AtomicWriteReceipt>
+    where
+        T: DeserializeOwned + Serialize + PartialEq,
+    {
+        let resource = guard.protected_resource(resource_id)?;
+        debug_assert_eq!(resource.resource_id(), resource_id);
+        resource.verify_live_identity()?;
+        let mut atomic =
+            AtomicWrite::new(RealAtomicFilesystem::new(resource.to_anchored_resource()));
+        atomic.write::<T>(payload, policy, Some(guard))
+    }
+}
+
 pub struct RealTemp {
     fd: OwnedFd,
     name: LeafName,

--- a/packages/d2b-state/src/lock.rs
+++ b/packages/d2b-state/src/lock.rs
@@ -10,7 +10,8 @@ use d2b_contracts::v2_state::{
     OwnershipEpoch, ResourceId,
 };
 use d2b_core::{
-    storage::{ActorKind, DegradeScope, StoragePathKind, StoragePathSpec},
+    contract_id::ContractId,
+    storage::{ActorKind, DegradeScope, StorageJson, StoragePathKind, StoragePathSpec},
     sync::{
         FdPassingMechanism, InheritancePolicy, LockAdoptionPolicy, LockKind as GeneratedLockKind,
         LockSpec as GeneratedLockSpec, LockStalePolicy, LockTimeoutKind, SyncJson,
@@ -24,9 +25,38 @@ use nix::{
 use rustix::fs::{FileType, Mode, OFlags};
 
 use crate::{
-    AnchoredResource, Error, ErrorCode, MetadataExpectation, RelativePath, Result,
-    path::dup_cloexec,
+    AnchoredDir, AnchoredResource, Error, ErrorCode, MetadataExpectation, RelativePath, Result,
+    path::{GeneratedResource, dup_cloexec},
 };
+
+/// Ceiling on how long a single bounded-wait poll iteration sleeps, used by
+/// both [`LockSet::acquire_with_clock`] and
+/// [`LockSet::acquire_from_generated_with_clock`]. Every sleep is computed
+/// as `remaining_time_before_deadline.min(MAX_LOCK_POLL_BACKOFF)` — this is
+/// a *cap*, never an unconditional sleep duration, so a short or
+/// soon-to-expire deadline is never overshot by an invented fixed sleep.
+const MAX_LOCK_POLL_BACKOFF: Duration = Duration::from_millis(2);
+
+/// Sleeps for the remaining time before `deadline` (measured from
+/// `started`), capped at [`MAX_LOCK_POLL_BACKOFF`], or fails closed with
+/// [`ErrorCode::Deadline`] if `deadline` has already elapsed. Never sleeps
+/// past what remains before the deadline: a sub-cap remaining duration
+/// (for example, a lock with a 1ms bounded-wait timeout) sleeps for exactly
+/// that remaining duration, never the full cap, so a short or nearly
+/// expired deadline is never overshot by an invented fixed sleep.
+fn poll_backoff_or_deadline<C: Clock + ?Sized>(
+    clock: &C,
+    started: Instant,
+    deadline: Duration,
+) -> Result<()> {
+    let elapsed = clock.now().saturating_duration_since(started);
+    if elapsed >= deadline {
+        return Err(Error::Code(ErrorCode::Deadline));
+    }
+    let remaining = deadline - elapsed;
+    clock.sleep(remaining.min(MAX_LOCK_POLL_BACKOFF));
+    Ok(())
+}
 
 pub trait Cancellation {
     fn is_cancelled(&self) -> bool;
@@ -108,16 +138,26 @@ impl OfdTransfer<'_> {
 pub struct LockGuard {
     fd: OwnedFd,
     lock_id: ResourceId,
-    resource_id: ResourceId,
+    /// The lock file's own storage-row resource id (the file this guard's
+    /// `fd` is actually opened/locked against). Distinct from
+    /// [`Self::protected_resources`], which names the *protected state*
+    /// resources this lock authorizes mutation of — never the same field
+    /// doing double duty (see [`Self::validate_state_binding`] and
+    /// [`Self::bind_protected_resource`]).
+    lock_file_resource_id: ResourceId,
     owner: AuthorityRef,
     ownership_epoch: OwnershipEpoch,
     global_order: u32,
     transfer: FdTransferPolicy,
     held: bool,
-    /// Storage resource ids this lock protects, beyond the lock file's own
-    /// `resource_id`. Empty for guards acquired via the legacy
-    /// `v2_state::LockSpec`-based [`LockSet::acquire`]/`acquire_with_clock`,
-    /// which has no generated notion of a protected-resource set.
+    /// Storage resource ids this lock protects. For guards acquired via the
+    /// legacy `v2_state::LockSpec`-based [`LockSet::acquire`]/
+    /// `acquire_with_clock`, this is always exactly `[resource.resource_id]`
+    /// (the single resource that API has ever protected), preserving that
+    /// path's existing single-resource semantics. For guards acquired via
+    /// [`LockSet::acquire_from_generated`], this is the caller-supplied,
+    /// inventory-validated `protected_resource_ids` set — distinct from
+    /// [`Self::lock_file_resource_id`].
     protected_resources: Vec<ResourceId>,
     /// Generated stale/adoption/degrade policy, carried through losslessly
     /// from the generated `sync.json` row. `None` for guards acquired via
@@ -130,13 +170,12 @@ pub struct LockGuard {
     generated_stale_policy: Option<LockStalePolicy>,
     generated_adoption_policy: Option<LockAdoptionPolicy>,
     generated_degrade_scope: Option<DegradeScope>,
-    /// `(dev, ino)` of the resource's containing directory at bind time (see
-    /// [`AnchoredResource::directory_identity`]), used by
-    /// [`LockGuard::verify_binding`] to reject a resource whose containing
-    /// directory was replaced after resolution.
-    directory_identity: Option<(u64, u64)>,
     /// Whether this call created the lock file (as opposed to opening an
-    /// already-existing one).
+    /// already-existing one). Always `false` for guards acquired via
+    /// [`LockSet::acquire_from_generated`], which never creates a lock file
+    /// (see that method's docs): a generated lock file is exclusively
+    /// broker-created, and the generated acquire path only ever opens an
+    /// existing one.
     created: bool,
 }
 
@@ -144,7 +183,7 @@ impl fmt::Debug for LockGuard {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LockGuard")
             .field("lock_id", &self.lock_id)
-            .field("resource_id", &self.resource_id)
+            .field("lock_file_resource_id", &self.lock_file_resource_id)
             .field("ownership_epoch", &self.ownership_epoch)
             .field("global_order", &self.global_order)
             .field("held", &self.held)
@@ -162,8 +201,12 @@ impl LockGuard {
         self.global_order
     }
 
-    pub fn resource_id(&self) -> &ResourceId {
-        &self.resource_id
+    /// The lock file's own storage-row resource id — i.e. the identity of
+    /// the file this guard's held descriptor is actually locked against.
+    /// This is *not* one of [`Self::protected_resources`] unless a caller
+    /// explicitly requested the lock file itself as a protected resource.
+    pub fn lock_file_resource_id(&self) -> &ResourceId {
+        &self.lock_file_resource_id
     }
 
     pub fn owner(&self) -> &AuthorityRef {
@@ -178,9 +221,9 @@ impl LockGuard {
         self.held
     }
 
-    /// Storage resource ids protected by this lock (beyond the lock file's
-    /// own `resource_id`), as bound at acquisition time by
-    /// [`LockSet::acquire_from_generated`]. Empty for legacy-path guards.
+    /// Storage resource ids protected by this lock. See the field docs on
+    /// [`LockGuard::protected_resources`] for exactly what this contains
+    /// for each acquisition path.
     pub fn protected_resources(&self) -> &[ResourceId] {
         &self.protected_resources
     }
@@ -220,23 +263,60 @@ impl LockGuard {
         Ok((stat.st_dev, stat.st_ino))
     }
 
-    /// Verifies that `resource` is exactly the resource this guard is bound
-    /// to: same `resource_id`, and — for resources resolved via
-    /// [`AnchoredResource::resolve_generated`] — the same containing
-    /// directory identity captured at bind time. Rejects a resource whose
-    /// `resource_id` matches by coincidence/forgery but whose directory was
-    /// replaced (or that was never bound through the guarded resolution
-    /// path when the guard requires it).
-    pub fn verify_binding(&self, resource: &AnchoredResource) -> Result<()> {
-        if resource.resource_id != self.resource_id {
+    /// Opens one of the resources this held guard authorizes mutation for,
+    /// resolved fresh via a trusted-root + `openat2` walk against `storage`'s
+    /// validated inventory and `anchor`/`anchor_path` — never an inferred
+    /// parent/path relationship, and never a caller-supplied resource
+    /// accepted on trust. `resource_id` must both:
+    ///
+    /// - resolve to exactly one row in `storage`'s validated inventory
+    ///   (missing or duplicate ids fail closed), and
+    /// - be a member of [`Self::protected_resources`] as bound at
+    ///   acquisition time — a resource this specific guard does not
+    ///   authorize is rejected even if it exists and is otherwise
+    ///   well-formed.
+    ///
+    /// On success, returns the legacy [`AnchoredResource`] shape so
+    /// existing atomic/audit consumers can use it without any change to
+    /// their own code; the resolution backing it is exactly as
+    /// non-forgeable as [`LockSet::acquire_from_generated`]'s own lock-file
+    /// resolution — the returned value is a fresh capability, not a clone
+    /// of anything the caller supplied.
+    pub fn bind_protected_resource(
+        &self,
+        storage: &StorageJson,
+        resource_id: &ContractId,
+        anchor: &AnchoredDir,
+        anchor_path: &std::path::Path,
+        metadata: MetadataExpectation,
+    ) -> Result<AnchoredResource> {
+        if !self.held {
+            return Err(Error::Code(ErrorCode::LockReleased));
+        }
+        metadata.validate()?;
+        storage
+            .validate_unique_ids()
+            .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
+        let row = find_unique_storage_row(storage, resource_id)?;
+        if row.kind != StoragePathKind::RegularFile {
+            return Err(Error::Code(ErrorCode::InvalidSchema));
+        }
+        let encoded = encode_resource_id(row.id.as_str())?;
+        if !self.protected_resources.contains(&encoded) {
             return Err(Error::Code(ErrorCode::LockMismatch));
         }
-        if let Some(expected) = self.directory_identity
-            && resource.directory_identity() != Some(expected)
-        {
-            return Err(Error::Code(ErrorCode::LockMismatch));
+        let row_mode =
+            u32::from_str_radix(&row.mode, 8).map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
+        if metadata.mode != row_mode {
+            return Err(Error::Code(ErrorCode::MetadataMismatch));
         }
-        Ok(())
+        let generated = GeneratedResource::resolve(
+            anchor,
+            anchor_path,
+            encoded,
+            std::path::Path::new(row.path_template.as_str()),
+        )?;
+        Ok(generated.into_anchored_resource())
     }
 
     pub fn authorize_transfer(&mut self, requested: FdTransferPolicy) -> Result<OfdTransfer<'_>> {
@@ -272,7 +352,7 @@ impl LockGuard {
             return Err(Error::Code(ErrorCode::LockReleased));
         }
         if &self.lock_id != lock_id
-            || &self.resource_id != resource_id
+            || !self.protected_resources.contains(resource_id)
             || &self.owner != owner
             || self.ownership_epoch != ownership_epoch
             || self.transfer != FdTransferPolicy::Never
@@ -394,10 +474,7 @@ impl LockSet {
                     if spec.contention == ContentionPolicy::FailFast {
                         return Err(Error::Code(ErrorCode::LockContended));
                     }
-                    if clock.now().saturating_duration_since(started) >= deadline {
-                        return Err(Error::Code(ErrorCode::Deadline));
-                    }
-                    clock.sleep(Duration::from_millis(1));
+                    poll_backoff_or_deadline(clock, started, deadline)?;
                 }
                 Err(error) => {
                     return Err(Error::Os {
@@ -411,17 +488,16 @@ impl LockSet {
         self.guards.push(LockGuard {
             fd,
             lock_id: spec.lock_id.clone(),
-            resource_id: spec.key.resource_id.clone(),
+            lock_file_resource_id: spec.key.resource_id.clone(),
             owner: spec.owner.clone(),
             ownership_epoch,
             global_order: spec.global_order,
             transfer: spec.fd_transfer,
             held: true,
-            protected_resources: Vec::new(),
+            protected_resources: vec![resource.resource_id.clone()],
             generated_stale_policy: None,
             generated_adoption_policy: None,
             generated_degrade_scope: None,
-            directory_identity: resource.directory_identity(),
             created,
         });
         Ok(self
@@ -452,24 +528,43 @@ impl LockSet {
     /// is invented, defaulted, or reinterpreted, and any field this
     /// function cannot validate causes it to fail closed.
     ///
-    /// - `sync` is the full generated document (needed to derive the exact
-    ///   total acquire order via [`SyncJson::global_order_rank`]).
-    /// - `lock` is the specific generated lock row being acquired.
-    /// - `lock_row` is the generated storage row for `lock`'s own lock
-    ///   file (`lock.resource_id` must name it); it supplies the lock
-    ///   file's declared mode, kind, and path template, cross-checked
-    ///   against `resource` and `metadata` rather than trusted blindly.
-    /// - `protected` are the generated storage rows this lock is being
-    ///   used to protect. The caller supplies them (there is no generated
-    ///   parent/child field linking a lock to the resources it protects);
-    ///   each row's `scope` is checked against `lock.scope` so an
-    ///   unrelated resource cannot be smuggled in as "protected" by this
-    ///   lock.
-    /// - `resource` must already be bound via
-    ///   [`AnchoredResource::resolve_generated`] against `lock_row`; this
-    ///   function independently re-derives `lock_row`'s resource id and
-    ///   rejects a mismatch, so a caller cannot pair an unrelated
-    ///   `AnchoredResource` with a given `lock`/`lock_row`.
+    /// Callers never hand in a detached `&GeneratedLockSpec`/
+    /// `&StoragePathSpec`/`&AnchoredResource` — a prior shape of this API
+    /// did, which let a caller substitute an arbitrary same-id row or
+    /// resource that was never actually looked up from the trusted
+    /// document. Instead:
+    ///
+    /// - `sync`/`storage` are the full trusted generated documents. This
+    ///   function resolves every row it needs — the lock, its own
+    ///   lock-file storage row, and each protected resource's storage row —
+    ///   directly from these documents by opaque id.
+    ///   `sync.validate_lock_order()` and `storage.validate_unique_ids()`
+    ///   are re-run here so a caller cannot pass an already-invalid
+    ///   document and have a stale or duplicate row silently resolved.
+    /// - `lock_id` is the opaque generated id of the lock to acquire; it
+    ///   must resolve to exactly one row in `sync.locks` (a missing or
+    ///   duplicate id fails closed).
+    /// - `protected_resource_ids` are the opaque ids of the storage
+    ///   resources this acquisition protects. There is no generated
+    ///   parent/child field linking a lock to the resources it protects,
+    ///   so the caller supplies them; each one must resolve to exactly one
+    ///   row in `storage`, must not repeat, and that row's `scope` is
+    ///   checked against the lock's own `scope` so an unrelated resource
+    ///   cannot be smuggled in as "protected" by this lock. The lock file's
+    ///   own storage row (named by `lock.resource_id`) is a distinct
+    ///   concept from a protected resource; see [`LockGuard`]'s field docs.
+    /// - `anchor`/`anchor_path` are the trusted pre-opened root and its
+    ///   absolute path. The lock file's own storage row is resolved
+    ///   beneath `anchor` via [`GeneratedResource::resolve`] only *after*
+    ///   every other validation succeeds, directly from the row's own id —
+    ///   there is no longer a separate caller-supplied resource parameter
+    ///   that could be mismatched with the wrong lock/row.
+    /// - The generated lock file is opened, never created (`OFlags::RDWR`
+    ///   only — no `CREATE`/`EXCL`). A generated lock file is exclusively
+    ///   broker-created; if it is missing, this fails closed with
+    ///   [`ErrorCode::Missing`] and the caller must trigger broker
+    ///   reconciliation rather than have this function silently create
+    ///   one.
     /// - `owner` is rendered to the exact `(ActorKind, value)` convention
     ///   the Nix generator uses and checked against `lock.owner_process`;
     ///   since this API accepts only one authority, `lock.owner_process`
@@ -479,10 +574,11 @@ impl LockSet {
     pub fn acquire_from_generated(
         &mut self,
         sync: &SyncJson,
-        lock: &GeneratedLockSpec,
-        lock_row: &StoragePathSpec,
-        protected: &[StoragePathSpec],
-        resource: &AnchoredResource,
+        storage: &StorageJson,
+        lock_id: &ContractId,
+        protected_resource_ids: &[ContractId],
+        anchor: &AnchoredDir,
+        anchor_path: &std::path::Path,
         owner: AuthorityRef,
         ownership_epoch: OwnershipEpoch,
         metadata: MetadataExpectation,
@@ -490,10 +586,11 @@ impl LockSet {
     ) -> Result<&mut LockGuard> {
         self.acquire_from_generated_with_clock(
             sync,
-            lock,
-            lock_row,
-            protected,
-            resource,
+            storage,
+            lock_id,
+            protected_resource_ids,
+            anchor,
+            anchor_path,
             owner,
             ownership_epoch,
             metadata,
@@ -506,18 +603,41 @@ impl LockSet {
     pub fn acquire_from_generated_with_clock<C: Clock + ?Sized>(
         &mut self,
         sync: &SyncJson,
-        lock: &GeneratedLockSpec,
-        lock_row: &StoragePathSpec,
-        protected: &[StoragePathSpec],
-        resource: &AnchoredResource,
+        storage: &StorageJson,
+        lock_id: &ContractId,
+        protected_resource_ids: &[ContractId],
+        anchor: &AnchoredDir,
+        anchor_path: &std::path::Path,
         owner: AuthorityRef,
         ownership_epoch: OwnershipEpoch,
         metadata: MetadataExpectation,
         cancellation: &(impl Cancellation + ?Sized),
         clock: &C,
     ) -> Result<&mut LockGuard> {
+        sync.validate_lock_order()
+            .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
+        storage
+            .validate_unique_ids()
+            .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
+
+        let lock = find_unique_lock(sync, lock_id)?;
+        let lock_resource_id = lock
+            .resource_id
+            .as_ref()
+            .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+        let lock_row = find_unique_storage_row(storage, lock_resource_id)?;
+
+        let mut seen_requested = std::collections::BTreeSet::new();
+        let mut protected_rows = Vec::with_capacity(protected_resource_ids.len());
+        for id in protected_resource_ids {
+            if !seen_requested.insert(id.clone()) {
+                return Err(Error::Code(ErrorCode::InvalidSchema));
+            }
+            protected_rows.push(find_unique_storage_row(storage, id)?);
+        }
+
         let binding =
-            validate_generated_lock(sync, lock, lock_row, protected, resource, &owner, metadata)?;
+            validate_generated_lock(sync, lock, lock_row, &protected_rows, &owner, metadata)?;
 
         if self.held(&binding.lock_id)
             || self
@@ -529,25 +649,18 @@ impl LockSet {
             return Err(Error::Code(ErrorCode::LockOrder));
         }
 
-        let path = RelativePath::from_components([resource.leaf.as_str()])?;
-        let (fd, created) = match resource.directory.open_beneath(
-            &path,
-            OFlags::RDWR | OFlags::CREATE | OFlags::EXCL,
-            Mode::from_raw_mode(metadata.mode),
-        ) {
-            Ok(fd) => (fd, true),
-            Err(error) if error.code() == ErrorCode::AlreadyExists => (
-                resource
-                    .directory
-                    .open_beneath(&path, OFlags::RDWR, Mode::empty())?,
-                false,
-            ),
-            Err(error) => return Err(error),
-        };
-        if created {
-            rustix::fs::fchmod(&fd, Mode::from_raw_mode(metadata.mode))
-                .map_err(|error| Error::io(ErrorCode::Io, error))?;
-        }
+        let resource = GeneratedResource::resolve(
+            anchor,
+            anchor_path,
+            binding.lock_file_resource_id.clone(),
+            std::path::Path::new(lock_row.path_template.as_str()),
+        )?;
+
+        // Generated lock files are exclusively broker-created: open only,
+        // never create. A missing file fails closed with
+        // `ErrorCode::Missing` (naturally surfaced by `open_beneath`'s
+        // NOENT mapping) rather than being silently conjured here.
+        let fd = resource.open(OFlags::RDWR, Mode::empty())?;
         validate_metadata(&fd, metadata)?;
 
         // `lock.cloexec_required` was already checked true by
@@ -578,10 +691,7 @@ impl LockSet {
                     let deadline = binding
                         .deadline
                         .expect("bounded-wait binding always carries a validated deadline");
-                    if clock.now().saturating_duration_since(started) >= deadline {
-                        return Err(Error::Code(ErrorCode::Deadline));
-                    }
-                    clock.sleep(Duration::from_millis(1));
+                    poll_backoff_or_deadline(clock, started, deadline)?;
                 }
                 Err(error) => {
                     return Err(Error::Os {
@@ -595,7 +705,7 @@ impl LockSet {
         self.guards.push(LockGuard {
             fd,
             lock_id: binding.lock_id,
-            resource_id: resource.resource_id.clone(),
+            lock_file_resource_id: binding.lock_file_resource_id,
             owner,
             ownership_epoch,
             global_order: binding.global_order,
@@ -605,8 +715,10 @@ impl LockSet {
             generated_stale_policy: Some(lock.stale_policy.clone()),
             generated_adoption_policy: Some(lock.adoption_policy),
             generated_degrade_scope: Some(lock.degrade_scope),
-            directory_identity: resource.directory_identity(),
-            created,
+            // The generated acquisition path never creates a lock file
+            // (see this method's docs): it only ever opens an
+            // already-existing, broker-created one.
+            created: false,
         });
         Ok(self
             .guards
@@ -615,12 +727,48 @@ impl LockSet {
     }
 }
 
+/// Looks up exactly one lock row in `sync.locks` by opaque id. A missing or
+/// duplicate id fails closed rather than silently picking the first/last
+/// match.
+fn find_unique_lock<'a>(sync: &'a SyncJson, lock_id: &ContractId) -> Result<&'a GeneratedLockSpec> {
+    let mut matches = sync.locks.iter().filter(|lock| &lock.id == lock_id);
+    let found = matches
+        .next()
+        .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+    if matches.next().is_some() {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    Ok(found)
+}
+
+/// Looks up exactly one storage row in `storage.paths` by opaque id. A
+/// missing or duplicate id fails closed rather than silently picking the
+/// first/last match.
+fn find_unique_storage_row<'a>(
+    storage: &'a StorageJson,
+    id: &ContractId,
+) -> Result<&'a StoragePathSpec> {
+    let mut matches = storage.paths.iter().filter(|row| &row.id == id);
+    let found = matches
+        .next()
+        .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+    if matches.next().is_some() {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    Ok(found)
+}
+
 /// The fully-validated, ready-to-acquire projection of a generated
 /// `d2b_core::sync::LockSpec`, produced by [`validate_generated_lock`].
 /// Every field here is either copied verbatim from the generated contract
 /// or deterministically derived from it (never invented).
 struct GeneratedLockBinding {
     lock_id: ResourceId,
+    /// The lock-file's own storage-row resource id, encoded from
+    /// `lock_row.id`. Kept distinct from [`Self::protected_resources`] —
+    /// see [`LockGuard`]'s field docs for why the lock file and the
+    /// resources it protects are never conflated.
+    lock_file_resource_id: ResourceId,
     global_order: u32,
     protected_resources: Vec<ResourceId>,
     fd_transfer: FdTransferPolicy,
@@ -636,8 +784,7 @@ fn validate_generated_lock(
     sync: &SyncJson,
     lock: &GeneratedLockSpec,
     lock_row: &StoragePathSpec,
-    protected: &[StoragePathSpec],
-    resource: &AnchoredResource,
+    protected: &[&StoragePathSpec],
     owner: &AuthorityRef,
     metadata: MetadataExpectation,
 ) -> Result<GeneratedLockBinding> {
@@ -680,10 +827,6 @@ fn validate_generated_lock(
     {
         return Err(Error::Code(ErrorCode::InvalidSchema));
     }
-    let encoded_resource = encode_resource_id(lock_row.id.as_str())?;
-    if encoded_resource != resource.resource_id {
-        return Err(Error::Code(ErrorCode::LockMismatch));
-    }
 
     let row_mode = u32::from_str_radix(&lock_row.mode, 8)
         .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
@@ -702,8 +845,9 @@ fn validate_generated_lock(
     }
 
     let lock_id = encode_resource_id(lock.id.as_str())?;
+    let lock_file_resource_id = encode_resource_id(lock_row.id.as_str())?;
     let mut seen = std::collections::BTreeSet::new();
-    if !seen.insert(lock_id.clone()) || !seen.insert(resource.resource_id.clone()) {
+    if !seen.insert(lock_id.clone()) || !seen.insert(lock_file_resource_id.clone()) {
         return Err(Error::Code(ErrorCode::InvalidSchema));
     }
     let mut protected_resources = Vec::with_capacity(protected.len());
@@ -753,6 +897,7 @@ fn validate_generated_lock(
 
     Ok(GeneratedLockBinding {
         lock_id,
+        lock_file_resource_id,
         global_order,
         protected_resources,
         fd_transfer,
@@ -869,7 +1014,9 @@ fn set_ofd_lock(fd: &OwnedFd, lock_type: i16) -> nix::Result<()> {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         fs,
+        os::unix::fs::PermissionsExt,
         path::{Path, PathBuf},
         sync::atomic::{AtomicU64, Ordering},
     };
@@ -891,6 +1038,18 @@ mod tests {
     use crate::AnchoredDir;
 
     static SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
+
+    /// The fixed, fake absolute directory every test's `StoragePathSpec`
+    /// rows declare their `path_template` beneath (see
+    /// [`valid_storage_row`]). [`GeneratedResource::resolve`] only ever
+    /// uses `anchor_path` for a pure string `strip_prefix` computation
+    /// against the row's declared path — it never checks that `anchor`
+    /// (the real, opened scratch-directory descriptor used for every
+    /// actual filesystem operation) truly lives at this path on disk — so
+    /// tests can use one fixed, human-readable `anchor_path` constant
+    /// while still exercising the real trusted-root `openat2` resolution
+    /// against a real per-test scratch directory.
+    const ANCHOR_PATH: &str = "/var/lib/d2b/r/realm/controller";
 
     struct Scratch(PathBuf);
 
@@ -976,14 +1135,15 @@ mod tests {
     }
 
     /// A fully-populated, schema-valid regular-file `StoragePathSpec`
-    /// mirroring the paired lock-file rows added to
+    /// mirroring the paired lock-file/protected-resource rows added to
     /// `nixos-modules/realm-storage-rows.nix` (mode `0600`, process-scoped,
-    /// not adoptable, no follow).
-    fn valid_storage_row(id: &str, owner: ActorRef) -> StoragePathSpec {
+    /// not adoptable, no follow). `leaf` names the file beneath a per-test
+    /// scratch directory so distinct rows in one test never collide.
+    fn valid_storage_row(id: &str, leaf: &str, owner: ActorRef) -> StoragePathSpec {
         StoragePathSpec {
             id: ContractId::parse(id).unwrap(),
             scope: ContractId::parse("host").unwrap(),
-            path_template: PathTemplate::parse("/var/lib/d2b/r/realm/controller/state.lock")
+            path_template: PathTemplate::parse(format!("/var/lib/d2b/r/realm/controller/{leaf}"))
                 .unwrap(),
             kind: StoragePathKind::RegularFile,
             lifecycle: StorageLifecycle::ProcessScoped,
@@ -1014,10 +1174,21 @@ mod tests {
         }
     }
 
-    fn sync_of(lock: &GeneratedLockSpec) -> SyncJson {
+    fn sync_of(locks: Vec<GeneratedLockSpec>) -> SyncJson {
         SyncJson {
             schema_version: "1".to_owned(),
-            locks: vec![lock.clone()],
+            locks,
+        }
+    }
+
+    fn storage_of(paths: Vec<StoragePathSpec>) -> StorageJson {
+        StorageJson {
+            schema_version: "1".to_owned(),
+            roots: Vec::new(),
+            paths,
+            restart_policies: Vec::new(),
+            degraded_states: Vec::new(),
+            remediations: Vec::new(),
         }
     }
 
@@ -1031,20 +1202,45 @@ mod tests {
         }
     }
 
-    /// Resolves `resource_id`/`leaf` beneath `scratch` exactly the way a
-    /// real caller would: via [`AnchoredResource::resolve_generated`]
-    /// against a trusted anchor, never a raw struct literal.
-    fn resolve(scratch: &Path, resource_id: &str, leaf: &str) -> (AnchoredDir, AnchoredResource) {
-        let anchor = AnchoredDir::open_trusted(scratch).unwrap();
-        let row_path = scratch.join(leaf);
-        let resource = AnchoredResource::resolve_generated(
-            &anchor,
-            scratch,
-            ResourceId::parse(resource_id).unwrap(),
-            &row_path,
-        )
-        .unwrap();
-        (anchor, resource)
+    /// A fully-scripted [`Clock`] for precisely testing
+    /// [`poll_backoff_or_deadline`]'s capped-backoff arithmetic without any
+    /// dependency on real wall-clock timing. `now()` returns each queued
+    /// instant in order (panicking if exhausted, so a test that scripts too
+    /// few calls fails loudly rather than silently reusing a stale value);
+    /// every `sleep()` call is recorded verbatim, never actually sleeping.
+    struct FakeClock {
+        base: Instant,
+        nows: std::cell::RefCell<VecDeque<Duration>>,
+        sleeps: std::cell::RefCell<Vec<Duration>>,
+    }
+
+    impl FakeClock {
+        fn new(nows: impl IntoIterator<Item = Duration>) -> Self {
+            Self {
+                base: Instant::now(),
+                nows: std::cell::RefCell::new(nows.into_iter().collect()),
+                sleeps: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+
+        fn recorded_sleeps(&self) -> Vec<Duration> {
+            self.sleeps.borrow().clone()
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now(&self) -> Instant {
+            let offset = self
+                .nows
+                .borrow_mut()
+                .pop_front()
+                .expect("FakeClock::now() called more times than scripted");
+            self.base + offset
+        }
+
+        fn sleep(&self, duration: Duration) {
+            self.sleeps.borrow_mut().push(duration);
+        }
     }
 
     #[test]
@@ -1079,35 +1275,105 @@ mod tests {
         assert!(render_authority(&AuthorityRef::Pid1).is_err());
     }
 
+    /// Precisely exercises [`poll_backoff_or_deadline`]'s capped-backoff
+    /// arithmetic with a fully-scripted fake clock: a short (sub-cap)
+    /// remaining duration sleeps for exactly that remaining duration, never
+    /// the fixed [`MAX_LOCK_POLL_BACKOFF`] cap, and an elapsed deadline
+    /// fails closed without sleeping at all.
     #[test]
-    fn acquire_from_generated_round_trips_authority_order_and_policy() {
+    fn poll_backoff_or_deadline_caps_to_remaining_never_overshoots() {
+        // Deadline is 3ms. First poll: 0ms elapsed -> 3ms remaining, capped
+        // at the 2ms MAX_LOCK_POLL_BACKOFF -> sleeps exactly 2ms (the cap).
+        // Second poll: 2ms elapsed -> 1ms remaining, *below* the cap ->
+        // sleeps exactly 1ms (proving "cap to remaining" is distinct from
+        // "always sleep the cap").
+        let deadline = Duration::from_millis(3);
+        let clock = FakeClock::new([
+            Duration::from_millis(0),
+            Duration::from_millis(0),
+            Duration::from_millis(2),
+        ]);
+        let started = clock.now();
+        poll_backoff_or_deadline(&clock, started, deadline).unwrap();
+        poll_backoff_or_deadline(&clock, started, deadline).unwrap();
+        assert_eq!(
+            clock.recorded_sleeps(),
+            vec![Duration::from_millis(2), Duration::from_millis(1)]
+        );
+    }
+
+    #[test]
+    fn poll_backoff_or_deadline_handles_sub_millisecond_remaining() {
+        // Deadline is 1ms; 900us have already elapsed, leaving only 100us
+        // remaining — far below the 2ms cap. The sleep must be exactly the
+        // 100us remaining, never rounded up to the cap.
+        let deadline = Duration::from_millis(1);
+        let clock = FakeClock::new([Duration::from_micros(0), Duration::from_micros(900)]);
+        let started = clock.now();
+        poll_backoff_or_deadline(&clock, started, deadline).unwrap();
+        assert_eq!(clock.recorded_sleeps(), vec![Duration::from_micros(100)]);
+    }
+
+    #[test]
+    fn poll_backoff_or_deadline_fails_closed_without_sleeping_when_elapsed() {
+        let deadline = Duration::from_millis(1);
+        let clock = FakeClock::new([Duration::from_millis(0), Duration::from_millis(1)]);
+        let started = clock.now();
+        let err = poll_backoff_or_deadline(&clock, started, deadline).unwrap_err();
+        assert_eq!(err.code(), ErrorCode::Deadline);
+        assert!(clock.recorded_sleeps().is_empty());
+    }
+
+    #[test]
+    fn acquire_from_generated_round_trips_authority_order_and_protected_resource() {
         let scratch = Scratch::new("generated-ok");
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
-        let row = valid_storage_row(
+        let lock_row = valid_storage_row(
             "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
             "state.lock",
+            owner.clone(),
         );
+        // A distinct resource this lock protects — never the lock file
+        // itself — sharing the lock's scope, matching the real
+        // `lock:workload-state:<id>` / `workload-state-data` pairing in
+        // `nixos-modules/realm-storage-rows.nix`.
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        // The generated adapter only ever opens a lock file that already
+        // exists (broker-created); the protected resource is a plain file
+        // the guard authorizes, not something this API touches directly.
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        fs::write(scratch.0.join("state.json"), b"{}").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row.clone(), protected_row.clone()]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let guard = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
-                &[],
-                &resource,
+                &storage,
+                &lock.id,
+                std::slice::from_ref(&protected_row.id),
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
@@ -1116,10 +1382,16 @@ mod tests {
             .unwrap();
 
         assert!(guard.is_held());
-        assert!(guard.created());
+        assert!(!guard.created());
         assert_eq!(guard.global_order(), 0);
-        assert_eq!(guard.resource_id(), &resource.resource_id);
-        assert!(guard.protected_resources().is_empty());
+        assert_eq!(
+            guard.lock_file_resource_id().as_str(),
+            "path-realm-controller-lock-my-realm"
+        );
+        assert_eq!(
+            guard.protected_resources(),
+            &[ResourceId::parse("path-realm-workload-state-my-realm").unwrap()]
+        );
         assert_eq!(
             guard.generated_adoption_policy(),
             Some(LockAdoptionPolicy::ReacquireAfterProof)
@@ -1131,137 +1403,478 @@ mod tests {
         let flags = rustix::fs::fcntl_getfd(&guard.fd).unwrap();
         assert!(flags.contains(rustix::io::FdFlags::CLOEXEC));
 
-        assert!(guard.verify_binding(&resource).is_ok());
+        // `validate_state_binding` authorizes the *protected* resource, not
+        // the lock file's own resource id.
+        assert!(
+            guard
+                .validate_state_binding(
+                    guard.lock_id(),
+                    &ResourceId::parse("path-realm-workload-state-my-realm").unwrap(),
+                    guard.owner(),
+                    guard.ownership_epoch(),
+                )
+                .is_ok()
+        );
+        assert_eq!(
+            guard
+                .validate_state_binding(
+                    guard.lock_id(),
+                    guard.lock_file_resource_id(),
+                    guard.owner(),
+                    guard.ownership_epoch(),
+                )
+                .unwrap_err()
+                .code(),
+            ErrorCode::LockMismatch
+        );
+
+        // A guard-bound resolution of the protected resource: opaque,
+        // non-forgeable, derived only from the held guard's authorized set
+        // plus a fresh trusted-root walk.
+        let bound = guard
+            .bind_protected_resource(
+                &storage,
+                &protected_row.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                host_metadata(&scratch.0, 0o600),
+            )
+            .unwrap();
+        assert_eq!(
+            bound.resource_id.as_str(),
+            "path-realm-workload-state-my-realm"
+        );
     }
 
     #[test]
-    fn acquire_from_generated_rejects_mismatched_resource() {
-        let scratch = Scratch::new("generated-mismatch");
+    fn acquire_from_generated_missing_lock_file_fails_closed_without_creating() {
+        let scratch = Scratch::new("generated-missing-lock-file");
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        // Bound against a DIFFERENT resource id than the lock/row declare.
-        let (_anchor, resource) = resolve(&scratch.0, "totally-unrelated-resource", "state.lock");
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        // Deliberately do NOT create `state.lock` on disk: a generated
+        // lock file is exclusively broker-created, so the adapter must
+        // open-only and fail closed rather than conjuring one.
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let err = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
+                &storage,
+                &lock.id,
                 &[],
-                &resource,
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
                 &NeverCancelled,
             )
             .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::Missing);
+        assert!(!scratch.0.join("state.lock").exists());
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_unknown_lock_id() {
+        let scratch = Scratch::new("generated-unknown-lock");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner.clone(),
+        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &ContractId::parse("lock:does-not-exist").unwrap(),
+                &[],
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_unknown_protected_resource_id() {
+        let scratch = Scratch::new("generated-unknown-protected");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner.clone(),
+        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &[ContractId::parse("path:does-not-exist").unwrap()],
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_duplicate_requested_protected_resource_ids() {
+        let scratch = Scratch::new("generated-duplicate-protected");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner.clone(),
+        );
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        fs::write(scratch.0.join("state.json"), b"{}").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, protected_row.clone()]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        // The same protected id requested twice in one call — a caller
+        // smuggling a duplicate — must be rejected even though the id
+        // itself is a valid, unique row in `storage`.
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &[protected_row.id.clone(), protected_row.id],
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn protected_resource_scope_mismatch_fails_closed() {
+        let scratch = Scratch::new("protected-scope-mismatch");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner.clone(),
+        );
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let mut foreign =
+            valid_storage_row("path:realm-workloads:my-realm", "workloads.json", owner);
+        foreign.scope = ContractId::parse("vm").unwrap();
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        fs::write(scratch.0.join("workloads.json"), b"{}").unwrap();
+        fs::set_permissions(
+            scratch.0.join("workloads.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, foreign.clone()]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &[foreign.id],
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn bind_protected_resource_rejects_resource_not_authorized_by_this_guard() {
+        let scratch = Scratch::new("bind-unauthorized");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner.clone(),
+        );
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        // Exists in the trusted inventory and on disk, but is never listed
+        // as a protected resource for this acquisition.
+        let unauthorized =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        fs::write(scratch.0.join("state.json"), b"{}").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, unauthorized.clone()]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let guard = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &[],
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap();
+
+        let err = guard
+            .bind_protected_resource(
+                &storage,
+                &unauthorized.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                host_metadata(&scratch.0, 0o600),
+            )
+            .unwrap_err();
         assert_eq!(err.code(), ErrorCode::LockMismatch);
     }
 
     #[test]
-    fn verify_binding_rejects_wrong_resource_id() {
-        let scratch = Scratch::new("verify-wrong-id");
+    fn bind_protected_resource_rejects_after_release() {
+        let scratch = Scratch::new("bind-after-release");
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
-        let row = valid_storage_row(
+        let lock_row = valid_storage_row(
             "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
             "state.lock",
+            owner.clone(),
         );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        fs::write(scratch.0.join("state.json"), b"{}").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, protected_row.clone()]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
-        let guard = set
-            .acquire_from_generated(
-                &sync,
-                &lock,
-                &row,
-                &[],
-                &resource,
-                realm_controller("my-realm"),
-                OwnershipEpoch::new(1).unwrap(),
-                metadata,
-                &NeverCancelled,
-            )
+        set.acquire_from_generated(
+            &sync,
+            &storage,
+            &lock.id,
+            std::slice::from_ref(&protected_row.id),
+            &anchor,
+            Path::new(ANCHOR_PATH),
+            realm_controller("my-realm"),
+            OwnershipEpoch::new(1).unwrap(),
+            metadata,
+            &NeverCancelled,
+        )
+        .unwrap();
+        set.last_mut()
+            .expect("guard was inserted immediately above")
+            .release_in_place()
             .unwrap();
+        let guard = set.last().expect("released guard remains in the set");
 
-        let (_other_anchor, forged) = resolve(&scratch.0, "some-other-resource", "state.lock");
-        assert_eq!(
-            guard.verify_binding(&forged).unwrap_err().code(),
-            ErrorCode::LockMismatch
-        );
+        let err = guard
+            .bind_protected_resource(
+                &storage,
+                &protected_row.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                host_metadata(&scratch.0, 0o600),
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::LockReleased);
     }
 
     #[test]
-    fn verify_binding_rejects_replaced_directory() {
-        let scratch = Scratch::new("verify-replaced-dir");
+    fn acquire_from_generated_enforces_total_order_across_two_locks() {
+        let scratch = Scratch::new("generated-total-order");
         let owner = controller_actor("my-realm");
-        let lock = valid_generated_lock(
-            "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
-            owner,
+        // "aaa" sorts before "bbb" under the acquire-order key, so `first`
+        // must always be acquired before `second`.
+        let mut first = valid_generated_lock(
+            "lock:aaa-realm-controller:my-realm",
+            "path:aaa-realm-controller-lock:my-realm",
+            owner.clone(),
         );
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
+        first.acquire_order.normalized_path = ContractId::parse("aaa").unwrap();
+        first.acquire_order.lock_id = first.id.clone();
+        let mut second = valid_generated_lock(
+            "lock:bbb-realm-controller:my-realm",
+            "path:bbb-realm-controller-lock:my-realm",
+            owner.clone(),
         );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
+        second.acquire_order.normalized_path = ContractId::parse("bbb").unwrap();
+        second.acquire_order.lock_id = second.id.clone();
+        let first_row = valid_storage_row(
+            "path:aaa-realm-controller-lock:my-realm",
+            "aaa.lock",
+            owner.clone(),
         );
+        let second_row =
+            valid_storage_row("path:bbb-realm-controller-lock:my-realm", "bbb.lock", owner);
+        fs::write(scratch.0.join("aaa.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("aaa.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        fs::write(scratch.0.join("bbb.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("bbb.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![first.clone(), second.clone()]);
+        let storage = storage_of(vec![first_row, second_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
-        let guard = set
+        // Acquiring the lower-ranked `second` while holding nothing yet is
+        // fine on its own, but acquiring `first` (a *lower* rank) after
+        // `second` (a *higher* rank) is already held must fail: total
+        // order forbids acquiring backwards.
+        set.acquire_from_generated(
+            &sync,
+            &storage,
+            &second.id,
+            &[],
+            &anchor,
+            Path::new(ANCHOR_PATH),
+            realm_controller("my-realm"),
+            OwnershipEpoch::new(1).unwrap(),
+            metadata,
+            &NeverCancelled,
+        )
+        .unwrap();
+        let err = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
+                &storage,
+                &first.id,
                 &[],
-                &resource,
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
                 &NeverCancelled,
             )
-            .unwrap();
-
-        // Same resource id, but resolved against a *different* directory:
-        // simulates the containing directory being replaced out from under
-        // an earlier resolution.
-        let elsewhere = Scratch::new("verify-replaced-dir-elsewhere");
-        fs::write(elsewhere.0.join("state.lock"), b"").unwrap();
-        let (_other_anchor, replaced) = resolve(
-            &elsewhere.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
-        assert_eq!(
-            guard.verify_binding(&replaced).unwrap_err().code(),
-            ErrorCode::LockMismatch
-        );
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::LockOrder);
     }
 
     #[test]
@@ -1271,28 +1884,30 @@ mod tests {
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let guard = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
+                &storage,
+                &lock.id,
                 &[],
-                &resource,
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
@@ -1326,29 +1941,31 @@ mod tests {
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
         lock.cloexec_required = false;
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let err = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
+                &storage,
+                &lock.id,
                 &[],
-                &resource,
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
@@ -1365,32 +1982,34 @@ mod tests {
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
         lock.release_authority = ActorRef {
             kind: ActorKind::Broker,
             value: ContractId::parse("d2bbr-r-my-realm").unwrap(),
         };
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let err = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
+                &storage,
+                &lock.id,
                 &[],
-                &resource,
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
@@ -1407,32 +2026,34 @@ mod tests {
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
         lock.timeout_policy = LockTimeoutPolicy {
             kind: LockTimeoutKind::BoundedWait,
             timeout_ms: None,
         };
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let err = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
+                &storage,
+                &lock.id,
                 &[],
-                &resource,
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
@@ -1449,29 +2070,31 @@ mod tests {
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
         lock.timeout_policy.timeout_ms = Some(5);
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let err = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
+                &storage,
+                &lock.id,
                 &[],
-                &resource,
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
@@ -1482,88 +2105,59 @@ mod tests {
     }
 
     #[test]
-    fn protected_resource_scope_mismatch_fails_closed() {
-        let scratch = Scratch::new("protected-scope-mismatch");
+    fn bounded_wait_contention_times_out_against_a_real_conflicting_descriptor() {
+        let scratch = Scratch::new("bounded-wait-real-contention");
         let owner = controller_actor("my-realm");
-        let lock = valid_generated_lock(
+        let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
             "path:realm-controller-lock:my-realm",
-            owner,
+            owner.clone(),
         );
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        let mut foreign =
-            valid_storage_row("path:realm-workloads:my-realm", lock.owner_process.clone());
-        foreign.scope = ContractId::parse("vm").unwrap();
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
+        lock.timeout_policy = LockTimeoutPolicy {
+            kind: LockTimeoutKind::BoundedWait,
+            timeout_ms: Some(15),
+        };
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_path = scratch.0.join("state.lock");
+        fs::write(&lock_path, b"").unwrap();
+        fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600)).unwrap();
+
+        // Hold a conflicting OFD write lock via an independent open file
+        // description for the whole test, so every poll iteration inside
+        // `acquire_from_generated` observes real contention. The `OwnedFd`
+        // must stay alive for the entire test — dropping it (even as an
+        // unbound temporary) closes the descriptor and releases the OFD
+        // lock immediately, since OFD locks are tied to the open file
+        // description's last referencing descriptor, not to the process.
+        let contender = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .unwrap();
+        let _contender_fd = OwnedFd::from(contender);
+        set_ofd_lock(&_contender_fd, libc::F_WRLCK as i16).unwrap();
+
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
         let err = set
             .acquire_from_generated(
                 &sync,
-                &lock,
-                &row,
-                &[foreign],
-                &resource,
+                &storage,
+                &lock.id,
+                &[],
+                &anchor,
+                Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
                 OwnershipEpoch::new(1).unwrap(),
                 metadata,
                 &NeverCancelled,
             )
             .unwrap_err();
-        assert_eq!(err.code(), ErrorCode::InvalidSchema);
-    }
-
-    #[test]
-    fn protected_resource_id_collision_fails_closed() {
-        let scratch = Scratch::new("protected-collision");
-        let owner = controller_actor("my-realm");
-        let lock = valid_generated_lock(
-            "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
-            owner,
-        );
-        let row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        // `:` and `/` both collapse to `-`, so these two structurally
-        // distinct generated ids encode to the same ResourceId.
-        let mut colliding = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            lock.owner_process.clone(),
-        );
-        colliding.id = ContractId::parse("path/realm-controller-lock/my-realm").unwrap();
-        let sync = sync_of(&lock);
-        let (_anchor, resource) = resolve(
-            &scratch.0,
-            "path-realm-controller-lock-my-realm",
-            "state.lock",
-        );
-        let metadata = host_metadata(&scratch.0, 0o600);
-
-        let mut set = LockSet::new();
-        let err = set
-            .acquire_from_generated(
-                &sync,
-                &lock,
-                &row,
-                &[colliding],
-                &resource,
-                realm_controller("my-realm"),
-                OwnershipEpoch::new(1).unwrap(),
-                metadata,
-                &NeverCancelled,
-            )
-            .unwrap_err();
-        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+        assert_eq!(err.code(), ErrorCode::Deadline);
     }
 }

--- a/packages/d2b-state/src/lock.rs
+++ b/packages/d2b-state/src/lock.rs
@@ -9,6 +9,13 @@ use d2b_contracts::v2_state::{
     AuthorityRef, CancellationPolicy, ContentionPolicy, FdTransferPolicy, LockKind, LockSpec,
     OwnershipEpoch, ResourceId,
 };
+use d2b_core::{
+    storage::{ActorKind, DegradeScope, StoragePathKind, StoragePathSpec},
+    sync::{
+        FdPassingMechanism, InheritancePolicy, LockAdoptionPolicy, LockKind as GeneratedLockKind,
+        LockSpec as GeneratedLockSpec, LockStalePolicy, LockTimeoutKind, SyncJson,
+    },
+};
 use nix::{
     errno::Errno,
     fcntl::{FcntlArg, fcntl},
@@ -16,7 +23,10 @@ use nix::{
 };
 use rustix::fs::{FileType, Mode, OFlags};
 
-use crate::{AnchoredResource, Error, ErrorCode, MetadataExpectation, RelativePath, Result};
+use crate::{
+    AnchoredResource, Error, ErrorCode, MetadataExpectation, RelativePath, Result,
+    path::dup_cloexec,
+};
 
 pub trait Cancellation {
     fn is_cancelled(&self) -> bool;
@@ -75,6 +85,18 @@ impl OfdTransfer<'_> {
         self.policy
     }
 
+    /// Returns a fresh `O_CLOEXEC` duplicate of the held descriptor,
+    /// suitable for handing to `SCM_RIGHTS`/explicit-fd-mapping transport
+    /// without exposing the guard's own descriptor value to the recipient
+    /// (the recipient gets its own descriptor number referencing the same
+    /// open-file-description, so it cannot be used to interfere with this
+    /// guard's local descriptor). Always a CLOEXEC-safe
+    /// `fcntl(F_DUPFD_CLOEXEC)` duplicate — never a bare `dup`, which would
+    /// hand back a descriptor that survives `exec` in the recipient.
+    pub fn duplicate(&self) -> Result<OwnedFd> {
+        dup_cloexec(self.guard.fd.as_fd())
+    }
+
     /// Commits a successful descriptor transfer. The local guard then closes
     /// its descriptor without issuing `F_UNLCK`; the recipient's duplicate
     /// open-file description remains authoritative for the lock.
@@ -92,6 +114,30 @@ pub struct LockGuard {
     global_order: u32,
     transfer: FdTransferPolicy,
     held: bool,
+    /// Storage resource ids this lock protects, beyond the lock file's own
+    /// `resource_id`. Empty for guards acquired via the legacy
+    /// `v2_state::LockSpec`-based [`LockSet::acquire`]/`acquire_with_clock`,
+    /// which has no generated notion of a protected-resource set.
+    protected_resources: Vec<ResourceId>,
+    /// Generated stale/adoption/degrade policy, carried through losslessly
+    /// from the generated `sync.json` row. `None` for guards acquired via
+    /// the legacy path, which predates and does not carry this policy.
+    ///
+    /// Stored as the exact `d2b_core` generated types (not re-wrapped in a
+    /// new d2b-state type) so external callers can name them directly via
+    /// `d2b_core::sync`/`d2b_core::storage` without depending on a
+    /// re-export from this crate's private `lock` module.
+    generated_stale_policy: Option<LockStalePolicy>,
+    generated_adoption_policy: Option<LockAdoptionPolicy>,
+    generated_degrade_scope: Option<DegradeScope>,
+    /// `(dev, ino)` of the resource's containing directory at bind time (see
+    /// [`AnchoredResource::directory_identity`]), used by
+    /// [`LockGuard::verify_binding`] to reject a resource whose containing
+    /// directory was replaced after resolution.
+    directory_identity: Option<(u64, u64)>,
+    /// Whether this call created the lock file (as opposed to opening an
+    /// already-existing one).
+    created: bool,
 }
 
 impl fmt::Debug for LockGuard {
@@ -102,6 +148,7 @@ impl fmt::Debug for LockGuard {
             .field("ownership_epoch", &self.ownership_epoch)
             .field("global_order", &self.global_order)
             .field("held", &self.held)
+            .field("protected_resources", &self.protected_resources)
             .finish_non_exhaustive()
     }
 }
@@ -129,6 +176,67 @@ impl LockGuard {
 
     pub fn is_held(&self) -> bool {
         self.held
+    }
+
+    /// Storage resource ids protected by this lock (beyond the lock file's
+    /// own `resource_id`), as bound at acquisition time by
+    /// [`LockSet::acquire_from_generated`]. Empty for legacy-path guards.
+    pub fn protected_resources(&self) -> &[ResourceId] {
+        &self.protected_resources
+    }
+
+    /// The generated stale-lock policy for this lock, if it was acquired via
+    /// [`LockSet::acquire_from_generated`].
+    pub fn generated_stale_policy(&self) -> Option<&LockStalePolicy> {
+        self.generated_stale_policy.as_ref()
+    }
+
+    /// The generated adoption policy for this lock, if it was acquired via
+    /// [`LockSet::acquire_from_generated`].
+    pub fn generated_adoption_policy(&self) -> Option<LockAdoptionPolicy> {
+        self.generated_adoption_policy
+    }
+
+    /// The generated degrade scope for this lock, if it was acquired via
+    /// [`LockSet::acquire_from_generated`].
+    pub fn generated_degrade_scope(&self) -> Option<DegradeScope> {
+        self.generated_degrade_scope
+    }
+
+    /// Whether this call created the lock file rather than opening an
+    /// already-existing one.
+    pub fn created(&self) -> bool {
+        self.created
+    }
+
+    /// The exact `(dev, ino)` identity of the held lock-file descriptor,
+    /// queried fresh via `fstat` on every call. Because this reads the
+    /// already-held descriptor rather than re-resolving the filesystem
+    /// path, it reports the identity of the file this guard actually locked
+    /// even if the path was later unlinked and replaced by something else —
+    /// it can never be fooled by a path-level replacement race.
+    pub fn fd_identity(&self) -> Result<(u64, u64)> {
+        let stat = rustix::fs::fstat(&self.fd).map_err(|error| Error::io(ErrorCode::Io, error))?;
+        Ok((stat.st_dev, stat.st_ino))
+    }
+
+    /// Verifies that `resource` is exactly the resource this guard is bound
+    /// to: same `resource_id`, and — for resources resolved via
+    /// [`AnchoredResource::resolve_generated`] — the same containing
+    /// directory identity captured at bind time. Rejects a resource whose
+    /// `resource_id` matches by coincidence/forgery but whose directory was
+    /// replaced (or that was never bound through the guarded resolution
+    /// path when the guard requires it).
+    pub fn verify_binding(&self, resource: &AnchoredResource) -> Result<()> {
+        if resource.resource_id != self.resource_id {
+            return Err(Error::Code(ErrorCode::LockMismatch));
+        }
+        if let Some(expected) = self.directory_identity
+            && resource.directory_identity() != Some(expected)
+        {
+            return Err(Error::Code(ErrorCode::LockMismatch));
+        }
+        Ok(())
     }
 
     pub fn authorize_transfer(&mut self, requested: FdTransferPolicy) -> Result<OfdTransfer<'_>> {
@@ -309,6 +417,12 @@ impl LockSet {
             global_order: spec.global_order,
             transfer: spec.fd_transfer,
             held: true,
+            protected_resources: Vec::new(),
+            generated_stale_policy: None,
+            generated_adoption_policy: None,
+            generated_degrade_scope: None,
+            directory_identity: resource.directory_identity(),
+            created,
         });
         Ok(self
             .guards
@@ -327,6 +441,384 @@ impl LockSet {
 
     pub fn last_mut(&mut self) -> Option<&mut LockGuard> {
         self.guards.last_mut()
+    }
+
+    /// Acquires a lock driven directly by the generated `sync.json` contract
+    /// (`d2b_core::sync::LockSpec`), rather than the hand-built
+    /// `v2_state::LockSpec` used by [`Self::acquire`]. This is the
+    /// canonical bridge: every field the generated contract carries is
+    /// consumed as-is (order, timeout/contention, stale/adoption/degrade
+    /// policy, fd-transfer mechanism, protected-resource binding); nothing
+    /// is invented, defaulted, or reinterpreted, and any field this
+    /// function cannot validate causes it to fail closed.
+    ///
+    /// - `sync` is the full generated document (needed to derive the exact
+    ///   total acquire order via [`SyncJson::global_order_rank`]).
+    /// - `lock` is the specific generated lock row being acquired.
+    /// - `lock_row` is the generated storage row for `lock`'s own lock
+    ///   file (`lock.resource_id` must name it); it supplies the lock
+    ///   file's declared mode, kind, and path template, cross-checked
+    ///   against `resource` and `metadata` rather than trusted blindly.
+    /// - `protected` are the generated storage rows this lock is being
+    ///   used to protect. The caller supplies them (there is no generated
+    ///   parent/child field linking a lock to the resources it protects);
+    ///   each row's `scope` is checked against `lock.scope` so an
+    ///   unrelated resource cannot be smuggled in as "protected" by this
+    ///   lock.
+    /// - `resource` must already be bound via
+    ///   [`AnchoredResource::resolve_generated`] against `lock_row`; this
+    ///   function independently re-derives `lock_row`'s resource id and
+    ///   rejects a mismatch, so a caller cannot pair an unrelated
+    ///   `AnchoredResource` with a given `lock`/`lock_row`.
+    /// - `owner` is rendered to the exact `(ActorKind, value)` convention
+    ///   the Nix generator uses and checked against `lock.owner_process`;
+    ///   since this API accepts only one authority, `lock.owner_process`
+    ///   and `lock.release_authority` must be structurally identical, or
+    ///   this fails closed rather than picking one arbitrarily.
+    #[allow(clippy::too_many_arguments)]
+    pub fn acquire_from_generated(
+        &mut self,
+        sync: &SyncJson,
+        lock: &GeneratedLockSpec,
+        lock_row: &StoragePathSpec,
+        protected: &[StoragePathSpec],
+        resource: &AnchoredResource,
+        owner: AuthorityRef,
+        ownership_epoch: OwnershipEpoch,
+        metadata: MetadataExpectation,
+        cancellation: &(impl Cancellation + ?Sized),
+    ) -> Result<&mut LockGuard> {
+        self.acquire_from_generated_with_clock(
+            sync,
+            lock,
+            lock_row,
+            protected,
+            resource,
+            owner,
+            ownership_epoch,
+            metadata,
+            cancellation,
+            &SystemClock,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn acquire_from_generated_with_clock<C: Clock + ?Sized>(
+        &mut self,
+        sync: &SyncJson,
+        lock: &GeneratedLockSpec,
+        lock_row: &StoragePathSpec,
+        protected: &[StoragePathSpec],
+        resource: &AnchoredResource,
+        owner: AuthorityRef,
+        ownership_epoch: OwnershipEpoch,
+        metadata: MetadataExpectation,
+        cancellation: &(impl Cancellation + ?Sized),
+        clock: &C,
+    ) -> Result<&mut LockGuard> {
+        let binding =
+            validate_generated_lock(sync, lock, lock_row, protected, resource, &owner, metadata)?;
+
+        if self.held(&binding.lock_id)
+            || self
+                .guards
+                .iter()
+                .filter(|guard| guard.held)
+                .any(|guard| guard.global_order >= binding.global_order)
+        {
+            return Err(Error::Code(ErrorCode::LockOrder));
+        }
+
+        let path = RelativePath::from_components([resource.leaf.as_str()])?;
+        let (fd, created) = match resource.directory.open_beneath(
+            &path,
+            OFlags::RDWR | OFlags::CREATE | OFlags::EXCL,
+            Mode::from_raw_mode(metadata.mode),
+        ) {
+            Ok(fd) => (fd, true),
+            Err(error) if error.code() == ErrorCode::AlreadyExists => (
+                resource
+                    .directory
+                    .open_beneath(&path, OFlags::RDWR, Mode::empty())?,
+                false,
+            ),
+            Err(error) => return Err(error),
+        };
+        if created {
+            rustix::fs::fchmod(&fd, Mode::from_raw_mode(metadata.mode))
+                .map_err(|error| Error::io(ErrorCode::Io, error))?;
+        }
+        validate_metadata(&fd, metadata)?;
+
+        // `lock.cloexec_required` was already checked true by
+        // `validate_generated_lock`; confirm the fd we actually hold is
+        // CLOEXEC rather than trusting the requested open flags alone.
+        let fd_flags =
+            rustix::fs::fcntl_getfd(&fd).map_err(|error| Error::io(ErrorCode::Io, error))?;
+        if !fd_flags.contains(rustix::io::FdFlags::CLOEXEC) {
+            return Err(Error::Code(ErrorCode::InvalidSchema));
+        }
+
+        let started = clock.now();
+        loop {
+            // The generated contract has no distinct cancellation-policy
+            // field (unlike `v2_state::LockSpec::cancellation`); honouring
+            // cancellation unconditionally is the strictly safer choice
+            // and is never less correct than any generated policy could
+            // require, so it is not an invented value.
+            if cancellation.acquisition_abandoned() || cancellation.is_cancelled() {
+                return Err(Error::Code(ErrorCode::Cancelled));
+            }
+            match set_ofd_lock(&fd, libc::F_WRLCK as i16) {
+                Ok(()) => break,
+                Err(Errno::EAGAIN | Errno::EACCES) => {
+                    if binding.fail_fast {
+                        return Err(Error::Code(ErrorCode::LockContended));
+                    }
+                    let deadline = binding
+                        .deadline
+                        .expect("bounded-wait binding always carries a validated deadline");
+                    if clock.now().saturating_duration_since(started) >= deadline {
+                        return Err(Error::Code(ErrorCode::Deadline));
+                    }
+                    clock.sleep(Duration::from_millis(1));
+                }
+                Err(error) => {
+                    return Err(Error::Os {
+                        code: ErrorCode::Io,
+                        errno: Some(error as i32),
+                    });
+                }
+            }
+        }
+
+        self.guards.push(LockGuard {
+            fd,
+            lock_id: binding.lock_id,
+            resource_id: resource.resource_id.clone(),
+            owner,
+            ownership_epoch,
+            global_order: binding.global_order,
+            transfer: binding.fd_transfer,
+            held: true,
+            protected_resources: binding.protected_resources,
+            generated_stale_policy: Some(lock.stale_policy.clone()),
+            generated_adoption_policy: Some(lock.adoption_policy),
+            generated_degrade_scope: Some(lock.degrade_scope),
+            directory_identity: resource.directory_identity(),
+            created,
+        });
+        Ok(self
+            .guards
+            .last_mut()
+            .expect("guard was inserted immediately above"))
+    }
+}
+
+/// The fully-validated, ready-to-acquire projection of a generated
+/// `d2b_core::sync::LockSpec`, produced by [`validate_generated_lock`].
+/// Every field here is either copied verbatim from the generated contract
+/// or deterministically derived from it (never invented).
+struct GeneratedLockBinding {
+    lock_id: ResourceId,
+    global_order: u32,
+    protected_resources: Vec<ResourceId>,
+    fd_transfer: FdTransferPolicy,
+    /// `true` for `FailFast`/`NoWait` (a single non-blocking attempt with no
+    /// stored deadline value at all — not even a synthetic 1ms one); `false`
+    /// for `BoundedWait`, in which case `deadline` is always `Some`.
+    fail_fast: bool,
+    deadline: Option<Duration>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_generated_lock(
+    sync: &SyncJson,
+    lock: &GeneratedLockSpec,
+    lock_row: &StoragePathSpec,
+    protected: &[StoragePathSpec],
+    resource: &AnchoredResource,
+    owner: &AuthorityRef,
+    metadata: MetadataExpectation,
+) -> Result<GeneratedLockBinding> {
+    metadata.validate()?;
+
+    if lock.kind != GeneratedLockKind::Ofd || !lock.cloexec_required {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    let inheritance_consistent = matches!(
+        (lock.inheritance_policy, lock.fd_passing_policy.mechanism),
+        (InheritancePolicy::CloseOnExec, FdPassingMechanism::None)
+            | (
+                InheritancePolicy::ScmRightsOnly,
+                FdPassingMechanism::ScmRights
+            )
+            | (
+                InheritancePolicy::ExplicitFdMappingOnly,
+                FdPassingMechanism::ExplicitFdMapping
+            )
+    );
+    if !inheritance_consistent {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    if !lock.allowed_holders.contains(&lock.owner_process) {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+
+    let declared_resource = lock
+        .resource_id
+        .as_ref()
+        .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+    if *declared_resource != lock_row.id || lock.scope != lock_row.scope {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    if lock_row.kind != StoragePathKind::RegularFile {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    if let Some(template) = &lock.path_template
+        && *template != lock_row.path_template
+    {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    let encoded_resource = encode_resource_id(lock_row.id.as_str())?;
+    if encoded_resource != resource.resource_id {
+        return Err(Error::Code(ErrorCode::LockMismatch));
+    }
+
+    let row_mode = u32::from_str_radix(&lock_row.mode, 8)
+        .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
+    if metadata.mode != row_mode {
+        return Err(Error::Code(ErrorCode::MetadataMismatch));
+    }
+
+    if lock.owner_process != lock.release_authority {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    let (rendered_kind, rendered_value) = render_authority(owner)?;
+    if lock.owner_process.kind != rendered_kind
+        || lock.owner_process.value.as_str() != rendered_value
+    {
+        return Err(Error::Code(ErrorCode::LockMismatch));
+    }
+
+    let lock_id = encode_resource_id(lock.id.as_str())?;
+    let mut seen = std::collections::BTreeSet::new();
+    if !seen.insert(lock_id.clone()) || !seen.insert(resource.resource_id.clone()) {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    let mut protected_resources = Vec::with_capacity(protected.len());
+    for row in protected {
+        if row.scope != lock.scope {
+            return Err(Error::Code(ErrorCode::InvalidSchema));
+        }
+        let encoded = encode_resource_id(row.id.as_str())?;
+        if !seen.insert(encoded.clone()) {
+            return Err(Error::Code(ErrorCode::InvalidSchema));
+        }
+        protected_resources.push(encoded);
+    }
+
+    let fd_transfer = match lock.fd_passing_policy.mechanism {
+        FdPassingMechanism::None => FdTransferPolicy::Never,
+        FdPassingMechanism::ScmRights => FdTransferPolicy::ScmRightsLeaseHandoff,
+        FdPassingMechanism::ExplicitFdMapping => FdTransferPolicy::ExplicitFdMapping,
+    };
+
+    let (fail_fast, deadline) = match lock.timeout_policy.kind {
+        LockTimeoutKind::FailFast | LockTimeoutKind::NoWait => {
+            if lock.timeout_policy.timeout_ms.is_some() {
+                return Err(Error::Code(ErrorCode::InvalidSchema));
+            }
+            (true, None)
+        }
+        LockTimeoutKind::BoundedWait => {
+            let timeout_ms = lock
+                .timeout_policy
+                .timeout_ms
+                .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+            if timeout_ms == 0
+                || timeout_ms > u64::from(d2b_contracts::v2_state::MAX_LOCK_DEADLINE_MS)
+            {
+                return Err(Error::Code(ErrorCode::InvalidSchema));
+            }
+            (false, Some(Duration::from_millis(timeout_ms)))
+        }
+    };
+
+    let global_order = sync
+        .global_order_rank(&lock.id)
+        .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+    let global_order =
+        u32::try_from(global_order).map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
+
+    Ok(GeneratedLockBinding {
+        lock_id,
+        global_order,
+        protected_resources,
+        fd_transfer,
+        fail_fast,
+        deadline,
+    })
+}
+
+/// Encodes a generated `ContractId` (charset `[A-Za-z0-9._:/@+-]`, up to
+/// 160 bytes) into the runtime `ResourceId` charset
+/// (`^[a-z][a-z0-9-]{0,63}$`). Namespace separators (`:`/`/`) and other
+/// punctuation collapse to `-`, consecutive separators collapse to one,
+/// and leading/trailing separators are trimmed — a deterministic
+/// structural transform, not a substitute value. Any uppercase byte is
+/// treated as unrepresentable (the target charset has no case
+/// distinction, so silently downcasing could collide two structurally
+/// distinct generated ids) and fails closed rather than being coerced.
+/// Callers combining multiple encoded ids in one call MUST additionally
+/// check for collisions across the encoded set, since this encoding is
+/// not proven injective in general (see the `BTreeSet` check in
+/// [`validate_generated_lock`]).
+fn encode_resource_id(raw: &str) -> Result<ResourceId> {
+    if raw.is_empty() || raw.bytes().any(|byte| byte.is_ascii_uppercase()) {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    let mut out = String::with_capacity(raw.len());
+    let mut last_was_sep = false;
+    for byte in raw.bytes() {
+        let mapped = match byte {
+            b'a'..=b'z' | b'0'..=b'9' => byte as char,
+            b'-' | b':' | b'/' | b'.' | b'_' | b'@' | b'+' => '-',
+            _ => return Err(Error::Code(ErrorCode::InvalidSchema)),
+        };
+        if mapped == '-' {
+            if last_was_sep {
+                continue;
+            }
+            last_was_sep = true;
+        } else {
+            last_was_sep = false;
+        }
+        out.push(mapped);
+    }
+    let trimmed = out.trim_matches('-');
+    if trimmed.is_empty() {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    ResourceId::parse(trimmed).map_err(|_| Error::Code(ErrorCode::InvalidSchema))
+}
+
+/// Renders an `AuthorityRef` to the exact `(ActorKind, value)` pair the Nix
+/// generator uses for the corresponding `d2b_core::storage::ActorRef` (see
+/// `controllerActor`/`brokerActor` in `nixos-modules/realm-storage-rows.nix`).
+/// Only the two authority kinds the generated realm-controller/broker locks
+/// actually use are supported; every other `AuthorityRef` variant has no
+/// Nix-side naming convention today and fails closed rather than guessing
+/// one.
+fn render_authority(authority: &AuthorityRef) -> Result<(ActorKind, String)> {
+    match authority {
+        AuthorityRef::RealmController { realm_id } => {
+            Ok((ActorKind::Daemon, format!("d2bd-r-{}", realm_id.as_str())))
+        }
+        AuthorityRef::RealmBroker { realm_id } => {
+            Ok((ActorKind::Broker, format!("d2bbr-r-{}", realm_id.as_str())))
+        }
+        _ => Err(Error::Code(ErrorCode::InvalidSchema)),
     }
 }
 
@@ -372,4 +864,706 @@ fn set_ofd_lock(fd: &OwnedFd, lock_type: i16) -> nix::Result<()> {
         l_pid: 0,
     };
     fcntl(fd.as_raw_fd(), FcntlArg::F_OFD_SETLK(&lock)).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use d2b_contracts::v2_identity::{RealmId, RealmPath};
+    use d2b_core::{
+        contract_id::{ContractId, PathTemplate},
+        storage::{
+            ActorRef, CleanupPolicy, DegradedReason, LeaseClass, PrincipalKind, PrincipalRef,
+            RepairPolicy, SensitivityClass, StorageAdoptionPolicy, StorageLifecycle,
+            StoragePersistence, StorageRestartPolicy,
+        },
+        sync::{
+            FdPassingPolicy, LockAcquireOrder, LockScopeClass, LockStaleKind, LockTimeoutPolicy,
+        },
+    };
+
+    use super::*;
+    use crate::AnchoredDir;
+
+    static SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(name: &str) -> Self {
+            let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("target")
+                .join("d2b-state-lock-tests")
+                .join(format!(
+                    "{name}-{}-{}",
+                    std::process::id(),
+                    SCRATCH_ID.fetch_add(1, Ordering::Relaxed)
+                ));
+            fs::create_dir_all(&root).unwrap();
+            Self(root)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// `RealmId` is an opaque 20-character derived short id, not a
+    /// free-form label; derive a stable one from a realm-path label so
+    /// every test call site for the same `label` produces the identical
+    /// `RealmId`.
+    fn test_realm_id(label: &str) -> RealmId {
+        RealmId::derive(&RealmPath::parse(format!("{label}.local-root")).unwrap())
+    }
+
+    fn realm_controller(label: &str) -> AuthorityRef {
+        AuthorityRef::RealmController {
+            realm_id: test_realm_id(label),
+        }
+    }
+
+    fn controller_actor(label: &str) -> ActorRef {
+        ActorRef {
+            kind: ActorKind::Daemon,
+            value: ContractId::parse(format!("d2bd-r-{}", test_realm_id(label).as_str())).unwrap(),
+        }
+    }
+
+    /// A fully-populated, schema-valid `GeneratedLockSpec` mirroring the
+    /// exact shape `nixos-modules/realm-storage-rows.nix`'s `mkOfdLock`
+    /// renders for a controller-owned realm lock. Individual fields are
+    /// overridden per test to exercise a single failure mode at a time.
+    fn valid_generated_lock(id: &str, resource_id: &str, owner: ActorRef) -> GeneratedLockSpec {
+        GeneratedLockSpec {
+            id: ContractId::parse(id).unwrap(),
+            scope: ContractId::parse("host").unwrap(),
+            path_template: None,
+            resource_id: Some(ContractId::parse(resource_id).unwrap()),
+            kind: GeneratedLockKind::Ofd,
+            owner_process: owner.clone(),
+            allowed_holders: vec![owner.clone()],
+            inheritance_policy: InheritancePolicy::CloseOnExec,
+            fd_passing_policy: FdPassingPolicy {
+                mechanism: FdPassingMechanism::None,
+                lease_transfer_record_required: false,
+            },
+            acquire_order: LockAcquireOrder {
+                scope_class: LockScopeClass::Host,
+                anchored_root: ContractId::parse("state").unwrap(),
+                normalized_path: ContractId::parse(id).unwrap(),
+                lock_id: ContractId::parse(id).unwrap(),
+            },
+            timeout_policy: LockTimeoutPolicy {
+                kind: LockTimeoutKind::FailFast,
+                timeout_ms: None,
+            },
+            stale_policy: LockStalePolicy {
+                kind: LockStaleKind::PidfdProofRequired,
+                degraded_reason: DegradedReason::LockOwnerAmbiguous,
+            },
+            adoption_policy: LockAdoptionPolicy::ReacquireAfterProof,
+            degrade_scope: DegradeScope::Realm,
+            release_authority: owner,
+            cloexec_required: true,
+        }
+    }
+
+    /// A fully-populated, schema-valid regular-file `StoragePathSpec`
+    /// mirroring the paired lock-file rows added to
+    /// `nixos-modules/realm-storage-rows.nix` (mode `0600`, process-scoped,
+    /// not adoptable, no follow).
+    fn valid_storage_row(id: &str, owner: ActorRef) -> StoragePathSpec {
+        StoragePathSpec {
+            id: ContractId::parse(id).unwrap(),
+            scope: ContractId::parse("host").unwrap(),
+            path_template: PathTemplate::parse("/var/lib/d2b/r/realm/controller/state.lock")
+                .unwrap(),
+            kind: StoragePathKind::RegularFile,
+            lifecycle: StorageLifecycle::ProcessScoped,
+            persistence: StoragePersistence::ProcessScoped,
+            owner: PrincipalRef {
+                kind: PrincipalKind::Role,
+                value: ContractId::parse("d2bd").unwrap(),
+            },
+            group: PrincipalRef {
+                kind: PrincipalKind::Role,
+                value: ContractId::parse("d2bd").unwrap(),
+            },
+            mode: "0600".to_owned(),
+            access_acl: Vec::new(),
+            default_acl: Vec::new(),
+            creator: owner.clone(),
+            writers: vec![owner.clone()],
+            readers: vec![owner],
+            cleanup_policy: CleanupPolicy::Never,
+            repair_policy: RepairPolicy::None,
+            restart_policy: StorageRestartPolicy::NotApplicable,
+            adoption_policy: StorageAdoptionPolicy::NotAdoptable,
+            lease_class: LeaseClass::None,
+            sensitivity: SensitivityClass::Private,
+            no_follow: true,
+            recursive: false,
+            invariants: Vec::new(),
+        }
+    }
+
+    fn sync_of(lock: &GeneratedLockSpec) -> SyncJson {
+        SyncJson {
+            schema_version: "1".to_owned(),
+            locks: vec![lock.clone()],
+        }
+    }
+
+    fn host_metadata(path: &Path, mode: u32) -> MetadataExpectation {
+        use std::os::unix::fs::MetadataExt;
+        let parent = fs::metadata(path).unwrap();
+        MetadataExpectation {
+            uid: parent.uid(),
+            gid: parent.gid(),
+            mode,
+        }
+    }
+
+    /// Resolves `resource_id`/`leaf` beneath `scratch` exactly the way a
+    /// real caller would: via [`AnchoredResource::resolve_generated`]
+    /// against a trusted anchor, never a raw struct literal.
+    fn resolve(scratch: &Path, resource_id: &str, leaf: &str) -> (AnchoredDir, AnchoredResource) {
+        let anchor = AnchoredDir::open_trusted(scratch).unwrap();
+        let row_path = scratch.join(leaf);
+        let resource = AnchoredResource::resolve_generated(
+            &anchor,
+            scratch,
+            ResourceId::parse(resource_id).unwrap(),
+            &row_path,
+        )
+        .unwrap();
+        (anchor, resource)
+    }
+
+    #[test]
+    fn encode_resource_id_collapses_separators_and_trims() {
+        assert_eq!(
+            encode_resource_id("path:realm-controller-lock:my-realm")
+                .unwrap()
+                .as_str(),
+            "path-realm-controller-lock-my-realm"
+        );
+        assert_eq!(
+            encode_resource_id("provider/foo/state").unwrap().as_str(),
+            "provider-foo-state"
+        );
+    }
+
+    #[test]
+    fn encode_resource_id_rejects_uppercase_and_empty() {
+        assert!(encode_resource_id("Path:Bad").is_err());
+        assert!(encode_resource_id("").is_err());
+    }
+
+    #[test]
+    fn render_authority_supports_only_realm_controller_and_broker() {
+        assert!(render_authority(&realm_controller("my-realm")).is_ok());
+        assert!(
+            render_authority(&AuthorityRef::RealmBroker {
+                realm_id: test_realm_id("my-realm"),
+            })
+            .is_ok()
+        );
+        assert!(render_authority(&AuthorityRef::Pid1).is_err());
+    }
+
+    #[test]
+    fn acquire_from_generated_round_trips_authority_order_and_policy() {
+        let scratch = Scratch::new("generated-ok");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let guard = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap();
+
+        assert!(guard.is_held());
+        assert!(guard.created());
+        assert_eq!(guard.global_order(), 0);
+        assert_eq!(guard.resource_id(), &resource.resource_id);
+        assert!(guard.protected_resources().is_empty());
+        assert_eq!(
+            guard.generated_adoption_policy(),
+            Some(LockAdoptionPolicy::ReacquireAfterProof)
+        );
+        assert_eq!(guard.generated_degrade_scope(), Some(DegradeScope::Realm));
+        assert!(guard.generated_stale_policy().is_some());
+
+        // The fd we actually hold must be CLOEXEC.
+        let flags = rustix::fs::fcntl_getfd(&guard.fd).unwrap();
+        assert!(flags.contains(rustix::io::FdFlags::CLOEXEC));
+
+        assert!(guard.verify_binding(&resource).is_ok());
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_mismatched_resource() {
+        let scratch = Scratch::new("generated-mismatch");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        // Bound against a DIFFERENT resource id than the lock/row declare.
+        let (_anchor, resource) = resolve(&scratch.0, "totally-unrelated-resource", "state.lock");
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::LockMismatch);
+    }
+
+    #[test]
+    fn verify_binding_rejects_wrong_resource_id() {
+        let scratch = Scratch::new("verify-wrong-id");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let guard = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap();
+
+        let (_other_anchor, forged) = resolve(&scratch.0, "some-other-resource", "state.lock");
+        assert_eq!(
+            guard.verify_binding(&forged).unwrap_err().code(),
+            ErrorCode::LockMismatch
+        );
+    }
+
+    #[test]
+    fn verify_binding_rejects_replaced_directory() {
+        let scratch = Scratch::new("verify-replaced-dir");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let guard = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap();
+
+        // Same resource id, but resolved against a *different* directory:
+        // simulates the containing directory being replaced out from under
+        // an earlier resolution.
+        let elsewhere = Scratch::new("verify-replaced-dir-elsewhere");
+        fs::write(elsewhere.0.join("state.lock"), b"").unwrap();
+        let (_other_anchor, replaced) = resolve(
+            &elsewhere.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        assert_eq!(
+            guard.verify_binding(&replaced).unwrap_err().code(),
+            ErrorCode::LockMismatch
+        );
+    }
+
+    #[test]
+    fn fd_identity_is_immune_to_path_replacement_race() {
+        let scratch = Scratch::new("fd-identity-race");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let guard = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap();
+
+        let original_identity = guard.fd_identity().unwrap();
+
+        // Simulate a replacement race: unlink the path and create a fresh
+        // file there while the guard is still held.
+        let path = scratch.0.join("state.lock");
+        fs::remove_file(&path).unwrap();
+        fs::write(&path, b"replaced").unwrap();
+        let replaced_identity = {
+            use std::os::unix::fs::MetadataExt;
+            let stat = fs::metadata(&path).unwrap();
+            (stat.dev(), stat.ino())
+        };
+
+        // The held descriptor's identity is unaffected by the path-level
+        // replacement: it still reports the *original* file it locked.
+        assert_eq!(guard.fd_identity().unwrap(), original_identity);
+        assert_ne!(original_identity, replaced_identity);
+    }
+
+    #[test]
+    fn cloexec_required_false_fails_closed() {
+        let scratch = Scratch::new("cloexec-false");
+        let owner = controller_actor("my-realm");
+        let mut lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        lock.cloexec_required = false;
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn release_authority_mismatch_fails_closed() {
+        let scratch = Scratch::new("release-mismatch");
+        let owner = controller_actor("my-realm");
+        let mut lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        lock.release_authority = ActorRef {
+            kind: ActorKind::Broker,
+            value: ContractId::parse("d2bbr-r-my-realm").unwrap(),
+        };
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn bounded_wait_without_timeout_fails_closed() {
+        let scratch = Scratch::new("bounded-wait-missing");
+        let owner = controller_actor("my-realm");
+        let mut lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        lock.timeout_policy = LockTimeoutPolicy {
+            kind: LockTimeoutKind::BoundedWait,
+            timeout_ms: None,
+        };
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn fail_fast_with_extraneous_timeout_fails_closed() {
+        let scratch = Scratch::new("fail-fast-extraneous");
+        let owner = controller_actor("my-realm");
+        let mut lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        lock.timeout_policy.timeout_ms = Some(5);
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn protected_resource_scope_mismatch_fails_closed() {
+        let scratch = Scratch::new("protected-scope-mismatch");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        let mut foreign =
+            valid_storage_row("path:realm-workloads:my-realm", lock.owner_process.clone());
+        foreign.scope = ContractId::parse("vm").unwrap();
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[foreign],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn protected_resource_id_collision_fails_closed() {
+        let scratch = Scratch::new("protected-collision");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-controller-lock:my-realm",
+            owner,
+        );
+        let row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        // `:` and `/` both collapse to `-`, so these two structurally
+        // distinct generated ids encode to the same ResourceId.
+        let mut colliding = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            lock.owner_process.clone(),
+        );
+        colliding.id = ContractId::parse("path/realm-controller-lock/my-realm").unwrap();
+        let sync = sync_of(&lock);
+        let (_anchor, resource) = resolve(
+            &scratch.0,
+            "path-realm-controller-lock-my-realm",
+            "state.lock",
+        );
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &lock,
+                &row,
+                &[colliding],
+                &resource,
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
 }

--- a/packages/d2b-state/src/lock.rs
+++ b/packages/d2b-state/src/lock.rs
@@ -28,7 +28,7 @@ use rustix::fs::{FileType, Mode, OFlags};
 
 use crate::{
     AnchoredDir, AnchoredResource, Error, ErrorCode, MetadataExpectation, RelativePath, Result,
-    path::{GeneratedResource, dup_cloexec},
+    path::{GeneratedResource, GuardedResource, dup_cloexec},
 };
 
 /// Ceiling on how long a single bounded-wait poll iteration sleeps, used by
@@ -58,6 +58,17 @@ fn poll_backoff_or_deadline<C: Clock + ?Sized>(
     let remaining = deadline - elapsed;
     clock.sleep(remaining.min(MAX_LOCK_POLL_BACKOFF));
     Ok(())
+}
+
+/// Rechecks the absolute deadline without sleeping, reporting whether it has
+/// already elapsed. Called at the top of every acquisition retry *after*
+/// the first attempt (never before the first, so a caller always gets one
+/// real attempt even with a near-zero deadline), so a late wakeup from
+/// [`poll_backoff_or_deadline`]'s sleep — for example the OS scheduling a
+/// thread back later than requested — can never let a subsequent
+/// `set_ofd_lock` attempt win the lock after the deadline has elapsed.
+fn deadline_elapsed<C: Clock + ?Sized>(clock: &C, started: Instant, deadline: Duration) -> bool {
+    clock.now().saturating_duration_since(started) >= deadline
 }
 
 pub trait Cancellation {
@@ -145,7 +156,7 @@ pub struct LockGuard {
     /// [`Self::protected_resources`], which names the *protected state*
     /// resource this lock authorizes mutation of — never the same field
     /// doing double duty (see [`Self::validate_state_binding`] and
-    /// [`Self::bind_protected_resource`]).
+    /// [`Self::protected_resource`]).
     lock_file_resource_id: ResourceId,
     owner: AuthorityRef,
     ownership_epoch: OwnershipEpoch,
@@ -163,14 +174,22 @@ pub struct LockGuard {
     /// semantic), never a caller-supplied set. Distinct from
     /// [`Self::lock_file_resource_id`].
     protected_resources: Vec<ResourceId>,
-    /// The protected resource's own generated `ContractId`, present only for
-    /// guards acquired via [`LockSet::acquire_from_generated`] (the only
-    /// path that can re-resolve a resource by trusted-root + generated row;
-    /// see [`Self::bind_protected_resource`]). `None` for legacy
-    /// `acquire`/`acquire_with_clock`-acquired guards, which are handed
-    /// their protected resource directly as an [`AnchoredResource`] at
-    /// acquisition time and have no generated-inventory id to re-resolve.
-    protected_resource_contract_id: Option<ContractId>,
+    /// The protected resource's own acquisition-time-resolved capability,
+    /// present only for guards acquired via
+    /// [`LockSet::acquire_from_generated`] (the only path that resolves a
+    /// protected resource at all; see [`Self::protected_resource`]). `None`
+    /// for legacy `acquire`/`acquire_with_clock`-acquired guards, which are
+    /// handed their protected resource directly as an [`AnchoredResource`]
+    /// at acquisition time and have no generated-inventory row to resolve.
+    ///
+    /// Resolved exactly once, inside `acquire_from_generated_with_clock`,
+    /// immediately from the trusted `storage`/`anchor` the caller supplied
+    /// to *that* call — never re-resolved, and never re-derived from a
+    /// later call's inventory/anchor. [`Self::protected_resource`] only
+    /// ever borrows this value; it accepts no inventory/anchor/metadata
+    /// parameters of its own, so a caller cannot pair this guard's identity
+    /// with a different resolution after the fact.
+    protected_resource: Option<GeneratedResource>,
     /// Generated stale/adoption/degrade policy, carried through losslessly
     /// from the generated `sync.json` row. `None` for guards acquired via
     /// the legacy path, which predates and does not carry this policy.
@@ -275,65 +294,45 @@ impl LockGuard {
         Ok((stat.st_dev, stat.st_ino))
     }
 
-    /// Opens the single resource this held guard authorizes mutation for,
-    /// resolved fresh via a trusted-root + `openat2` walk against `storage`'s
-    /// validated inventory and `anchor`/`anchor_path` — never an inferred
-    /// parent/path relationship. There is no `resource_id` parameter: which
-    /// resource is protected is decided exclusively by the generated lock's
-    /// own `resource_id` field at acquisition time (see
-    /// [`LockSet::acquire_from_generated`]'s docs) — a caller cannot select
-    /// or substitute a different resource here, even one that exists and is
-    /// otherwise well-formed.
+    /// Borrows the single resource this held guard authorizes mutation for,
+    /// resolved exactly once at acquisition time (see
+    /// [`LockSet::acquire_from_generated`]'s docs) and retained by the
+    /// guard for its whole lifetime — never re-resolved against a
+    /// caller-supplied inventory, anchor, or path here. There is no
+    /// `storage`/`anchor`/`metadata` parameter of any kind: which resource
+    /// is protected, and the exact filesystem resolution backing it, were
+    /// both decided once, at acquisition time, from the generated
+    /// contract alone. `resource_id` only *selects* among (in practice,
+    /// confirms identity with) [`Self::protected_resources`]; it can never
+    /// cause a different resolution to be substituted.
     ///
     /// Only available for guards acquired via
-    /// [`LockSet::acquire_from_generated`] (legacy `acquire`-acquired guards
-    /// have no generated-inventory id to re-resolve and fail closed here).
+    /// [`LockSet::acquire_from_generated`] (legacy `acquire`-acquired
+    /// guards have no generated-inventory row to retain and fail closed
+    /// here).
     ///
-    /// On success, returns the legacy [`AnchoredResource`] shape so
-    /// existing atomic/audit consumers can use it without any change to
-    /// their own code; the resolution backing it is exactly as
-    /// non-forgeable as [`LockSet::acquire_from_generated`]'s own lock-file
-    /// resolution — the returned value is a fresh capability, not a clone
-    /// of anything the caller supplied.
-    pub fn bind_protected_resource(
+    /// The returned [`GuardedResource`] borrows `self` for its `'guard`
+    /// lifetime: it cannot outlive this guard, has no public constructor,
+    /// no field access, and no `Clone`/`Copy` impl. Its only sanctioned
+    /// consumer is `d2b-state`'s own guarded `AtomicWrite` read/write API
+    /// (`atomic::AtomicWrite::read_guarded`/`write_guarded`), which
+    /// verifies live fstat identity against the acquisition-time snapshot
+    /// before using it.
+    pub(crate) fn protected_resource(
         &self,
-        storage: &StorageJson,
-        anchor: &AnchoredDir,
-        anchor_path: &std::path::Path,
-        metadata: MetadataExpectation,
-    ) -> Result<AnchoredResource> {
+        resource_id: &ResourceId,
+    ) -> Result<GuardedResource<'_>> {
         if !self.held {
             return Err(Error::Code(ErrorCode::LockReleased));
         }
-        metadata.validate()?;
-        storage
-            .validate_unique_ids()
-            .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
-        let resource_id = self
-            .protected_resource_contract_id
-            .as_ref()
-            .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
-        let row = find_unique_storage_row(storage, resource_id)?;
-        let encoded = encode_resource_id(row.id.as_str())?;
-        // Always true by construction (this row's id is exactly what was
-        // encoded into `protected_resources` at acquisition time); kept as
-        // a fail-closed defense against a future refactor weakening that
-        // invariant rather than trusted silently.
-        if !self.protected_resources.contains(&encoded) {
+        if !self.protected_resources.contains(resource_id) {
             return Err(Error::Code(ErrorCode::LockMismatch));
         }
-        let row_mode =
-            u32::from_str_radix(&row.mode, 8).map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
-        if metadata.mode != row_mode {
-            return Err(Error::Code(ErrorCode::MetadataMismatch));
-        }
-        let generated = GeneratedResource::resolve(
-            anchor,
-            anchor_path,
-            encoded,
-            std::path::Path::new(row.path_template.as_str()),
-        )?;
-        Ok(generated.into_anchored_resource())
+        let resource = self
+            .protected_resource
+            .as_ref()
+            .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+        Ok(GuardedResource::new(resource))
     }
 
     pub fn authorize_transfer(&mut self, requested: FdTransferPolicy) -> Result<OfdTransfer<'_>> {
@@ -478,6 +477,7 @@ impl LockSet {
 
         let started = clock.now();
         let deadline = Duration::from_millis(u64::from(spec.deadline_ms));
+        let mut attempted = false;
         loop {
             if cancellation.acquisition_abandoned()
                 || (spec.cancellation == CancellationPolicy::Cancellable
@@ -485,6 +485,10 @@ impl LockSet {
             {
                 return Err(Error::Code(ErrorCode::Cancelled));
             }
+            if attempted && deadline_elapsed(clock, started, deadline) {
+                return Err(Error::Code(ErrorCode::Deadline));
+            }
+            attempted = true;
             match set_ofd_lock(&fd, libc::F_WRLCK as i16) {
                 Ok(()) => break,
                 Err(Errno::EAGAIN | Errno::EACCES) => {
@@ -512,7 +516,7 @@ impl LockSet {
             transfer: spec.fd_transfer,
             held: true,
             protected_resources: vec![resource.resource_id.clone()],
-            protected_resource_contract_id: None,
+            protected_resource: None,
             generated_stale_policy: None,
             generated_adoption_policy: None,
             generated_degrade_scope: None,
@@ -688,6 +692,19 @@ impl LockSet {
             std::path::Path::new(lock_row.path_template.as_str()),
         )?;
 
+        // The protected resource is resolved exactly once, here, at
+        // acquisition time, from the trusted `storage`/`anchor` this call
+        // was given — never re-resolved later against a caller-supplied
+        // inventory or anchor. It is retained by the pushed [`LockGuard`]
+        // for its whole lifetime; [`LockGuard::protected_resource`] only
+        // ever borrows this exact resolution.
+        let protected_resource = GeneratedResource::resolve(
+            anchor,
+            anchor_path,
+            binding.protected_resources[0].clone(),
+            std::path::Path::new(protected_row.path_template.as_str()),
+        )?;
+
         // Generated lock files are exclusively broker-created: open only,
         // never create. A missing file fails closed with
         // `ErrorCode::Missing` (naturally surfaced by `open_beneath`'s
@@ -705,6 +722,7 @@ impl LockSet {
         }
 
         let started = clock.now();
+        let mut attempted = false;
         loop {
             // The generated contract has no distinct cancellation-policy
             // field (unlike `v2_state::LockSpec::cancellation`); honouring
@@ -714,6 +732,15 @@ impl LockSet {
             if cancellation.acquisition_abandoned() || cancellation.is_cancelled() {
                 return Err(Error::Code(ErrorCode::Cancelled));
             }
+            if attempted && !binding.fail_fast {
+                let deadline = binding
+                    .deadline
+                    .expect("bounded-wait binding always carries a validated deadline");
+                if deadline_elapsed(clock, started, deadline) {
+                    return Err(Error::Code(ErrorCode::Deadline));
+                }
+            }
+            attempted = true;
             match set_ofd_lock(&fd, libc::F_WRLCK as i16) {
                 Ok(()) => break,
                 Err(Errno::EAGAIN | Errno::EACCES) => {
@@ -744,7 +771,7 @@ impl LockSet {
             transfer: binding.fd_transfer,
             held: true,
             protected_resources: binding.protected_resources,
-            protected_resource_contract_id: Some(protected_resource_id.clone()),
+            protected_resource: Some(protected_resource),
             generated_stale_policy: Some(lock.stale_policy.clone()),
             generated_adoption_policy: Some(lock.adoption_policy),
             generated_degrade_scope: Some(lock.degrade_scope),
@@ -1422,6 +1449,31 @@ mod tests {
         assert!(clock.recorded_sleeps().is_empty());
     }
 
+    /// Deterministically exercises the deadline recheck both acquisition
+    /// loops perform at the top of every retry *after* the first attempt:
+    /// a scripted clock that reports the deadline as already elapsed by
+    /// the second call must report `deadline_elapsed == true`, while the
+    /// very first call (before any attempt) is never even consulted by
+    /// the loops (that invariant is exercised end-to-end by
+    /// [`bounded_wait_never_acquires_after_a_late_wakeup_past_deadline`]
+    /// below; this test isolates just the pure elapsed-check arithmetic).
+    #[test]
+    fn deadline_elapsed_reports_true_only_once_the_deadline_has_passed() {
+        let deadline = Duration::from_millis(5);
+        let clock = FakeClock::new([
+            Duration::from_millis(0),
+            Duration::from_millis(3),
+            Duration::from_millis(4),
+            Duration::from_millis(5),
+            Duration::from_millis(6),
+        ]);
+        let started = clock.now();
+        assert!(!deadline_elapsed(&clock, started, deadline));
+        assert!(!deadline_elapsed(&clock, started, deadline));
+        assert!(deadline_elapsed(&clock, started, deadline));
+        assert!(deadline_elapsed(&clock, started, deadline));
+    }
+
     #[test]
     fn acquire_from_generated_round_trips_authority_order_and_protected_resource() {
         let scratch = Scratch::new("generated-ok");
@@ -1528,20 +1580,24 @@ mod tests {
             ErrorCode::LockMismatch
         );
 
-        // A guard-bound resolution of the protected resource: opaque,
-        // non-forgeable, derived only from the held guard's authorized set
-        // plus a fresh trusted-root walk.
-        let bound = guard
-            .bind_protected_resource(
-                &storage,
-                &anchor,
-                Path::new(ANCHOR_PATH),
-                host_metadata(&scratch.0, 0o600),
-            )
-            .unwrap();
+        // A guard-bound, acquisition-time-resolved capability for the
+        // protected resource: opaque, non-forgeable, borrowed from the
+        // guard's own retained resolution rather than re-derived from any
+        // caller-supplied inventory/anchor.
+        let protected_id = ResourceId::parse("path-realm-workload-state-my-realm").unwrap();
+        let bound = guard.protected_resource(&protected_id).unwrap();
+        assert_eq!(bound.resource_id(), &protected_id);
+        assert!(bound.verify_live_identity().is_ok());
+
+        // Selecting the lock file's own resource id (instead of the
+        // protected resource's) is rejected: the two are never conflated.
         assert_eq!(
-            bound.resource_id.as_str(),
-            "path-realm-workload-state-my-realm"
+            guard
+                .protected_resource(guard.lock_file_resource_id())
+                .err()
+                .unwrap()
+                .code(),
+            ErrorCode::LockMismatch
         );
     }
 
@@ -1949,7 +2005,7 @@ mod tests {
     }
 
     #[test]
-    fn bind_protected_resource_rejects_after_release() {
+    fn protected_resource_rejects_after_release() {
         let scratch = Scratch::new("bind-after-release");
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
@@ -2001,14 +2057,8 @@ mod tests {
             .unwrap();
         let guard = set.last().expect("released guard remains in the set");
 
-        let err = guard
-            .bind_protected_resource(
-                &storage,
-                &anchor,
-                Path::new(ANCHOR_PATH),
-                host_metadata(&scratch.0, 0o600),
-            )
-            .unwrap_err();
+        let protected_id = ResourceId::parse("path-realm-workload-state-my-realm").unwrap();
+        let err = guard.protected_resource(&protected_id).err().unwrap();
         assert_eq!(err.code(), ErrorCode::LockReleased);
     }
 
@@ -2418,5 +2468,189 @@ mod tests {
             )
             .unwrap_err();
         assert_eq!(err.code(), ErrorCode::Deadline);
+    }
+
+    /// End-to-end proof (real threads, real OFD lock contention,
+    /// [`SystemClock`], generous timing margins) that a late wakeup can
+    /// never let acquisition win a lock after its own deadline has
+    /// passed. A background thread holds the conflicting OFD lock until
+    /// well *after* `acquire_from_generated`'s bounded-wait deadline has
+    /// elapsed, then releases it — so the only way this call could ever
+    /// observe `set_ofd_lock` succeed is if it attempted one *after* its
+    /// deadline, exactly the late-wakeup race the top-of-loop deadline
+    /// recheck exists to close. Without that recheck, a poll iteration's
+    /// sleep could return late (after the deadline) and immediately
+    /// attempt (and, once the background thread has released, win) the
+    /// lock; with it, the call must fail closed with `ErrorCode::Deadline`
+    /// every time, regardless of exactly when the background thread
+    /// releases relative to the deadline.
+    #[test]
+    fn bounded_wait_never_acquires_after_a_late_wakeup_past_deadline() {
+        let scratch = Scratch::new("bounded-wait-late-wakeup");
+        let owner = controller_actor("my-realm");
+        let mut lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        // A short 15ms deadline against a background hold released only
+        // at ~60ms: any implementation missing the late-wakeup recheck
+        // would have ample real-world scheduling slack to observe the
+        // held lock as free on some poll iteration whose own sleep
+        // overran past 15ms, and could then win it — this margin makes
+        // that outcome the overwhelmingly likely failure mode if the
+        // fix regresses, while the fixed implementation must still fail
+        // closed every time.
+        lock.timeout_policy = LockTimeoutPolicy {
+            kind: LockTimeoutKind::BoundedWait,
+            timeout_ms: Some(15),
+        };
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        let lock_path = scratch.0.join("state.lock");
+        fs::write(&lock_path, b"").unwrap();
+        fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600)).unwrap();
+
+        let contender = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .unwrap();
+        let contender_fd = OwnedFd::from(contender);
+        set_ofd_lock(&contender_fd, libc::F_WRLCK as i16).unwrap();
+
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(60));
+            set_ofd_lock(&contender_fd, libc::F_UNLCK as i16).unwrap();
+        });
+
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, protected_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::Deadline);
+        assert!(set.last().is_none());
+
+        handle.join().unwrap();
+    }
+
+    /// End-to-end proof that the guarded `AtomicWrite` API
+    /// (`atomic::AtomicWrite::write_guarded`/`read_guarded`) round-trips
+    /// through exactly the acquisition-time-bound capability a generated
+    /// guard retains — never a caller-supplied `AnchoredResource` — and
+    /// rejects a mismatched `resource_id` even though the guard is held
+    /// and every other input is otherwise valid.
+    #[test]
+    fn guarded_atomic_write_round_trips_and_rejects_wrong_resource_id() {
+        let scratch = Scratch::new("guarded-atomic-round-trip");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, protected_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let guard = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap();
+        let protected_id = ResourceId::parse("path-realm-workload-state-my-realm").unwrap();
+
+        let generation_one = d2b_contracts::v2_state::Generation::new(1).unwrap();
+        let write_policy = crate::atomic::WritePolicy {
+            metadata,
+            writer: realm_controller("my-realm"),
+            config_generation: generation_one,
+            state_generation: generation_one,
+            expected_previous: None,
+            lock_id: guard.lock_id().clone(),
+            ownership_epoch: guard.ownership_epoch(),
+        };
+        let receipt =
+            crate::atomic::AtomicWrite::<crate::atomic::RealAtomicFilesystem>::write_guarded(
+                guard,
+                &protected_id,
+                &42u64,
+                &write_policy,
+            )
+            .unwrap();
+        assert_eq!(receipt.resource_id, protected_id);
+
+        let read_policy = crate::atomic::ReadPolicy {
+            metadata,
+            writer: realm_controller("my-realm"),
+            config_generation: generation_one,
+            state_generation: crate::atomic::GenerationPolicy::Exact(generation_one),
+        };
+        let state =
+            crate::atomic::AtomicWrite::<crate::atomic::RealAtomicFilesystem>::read_guarded::<u64>(
+                guard,
+                &protected_id,
+                &read_policy,
+            )
+            .unwrap();
+        assert_eq!(state.payload, 42u64);
+
+        // The lock file's own resource id is a distinct concept from the
+        // protected resource: selecting it here is rejected exactly like
+        // any other unrelated id, never silently substituted.
+        let err =
+            crate::atomic::AtomicWrite::<crate::atomic::RealAtomicFilesystem>::read_guarded::<u64>(
+                guard,
+                guard.lock_file_resource_id(),
+                &read_policy,
+            )
+            .err()
+            .unwrap();
+        assert_eq!(err.code(), ErrorCode::LockMismatch);
     }
 }

--- a/packages/d2b-state/src/lock.rs
+++ b/packages/d2b-state/src/lock.rs
@@ -10,8 +10,10 @@ use d2b_contracts::v2_state::{
     OwnershipEpoch, ResourceId,
 };
 use d2b_core::{
-    contract_id::ContractId,
-    storage::{ActorKind, DegradeScope, StorageJson, StoragePathKind, StoragePathSpec},
+    contract_id::{ContractId, PathTemplate},
+    storage::{
+        ActorKind, DegradeScope, StorageInvariant, StorageJson, StoragePathKind, StoragePathSpec,
+    },
     sync::{
         FdPassingMechanism, InheritancePolicy, LockAdoptionPolicy, LockKind as GeneratedLockKind,
         LockSpec as GeneratedLockSpec, LockStalePolicy, LockTimeoutKind, SyncJson,
@@ -141,7 +143,7 @@ pub struct LockGuard {
     /// The lock file's own storage-row resource id (the file this guard's
     /// `fd` is actually opened/locked against). Distinct from
     /// [`Self::protected_resources`], which names the *protected state*
-    /// resources this lock authorizes mutation of — never the same field
+    /// resource this lock authorizes mutation of — never the same field
     /// doing double duty (see [`Self::validate_state_binding`] and
     /// [`Self::bind_protected_resource`]).
     lock_file_resource_id: ResourceId,
@@ -155,10 +157,20 @@ pub struct LockGuard {
     /// `acquire_with_clock`, this is always exactly `[resource.resource_id]`
     /// (the single resource that API has ever protected), preserving that
     /// path's existing single-resource semantics. For guards acquired via
-    /// [`LockSet::acquire_from_generated`], this is the caller-supplied,
-    /// inventory-validated `protected_resource_ids` set — distinct from
+    /// [`LockSet::acquire_from_generated`], this is always exactly
+    /// `[encode(lock.resource_id)]` — the single protected resource named by
+    /// the generated lock's own `resource_id` field (its schema-intended
+    /// semantic), never a caller-supplied set. Distinct from
     /// [`Self::lock_file_resource_id`].
     protected_resources: Vec<ResourceId>,
+    /// The protected resource's own generated `ContractId`, present only for
+    /// guards acquired via [`LockSet::acquire_from_generated`] (the only
+    /// path that can re-resolve a resource by trusted-root + generated row;
+    /// see [`Self::bind_protected_resource`]). `None` for legacy
+    /// `acquire`/`acquire_with_clock`-acquired guards, which are handed
+    /// their protected resource directly as an [`AnchoredResource`] at
+    /// acquisition time and have no generated-inventory id to re-resolve.
+    protected_resource_contract_id: Option<ContractId>,
     /// Generated stale/adoption/degrade policy, carried through losslessly
     /// from the generated `sync.json` row. `None` for guards acquired via
     /// the legacy path, which predates and does not carry this policy.
@@ -263,18 +275,19 @@ impl LockGuard {
         Ok((stat.st_dev, stat.st_ino))
     }
 
-    /// Opens one of the resources this held guard authorizes mutation for,
+    /// Opens the single resource this held guard authorizes mutation for,
     /// resolved fresh via a trusted-root + `openat2` walk against `storage`'s
     /// validated inventory and `anchor`/`anchor_path` — never an inferred
-    /// parent/path relationship, and never a caller-supplied resource
-    /// accepted on trust. `resource_id` must both:
+    /// parent/path relationship. There is no `resource_id` parameter: which
+    /// resource is protected is decided exclusively by the generated lock's
+    /// own `resource_id` field at acquisition time (see
+    /// [`LockSet::acquire_from_generated`]'s docs) — a caller cannot select
+    /// or substitute a different resource here, even one that exists and is
+    /// otherwise well-formed.
     ///
-    /// - resolve to exactly one row in `storage`'s validated inventory
-    ///   (missing or duplicate ids fail closed), and
-    /// - be a member of [`Self::protected_resources`] as bound at
-    ///   acquisition time — a resource this specific guard does not
-    ///   authorize is rejected even if it exists and is otherwise
-    ///   well-formed.
+    /// Only available for guards acquired via
+    /// [`LockSet::acquire_from_generated`] (legacy `acquire`-acquired guards
+    /// have no generated-inventory id to re-resolve and fail closed here).
     ///
     /// On success, returns the legacy [`AnchoredResource`] shape so
     /// existing atomic/audit consumers can use it without any change to
@@ -285,7 +298,6 @@ impl LockGuard {
     pub fn bind_protected_resource(
         &self,
         storage: &StorageJson,
-        resource_id: &ContractId,
         anchor: &AnchoredDir,
         anchor_path: &std::path::Path,
         metadata: MetadataExpectation,
@@ -297,11 +309,16 @@ impl LockGuard {
         storage
             .validate_unique_ids()
             .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
+        let resource_id = self
+            .protected_resource_contract_id
+            .as_ref()
+            .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
         let row = find_unique_storage_row(storage, resource_id)?;
-        if row.kind != StoragePathKind::RegularFile {
-            return Err(Error::Code(ErrorCode::InvalidSchema));
-        }
         let encoded = encode_resource_id(row.id.as_str())?;
+        // Always true by construction (this row's id is exactly what was
+        // encoded into `protected_resources` at acquisition time); kept as
+        // a fail-closed defense against a future refactor weakening that
+        // invariant rather than trusted silently.
         if !self.protected_resources.contains(&encoded) {
             return Err(Error::Code(ErrorCode::LockMismatch));
         }
@@ -495,6 +512,7 @@ impl LockSet {
             transfer: spec.fd_transfer,
             held: true,
             protected_resources: vec![resource.resource_id.clone()],
+            protected_resource_contract_id: None,
             generated_stale_policy: None,
             generated_adoption_policy: None,
             generated_degrade_scope: None,
@@ -529,36 +547,45 @@ impl LockSet {
     /// function cannot validate causes it to fail closed.
     ///
     /// Callers never hand in a detached `&GeneratedLockSpec`/
-    /// `&StoragePathSpec`/`&AnchoredResource` — a prior shape of this API
-    /// did, which let a caller substitute an arbitrary same-id row or
-    /// resource that was never actually looked up from the trusted
-    /// document. Instead:
+    /// `&StoragePathSpec`/`&AnchoredResource`, nor any caller-supplied
+    /// protected-resource selection — a prior shape of this API accepted
+    /// both, which let a caller substitute an arbitrary same-id row or pick
+    /// which resource a lock protects. Instead:
     ///
     /// - `sync`/`storage` are the full trusted generated documents. This
-    ///   function resolves every row it needs — the lock, its own
-    ///   lock-file storage row, and each protected resource's storage row —
-    ///   directly from these documents by opaque id.
-    ///   `sync.validate_lock_order()` and `storage.validate_unique_ids()`
-    ///   are re-run here so a caller cannot pass an already-invalid
-    ///   document and have a stale or duplicate row silently resolved.
+    ///   function resolves every row it needs directly from these documents
+    ///   by opaque id/template — the lock, the single protected resource it
+    ///   names, and its own lock-file storage row. `sync.validate_lock_order()`
+    ///   and `storage.validate_unique_ids()` are re-run here so a caller
+    ///   cannot pass an already-invalid document and have a stale or
+    ///   duplicate row silently resolved.
     /// - `lock_id` is the opaque generated id of the lock to acquire; it
     ///   must resolve to exactly one row in `sync.locks` (a missing or
     ///   duplicate id fails closed).
-    /// - `protected_resource_ids` are the opaque ids of the storage
-    ///   resources this acquisition protects. There is no generated
-    ///   parent/child field linking a lock to the resources it protects,
-    ///   so the caller supplies them; each one must resolve to exactly one
-    ///   row in `storage`, must not repeat, and that row's `scope` is
-    ///   checked against the lock's own `scope` so an unrelated resource
-    ///   cannot be smuggled in as "protected" by this lock. The lock file's
-    ///   own storage row (named by `lock.resource_id`) is a distinct
-    ///   concept from a protected resource; see [`LockGuard`]'s field docs.
+    /// - The lock's own `resource_id` field names the *protected state*
+    ///   resource this lock guards — its schema-intended semantic. A `None`
+    ///   `resource_id` fails closed (`ErrorCode::InvalidSchema`): every
+    ///   generated lock must declare what it protects. That id must resolve
+    ///   to exactly one row in `storage` (missing/duplicate ids fail
+    ///   closed) sharing the lock's own `scope`; there is no caller
+    ///   parameter of any kind that selects or overrides this — it is
+    ///   entirely schema-derived. [`LockGuard::protected_resources`] is
+    ///   always exactly this single encoded id.
+    /// - The lock file's own storage row (a distinct concept from the
+    ///   protected resource — see [`LockGuard`]'s field docs) is *not*
+    ///   named by any id field. It is resolved internally by requiring
+    ///   exactly one `RegularFile` row in `storage` whose `path_template`
+    ///   exactly equals the lock's own (mandatory) `path_template` — a
+    ///   missing or duplicate match fails closed. That row's `scope`,
+    ///   owner identity (`owner.value`, compared against
+    ///   `lock.owner_process.value`), and safety invariants
+    ///   (`no-symlink`/`no-magic-link`) are all validated to actually
+    ///   belong to this lock rather than being a coincidental path
+    ///   collision.
     /// - `anchor`/`anchor_path` are the trusted pre-opened root and its
     ///   absolute path. The lock file's own storage row is resolved
     ///   beneath `anchor` via [`GeneratedResource::resolve`] only *after*
-    ///   every other validation succeeds, directly from the row's own id —
-    ///   there is no longer a separate caller-supplied resource parameter
-    ///   that could be mismatched with the wrong lock/row.
+    ///   every other validation succeeds, directly from the row's own id.
     /// - The generated lock file is opened, never created (`OFlags::RDWR`
     ///   only — no `CREATE`/`EXCL`). A generated lock file is exclusively
     ///   broker-created; if it is missing, this fails closed with
@@ -576,7 +603,6 @@ impl LockSet {
         sync: &SyncJson,
         storage: &StorageJson,
         lock_id: &ContractId,
-        protected_resource_ids: &[ContractId],
         anchor: &AnchoredDir,
         anchor_path: &std::path::Path,
         owner: AuthorityRef,
@@ -588,7 +614,6 @@ impl LockSet {
             sync,
             storage,
             lock_id,
-            protected_resource_ids,
             anchor,
             anchor_path,
             owner,
@@ -605,7 +630,6 @@ impl LockSet {
         sync: &SyncJson,
         storage: &StorageJson,
         lock_id: &ContractId,
-        protected_resource_ids: &[ContractId],
         anchor: &AnchoredDir,
         anchor_path: &std::path::Path,
         owner: AuthorityRef,
@@ -621,23 +645,31 @@ impl LockSet {
             .map_err(|_| Error::Code(ErrorCode::InvalidSchema))?;
 
         let lock = find_unique_lock(sync, lock_id)?;
-        let lock_resource_id = lock
+
+        // `lock.resource_id` names the *protected state* resource (its
+        // schema-intended semantic) — not the lock file's own row. A null
+        // id fails closed: every generated lock must declare what it
+        // protects, and nothing here may substitute a caller's choice for
+        // it.
+        let protected_resource_id = lock
             .resource_id
             .as_ref()
             .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
-        let lock_row = find_unique_storage_row(storage, lock_resource_id)?;
+        let protected_row = find_unique_storage_row(storage, protected_resource_id)?;
 
-        let mut seen_requested = std::collections::BTreeSet::new();
-        let mut protected_rows = Vec::with_capacity(protected_resource_ids.len());
-        for id in protected_resource_ids {
-            if !seen_requested.insert(id.clone()) {
-                return Err(Error::Code(ErrorCode::InvalidSchema));
-            }
-            protected_rows.push(find_unique_storage_row(storage, id)?);
-        }
+        // The lock file's own storage row is a distinct concept, resolved
+        // internally — never supplied by a caller — by exact
+        // `path_template` match against this lock's own (mandatory)
+        // template. This is the only way to recover that pairing without a
+        // second schema field.
+        let lock_path_template = lock
+            .path_template
+            .as_ref()
+            .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+        let lock_row = find_unique_lock_file_row(storage, lock_path_template)?;
 
         let binding =
-            validate_generated_lock(sync, lock, lock_row, &protected_rows, &owner, metadata)?;
+            validate_generated_lock(sync, lock, lock_row, protected_row, &owner, metadata)?;
 
         if self.held(&binding.lock_id)
             || self
@@ -712,6 +744,7 @@ impl LockSet {
             transfer: binding.fd_transfer,
             held: true,
             protected_resources: binding.protected_resources,
+            protected_resource_contract_id: Some(protected_resource_id.clone()),
             generated_stale_policy: Some(lock.stale_policy.clone()),
             generated_adoption_policy: Some(lock.adoption_policy),
             generated_degrade_scope: Some(lock.degrade_scope),
@@ -758,6 +791,31 @@ fn find_unique_storage_row<'a>(
     Ok(found)
 }
 
+/// Looks up exactly one storage row in `storage.paths` whose `path_template`
+/// exactly equals `path_template` — the mechanism by which a lock's own
+/// lock-file row is resolved, since `d2b_core::sync::LockSpec` has no id
+/// field naming that row directly (its `resource_id` names the *protected*
+/// resource instead; see [`validate_generated_lock`]'s docs). A missing or
+/// duplicate match fails closed rather than silently picking the
+/// first/last one. Kind/scope/owner/invariant conformance of the found row
+/// is checked separately by [`validate_generated_lock`].
+fn find_unique_lock_file_row<'a>(
+    storage: &'a StorageJson,
+    path_template: &PathTemplate,
+) -> Result<&'a StoragePathSpec> {
+    let mut matches = storage
+        .paths
+        .iter()
+        .filter(|row| &row.path_template == path_template);
+    let found = matches
+        .next()
+        .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
+    if matches.next().is_some() {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    Ok(found)
+}
+
 /// The fully-validated, ready-to-acquire projection of a generated
 /// `d2b_core::sync::LockSpec`, produced by [`validate_generated_lock`].
 /// Every field here is either copied verbatim from the generated contract
@@ -765,11 +823,14 @@ fn find_unique_storage_row<'a>(
 struct GeneratedLockBinding {
     lock_id: ResourceId,
     /// The lock-file's own storage-row resource id, encoded from
-    /// `lock_row.id`. Kept distinct from [`Self::protected_resources`] —
-    /// see [`LockGuard`]'s field docs for why the lock file and the
-    /// resources it protects are never conflated.
+    /// `lock_row.id` (the row found by exact `path_template` match — see
+    /// [`find_unique_lock_file_row`]). Kept distinct from
+    /// [`Self::protected_resources`] — see [`LockGuard`]'s field docs for
+    /// why the lock file and the resource it protects are never conflated.
     lock_file_resource_id: ResourceId,
     global_order: u32,
+    /// Always exactly one element: `encode(lock.resource_id)`. See
+    /// [`LockGuard::protected_resources`]'s field docs.
     protected_resources: Vec<ResourceId>,
     fd_transfer: FdTransferPolicy,
     /// `true` for `FailFast`/`NoWait` (a single non-blocking attempt with no
@@ -779,12 +840,20 @@ struct GeneratedLockBinding {
     deadline: Option<Duration>,
 }
 
+/// Validates a generated lock against its schema-resolved lock-file row
+/// (`lock_row`, found internally by `path_template` — see
+/// [`find_unique_lock_file_row`]) and its schema-declared protected
+/// resource row (`protected_row`, found by `lock.resource_id` — see
+/// [`find_unique_storage_row`]). Neither row is caller-suppliable; both are
+/// resolved exclusively from the trusted `sync`/`storage` documents by
+/// [`LockSet::acquire_from_generated_with_clock`] before this function is
+/// ever called.
 #[allow(clippy::too_many_arguments)]
 fn validate_generated_lock(
     sync: &SyncJson,
     lock: &GeneratedLockSpec,
     lock_row: &StoragePathSpec,
-    protected: &[&StoragePathSpec],
+    protected_row: &StoragePathSpec,
     owner: &AuthorityRef,
     metadata: MetadataExpectation,
 ) -> Result<GeneratedLockBinding> {
@@ -812,18 +881,38 @@ fn validate_generated_lock(
         return Err(Error::Code(ErrorCode::InvalidSchema));
     }
 
-    let declared_resource = lock
-        .resource_id
-        .as_ref()
-        .ok_or(Error::Code(ErrorCode::InvalidSchema))?;
-    if *declared_resource != lock_row.id || lock.scope != lock_row.scope {
+    // The protected resource (named by `lock.resource_id`) must share this
+    // lock's scope — an unrelated-scope resource can never be "protected"
+    // by this lock, even though the id is schema-declared rather than
+    // caller-supplied.
+    if protected_row.scope != lock.scope {
         return Err(Error::Code(ErrorCode::InvalidSchema));
     }
-    if lock_row.kind != StoragePathKind::RegularFile {
+
+    // The lock file's own row — resolved internally by exact
+    // `path_template` match — must actually be a regular file in this
+    // lock's own scope. `lock.path_template` was the key used to find it;
+    // re-check it matches here too, for defense in depth against a future
+    // refactor of the lookup itself.
+    if lock_row.kind != StoragePathKind::RegularFile || lock_row.scope != lock.scope {
         return Err(Error::Code(ErrorCode::InvalidSchema));
     }
-    if let Some(template) = &lock.path_template
-        && *template != lock_row.path_template
+    if lock.path_template.as_ref() != Some(&lock_row.path_template) {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    // The lock file's declared owner must name the same authority as this
+    // lock's own owner/release authority — an owner mismatch between the
+    // lock and its physical file is rejected rather than silently
+    // accepted.
+    if lock.owner_process.value.as_str() != lock_row.owner.value.as_str() {
+        return Err(Error::Code(ErrorCode::InvalidSchema));
+    }
+    // The lock file's row must declare the safety invariants the runtime
+    // actually enforces via `openat2` (no-symlink/no-magic-link) — if the
+    // schema doesn't declare them, treat the contract as malformed rather
+    // than relying solely on the runtime flags to make up for it.
+    if !lock_row.invariants.contains(&StorageInvariant::NoSymlink)
+        || !lock_row.invariants.contains(&StorageInvariant::NoMagicLink)
     {
         return Err(Error::Code(ErrorCode::InvalidSchema));
     }
@@ -846,20 +935,13 @@ fn validate_generated_lock(
 
     let lock_id = encode_resource_id(lock.id.as_str())?;
     let lock_file_resource_id = encode_resource_id(lock_row.id.as_str())?;
+    let protected_resource = encode_resource_id(protected_row.id.as_str())?;
     let mut seen = std::collections::BTreeSet::new();
-    if !seen.insert(lock_id.clone()) || !seen.insert(lock_file_resource_id.clone()) {
+    if !seen.insert(lock_id.clone())
+        || !seen.insert(lock_file_resource_id.clone())
+        || !seen.insert(protected_resource.clone())
+    {
         return Err(Error::Code(ErrorCode::InvalidSchema));
-    }
-    let mut protected_resources = Vec::with_capacity(protected.len());
-    for row in protected {
-        if row.scope != lock.scope {
-            return Err(Error::Code(ErrorCode::InvalidSchema));
-        }
-        let encoded = encode_resource_id(row.id.as_str())?;
-        if !seen.insert(encoded.clone()) {
-            return Err(Error::Code(ErrorCode::InvalidSchema));
-        }
-        protected_resources.push(encoded);
     }
 
     let fd_transfer = match lock.fd_passing_policy.mechanism {
@@ -899,7 +981,7 @@ fn validate_generated_lock(
         lock_id,
         lock_file_resource_id,
         global_order,
-        protected_resources,
+        protected_resources: vec![protected_resource],
         fd_transfer,
         fail_fast,
         deadline,
@@ -1026,8 +1108,8 @@ mod tests {
         contract_id::{ContractId, PathTemplate},
         storage::{
             ActorRef, CleanupPolicy, DegradedReason, LeaseClass, PrincipalKind, PrincipalRef,
-            RepairPolicy, SensitivityClass, StorageAdoptionPolicy, StorageLifecycle,
-            StoragePersistence, StorageRestartPolicy,
+            RepairPolicy, SensitivityClass, StorageAdoptionPolicy, StorageInvariant,
+            StorageLifecycle, StoragePersistence, StorageRestartPolicy,
         },
         sync::{
             FdPassingPolicy, LockAcquireOrder, LockScopeClass, LockStaleKind, LockTimeoutPolicy,
@@ -1097,13 +1179,23 @@ mod tests {
 
     /// A fully-populated, schema-valid `GeneratedLockSpec` mirroring the
     /// exact shape `nixos-modules/realm-storage-rows.nix`'s `mkOfdLock`
-    /// renders for a controller-owned realm lock. Individual fields are
-    /// overridden per test to exercise a single failure mode at a time.
-    fn valid_generated_lock(id: &str, resource_id: &str, owner: ActorRef) -> GeneratedLockSpec {
+    /// renders for a controller-owned realm lock. `resource_id` is the
+    /// *protected state* resource this lock guards (its schema-intended
+    /// semantic) — never the lock file's own row; the lock file's own
+    /// storage row is resolved separately, internally, by exact
+    /// `path_template` match (see [`find_unique_lock_file_row`]), so it is
+    /// not named by any field here. Individual fields are overridden per
+    /// test to exercise a single failure mode at a time.
+    fn valid_generated_lock(
+        id: &str,
+        resource_id: &str,
+        path_template: &str,
+        owner: ActorRef,
+    ) -> GeneratedLockSpec {
         GeneratedLockSpec {
             id: ContractId::parse(id).unwrap(),
             scope: ContractId::parse("host").unwrap(),
-            path_template: None,
+            path_template: Some(PathTemplate::parse(path_template).unwrap()),
             resource_id: Some(ContractId::parse(resource_id).unwrap()),
             kind: GeneratedLockKind::Ofd,
             owner_process: owner.clone(),
@@ -1135,10 +1227,16 @@ mod tests {
     }
 
     /// A fully-populated, schema-valid regular-file `StoragePathSpec`
-    /// mirroring the paired lock-file/protected-resource rows added to
+    /// mirroring a lock-file/protected-resource row added to
     /// `nixos-modules/realm-storage-rows.nix` (mode `0600`, process-scoped,
-    /// not adoptable, no follow). `leaf` names the file beneath a per-test
-    /// scratch directory so distinct rows in one test never collide.
+    /// not adoptable, no follow, declaring the `no-symlink`/`no-magic-link`
+    /// invariants the runtime's `openat2` resolution actually enforces).
+    /// `leaf` names the file beneath a per-test scratch directory so
+    /// distinct rows in one test never collide. `owner`'s `value` becomes
+    /// this row's declared owner identity, mirroring the real Nix
+    /// generator's `controllerUser`/`brokerUser` (`PrincipalRef`) sharing
+    /// the same `value` string as `controllerActor`/`brokerActor`
+    /// (`ActorRef`).
     fn valid_storage_row(id: &str, leaf: &str, owner: ActorRef) -> StoragePathSpec {
         StoragePathSpec {
             id: ContractId::parse(id).unwrap(),
@@ -1150,11 +1248,11 @@ mod tests {
             persistence: StoragePersistence::ProcessScoped,
             owner: PrincipalRef {
                 kind: PrincipalKind::Role,
-                value: ContractId::parse("d2bd").unwrap(),
+                value: owner.value.clone(),
             },
             group: PrincipalRef {
                 kind: PrincipalKind::Role,
-                value: ContractId::parse("d2bd").unwrap(),
+                value: owner.value.clone(),
             },
             mode: "0600".to_owned(),
             access_acl: Vec::new(),
@@ -1170,7 +1268,7 @@ mod tests {
             sensitivity: SensitivityClass::Private,
             no_follow: true,
             recursive: false,
-            invariants: Vec::new(),
+            invariants: vec![StorageInvariant::NoSymlink, StorageInvariant::NoMagicLink],
         }
     }
 
@@ -1328,9 +1426,16 @@ mod tests {
     fn acquire_from_generated_round_trips_authority_order_and_protected_resource() {
         let scratch = Scratch::new("generated-ok");
         let owner = controller_actor("my-realm");
+        // `lock.resource_id` names the *protected* resource directly — its
+        // schema-intended semantic — matching the real
+        // `lock:realm-controller:<id>` / `realm-controller-state` pairing in
+        // `nixos-modules/realm-storage-rows.nix`. The lock file's own row is
+        // never named by an id field; it is resolved internally by exact
+        // `path_template` match.
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         let lock_row = valid_storage_row(
@@ -1338,10 +1443,6 @@ mod tests {
             "state.lock",
             owner.clone(),
         );
-        // A distinct resource this lock protects — never the lock file
-        // itself — sharing the lock's scope, matching the real
-        // `lock:workload-state:<id>` / `workload-state-data` pairing in
-        // `nixos-modules/realm-storage-rows.nix`.
         let protected_row =
             valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         // The generated adapter only ever opens a lock file that already
@@ -1371,7 +1472,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                std::slice::from_ref(&protected_row.id),
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -1434,7 +1534,6 @@ mod tests {
         let bound = guard
             .bind_protected_resource(
                 &storage,
-                &protected_row.id,
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 host_metadata(&scratch.0, 0o600),
@@ -1452,16 +1551,22 @@ mod tests {
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         // Deliberately do NOT create `state.lock` on disk: a generated
         // lock file is exclusively broker-created, so the adapter must
         // open-only and fail closed rather than conjuring one.
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -1471,7 +1576,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -1490,87 +1594,8 @@ mod tests {
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
-            owner.clone(),
-        );
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
-        fs::write(scratch.0.join("state.lock"), b"").unwrap();
-        fs::set_permissions(
-            scratch.0.join("state.lock"),
-            fs::Permissions::from_mode(0o600),
-        )
-        .unwrap();
-        let sync = sync_of(vec![lock]);
-        let storage = storage_of(vec![lock_row]);
-        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
-        let metadata = host_metadata(&scratch.0, 0o600);
-
-        let mut set = LockSet::new();
-        let err = set
-            .acquire_from_generated(
-                &sync,
-                &storage,
-                &ContractId::parse("lock:does-not-exist").unwrap(),
-                &[],
-                &anchor,
-                Path::new(ANCHOR_PATH),
-                realm_controller("my-realm"),
-                OwnershipEpoch::new(1).unwrap(),
-                metadata,
-                &NeverCancelled,
-            )
-            .unwrap_err();
-        assert_eq!(err.code(), ErrorCode::InvalidSchema);
-    }
-
-    #[test]
-    fn acquire_from_generated_rejects_unknown_protected_resource_id() {
-        let scratch = Scratch::new("generated-unknown-protected");
-        let owner = controller_actor("my-realm");
-        let lock = valid_generated_lock(
-            "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
-            owner.clone(),
-        );
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
-        fs::write(scratch.0.join("state.lock"), b"").unwrap();
-        fs::set_permissions(
-            scratch.0.join("state.lock"),
-            fs::Permissions::from_mode(0o600),
-        )
-        .unwrap();
-        let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
-        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
-        let metadata = host_metadata(&scratch.0, 0o600);
-
-        let mut set = LockSet::new();
-        let err = set
-            .acquire_from_generated(
-                &sync,
-                &storage,
-                &lock.id,
-                &[ContractId::parse("path:does-not-exist").unwrap()],
-                &anchor,
-                Path::new(ANCHOR_PATH),
-                realm_controller("my-realm"),
-                OwnershipEpoch::new(1).unwrap(),
-                metadata,
-                &NeverCancelled,
-            )
-            .unwrap_err();
-        assert_eq!(err.code(), ErrorCode::InvalidSchema);
-    }
-
-    #[test]
-    fn acquire_from_generated_rejects_duplicate_requested_protected_resource_ids() {
-        let scratch = Scratch::new("generated-duplicate-protected");
-        let owner = controller_actor("my-realm");
-        let lock = valid_generated_lock(
-            "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         let lock_row = valid_storage_row(
@@ -1586,27 +1611,283 @@ mod tests {
             fs::Permissions::from_mode(0o600),
         )
         .unwrap();
-        fs::write(scratch.0.join("state.json"), b"{}").unwrap();
-        fs::set_permissions(
-            scratch.0.join("state.json"),
-            fs::Permissions::from_mode(0o600),
-        )
-        .unwrap();
-        let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row, protected_row.clone()]);
+        let sync = sync_of(vec![lock]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
         let mut set = LockSet::new();
-        // The same protected id requested twice in one call — a caller
-        // smuggling a duplicate — must be rejected even though the id
-        // itself is a valid, unique row in `storage`.
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &ContractId::parse("lock:does-not-exist").unwrap(),
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_unknown_protected_resource_id() {
+        let scratch = Scratch::new("generated-unknown-protected");
+        let owner = controller_actor("my-realm");
+        // `lock.resource_id` (the schema-declared protected resource) names
+        // a row absent from the trusted inventory: this must fail closed
+        // before anything about the lock file itself is even considered.
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:does-not-exist",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
         let err = set
             .acquire_from_generated(
                 &sync,
                 &storage,
                 &lock.id,
-                &[protected_row.id.clone(), protected_row.id],
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_null_resource_id() {
+        let scratch = Scratch::new("generated-null-resource-id");
+        let owner = controller_actor("my-realm");
+        let mut lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        // No caller parameter can substitute for a declared protected
+        // resource: a `None` `resource_id` must fail closed rather than
+        // silently protecting nothing (or the lock file itself).
+        lock.resource_id = None;
+        let lock_row =
+            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_duplicate_lock_file_path_template_matches() {
+        let scratch = Scratch::new("generated-duplicate-path-template");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        // Two distinct rows sharing the exact `path_template` the lock
+        // declares: there is no id field naming the lock-file row directly,
+        // so an ambiguous path match must fail closed rather than silently
+        // picking either one.
+        let mut lock_row_a = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let mut lock_row_b = valid_storage_row(
+            "path:realm-controller-lock-dup:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        lock_row_a.path_template =
+            PathTemplate::parse("/var/lib/d2b/r/realm/controller/state.lock").unwrap();
+        lock_row_b.path_template = lock_row_a.path_template.clone();
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row_a, lock_row_b, protected_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_missing_lock_file_path_template_match() {
+        let scratch = Scratch::new("generated-missing-path-template-match");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        // No row in `storage` shares the lock's `path_template` at all.
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![protected_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_lock_file_owner_mismatch() {
+        let scratch = Scratch::new("generated-lock-file-owner-mismatch");
+        let owner = controller_actor("my-realm");
+        let foreign_owner = controller_actor("other-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        // The lock-file row's own declared owner does not match
+        // `lock.owner_process.value` — a mismatch between the lock and the
+        // physical file it is supposed to guard.
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            foreign_owner,
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, protected_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
+                &anchor,
+                Path::new(ANCHOR_PATH),
+                realm_controller("my-realm"),
+                OwnershipEpoch::new(1).unwrap(),
+                metadata,
+                &NeverCancelled,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidSchema);
+    }
+
+    #[test]
+    fn acquire_from_generated_rejects_lock_file_missing_invariants() {
+        let scratch = Scratch::new("generated-lock-file-missing-invariants");
+        let owner = controller_actor("my-realm");
+        let lock = valid_generated_lock(
+            "lock:realm-controller:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
+            owner.clone(),
+        );
+        let mut lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        // The generator always declares `no-symlink`/`no-magic-link` on
+        // lock-file rows; a row missing either must be treated as a
+        // malformed contract rather than relying solely on the runtime's
+        // own `openat2` flags to compensate.
+        lock_row.invariants = Vec::new();
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
+        fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        fs::set_permissions(
+            scratch.0.join("state.lock"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let sync = sync_of(vec![lock.clone()]);
+        let storage = storage_of(vec![lock_row, protected_row]);
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let metadata = host_metadata(&scratch.0, 0o600);
+
+        let mut set = LockSet::new();
+        let err = set
+            .acquire_from_generated(
+                &sync,
+                &storage,
+                &lock.id,
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -1622,9 +1903,13 @@ mod tests {
     fn protected_resource_scope_mismatch_fails_closed() {
         let scratch = Scratch::new("protected-scope-mismatch");
         let owner = controller_actor("my-realm");
+        // `lock.resource_id` names a row in a different scope than the
+        // lock itself — an unrelated-scope resource can never be
+        // "protected" by this lock.
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workloads:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         let lock_row = valid_storage_row(
@@ -1641,14 +1926,8 @@ mod tests {
             fs::Permissions::from_mode(0o600),
         )
         .unwrap();
-        fs::write(scratch.0.join("workloads.json"), b"{}").unwrap();
-        fs::set_permissions(
-            scratch.0.join("workloads.json"),
-            fs::Permissions::from_mode(0o600),
-        )
-        .unwrap();
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row, foreign.clone()]);
+        let storage = storage_of(vec![lock_row, foreign]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -1658,7 +1937,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[foreign.id],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -1671,75 +1949,13 @@ mod tests {
     }
 
     #[test]
-    fn bind_protected_resource_rejects_resource_not_authorized_by_this_guard() {
-        let scratch = Scratch::new("bind-unauthorized");
-        let owner = controller_actor("my-realm");
-        let lock = valid_generated_lock(
-            "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
-            owner.clone(),
-        );
-        let lock_row = valid_storage_row(
-            "path:realm-controller-lock:my-realm",
-            "state.lock",
-            owner.clone(),
-        );
-        // Exists in the trusted inventory and on disk, but is never listed
-        // as a protected resource for this acquisition.
-        let unauthorized =
-            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
-        fs::write(scratch.0.join("state.lock"), b"").unwrap();
-        fs::set_permissions(
-            scratch.0.join("state.lock"),
-            fs::Permissions::from_mode(0o600),
-        )
-        .unwrap();
-        fs::write(scratch.0.join("state.json"), b"{}").unwrap();
-        fs::set_permissions(
-            scratch.0.join("state.json"),
-            fs::Permissions::from_mode(0o600),
-        )
-        .unwrap();
-        let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row, unauthorized.clone()]);
-        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
-        let metadata = host_metadata(&scratch.0, 0o600);
-
-        let mut set = LockSet::new();
-        let guard = set
-            .acquire_from_generated(
-                &sync,
-                &storage,
-                &lock.id,
-                &[],
-                &anchor,
-                Path::new(ANCHOR_PATH),
-                realm_controller("my-realm"),
-                OwnershipEpoch::new(1).unwrap(),
-                metadata,
-                &NeverCancelled,
-            )
-            .unwrap();
-
-        let err = guard
-            .bind_protected_resource(
-                &storage,
-                &unauthorized.id,
-                &anchor,
-                Path::new(ANCHOR_PATH),
-                host_metadata(&scratch.0, 0o600),
-            )
-            .unwrap_err();
-        assert_eq!(err.code(), ErrorCode::LockMismatch);
-    }
-
-    #[test]
     fn bind_protected_resource_rejects_after_release() {
         let scratch = Scratch::new("bind-after-release");
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         let lock_row = valid_storage_row(
@@ -1762,7 +1978,7 @@ mod tests {
         )
         .unwrap();
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row, protected_row.clone()]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -1771,7 +1987,6 @@ mod tests {
             &sync,
             &storage,
             &lock.id,
-            std::slice::from_ref(&protected_row.id),
             &anchor,
             Path::new(ANCHOR_PATH),
             realm_controller("my-realm"),
@@ -1789,7 +2004,6 @@ mod tests {
         let err = guard
             .bind_protected_resource(
                 &storage,
-                &protected_row.id,
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 host_metadata(&scratch.0, 0o600),
@@ -1806,14 +2020,16 @@ mod tests {
         // must always be acquired before `second`.
         let mut first = valid_generated_lock(
             "lock:aaa-realm-controller:my-realm",
-            "path:aaa-realm-controller-lock:my-realm",
+            "path:aaa-realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/aaa.lock",
             owner.clone(),
         );
         first.acquire_order.normalized_path = ContractId::parse("aaa").unwrap();
         first.acquire_order.lock_id = first.id.clone();
         let mut second = valid_generated_lock(
             "lock:bbb-realm-controller:my-realm",
-            "path:bbb-realm-controller-lock:my-realm",
+            "path:bbb-realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/bbb.lock",
             owner.clone(),
         );
         second.acquire_order.normalized_path = ContractId::parse("bbb").unwrap();
@@ -1823,8 +2039,18 @@ mod tests {
             "aaa.lock",
             owner.clone(),
         );
-        let second_row =
-            valid_storage_row("path:bbb-realm-controller-lock:my-realm", "bbb.lock", owner);
+        let second_row = valid_storage_row(
+            "path:bbb-realm-controller-lock:my-realm",
+            "bbb.lock",
+            owner.clone(),
+        );
+        let first_protected = valid_storage_row(
+            "path:aaa-realm-workload-state:my-realm",
+            "aaa.json",
+            owner.clone(),
+        );
+        let second_protected =
+            valid_storage_row("path:bbb-realm-workload-state:my-realm", "bbb.json", owner);
         fs::write(scratch.0.join("aaa.lock"), b"").unwrap();
         fs::set_permissions(
             scratch.0.join("aaa.lock"),
@@ -1838,7 +2064,12 @@ mod tests {
         )
         .unwrap();
         let sync = sync_of(vec![first.clone(), second.clone()]);
-        let storage = storage_of(vec![first_row, second_row]);
+        let storage = storage_of(vec![
+            first_row,
+            second_row,
+            first_protected,
+            second_protected,
+        ]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -1851,7 +2082,6 @@ mod tests {
             &sync,
             &storage,
             &second.id,
-            &[],
             &anchor,
             Path::new(ANCHOR_PATH),
             realm_controller("my-realm"),
@@ -1865,7 +2095,6 @@ mod tests {
                 &sync,
                 &storage,
                 &first.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -1883,11 +2112,17 @@ mod tests {
         let owner = controller_actor("my-realm");
         let lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         fs::write(scratch.0.join("state.lock"), b"").unwrap();
         fs::set_permissions(
             scratch.0.join("state.lock"),
@@ -1895,7 +2130,7 @@ mod tests {
         )
         .unwrap();
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -1905,7 +2140,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -1940,12 +2174,18 @@ mod tests {
         let owner = controller_actor("my-realm");
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         lock.cloexec_required = false;
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         fs::write(scratch.0.join("state.lock"), b"").unwrap();
         fs::set_permissions(
             scratch.0.join("state.lock"),
@@ -1953,7 +2193,7 @@ mod tests {
         )
         .unwrap();
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -1963,7 +2203,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -1981,15 +2220,21 @@ mod tests {
         let owner = controller_actor("my-realm");
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         lock.release_authority = ActorRef {
             kind: ActorKind::Broker,
             value: ContractId::parse("d2bbr-r-my-realm").unwrap(),
         };
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         fs::write(scratch.0.join("state.lock"), b"").unwrap();
         fs::set_permissions(
             scratch.0.join("state.lock"),
@@ -1997,7 +2242,7 @@ mod tests {
         )
         .unwrap();
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -2007,7 +2252,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -2025,15 +2269,21 @@ mod tests {
         let owner = controller_actor("my-realm");
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         lock.timeout_policy = LockTimeoutPolicy {
             kind: LockTimeoutKind::BoundedWait,
             timeout_ms: None,
         };
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         fs::write(scratch.0.join("state.lock"), b"").unwrap();
         fs::set_permissions(
             scratch.0.join("state.lock"),
@@ -2041,7 +2291,7 @@ mod tests {
         )
         .unwrap();
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -2051,7 +2301,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -2069,12 +2318,18 @@ mod tests {
         let owner = controller_actor("my-realm");
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         lock.timeout_policy.timeout_ms = Some(5);
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         fs::write(scratch.0.join("state.lock"), b"").unwrap();
         fs::set_permissions(
             scratch.0.join("state.lock"),
@@ -2082,7 +2337,7 @@ mod tests {
         )
         .unwrap();
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -2092,7 +2347,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),
@@ -2110,15 +2364,21 @@ mod tests {
         let owner = controller_actor("my-realm");
         let mut lock = valid_generated_lock(
             "lock:realm-controller:my-realm",
-            "path:realm-controller-lock:my-realm",
+            "path:realm-workload-state:my-realm",
+            "/var/lib/d2b/r/realm/controller/state.lock",
             owner.clone(),
         );
         lock.timeout_policy = LockTimeoutPolicy {
             kind: LockTimeoutKind::BoundedWait,
             timeout_ms: Some(15),
         };
-        let lock_row =
-            valid_storage_row("path:realm-controller-lock:my-realm", "state.lock", owner);
+        let lock_row = valid_storage_row(
+            "path:realm-controller-lock:my-realm",
+            "state.lock",
+            owner.clone(),
+        );
+        let protected_row =
+            valid_storage_row("path:realm-workload-state:my-realm", "state.json", owner);
         let lock_path = scratch.0.join("state.lock");
         fs::write(&lock_path, b"").unwrap();
         fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600)).unwrap();
@@ -2139,7 +2399,7 @@ mod tests {
         set_ofd_lock(&_contender_fd, libc::F_WRLCK as i16).unwrap();
 
         let sync = sync_of(vec![lock.clone()]);
-        let storage = storage_of(vec![lock_row]);
+        let storage = storage_of(vec![lock_row, protected_row]);
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let metadata = host_metadata(&scratch.0, 0o600);
 
@@ -2149,7 +2409,6 @@ mod tests {
                 &sync,
                 &storage,
                 &lock.id,
-                &[],
                 &anchor,
                 Path::new(ANCHOR_PATH),
                 realm_controller("my-realm"),

--- a/packages/d2b-state/src/path.rs
+++ b/packages/d2b-state/src/path.rs
@@ -5,7 +5,7 @@ use std::{
         fd::{AsFd, OwnedFd},
         unix::ffi::OsStrExt,
     },
-    path::Path,
+    path::{Component, Path},
     sync::Arc,
 };
 
@@ -161,6 +161,61 @@ impl AnchoredDir {
     pub(crate) fn fd(&self) -> impl AsFd + '_ {
         self.fd.as_ref().as_fd()
     }
+
+    /// Durably create (or idempotently adopt) a single-component directory
+    /// child beneath this anchor.
+    ///
+    /// On first creation this `fsync`s the newly-created child directory's
+    /// own fd (flushing its metadata) and then `fsync`s `self` (this
+    /// directory) so the new directory *entry* itself survives a crash
+    /// before this call returns success. A concurrent creator racing to the
+    /// same name is treated as success (idempotent retry: the child is
+    /// re-opened and adopted rather than erroring), which is exactly the
+    /// property first-write paths (gateway/restart) need. `mkdirat` targets
+    /// exactly one path component under an already-anchored, already
+    /// symlink-free directory fd, so no intermediate component can resolve
+    /// through a symlink or magic link.
+    pub fn ensure_durable_dir(&self, name: &LeafName, mode: Mode) -> Result<AnchoredDir> {
+        let relpath = RelativePath::from_components([name.as_str().to_owned()])?;
+        loop {
+            match self.open_beneath(&relpath, OFlags::RDONLY | OFlags::DIRECTORY, Mode::empty()) {
+                Ok(fd) => return AnchoredDir::from_owned_fd(fd),
+                Err(err) if err.code() == ErrorCode::Missing => {}
+                Err(err) => return Err(err),
+            }
+            match rustix::fs::mkdirat(self.fd(), name.as_str(), mode) {
+                Ok(()) => {
+                    let child = self.open_beneath(
+                        &relpath,
+                        OFlags::RDONLY | OFlags::DIRECTORY,
+                        Mode::empty(),
+                    )?;
+                    rustix::fs::fsync(&child).map_err(|error| Error::io(ErrorCode::Io, error))?;
+                    self.fsync_self()?;
+                    return AnchoredDir::from_owned_fd(child);
+                }
+                Err(rustix::io::Errno::EXIST) => {
+                    // Idempotent retry: someone else created it concurrently;
+                    // loop back around and adopt it via open_beneath.
+                    continue;
+                }
+                Err(error) => return Err(Error::io(ErrorCode::Io, error)),
+            }
+        }
+    }
+
+    pub(crate) fn fsync_self(&self) -> Result<()> {
+        rustix::fs::fsync(self.fd()).map_err(|error| Error::io(ErrorCode::Io, error))
+    }
+}
+
+/// Returns a fresh `O_CLOEXEC` duplicate of `fd`, sharing the same
+/// underlying open-file-description. Always uses `fcntl(F_DUPFD_CLOEXEC)`
+/// (`rustix::io::fcntl_dupfd_cloexec`) rather than bare `dup`/`F_DUPFD`,
+/// which would produce a descriptor that survives `exec` and leaks across
+/// privilege boundaries.
+pub(crate) fn dup_cloexec(fd: impl AsFd) -> Result<OwnedFd> {
+    rustix::io::fcntl_dupfd_cloexec(fd, 0).map_err(|error| Error::io(ErrorCode::Io, error))
 }
 
 #[derive(Clone)]
@@ -168,6 +223,13 @@ pub struct AnchoredResource {
     pub resource_id: ResourceId,
     pub directory: AnchoredDir,
     pub leaf: LeafName,
+    /// The `(dev, ino)` of `directory` at the moment this resource was
+    /// bound, captured only by [`AnchoredResource::resolve_generated`].
+    /// `None` for resources built via the generic [`AnchoredResource::new`]
+    /// constructor, which has no trusted-anchor/generated-row binding to
+    /// verify against. Used to detect a directory replaced out from under a
+    /// previously-bound resource (see [`crate::LockGuard::verify_binding`]).
+    directory_identity: Option<(u64, u64)>,
 }
 
 impl fmt::Debug for AnchoredResource {
@@ -184,10 +246,315 @@ impl AnchoredResource {
             resource_id,
             directory: directory.clone(),
             leaf,
+            directory_identity: None,
         }
+    }
+
+    /// Resolve a generated storage-contract row into a non-forgeable
+    /// resource capability.
+    ///
+    /// `anchor` must be a directory the caller already trusts (typically
+    /// opened via [`AnchoredDir::open_trusted`] against a broker/daemon-owned
+    /// root); `anchor_path` is the absolute filesystem path `anchor` was
+    /// opened at. `row_path` is the generated `StoragePathSpec`'s rendered
+    /// absolute path template and `row_id` its generated storage-row id
+    /// (already encoded to a [`ResourceId`] by the caller — this function
+    /// does not invent or reinterpret ids). The path is resolved from
+    /// `anchor` in a single `openat2` beneath/no-symlink/no-magic-link/
+    /// same-filesystem call (see `RESOLVE_SAFE`): a caller cannot pair an
+    /// arbitrary `anchor` with an arbitrary resource id and have it silently
+    /// succeed against a symlinked or cross-filesystem target. The exact
+    /// containing directory's `(dev, ino)` is captured at resolution time
+    /// so a later consumer (e.g. a held [`crate::LockGuard`]) can detect the
+    /// directory being replaced between resolution and use.
+    pub fn resolve_generated(
+        anchor: &AnchoredDir,
+        anchor_path: &Path,
+        resource_id: ResourceId,
+        row_path: &Path,
+    ) -> Result<Self> {
+        if !anchor_path.is_absolute() || !row_path.is_absolute() {
+            return Err(Error::Code(ErrorCode::PathRejected));
+        }
+        let relative = row_path
+            .strip_prefix(anchor_path)
+            .map_err(|_| Error::Code(ErrorCode::PathRejected))?;
+        let mut parts = Vec::new();
+        for component in relative.components() {
+            match component {
+                Component::Normal(part) => {
+                    parts.push(part.to_str().ok_or(Error::Code(ErrorCode::PathRejected))?);
+                }
+                _ => return Err(Error::Code(ErrorCode::PathRejected)),
+            }
+        }
+        let leaf_str = parts.pop().ok_or(Error::Code(ErrorCode::PathRejected))?;
+        let leaf = LeafName::parse(leaf_str)?;
+
+        let (directory, identity) = if parts.is_empty() {
+            // The lock/resource file lives directly in `anchor`: bind our
+            // own independent CLOEXEC descriptor rather than sharing the
+            // caller's `anchor` handle by reference, so this resource's
+            // lifetime and identity capture are self-contained.
+            let duplicated = dup_cloexec(anchor.fd())?;
+            let dir = AnchoredDir::from_owned_fd(duplicated)?;
+            let stat =
+                rustix::fs::fstat(dir.fd()).map_err(|error| Error::io(ErrorCode::Io, error))?;
+            (dir, (stat.st_dev, stat.st_ino))
+        } else {
+            let relpath = RelativePath::from_components(parts.into_iter().map(str::to_owned))?;
+            let fd =
+                anchor.open_beneath(&relpath, OFlags::RDONLY | OFlags::DIRECTORY, Mode::empty())?;
+            let stat = rustix::fs::fstat(&fd).map_err(|error| Error::io(ErrorCode::Io, error))?;
+            let identity = (stat.st_dev, stat.st_ino);
+            (AnchoredDir::from_owned_fd(fd)?, identity)
+        };
+
+        Ok(Self {
+            resource_id,
+            directory,
+            leaf,
+            directory_identity: Some(identity),
+        })
+    }
+
+    /// The exact `(dev, ino)` of [`Self::directory`] captured at
+    /// [`Self::resolve_generated`] time, or `None` for resources built via
+    /// the generic [`Self::new`] constructor.
+    pub fn directory_identity(&self) -> Option<(u64, u64)> {
+        self.directory_identity
     }
 
     pub(crate) fn leaf_os(&self) -> &OsStr {
         OsStr::new(self.leaf.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        os::unix::fs::symlink,
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use super::*;
+
+    static SCRATCH_ID: AtomicU64 = AtomicU64::new(0);
+
+    /// A scratch directory under `CARGO_MANIFEST_DIR/target/...`, never
+    /// `/tmp`, matching the convention used by `tests/state.rs` and
+    /// `lock.rs`'s own test module. Removed on drop.
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(name: &str) -> Self {
+            let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("target")
+                .join("d2b-state-path-tests")
+                .join(format!(
+                    "{name}-{}-{}",
+                    std::process::id(),
+                    SCRATCH_ID.fetch_add(1, Ordering::Relaxed)
+                ));
+            std::fs::create_dir_all(&root).unwrap();
+            Self(root)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn dup_cloexec_produces_a_cloexec_duplicate_sharing_the_same_file() {
+        let scratch = Scratch::new("dup-cloexec");
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let duplicated = dup_cloexec(anchor.fd()).unwrap();
+        let flags = rustix::fs::fcntl_getfd(&duplicated).unwrap();
+        assert!(flags.contains(rustix::io::FdFlags::CLOEXEC));
+        // Same open-file-description as the anchor: identical (dev, ino).
+        let anchor_stat = rustix::fs::fstat(anchor.fd()).unwrap();
+        let dup_stat = rustix::fs::fstat(&duplicated).unwrap();
+        assert_eq!(
+            (anchor_stat.st_dev, anchor_stat.st_ino),
+            (dup_stat.st_dev, dup_stat.st_ino)
+        );
+    }
+
+    #[test]
+    fn ensure_durable_dir_is_idempotent_and_returns_the_same_identity() {
+        let scratch = Scratch::new("durable-mkdir");
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let name = LeafName::parse("state").unwrap();
+
+        let first = anchor.ensure_durable_dir(&name, Mode::from(0o700)).unwrap();
+        let first_stat = rustix::fs::fstat(first.fd()).unwrap();
+
+        // Idempotent retry: calling again must adopt the existing directory
+        // rather than failing on EEXIST, and must observe the identical
+        // (dev, ino) — proving no delete+recreate raced underneath us.
+        let second = anchor.ensure_durable_dir(&name, Mode::from(0o700)).unwrap();
+        let second_stat = rustix::fs::fstat(second.fd()).unwrap();
+
+        assert_eq!(
+            (first_stat.st_dev, first_stat.st_ino),
+            (second_stat.st_dev, second_stat.st_ino)
+        );
+    }
+
+    #[test]
+    fn ensure_durable_dir_fsyncs_child_and_parent_and_is_retryable_after_fault_injection() {
+        let scratch = Scratch::new("durable-mkdir-fault");
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let name = LeafName::parse("audit").unwrap();
+
+        // Simulate a caller that retries after an earlier attempt raced a
+        // concurrent creator to EEXIST: pre-create the directory out from
+        // under the anchor exactly like a racing peer would, then confirm
+        // `ensure_durable_dir` still succeeds by adopting it (the EEXIST
+        // branch), rather than surfacing the race as a fatal error.
+        std::fs::create_dir(scratch.0.join(name.as_str())).unwrap();
+
+        let adopted = anchor.ensure_durable_dir(&name, Mode::from(0o700)).unwrap();
+        let stat = rustix::fs::fstat(adopted.fd()).unwrap();
+        assert_eq!(
+            rustix::fs::FileType::from_raw_mode(stat.st_mode),
+            rustix::fs::FileType::Directory
+        );
+
+        // A second retry after adoption must still be idempotent.
+        let retried = anchor.ensure_durable_dir(&name, Mode::from(0o700)).unwrap();
+        let retried_stat = rustix::fs::fstat(retried.fd()).unwrap();
+        assert_eq!(
+            (stat.st_dev, stat.st_ino),
+            (retried_stat.st_dev, retried_stat.st_ino)
+        );
+    }
+
+    #[test]
+    fn resolve_generated_rejects_symlinked_parent_component() {
+        let scratch = Scratch::new("resolve-symlink-parent");
+        let real_dir = scratch.0.join("real");
+        std::fs::create_dir(&real_dir).unwrap();
+        std::fs::write(real_dir.join("state.lock"), b"").unwrap();
+        let link = scratch.0.join("linked");
+        symlink(&real_dir, &link).unwrap();
+
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let resource_id = ResourceId::parse("real-lock").unwrap();
+        // The rendered row path walks through the symlinked component
+        // `linked/` rather than `real/`; `RESOLVE_SAFE`'s NO_SYMLINKS must
+        // reject this even though the final target byte-for-byte matches a
+        // legitimate resource.
+        let err = AnchoredResource::resolve_generated(
+            &anchor,
+            &scratch.0,
+            resource_id,
+            &link.join("state.lock"),
+        )
+        .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::PathRejected);
+    }
+
+    #[test]
+    fn resolve_generated_binds_the_containing_directory_not_the_leaf_itself() {
+        // `resolve_generated` deliberately only resolves and identity-binds
+        // the *containing directory* of a generated row's leaf; the leaf
+        // file itself is opened later (e.g. via `AnchoredDir::open_beneath`
+        // with `NOFOLLOW`) by the actual lock-acquire/open path. Prove the
+        // returned resource carries the leaf name unresolved (no
+        // symlink-following of the leaf happens here), and that the
+        // *directory-open* step this function performs is what the
+        // dedicated `open_beneath_rejects_symlinked_leaf` test below
+        // exercises for the actual file-open.
+        let scratch = Scratch::new("resolve-leaf-name-only");
+        let real_dir = scratch.0.join("real");
+        std::fs::create_dir(&real_dir).unwrap();
+        std::fs::write(real_dir.join("actual.lock"), b"").unwrap();
+        symlink(real_dir.join("actual.lock"), real_dir.join("state.lock")).unwrap();
+
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let resource_id = ResourceId::parse("real-lock").unwrap();
+        let resource = AnchoredResource::resolve_generated(
+            &anchor,
+            &scratch.0,
+            resource_id,
+            &real_dir.join("state.lock"),
+        )
+        .unwrap();
+        assert_eq!(resource.leaf.as_str(), "state.lock");
+    }
+
+    #[test]
+    fn open_beneath_rejects_symlinked_leaf_component() {
+        let scratch = Scratch::new("open-beneath-symlink-leaf");
+        std::fs::write(scratch.0.join("actual.lock"), b"").unwrap();
+        symlink(scratch.0.join("actual.lock"), scratch.0.join("state.lock")).unwrap();
+
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let relpath = RelativePath::from_components(["state.lock".to_owned()]).unwrap();
+        let err = anchor
+            .open_beneath(&relpath, OFlags::RDONLY, Mode::empty())
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::PathRejected);
+    }
+
+    #[test]
+    fn resolve_generated_rejects_relative_paths() {
+        let scratch = Scratch::new("resolve-relative");
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let resource_id = ResourceId::parse("real-lock").unwrap();
+        let err = AnchoredResource::resolve_generated(
+            &anchor,
+            &scratch.0,
+            resource_id,
+            Path::new("relative/state.lock"),
+        )
+        .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::PathRejected);
+    }
+
+    #[test]
+    fn resolve_generated_captures_directory_identity_for_nested_resource() {
+        let scratch = Scratch::new("resolve-nested");
+        let nested = scratch.0.join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("state.lock"), b"").unwrap();
+
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let resource_id = ResourceId::parse("nested-lock").unwrap();
+        let resource = AnchoredResource::resolve_generated(
+            &anchor,
+            &scratch.0,
+            resource_id,
+            &nested.join("state.lock"),
+        )
+        .unwrap();
+        let expected = rustix::fs::fstat(
+            rustix::fs::open(
+                &nested,
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            resource.directory_identity(),
+            Some((expected.st_dev, expected.st_ino))
+        );
+    }
+
+    #[test]
+    fn open_trusted_rejects_relative_and_nul_paths() {
+        assert_eq!(
+            AnchoredDir::open_trusted(Path::new("relative"))
+                .unwrap_err()
+                .code(),
+            ErrorCode::PathRejected
+        );
     }
 }

--- a/packages/d2b-state/src/path.rs
+++ b/packages/d2b-state/src/path.rs
@@ -307,6 +307,14 @@ pub(crate) struct GeneratedResource {
     resource_id: ResourceId,
     directory: AnchoredDir,
     leaf: LeafName,
+    /// The bound containing directory's `(dev, ino)`, captured via `fstat`
+    /// exactly once, at the end of [`Self::resolve`]'s own trusted-anchor +
+    /// `openat2` walk. This is the acquisition-time identity a held
+    /// [`crate::LockGuard`] retains and later re-verifies against (see
+    /// [`Self::verify_live_identity`]) — never recomputed from a
+    /// caller-supplied path/anchor after acquisition, which is exactly the
+    /// substitution this field closes off.
+    captured_identity: (u64, u64),
 }
 
 impl GeneratedResource {
@@ -363,27 +371,62 @@ impl GeneratedResource {
             AnchoredDir::from_owned_fd(fd)?
         };
 
+        let captured_identity = {
+            let stat = rustix::fs::fstat(directory.fd())
+                .map_err(|error| Error::io(ErrorCode::Io, error))?;
+            (stat.st_dev, stat.st_ino)
+        };
         Ok(Self {
             resource_id,
             directory,
             leaf,
+            captured_identity,
         })
     }
 
     /// The exact `(dev, ino)` of the bound containing directory, queried
-    /// fresh via `fstat` on *every* call — never a value captured or cached
-    /// from resolution time — so a consumer re-checking this at bind/use
-    /// time can never be fooled by a stale identity. Exercised by this
-    /// module's own tests (production code no longer caches or re-derives
-    /// directory identity through this type, since binding a protected
-    /// resource re-resolves fresh via [`Self::resolve`] on every call
-    /// instead); kept as a `#[cfg(test)]` verification hook rather than a
-    /// live production accessor.
+    /// fresh via `fstat` on *every* call — distinct from
+    /// [`Self::captured_identity`]/[`Self::verify_live_identity`], which
+    /// compare against the one-time snapshot taken at [`Self::resolve`]
+    /// time. Kept as a `#[cfg(test)]` verification hook for this module's
+    /// own tests to observe live directory state independently of the
+    /// captured snapshot (e.g. proving a replacement race is detectable),
+    /// not as a production accessor.
     #[cfg(test)]
     pub(crate) fn directory_identity(&self) -> Result<(u64, u64)> {
         let stat = rustix::fs::fstat(self.directory.fd())
             .map_err(|error| Error::io(ErrorCode::Io, error))?;
         Ok((stat.st_dev, stat.st_ino))
+    }
+
+    /// Re-`fstat`s the bound containing directory and compares it against
+    /// the `(dev, ino)` captured once at [`Self::resolve`] time. A
+    /// [`crate::LockGuard`] resolves and retains its protected resource
+    /// exactly once, at acquisition time; this is the guard's only
+    /// re-verification step before a consumer is allowed to read/write
+    /// through it — it detects a directory replacement race (unlink +
+    /// recreate under the same path between acquisition and use) without
+    /// re-walking the path or accepting a new anchor/inventory from the
+    /// caller.
+    pub(crate) fn verify_live_identity(&self) -> Result<()> {
+        let stat = rustix::fs::fstat(self.directory.fd())
+            .map_err(|error| Error::io(ErrorCode::Io, error))?;
+        if (stat.st_dev, stat.st_ino) != self.captured_identity {
+            return Err(Error::Code(ErrorCode::LockMismatch));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resource_id(&self) -> &ResourceId {
+        &self.resource_id
+    }
+
+    pub(crate) fn directory(&self) -> &AnchoredDir {
+        &self.directory
+    }
+
+    pub(crate) fn leaf(&self) -> &LeafName {
+        &self.leaf
     }
 
     /// Opens the bound leaf beneath the resolved, trusted directory. Uses
@@ -394,18 +437,60 @@ impl GeneratedResource {
         let path = RelativePath::from_components([self.leaf.as_str().to_owned()])?;
         self.directory.open_beneath(&path, flags, mode)
     }
+}
 
-    /// Converts into the legacy [`AnchoredResource`] shape consumed by
-    /// atomic/audit/broker code that predates the generated-contract
-    /// bridge. This is the one sanctioned way to hand a generated-resolved
-    /// resource to that code; the recipient still cannot re-derive or
-    /// mutate the resolution that produced it (it only gets the same
-    /// public fields any [`AnchoredResource::new`] caller could construct
-    /// by hand, with no way to tell the two apart — the non-forgeability
-    /// guarantee applies to *how this value was obtained*, not to the
-    /// legacy type's own shape).
-    pub(crate) fn into_anchored_resource(self) -> AnchoredResource {
-        AnchoredResource::new(self.resource_id, &self.directory, self.leaf)
+/// A non-forgeable, acquisition-time-bound borrow of a held
+/// [`crate::LockGuard`]'s single protected [`GeneratedResource`].
+///
+/// [`crate::LockGuard::protected_resource`] is the *only* way to obtain
+/// one, and it never re-resolves against a caller-supplied inventory,
+/// anchor, or path — it only ever borrows the exact [`GeneratedResource`]
+/// [`crate::LockSet::acquire_from_generated`] resolved once, at
+/// acquisition time. The `'guard` lifetime ties every `GuardedResource` to
+/// the specific [`crate::LockGuard`] it was borrowed from: it cannot
+/// outlive that guard (the borrow checker enforces this), it has no
+/// public constructor, no field access, and no `Clone`/`Copy` impl, so a
+/// caller can never manufacture one, retain one independently of the
+/// guard, or pair one guard's resolution with another guard's identity.
+/// The only sanctioned consumer is `d2b-state`'s own guarded
+/// `AtomicWrite` read/write API (see `atomic::AtomicWrite::read_guarded`/
+/// `write_guarded`), which uses the borrow for the duration of a single
+/// synchronous operation and never returns it (or anything derived from
+/// it that could outlive the guard) to its own caller.
+pub(crate) struct GuardedResource<'guard> {
+    resource: &'guard GeneratedResource,
+}
+
+impl<'guard> GuardedResource<'guard> {
+    pub(crate) fn new(resource: &'guard GeneratedResource) -> Self {
+        Self { resource }
+    }
+
+    pub(crate) fn resource_id(&self) -> &ResourceId {
+        self.resource.resource_id()
+    }
+
+    /// Re-verifies the borrowed resource's directory identity against the
+    /// snapshot captured when the owning guard acquired it. See
+    /// [`GeneratedResource::verify_live_identity`].
+    pub(crate) fn verify_live_identity(&self) -> Result<()> {
+        self.resource.verify_live_identity()
+    }
+
+    /// Builds a fresh legacy [`AnchoredResource`] handle from this borrow,
+    /// for immediate synchronous use by the guarded `AtomicWrite` API only
+    /// (never returned to an external caller). The recipient still cannot
+    /// re-derive or mutate the resolution that produced it (it only gets
+    /// the same public fields any [`AnchoredResource::new`] caller could
+    /// construct by hand, with no way to tell the two apart — the
+    /// non-forgeability guarantee applies to *how this value was
+    /// obtained*, not to the legacy type's own shape).
+    pub(crate) fn to_anchored_resource(&self) -> AnchoredResource {
+        AnchoredResource::new(
+            self.resource.resource_id().clone(),
+            self.resource.directory(),
+            self.resource.leaf().clone(),
+        )
     }
 }
 
@@ -728,6 +813,47 @@ mod tests {
         let first = resource.directory_identity().unwrap();
         let second = resource.directory_identity().unwrap();
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn verify_live_identity_detects_a_captured_identity_mismatch() {
+        // A held open file descriptor is, by construction, immune to a
+        // later path-level replacement: once `resolve` opens the
+        // containing directory, an `unlink`+`recreate` (or `rename`) at
+        // that same path can never change what the already-open fd
+        // refers to (POSIX `fstat` on an open descriptor always reports
+        // the original, possibly now-unlinked, inode). Provoking a
+        // *live* mismatch through ordinary filesystem operations alone
+        // is therefore not a meaningful test of `verify_live_identity`
+        // — this is precisely the "no re-walking the path" safety
+        // property the capability is meant to provide.
+        //
+        // What *is* testable in isolation is the comparison itself:
+        // `verify_live_identity` must fail closed whenever the
+        // acquisition-time `captured_identity` no longer matches the
+        // bound directory's live `(dev, ino)`, however that mismatch
+        // came to be. This test constructs that condition directly
+        // (same crate/module scope, so the private fields are visible)
+        // rather than fabricating an unrepresentable filesystem race.
+        let scratch = Scratch::new("resolve-identity-mismatch");
+        let nested = scratch.0.join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("state.lock"), b"").unwrap();
+
+        let directory = AnchoredDir::open_trusted(&nested).unwrap();
+        let resource_id = ResourceId::parse("nested-lock").unwrap();
+        let leaf = LeafName::parse("state.lock").unwrap();
+        let resource = GeneratedResource {
+            resource_id,
+            directory,
+            leaf,
+            captured_identity: (u64::MAX, u64::MAX),
+        };
+
+        assert_eq!(
+            resource.verify_live_identity().unwrap_err().code(),
+            ErrorCode::LockMismatch
+        );
     }
 
     #[test]

--- a/packages/d2b-state/src/path.rs
+++ b/packages/d2b-state/src/path.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::OsStr,
     fmt,
     os::{
-        fd::{AsFd, OwnedFd},
+        fd::{AsFd, BorrowedFd, OwnedFd},
         unix::ffi::OsStrExt,
     },
     path::{Component, Path},
@@ -163,37 +163,60 @@ impl AnchoredDir {
     }
 
     /// Durably create (or idempotently adopt) a single-component directory
-    /// child beneath this anchor.
-    ///
-    /// On first creation this `fsync`s the newly-created child directory's
-    /// own fd (flushing its metadata) and then `fsync`s `self` (this
-    /// directory) so the new directory *entry* itself survives a crash
-    /// before this call returns success. A concurrent creator racing to the
-    /// same name is treated as success (idempotent retry: the child is
-    /// re-opened and adopted rather than erroring), which is exactly the
-    /// property first-write paths (gateway/restart) need. `mkdirat` targets
-    /// exactly one path component under an already-anchored, already
-    /// symlink-free directory fd, so no intermediate component can resolve
-    /// through a symlink or magic link.
+    /// child beneath this anchor. Delegates to
+    /// [`Self::ensure_durable_dir_with_sync`] using the real `fsync(2)`
+    /// syscall; see that method for the exact durability contract.
     pub fn ensure_durable_dir(&self, name: &LeafName, mode: Mode) -> Result<AnchoredDir> {
+        self.ensure_durable_dir_with_sync(name, mode, &RealDurableSync)
+    }
+
+    /// Durably create (or idempotently adopt) a single-component directory
+    /// child beneath this anchor, using `sync` for every `fsync` call.
+    ///
+    /// Every success path — a fresh `mkdirat`, adopting a directory a
+    /// concurrent creator raced us to (`EEXIST`), and adopting a directory
+    /// that already existed before this call was ever made — funnels
+    /// through the *same* open-then-fsync-child-then-fsync-parent sequence
+    /// before returning, so durability is never conditional on which of
+    /// those three cases actually happened. A failed `fsync` (real I/O
+    /// fault, or an injected one via a test [`DurableSync`]) propagates as
+    /// an `Err` rather than being swallowed; the directory itself is left
+    /// exactly as `mkdirat`/the filesystem left it, so a caller can safely
+    /// retry this same call — the retry will adopt the existing directory
+    /// and attempt the fsyncs again, rather than erroring on a spurious
+    /// `EEXIST`. `mkdirat` targets exactly one path component under an
+    /// already-anchored, already symlink-free directory fd, so no
+    /// intermediate component can resolve through a symlink or magic link.
+    pub(crate) fn ensure_durable_dir_with_sync<S: DurableSync>(
+        &self,
+        name: &LeafName,
+        mode: Mode,
+        sync: &S,
+    ) -> Result<AnchoredDir> {
         let relpath = RelativePath::from_components([name.as_str().to_owned()])?;
         loop {
             match self.open_beneath(&relpath, OFlags::RDONLY | OFlags::DIRECTORY, Mode::empty()) {
-                Ok(fd) => return AnchoredDir::from_owned_fd(fd),
+                Ok(fd) => {
+                    // Whether `fd` was just freshly created by us, adopted
+                    // after racing a concurrent creator to `EEXIST` below, or
+                    // simply pre-existed before this call: none of those are
+                    // durability proof on their own. Fsync the child and then
+                    // the parent's directory entry before reporting success.
+                    sync.fsync(fd.as_fd())
+                        .map_err(|error| Error::io(ErrorCode::Io, error))?;
+                    sync.fsync(self.fd().as_fd())
+                        .map_err(|error| Error::io(ErrorCode::Io, error))?;
+                    return AnchoredDir::from_owned_fd(fd);
+                }
                 Err(err) if err.code() == ErrorCode::Missing => {}
                 Err(err) => return Err(err),
             }
             match rustix::fs::mkdirat(self.fd(), name.as_str(), mode) {
-                Ok(()) => {
-                    let child = self.open_beneath(
-                        &relpath,
-                        OFlags::RDONLY | OFlags::DIRECTORY,
-                        Mode::empty(),
-                    )?;
-                    rustix::fs::fsync(&child).map_err(|error| Error::io(ErrorCode::Io, error))?;
-                    self.fsync_self()?;
-                    return AnchoredDir::from_owned_fd(child);
-                }
+                // Loop back around rather than duplicating the
+                // open+fsync+fsync+return sequence here: the top of the loop
+                // adopts exactly what was just created and performs the
+                // fsyncs uniformly.
+                Ok(()) => continue,
                 Err(rustix::io::Errno::EXIST) => {
                     // Idempotent retry: someone else created it concurrently;
                     // loop back around and adopt it via open_beneath.
@@ -203,9 +226,23 @@ impl AnchoredDir {
             }
         }
     }
+}
 
-    pub(crate) fn fsync_self(&self) -> Result<()> {
-        rustix::fs::fsync(self.fd()).map_err(|error| Error::io(ErrorCode::Io, error))
+/// Seam for durably persisting directory metadata, allowing tests to inject
+/// `fsync` faults without touching real filesystem behaviour. Production
+/// code always uses [`RealDurableSync`]; only `#[cfg(test)]` code should
+/// implement any other [`DurableSync`].
+pub(crate) trait DurableSync {
+    fn fsync(&self, fd: BorrowedFd<'_>) -> rustix::io::Result<()>;
+}
+
+/// The real `fsync(2)` syscall, used by every non-test caller of
+/// [`AnchoredDir::ensure_durable_dir`].
+pub(crate) struct RealDurableSync;
+
+impl DurableSync for RealDurableSync {
+    fn fsync(&self, fd: BorrowedFd<'_>) -> rustix::io::Result<()> {
+        rustix::fs::fsync(fd)
     }
 }
 
@@ -223,13 +260,6 @@ pub struct AnchoredResource {
     pub resource_id: ResourceId,
     pub directory: AnchoredDir,
     pub leaf: LeafName,
-    /// The `(dev, ino)` of `directory` at the moment this resource was
-    /// bound, captured only by [`AnchoredResource::resolve_generated`].
-    /// `None` for resources built via the generic [`AnchoredResource::new`]
-    /// constructor, which has no trusted-anchor/generated-row binding to
-    /// verify against. Used to detect a directory replaced out from under a
-    /// previously-bound resource (see [`crate::LockGuard::verify_binding`]).
-    directory_identity: Option<(u64, u64)>,
 }
 
 impl fmt::Debug for AnchoredResource {
@@ -246,28 +276,56 @@ impl AnchoredResource {
             resource_id,
             directory: directory.clone(),
             leaf,
-            directory_identity: None,
         }
     }
 
-    /// Resolve a generated storage-contract row into a non-forgeable
-    /// resource capability.
+    pub(crate) fn leaf_os(&self) -> &OsStr {
+        OsStr::new(self.leaf.as_str())
+    }
+}
+
+/// A non-forgeable, generated-storage-row-bound resource capability.
+///
+/// Constructible only via [`GeneratedResource::resolve`], which performs
+/// the *entire* binding — trusted-anchor + generated absolute path
+/// resolution via a single `openat2` beneath/no-symlink/no-magic-link/
+/// same-filesystem call — in one atomic step. This type is deliberately
+/// crate-private (not re-exported from [`crate`]): it has no public
+/// constructor, no public field access, and no `Clone` impl, so an external
+/// caller can never fabricate one, pair an arbitrary [`AnchoredDir`] with a
+/// resource id it did not actually resolve, or retain a handle that
+/// outlives the specific resolution that produced it. `d2b-state`'s only
+/// external surfaces backed by this capability are
+/// [`crate::LockSet::acquire_from_generated`] (the paired lock file) and
+/// [`crate::LockGuard::bind_protected_resource`] (a protected resource the
+/// guard authorizes); both consume a `GeneratedResource` immediately and
+/// never expose it directly. The legacy [`AnchoredResource`] shape is left
+/// untouched by this type so `atomic.rs`/`audit.rs`/broker code that
+/// predates the generated-contract bridge needs no changes.
+#[derive(Debug)]
+pub(crate) struct GeneratedResource {
+    resource_id: ResourceId,
+    directory: AnchoredDir,
+    leaf: LeafName,
+}
+
+impl GeneratedResource {
+    /// Resolves a generated storage-contract row into a
+    /// [`GeneratedResource`].
     ///
     /// `anchor` must be a directory the caller already trusts (typically
     /// opened via [`AnchoredDir::open_trusted`] against a broker/daemon-owned
     /// root); `anchor_path` is the absolute filesystem path `anchor` was
     /// opened at. `row_path` is the generated `StoragePathSpec`'s rendered
-    /// absolute path template and `row_id` its generated storage-row id
-    /// (already encoded to a [`ResourceId`] by the caller — this function
-    /// does not invent or reinterpret ids). The path is resolved from
-    /// `anchor` in a single `openat2` beneath/no-symlink/no-magic-link/
-    /// same-filesystem call (see `RESOLVE_SAFE`): a caller cannot pair an
-    /// arbitrary `anchor` with an arbitrary resource id and have it silently
-    /// succeed against a symlinked or cross-filesystem target. The exact
-    /// containing directory's `(dev, ino)` is captured at resolution time
-    /// so a later consumer (e.g. a held [`crate::LockGuard`]) can detect the
-    /// directory being replaced between resolution and use.
-    pub fn resolve_generated(
+    /// absolute path template and `resource_id` its generated storage-row id
+    /// already encoded to a [`ResourceId`] by the caller — this function
+    /// does not invent or reinterpret ids, it only resolves the path. The
+    /// path is resolved from `anchor` in a single `openat2`
+    /// beneath/no-symlink/no-magic-link/same-filesystem call (see
+    /// `RESOLVE_SAFE`): a caller cannot pair an arbitrary `anchor` with an
+    /// arbitrary resource id and have it silently succeed against a
+    /// symlinked or cross-filesystem target.
+    pub(crate) fn resolve(
         anchor: &AnchoredDir,
         anchor_path: &Path,
         resource_id: ResourceId,
@@ -291,42 +349,63 @@ impl AnchoredResource {
         let leaf_str = parts.pop().ok_or(Error::Code(ErrorCode::PathRejected))?;
         let leaf = LeafName::parse(leaf_str)?;
 
-        let (directory, identity) = if parts.is_empty() {
-            // The lock/resource file lives directly in `anchor`: bind our
-            // own independent CLOEXEC descriptor rather than sharing the
+        let directory = if parts.is_empty() {
+            // The resource file lives directly in `anchor`: bind our own
+            // independent CLOEXEC descriptor rather than sharing the
             // caller's `anchor` handle by reference, so this resource's
-            // lifetime and identity capture are self-contained.
+            // lifetime is self-contained.
             let duplicated = dup_cloexec(anchor.fd())?;
-            let dir = AnchoredDir::from_owned_fd(duplicated)?;
-            let stat =
-                rustix::fs::fstat(dir.fd()).map_err(|error| Error::io(ErrorCode::Io, error))?;
-            (dir, (stat.st_dev, stat.st_ino))
+            AnchoredDir::from_owned_fd(duplicated)?
         } else {
             let relpath = RelativePath::from_components(parts.into_iter().map(str::to_owned))?;
             let fd =
                 anchor.open_beneath(&relpath, OFlags::RDONLY | OFlags::DIRECTORY, Mode::empty())?;
-            let stat = rustix::fs::fstat(&fd).map_err(|error| Error::io(ErrorCode::Io, error))?;
-            let identity = (stat.st_dev, stat.st_ino);
-            (AnchoredDir::from_owned_fd(fd)?, identity)
+            AnchoredDir::from_owned_fd(fd)?
         };
 
         Ok(Self {
             resource_id,
             directory,
             leaf,
-            directory_identity: Some(identity),
         })
     }
 
-    /// The exact `(dev, ino)` of [`Self::directory`] captured at
-    /// [`Self::resolve_generated`] time, or `None` for resources built via
-    /// the generic [`Self::new`] constructor.
-    pub fn directory_identity(&self) -> Option<(u64, u64)> {
-        self.directory_identity
+    /// The exact `(dev, ino)` of the bound containing directory, queried
+    /// fresh via `fstat` on *every* call — never a value captured or cached
+    /// from resolution time — so a consumer re-checking this at bind/use
+    /// time can never be fooled by a stale identity. Exercised by this
+    /// module's own tests (production code no longer caches or re-derives
+    /// directory identity through this type, since binding a protected
+    /// resource re-resolves fresh via [`Self::resolve`] on every call
+    /// instead); kept as a `#[cfg(test)]` verification hook rather than a
+    /// live production accessor.
+    #[cfg(test)]
+    pub(crate) fn directory_identity(&self) -> Result<(u64, u64)> {
+        let stat = rustix::fs::fstat(self.directory.fd())
+            .map_err(|error| Error::io(ErrorCode::Io, error))?;
+        Ok((stat.st_dev, stat.st_ino))
     }
 
-    pub(crate) fn leaf_os(&self) -> &OsStr {
-        OsStr::new(self.leaf.as_str())
+    /// Opens the bound leaf beneath the resolved, trusted directory. Uses
+    /// the same `openat2` beneath/no-symlink/no-magic-link/same-filesystem
+    /// policy as directory resolution: a symlinked leaf is rejected exactly
+    /// like a symlinked intermediate component.
+    pub(crate) fn open(&self, flags: OFlags, mode: Mode) -> Result<OwnedFd> {
+        let path = RelativePath::from_components([self.leaf.as_str().to_owned()])?;
+        self.directory.open_beneath(&path, flags, mode)
+    }
+
+    /// Converts into the legacy [`AnchoredResource`] shape consumed by
+    /// atomic/audit/broker code that predates the generated-contract
+    /// bridge. This is the one sanctioned way to hand a generated-resolved
+    /// resource to that code; the recipient still cannot re-derive or
+    /// mutate the resolution that produced it (it only gets the same
+    /// public fields any [`AnchoredResource::new`] caller could construct
+    /// by hand, with no way to tell the two apart — the non-forgeability
+    /// guarantee applies to *how this value was obtained*, not to the
+    /// legacy type's own shape).
+    pub(crate) fn into_anchored_resource(self) -> AnchoredResource {
+        AnchoredResource::new(self.resource_id, &self.directory, self.leaf)
     }
 }
 
@@ -406,8 +485,8 @@ mod tests {
     }
 
     #[test]
-    fn ensure_durable_dir_fsyncs_child_and_parent_and_is_retryable_after_fault_injection() {
-        let scratch = Scratch::new("durable-mkdir-fault");
+    fn ensure_durable_dir_adopts_after_eexist_race_and_is_retryable() {
+        let scratch = Scratch::new("durable-mkdir-race");
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let name = LeafName::parse("audit").unwrap();
 
@@ -434,6 +513,91 @@ mod tests {
         );
     }
 
+    /// A [`DurableSync`] that fails the first `remaining` `fsync` calls
+    /// (real I/O-fault injection), then delegates to the real syscall.
+    struct FaultingSync {
+        remaining: std::cell::Cell<u32>,
+    }
+
+    impl DurableSync for FaultingSync {
+        fn fsync(&self, fd: BorrowedFd<'_>) -> rustix::io::Result<()> {
+            let remaining = self.remaining.get();
+            if remaining > 0 {
+                self.remaining.set(remaining - 1);
+                return Err(rustix::io::Errno::IO);
+            }
+            rustix::fs::fsync(fd)
+        }
+    }
+
+    /// A [`DurableSync`] that always delegates to the real syscall but
+    /// counts how many times it was invoked.
+    struct CountingSync {
+        calls: std::cell::Cell<u32>,
+    }
+
+    impl DurableSync for CountingSync {
+        fn fsync(&self, fd: BorrowedFd<'_>) -> rustix::io::Result<()> {
+            self.calls.set(self.calls.get() + 1);
+            rustix::fs::fsync(fd)
+        }
+    }
+
+    #[test]
+    fn ensure_durable_dir_propagates_a_failed_fsync_and_is_retryable() {
+        let scratch = Scratch::new("durable-mkdir-fsync-fault");
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let name = LeafName::parse("state").unwrap();
+
+        // The very first fsync call (the freshly-created child) fails: the
+        // failure must propagate as an `Err`, not be swallowed, and must
+        // not be reported as success.
+        let faulting = FaultingSync {
+            remaining: std::cell::Cell::new(1),
+        };
+        let err = anchor
+            .ensure_durable_dir_with_sync(&name, Mode::from(0o700), &faulting)
+            .unwrap_err();
+        assert_eq!(err.code(), ErrorCode::Io);
+
+        // `mkdirat` itself already succeeded before the fsync fault, so a
+        // retry must adopt the now-existing directory, fsync successfully
+        // this time, and return the same durable identity — proving a
+        // caller can safely retry after a fsync fault instead of being
+        // stuck in a failed, half-durable state.
+        let retried = anchor.ensure_durable_dir(&name, Mode::from(0o700)).unwrap();
+        let stat = rustix::fs::fstat(retried.fd()).unwrap();
+        assert_eq!(
+            rustix::fs::FileType::from_raw_mode(stat.st_mode),
+            rustix::fs::FileType::Directory
+        );
+    }
+
+    #[test]
+    fn ensure_durable_dir_fsyncs_child_and_parent_even_for_a_preexisting_directory() {
+        let scratch = Scratch::new("durable-mkdir-preexisting");
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let name = LeafName::parse("state").unwrap();
+
+        // The directory already exists *before* `ensure_durable_dir` is
+        // ever called — no `mkdirat`/`EEXIST` path is exercised at all.
+        // Durability must still be proven: both the child and the parent
+        // must be fsynced exactly as the fresh-create path does.
+        std::fs::create_dir(scratch.0.join(name.as_str())).unwrap();
+
+        let counting = CountingSync {
+            calls: std::cell::Cell::new(0),
+        };
+        anchor
+            .ensure_durable_dir_with_sync(&name, Mode::from(0o700), &counting)
+            .unwrap();
+        assert_eq!(
+            counting.calls.get(),
+            2,
+            "must fsync both the child and the parent even for an already-existing directory"
+        );
+    }
+
     #[test]
     fn resolve_generated_rejects_symlinked_parent_component() {
         let scratch = Scratch::new("resolve-symlink-parent");
@@ -449,27 +613,23 @@ mod tests {
         // `linked/` rather than `real/`; `RESOLVE_SAFE`'s NO_SYMLINKS must
         // reject this even though the final target byte-for-byte matches a
         // legitimate resource.
-        let err = AnchoredResource::resolve_generated(
-            &anchor,
-            &scratch.0,
-            resource_id,
-            &link.join("state.lock"),
-        )
-        .unwrap_err();
+        let err =
+            GeneratedResource::resolve(&anchor, &scratch.0, resource_id, &link.join("state.lock"))
+                .unwrap_err();
         assert_eq!(err.code(), ErrorCode::PathRejected);
     }
 
     #[test]
     fn resolve_generated_binds_the_containing_directory_not_the_leaf_itself() {
-        // `resolve_generated` deliberately only resolves and identity-binds
-        // the *containing directory* of a generated row's leaf; the leaf
-        // file itself is opened later (e.g. via `AnchoredDir::open_beneath`
-        // with `NOFOLLOW`) by the actual lock-acquire/open path. Prove the
-        // returned resource carries the leaf name unresolved (no
-        // symlink-following of the leaf happens here), and that the
-        // *directory-open* step this function performs is what the
-        // dedicated `open_beneath_rejects_symlinked_leaf` test below
-        // exercises for the actual file-open.
+        // `resolve` deliberately only resolves and identity-binds the
+        // *containing directory* of a generated row's leaf; the leaf file
+        // itself is opened later (via `GeneratedResource::open`, which uses
+        // `AnchoredDir::open_beneath` with `NOFOLLOW`). Prove the returned
+        // resource carries the leaf name unresolved (no symlink-following
+        // of the leaf happens here), and that the *directory-open* step
+        // this function performs is what the dedicated
+        // `open_beneath_rejects_symlinked_leaf` test below exercises for
+        // the actual file-open.
         let scratch = Scratch::new("resolve-leaf-name-only");
         let real_dir = scratch.0.join("real");
         std::fs::create_dir(&real_dir).unwrap();
@@ -478,7 +638,7 @@ mod tests {
 
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let resource_id = ResourceId::parse("real-lock").unwrap();
-        let resource = AnchoredResource::resolve_generated(
+        let resource = GeneratedResource::resolve(
             &anchor,
             &scratch.0,
             resource_id,
@@ -507,7 +667,7 @@ mod tests {
         let scratch = Scratch::new("resolve-relative");
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let resource_id = ResourceId::parse("real-lock").unwrap();
-        let err = AnchoredResource::resolve_generated(
+        let err = GeneratedResource::resolve(
             &anchor,
             &scratch.0,
             resource_id,
@@ -526,7 +686,7 @@ mod tests {
 
         let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
         let resource_id = ResourceId::parse("nested-lock").unwrap();
-        let resource = AnchoredResource::resolve_generated(
+        let resource = GeneratedResource::resolve(
             &anchor,
             &scratch.0,
             resource_id,
@@ -543,9 +703,31 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            resource.directory_identity(),
-            Some((expected.st_dev, expected.st_ino))
+            resource.directory_identity().unwrap(),
+            (expected.st_dev, expected.st_ino)
         );
+    }
+
+    #[test]
+    fn resolve_generated_directory_identity_is_reread_not_cached() {
+        // `directory_identity()` must reflect the *current* fstat of the
+        // bound directory on every call, not a value captured once at
+        // resolve time — proving a later caller re-checking identity can
+        // never be fooled by a stale cached value.
+        let scratch = Scratch::new("resolve-identity-fresh");
+        std::fs::write(scratch.0.join("state.lock"), b"").unwrap();
+        let anchor = AnchoredDir::open_trusted(&scratch.0).unwrap();
+        let resource_id = ResourceId::parse("real-lock").unwrap();
+        let resource = GeneratedResource::resolve(
+            &anchor,
+            &scratch.0,
+            resource_id,
+            &scratch.0.join("state.lock"),
+        )
+        .unwrap();
+        let first = resource.directory_identity().unwrap();
+        let second = resource.directory_identity().unwrap();
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/packages/d2b/src/doctor.rs
+++ b/packages/d2b/src/doctor.rs
@@ -1155,6 +1155,9 @@ fn sync_contract_reason_slug(reason: &SyncContractValidationReason) -> &'static 
             "fd-passing-missing-lease-transfer-record"
         }
         SyncContractValidationReason::DuplicateAcquireOrder => "duplicate-acquire-order",
+        SyncContractValidationReason::LockMissingProtectedResourceId => {
+            "lock-missing-protected-resource-id"
+        }
         SyncContractValidationReason::Unclassified => "unclassified",
     }
 }
@@ -1810,6 +1813,52 @@ mod tests {
         report.push("metrics-endpoint", DoctorStatus::Warn, "unreachable");
         assert_eq!(report.exit_code(), 1);
         assert!(report.broker_ready());
+    }
+
+    #[test]
+    fn sync_contract_reason_slug_covers_every_variant_including_missing_protected_resource_id() {
+        assert_eq!(
+            sync_contract_reason_slug(&SyncContractValidationReason::DuplicateLockId),
+            "duplicate-lock-id"
+        );
+        assert_eq!(
+            sync_contract_reason_slug(&SyncContractValidationReason::OfdLockMissingCloexec),
+            "ofd-lock-missing-cloexec"
+        );
+        assert_eq!(
+            sync_contract_reason_slug(
+                &SyncContractValidationReason::FdPassingMissingLeaseTransferRecord
+            ),
+            "fd-passing-missing-lease-transfer-record"
+        );
+        assert_eq!(
+            sync_contract_reason_slug(&SyncContractValidationReason::DuplicateAcquireOrder),
+            "duplicate-acquire-order"
+        );
+        assert_eq!(
+            sync_contract_reason_slug(
+                &SyncContractValidationReason::LockMissingProtectedResourceId
+            ),
+            "lock-missing-protected-resource-id"
+        );
+        assert_eq!(
+            sync_contract_reason_slug(&SyncContractValidationReason::Unclassified),
+            "unclassified"
+        );
+    }
+
+    #[test]
+    fn invalid_contract_summary_reports_missing_protected_resource_id_as_a_typed_slug() {
+        let issues = vec![StorageLifecycleIssue::SyncContractInvalid {
+            contract_id: "daemon".to_owned(),
+            reason: SyncContractValidationReason::LockMissingProtectedResourceId,
+            offending_id: Some("lock:daemon".to_owned()),
+        }];
+        let summary = storage_lifecycle_invalid_contract_summary(&issues).unwrap();
+        assert_eq!(
+            summary,
+            "sync:daemon:lock-missing-protected-resource-id:lock:daemon"
+        );
     }
 
     #[test]

--- a/packages/d2bd/src/storage_lifecycle.rs
+++ b/packages/d2bd/src/storage_lifecycle.rs
@@ -347,6 +347,40 @@ mod tests {
     }
 
     #[test]
+    fn reports_missing_protected_resource_id_as_a_typed_reason_not_unclassified() {
+        let mut missing_resource_id = sync();
+        missing_resource_id.locks[0].resource_id = None;
+        let resolver = resolver_with_optional_contracts(
+            STORAGE_LIFECYCLE_CONTRACT_BUNDLE_VERSION,
+            Some(storage(true, true)),
+            Some(missing_resource_id),
+        );
+        let report = run_startup_contract_check(&resolver);
+        assert!(report.issues.iter().any(|issue| {
+            matches!(
+                issue,
+                StorageLifecycleIssue::SyncContractInvalid {
+                    contract_id,
+                    reason: SyncContractValidationReason::LockMissingProtectedResourceId,
+                    offending_id
+                } if contract_id == "sync.json" && offending_id.as_deref() == Some("lock:daemon")
+            )
+        }));
+        assert!(!report.issues.iter().any(|issue| {
+            matches!(
+                issue,
+                StorageLifecycleIssue::SyncContractInvalid {
+                    reason: SyncContractValidationReason::Unclassified,
+                    ..
+                }
+            )
+        }));
+        let serialized = serde_json::to_string(&report).expect("serialize missing-resource report");
+        assert!(serialized.contains("lock-missing-protected-resource-id"));
+        assert!(serialized.contains("lock:daemon"));
+    }
+
+    #[test]
     fn startup_report_carries_diagnostics_without_pidfd_authority() {
         let resolver = resolver_with_contracts(true, false);
         let report = run_startup_contract_check(&resolver);
@@ -537,7 +571,7 @@ mod tests {
                 id: ContractId::parse("lock:daemon").unwrap(),
                 scope: ContractId::parse("host").unwrap(),
                 path_template: Some(PathTemplate::parse("/run/d2b/daemon.lock").unwrap()),
-                resource_id: None,
+                resource_id: Some(ContractId::parse("path:run-root").unwrap()),
                 kind: LockKind::Ofd,
                 owner_process: actor(ActorKind::Daemon, "d2bd"),
                 allowed_holders: vec![actor(ActorKind::Daemon, "d2bd")],


### PR DESCRIPTION
## Summary

Freezes the ADR 0045 W8 generated state/lock authority consumed by secrets, gateway, and restart integration.

## Detailed changes

- Maps generated sync/storage inventories losslessly into runtime LockSet/LockGuard authority.
- Binds exact held lock-file and protected-resource identities through opaque guard-scoped capabilities.
- Adds broker-only durable lock-file reconciliation and durable anchored directory creation.
- Adds guarded AtomicWrite APIs, exact deadlines, aggregate store locking, typed validation reasons, schemas, and CLI diagnostics.
- Covers real rendered rows and full-workspace consumers.

## Architecture references

- [ADR 0034](https://github.com/vicondoa/d2b/blob/main/docs/adr/0034-storage-lifecycle-restart-and-synchronization.md)
- [ADR 0045](https://github.com/vicondoa/d2b/blob/main/docs/adr/0045-provider-and-transport-framework.md)

## Delivery state

- Base: `adr0045-w8-integration` @ `bad7e6ab`
- Head: `7b01178fb8569a1566baa15b99a7ab0b948bafb0`
- Tree: `056441ff0a050ad9b0e73fcc91444c731db04adf`
- Checks: focused/full-workspace validation and acceptance review pass
- Candidate: pending W8 integrated snapshot
