### PR TITLE
ADR-0045 W8: implement pure secrets transaction core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ deprecations ship one minor release before removal.
 
 ### Added
 
+- Added the W8 pure secrets transaction core with WorkloadId-scoped
+  generation/checksum/ownership-epoch CAS fencing, forward-only recovery,
+  bounded prune debt, closed audit outcomes, and replay-safe channel counters.
 - Split W8's remaining integration work at real file/contract boundaries so
   nine dependency-ready components can implement concurrently: secrets
   transactions, helper backend, shell client, gateway core, provider parity,

--- a/docs/how-to/rotate-secrets.md
+++ b/docs/how-to/rotate-secrets.md
@@ -6,26 +6,32 @@
 > (`packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs`,
 > `packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs`,
 > `packages/d2b-sk-frontend/src/secrets_channel.rs`) implements a
-> crash-safe provision/rotate/rollback/retire engine plus a replay-safe
-> guest-side channel-state holder, but **none of it is wired into a
-> broker op, wire DTO, audit sink, or `d2b` CLI verb yet.** There is no
-> `d2b secrets rotate`-style command today, and nothing in these
-> modules is reachable from a running broker or guest transport. This
-> page describes the operator-facing procedure once that wiring lands,
-> and what a reviewer can check in the meantime. See
+> **pure transaction core** for provision/rotate/rollback/retire (the
+> W8fu6 ports-and-adapters rewrite) plus a replay-safe guest-side
+> channel-state holder, but **none of it is wired into a broker op,
+> wire DTO, audit sink, storage adapter, or `d2b` CLI verb yet.** There
+> is no `d2b secrets rotate`-style command today, and nothing in these
+> modules is reachable from a running broker or guest transport — the
+> engine has zero side effects of its own and only ever calls the
+> caller-injected `SecretsAuthorityPort` trait. This page describes the
+> operator-facing procedure once that wiring (and, above all, a real
+> `SecretsAuthorityPort` adapter) lands, and what a reviewer can check
+> in the meantime. See
 > [the reference doc's "Integration wiring points"](../reference/secrets-lifecycle.md#integration-wiring-points-not-performed-by-this-component)
 > for the exact remaining steps.
 
 Per-realm secrets material — TPM-bound credentials, guest signing
-keys, and security-key channel state — is provisioned once and
-rotated periodically or on demand. Every rotation retains exactly one
-prior generation so a bad rotation can be rolled back, every action is
-fail-closed against a tampered or missing identity marker, and every
-action is safe to resume after a broker crash mid-transaction (see the
-reference doc's "Cross-process locking and the durable transaction
-log" section).
+keys, and security-key channel state — is provisioned once and rotated
+periodically or on demand. Every rotation retains exactly one prior
+generation so a bad rotation can be rolled back; every action is
+fail-closed against a mismatched or corrupted digest; and every action
+is either fully applied and durably committed, or has mutated nothing
+at all — the engine never leaves a caller unsure whether a rotation
+"partly happened" (see the reference doc's "W8fu6: a pure transaction
+core behind an injected port" section for how compare-and-swap fencing
+replaces the earlier filesystem-anchored lock + crash-recovery design).
 
-## Once wired: rotating a VM's secret material
+## Once wired: rotating a workload's secret material
 
 1. Confirm the target kind is currently provisioned (an unprovisioned
    kind must be provisioned first, not rotated):
@@ -40,17 +46,21 @@ log" section).
    d2b vm secrets rotate <vm> --kind guest-signing-key
    ```
 
-   This stages and fsyncs a fresh generation, atomically swaps
-   `current` to it, durably commits the marker, retains the
-   immediately-prior generation, and prunes anything older only after
-   the new marker is committed. The new generation's epoch number is
-   always strictly greater than any epoch this lineage has ever used
-   (including ones a prior `rollback` moved away from), so a rotate
-   can never collide with or resurrect a still-materialised generation.
-   A `marker-tampered-or-missing-material`-shaped failure (any of the
-   `identity-*-mismatch` reasons) means the on-disk identity no longer
-   matches the tracked marker — stop and investigate before retrying;
-   do not delete state by hand.
+   This stages a fresh generation's material through the storage
+   adapter, then atomically compare-and-swaps the durable state to make
+   it active and retain the immediately-prior generation, fencing off
+   any concurrent writer that read the same starting state. The new
+   generation's epoch number is always strictly greater than any epoch
+   this lineage has ever used (including ones a prior `rollback` moved
+   away from), so a rotate can never collide with or resurrect a
+   still-materialized generation. Immediately after the commit succeeds,
+   the engine re-reads the live digest of exactly the epoch it just
+   activated and compares it against what it staged — if some other
+   writer's late write landed in between, this is detected and the
+   pair is quarantined rather than reporting a false success. A
+   `checksum-mismatch` or `quarantined` failure means live storage no
+   longer matches the tracked identity — stop and investigate before
+   retrying; do not attempt to repair state by hand outside the engine.
 
 3. If the new material is bad, roll back to the retained prior
    generation:
@@ -61,53 +71,60 @@ log" section).
 
    This fails with `no-rollback-target` if no prior generation is
    tracked (nothing to roll back to). A rollback legitimately moves the
-   active generation's epoch *backwards*; it is still subject to the
-   same identity-tamper verification as a rotate.
+   active generation's epoch *backwards*; it independently re-verifies
+   the rollback target's live digest against the tracked identity
+   before committing, just like a rotate does for the generation it
+   activates.
 
-4. To retire a kind entirely (e.g. the VM is being decommissioned):
+4. To retire a kind entirely (e.g. the workload is being
+   decommissioned):
 
    ```bash
    d2b vm secrets retire <vm> --kind guest-signing-key
    ```
 
-   Retiring always enumerates and validates the entire on-disk
-   generation tree first, regardless of what the marker says — a
-   missing marker is never treated as proof the tree is already clean.
-   Retiring is idempotent: retiring an already-retired or
-   never-provisioned kind reports `verified_clean`, not an error. Any
-   entry retirement cannot account for (unexpected name, unexpected
-   type, or a hard-linked material file) aborts the whole retirement
-   with zero deletions (`retirement-tree-anomaly`) rather than deleting
-   what it can and leaving the rest.
+   Retiring commits a tombstoned durable state (no active, no
+   previous, `retired: true`) first, then attempts to prune the
+   now-superseded generations. Retiring is idempotent: retiring an
+   already-retired or never-provisioned kind reports `verified_clean`,
+   not an error.
 
 Repeat with `--kind tpm-bound-credential` or
 `--kind security-key-channel-state` for the other two closed-set
 kinds.
 
-## If the broker crashed mid-rotation
+## If a prune could not complete synchronously
 
-Once wired, the integrator is expected to call
-`recover_in_flight_transaction` for every known `(vm, kind)` pair at
-controller/broker startup (see the reference doc's wiring point §7),
-so a leftover transaction from a crash mid-rotate/rollback/retire is
-drained automatically before any new request is dispatched. If that
-startup sweep is not yet wired, the same recovery runs automatically
-as the first step of the *next* `rotate`/`rollback`/`retire`/`provision`
-call for that exact `(vm, kind)` pair — there is no separate manual
-"resume" command. A recovery that finds the leftover transaction
-already past its commit point only ever completes it forward (finishes
-the marker write, pruning, or tombstoning); it never reverts an
-already-activated `current` swap or resurrects an already-deleted
-generation. A recovery that cannot verify the leftover state against
-what was logged before the crash fails closed
-(`recovery-content-mismatch`/`recovery-ambiguous`) without touching
-anything further — this needs operator/integrator investigation, not a
-retry.
+Committing the tombstoned or rotated state and pruning the superseded
+generation's material are two separate steps against the storage
+adapter. If the prune does not fully succeed at commit time, the
+still-owed epochs are recorded as durable `pending_prune` debt on the
+already-committed state — the rotation/retirement itself is **not**
+rolled back or reported as failed, and the caller sees the normal
+success result with an additional `prune_deferred: true` flag in the
+audit record. There is no separate manual "resume pruning" command:
+the very next `provision`/`rotate`/`rollback`/`retire` call for that
+exact `(workload, kind)` pair automatically re-attempts every
+outstanding prune before doing its own work, and will refuse to
+proceed with `prune-debt-unresolved` if any of it still cannot be
+resolved. This debt is self-healing and monotonically shrinks; it is
+never lost and never silently abandoned.
+
+## If a compare-and-swap is fenced
+
+`ownership-fenced` means another writer's transition committed first;
+the failed call mutated nothing at all (compare-and-swap is
+all-or-nothing). There is no partial state to recover — simply retry
+the same action, which will re-read the now-current state and compute
+a fresh transition against it.
 
 ## Today: verifying the engine directly
 
-Until the CLI/broker/audit-sink wiring lands, the engine can only be
-exercised through its Rust API and inline test suite:
+Until a real `SecretsAuthorityPort` adapter and the CLI/broker/audit-
+sink wiring land, the engine can only be exercised through its Rust
+API and inline test suite, entirely against the in-memory
+fault-injecting `FakeAuthorityPort` test double defined in
+`secrets_lifecycle.rs`'s own `#[cfg(test)] mod fake_port`:
 
 ```bash
 cd packages
@@ -117,12 +134,15 @@ cargo test -p d2b-sk-frontend secrets_channel::
 ```
 
 Every provision/rotate/rollback/retire transition, every fail-closed
-tamper/drift/anomaly case, crash recovery at each phase of both the
-promote and retire state machines, cross-process lock contention, and
+denial/quarantine/fencing case, the "last stage wins" race and its
+closure via post-commit digest re-verification, forward-recovery
+prune-debt draining under repeated and then resolved prune faults, and
 the guest-side channel-state replay/tamper guard (including across a
 retire-then-reprovision boundary) are covered by inline `#[cfg(test)]`
 cases in `secrets_lifecycle.rs` and `secrets_channel.rs`. Reviewers
 should not expect these tests to run standalone from a fresh checkout
-without a temporary local `pub mod` wiring edit, since neither module
-is referenced from `ops/mod.rs` or `lib.rs` yet — see the reference
-doc's wiring-points list.
+without a temporary local `pub mod` wiring edit, since neither
+`secrets_lifecycle` nor `secrets_rotation_audit` is referenced from
+`ops/mod.rs` yet, and `secrets_channel` is not referenced from
+`d2b-sk-frontend`'s `lib.rs` yet — see the reference doc's
+wiring-points list.

--- a/docs/how-to/rotate-secrets.md
+++ b/docs/how-to/rotate-secrets.md
@@ -3,20 +3,27 @@
 **Diataxis category:** how-to.
 
 > Status: the W8 `secrets-lifecycle` component
-> (`packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs`) implements
-> the provision/rotate/rollback/retire engine, but it is **not yet
-> wired** into a broker op, wire DTO, or `d2b` CLI verb. There is no
-> `d2b secrets rotate`-style command today. This page describes the
-> operator-facing procedure once that wiring lands, and what an
-> integrator or reviewer can check in the meantime. See
+> (`packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs`,
+> `packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs`,
+> `packages/d2b-sk-frontend/src/secrets_channel.rs`) implements a
+> crash-safe provision/rotate/rollback/retire engine plus a replay-safe
+> guest-side channel-state holder, but **none of it is wired into a
+> broker op, wire DTO, audit sink, or `d2b` CLI verb yet.** There is no
+> `d2b secrets rotate`-style command today, and nothing in these
+> modules is reachable from a running broker or guest transport. This
+> page describes the operator-facing procedure once that wiring lands,
+> and what a reviewer can check in the meantime. See
 > [the reference doc's "Integration wiring points"](../reference/secrets-lifecycle.md#integration-wiring-points-not-performed-by-this-component)
 > for the exact remaining steps.
 
 Per-realm secrets material — TPM-bound credentials, guest signing
 keys, and security-key channel state — is provisioned once and
 rotated periodically or on demand. Every rotation retains exactly one
-prior generation so a bad rotation can be rolled back, and every
-action is fail-closed against a tampered or missing identity marker.
+prior generation so a bad rotation can be rolled back, every action is
+fail-closed against a tampered or missing identity marker, and every
+action is safe to resume after a broker crash mid-transaction (see the
+reference doc's "Cross-process locking and the durable transaction
+log" section).
 
 ## Once wired: rotating a VM's secret material
 
@@ -33,12 +40,17 @@ action is fail-closed against a tampered or missing identity marker.
    d2b vm secrets rotate <vm> --kind guest-signing-key
    ```
 
-   This creates a fresh generation, atomically swaps `current` to it,
-   retains the immediately-prior generation, and prunes anything
-   older. A `stale-marker`/`marker-tampered-or-missing-material`
-   failure means the on-disk identity no longer matches the tracked
-   marker — stop and investigate before retrying; do not delete state
-   by hand.
+   This stages and fsyncs a fresh generation, atomically swaps
+   `current` to it, durably commits the marker, retains the
+   immediately-prior generation, and prunes anything older only after
+   the new marker is committed. The new generation's epoch number is
+   always strictly greater than any epoch this lineage has ever used
+   (including ones a prior `rollback` moved away from), so a rotate
+   can never collide with or resurrect a still-materialised generation.
+   A `marker-tampered-or-missing-material`-shaped failure (any of the
+   `identity-*-mismatch` reasons) means the on-disk identity no longer
+   matches the tracked marker — stop and investigate before retrying;
+   do not delete state by hand.
 
 3. If the new material is bad, roll back to the retained prior
    generation:
@@ -48,7 +60,9 @@ action is fail-closed against a tampered or missing identity marker.
    ```
 
    This fails with `no-rollback-target` if no prior generation is
-   tracked (nothing to roll back to).
+   tracked (nothing to roll back to). A rollback legitimately moves the
+   active generation's epoch *backwards*; it is still subject to the
+   same identity-tamper verification as a rotate.
 
 4. To retire a kind entirely (e.g. the VM is being decommissioned):
 
@@ -56,29 +70,59 @@ action is fail-closed against a tampered or missing identity marker.
    d2b vm secrets retire <vm> --kind guest-signing-key
    ```
 
+   Retiring always enumerates and validates the entire on-disk
+   generation tree first, regardless of what the marker says — a
+   missing marker is never treated as proof the tree is already clean.
    Retiring is idempotent: retiring an already-retired or
-   never-provisioned kind reports `verified_clean`, not an error.
+   never-provisioned kind reports `verified_clean`, not an error. Any
+   entry retirement cannot account for (unexpected name, unexpected
+   type, or a hard-linked material file) aborts the whole retirement
+   with zero deletions (`retirement-tree-anomaly`) rather than deleting
+   what it can and leaving the rest.
 
 Repeat with `--kind tpm-bound-credential` or
 `--kind security-key-channel-state` for the other two closed-set
 kinds.
 
+## If the broker crashed mid-rotation
+
+Once wired, the integrator is expected to call
+`recover_in_flight_transaction` for every known `(vm, kind)` pair at
+controller/broker startup (see the reference doc's wiring point §7),
+so a leftover transaction from a crash mid-rotate/rollback/retire is
+drained automatically before any new request is dispatched. If that
+startup sweep is not yet wired, the same recovery runs automatically
+as the first step of the *next* `rotate`/`rollback`/`retire`/`provision`
+call for that exact `(vm, kind)` pair — there is no separate manual
+"resume" command. A recovery that finds the leftover transaction
+already past its commit point only ever completes it forward (finishes
+the marker write, pruning, or tombstoning); it never reverts an
+already-activated `current` swap or resurrects an already-deleted
+generation. A recovery that cannot verify the leftover state against
+what was logged before the crash fails closed
+(`recovery-content-mismatch`/`recovery-ambiguous`) without touching
+anything further — this needs operator/integrator investigation, not a
+retry.
+
 ## Today: verifying the engine directly
 
-Until the CLI/broker wiring lands, the engine can only be exercised
-through its Rust API and inline test suite:
+Until the CLI/broker/audit-sink wiring lands, the engine can only be
+exercised through its Rust API and inline test suite:
 
 ```bash
 cd packages
-cargo test -p d2b-priv-broker secrets_lifecycle::
+cargo test -p d2b-priv-broker --lib secrets_lifecycle::
+cargo test -p d2b-priv-broker --lib secrets_rotation_audit::
 cargo test -p d2b-sk-frontend secrets_channel::
 ```
 
 Every provision/rotate/rollback/retire transition, every fail-closed
-tamper/drift case, and the guest-side channel-state generation-replay
-guard are covered by inline `#[cfg(test)]` cases in
-`secrets_lifecycle.rs` and `secrets_channel.rs`. Reviewers should not
-expect these tests to run standalone from a fresh checkout without a
-temporary local `pub mod` wiring edit, since neither module is
-referenced from `ops/mod.rs` or `lib.rs` yet — see the reference doc's
-wiring-points list.
+tamper/drift/anomaly case, crash recovery at each phase of both the
+promote and retire state machines, cross-process lock contention, and
+the guest-side channel-state replay/tamper guard (including across a
+retire-then-reprovision boundary) are covered by inline `#[cfg(test)]`
+cases in `secrets_lifecycle.rs` and `secrets_channel.rs`. Reviewers
+should not expect these tests to run standalone from a fresh checkout
+without a temporary local `pub mod` wiring edit, since neither module
+is referenced from `ops/mod.rs` or `lib.rs` yet — see the reference
+doc's wiring-points list.

--- a/docs/how-to/rotate-secrets.md
+++ b/docs/how-to/rotate-secrets.md
@@ -1,0 +1,84 @@
+# Rotate secrets
+
+**Diataxis category:** how-to.
+
+> Status: the W8 `secrets-lifecycle` component
+> (`packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs`) implements
+> the provision/rotate/rollback/retire engine, but it is **not yet
+> wired** into a broker op, wire DTO, or `d2b` CLI verb. There is no
+> `d2b secrets rotate`-style command today. This page describes the
+> operator-facing procedure once that wiring lands, and what an
+> integrator or reviewer can check in the meantime. See
+> [the reference doc's "Integration wiring points"](../reference/secrets-lifecycle.md#integration-wiring-points-not-performed-by-this-component)
+> for the exact remaining steps.
+
+Per-realm secrets material — TPM-bound credentials, guest signing
+keys, and security-key channel state — is provisioned once and
+rotated periodically or on demand. Every rotation retains exactly one
+prior generation so a bad rotation can be rolled back, and every
+action is fail-closed against a tampered or missing identity marker.
+
+## Once wired: rotating a VM's secret material
+
+1. Confirm the target kind is currently provisioned (an unprovisioned
+   kind must be provisioned first, not rotated):
+
+   ```bash
+   d2b vm secrets status <vm> --kind guest-signing-key
+   ```
+
+2. Rotate it:
+
+   ```bash
+   d2b vm secrets rotate <vm> --kind guest-signing-key
+   ```
+
+   This creates a fresh generation, atomically swaps `current` to it,
+   retains the immediately-prior generation, and prunes anything
+   older. A `stale-marker`/`marker-tampered-or-missing-material`
+   failure means the on-disk identity no longer matches the tracked
+   marker — stop and investigate before retrying; do not delete state
+   by hand.
+
+3. If the new material is bad, roll back to the retained prior
+   generation:
+
+   ```bash
+   d2b vm secrets rollback <vm> --kind guest-signing-key
+   ```
+
+   This fails with `no-rollback-target` if no prior generation is
+   tracked (nothing to roll back to).
+
+4. To retire a kind entirely (e.g. the VM is being decommissioned):
+
+   ```bash
+   d2b vm secrets retire <vm> --kind guest-signing-key
+   ```
+
+   Retiring is idempotent: retiring an already-retired or
+   never-provisioned kind reports `verified_clean`, not an error.
+
+Repeat with `--kind tpm-bound-credential` or
+`--kind security-key-channel-state` for the other two closed-set
+kinds.
+
+## Today: verifying the engine directly
+
+Until the CLI/broker wiring lands, the engine can only be exercised
+through its Rust API and inline test suite:
+
+```bash
+cd packages
+cargo test -p d2b-priv-broker secrets_lifecycle::
+cargo test -p d2b-sk-frontend secrets_channel::
+```
+
+Every provision/rotate/rollback/retire transition, every fail-closed
+tamper/drift case, and the guest-side channel-state generation-replay
+guard are covered by inline `#[cfg(test)]` cases in
+`secrets_lifecycle.rs` and `secrets_channel.rs`. Reviewers should not
+expect these tests to run standalone from a fresh checkout without a
+temporary local `pub mod` wiring edit, since neither module is
+referenced from `ops/mod.rs` or `lib.rs` yet — see the reference doc's
+wiring-points list.

--- a/docs/reference/secrets-lifecycle.md
+++ b/docs/reference/secrets-lifecycle.md
@@ -1,0 +1,195 @@
+# Reference: per-realm secrets lifecycle
+
+> Component: W8 `secrets-lifecycle`. Owns
+> `packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs`,
+> `packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs`, and
+> `packages/d2b-sk-frontend/src/secrets_channel.rs`. This is the
+> storage/atomicity/rotation-state layer only — see "Non-goals" below
+> for what it deliberately does not do.
+
+This page is the contract for the provision/rotate/rollback/retire
+engine that tracks per-realm secrets material: TPM-bound credentials,
+guest signing keys, and security-key channel state (the closed
+[`SecretKind`] set). It follows the broker's existing fd-relative,
+anchored, atomic, identity-bound, fail-closed conventions (the same
+family as `swtpm_dir.rs`'s hardening step and `store_sync_audit.rs`'s
+typed audit schema), applied generically across all three secret
+kinds through one shared engine rather than three separate ones.
+
+## Scope and invariants
+
+- **Generic across kinds.** [`SecretKind::TpmBoundCredential`],
+  [`SecretKind::GuestSigningKey`], and
+  [`SecretKind::SecurityKeyChannelState`] all flow through the same
+  `provision`/`rotate`/`rollback`/`retire` functions, parameterized by
+  [`SecretsLifecyclePaths`] (derived per `(vm_id, kind)` via
+  `derive_paths`). Generating the raw material itself — running
+  `ssh-keygen`, deriving a TPM attestation blob, or producing
+  channel-binding wire material — stays the caller's concern; this
+  engine only owns storage, atomicity, and rotation-state tracking.
+- **Fd-relative and anchored.** Every filesystem mutation goes through
+  `crate::sys::path_safe`'s existing primitives (`ensure_dir`,
+  `open_at`, `mkdir_at_exclusive`, `create_file_at_safe`,
+  `atomic_replace_fd_with_owner`, `remove_path_safe`, `fstat_fd`,
+  `fstatat_nofollow`) — no bare `std::fs` path-string call ever
+  touches a role-writable directory.
+- **Atomic generation activation.** Each `(vm, kind)` has an on-disk
+  layout of `<per_vm_state_root>/secrets/<kind-slug>/generations/<n>/material`
+  plus a `current` symlink, atomically swapped with a hidden-name
+  symlink-then-`renameat` sequence directly against the already-open
+  `secrets_dir` fd (the same rename-based atomic-swap idiom used
+  elsewhere in the broker/host, reimplemented locally here rather than
+  reusing `d2b_host::hardlink_farm::swap_current_symlink`, which is
+  coupled to that module's own `marker.json` schema).
+- **Identity-bound tamper guard.** A dedicated marker file per
+  `(vm, kind)` under `/var/lib/d2b/secrets-lifecycle-markers/<vm_id>/<kind-slug>`
+  (root-owned, `0600`, JSON) records the active generation number plus
+  the active generation directory's `st_dev`/`st_ino`. `rotate`,
+  `rollback`, and `retire` all re-verify that identity against the
+  live directory before mutating, so a TOCTOU replacement of the
+  active generation's content is caught rather than silently rotated
+  or retired forward. This marker tree is independent of
+  `swtpm_dir.rs`'s own per-VM marker
+  (`/var/lib/d2b/swtpm-markers/<vm>`) — this component never reads or
+  writes that file.
+- **Fail-closed on drift, not just on error.** Mirroring the
+  `swtpm_dir.rs` philosophy:
+  - `provision` refuses (`already-provisioned`) if active material
+    already exists;
+  - `provision` fails closed (`previously-provisioned-material-missing`)
+    if the marker says active but the generation vanished;
+  - `provision` fails closed (`marker-tampered-or-missing-material`) if
+    material exists on disk with **no** matching active marker — never
+    silently adopted;
+  - `rotate`/`rollback`/`retire` all fail closed
+    (`marker-tampered-or-missing-material`) if the live active
+    generation's identity does not match the marker.
+- **Bounded retention.** Exactly one previous generation is retained
+  at a time (tracked by the marker's `generation`/`previous_generation`
+  pair, never by directory enumeration). `rotate` prunes anything older
+  than the immediately-prior generation on a best-effort basis (a
+  prune failure never rolls back an already-committed rotate).
+  `rollback` restores the immediately-prior generation and fails
+  closed (`no-rollback-target`) if none is tracked. `retire` is
+  idempotent and removes every generation the marker still tracks.
+- **Redaction.** No public function in this module ever returns or
+  logs a raw path, a raw secret byte, or a raw `io::Error` message.
+  Errors are a closed-set `&'static str` reason slug
+  (`secrets_lifecycle::reasons::*`) plus a fully-formed
+  [`SecretsLifecycleAuditFields`] record. That record itself never
+  carries a path (only an FNV1a-64 `base_dir_hash`, parity with
+  `crate::ops::hosts::stable_hash_str`) or raw material (only a
+  SHA-256 `material_digest_hex` fingerprint). [`SecretMaterial`]'s
+  `Debug` impl never prints its bytes, and the bytes are held in a
+  `zeroize::Zeroizing<Vec<u8>>` so they are wiped on drop.
+- **Guest-side channel state** (`secrets_channel.rs`, in
+  `d2b-sk-frontend`) mirrors the same lifecycle shape in memory only:
+  [`ChannelState::provision`]/`rotate`/`retire`/`current`, with
+  `rotate` refusing a non-strictly-increasing generation
+  (`stale-reconnect-generation`) as a replay/rollback defense. It is a
+  standalone module with zero dependency on the rest of that crate
+  (only `std`), so it can be validated independently of the guest
+  session/transport wiring.
+
+## Non-goals
+
+- This component does not add a new broker op enum family, edit
+  `runtime.rs`/`lib.rs`, or add a new wire request/response DTO. Those
+  are explicit integration follow-ups (see below).
+- This component never touches `swtpm_dir.rs`'s physical TPM NVRAM
+  state, `security_key.rs`'s CTAPHID transport, or any
+  `guest_material_*` file directly. `SecretKind::TpmBoundCredential`
+  tracks rotation/retirement bookkeeping layered *atop* swtpm's own
+  identity; it is not a replacement for `swtpm_dir.rs`.
+- This component does not decide *how* material is generated for any
+  kind (ssh-keygen invocation, TPM attestation derivation, or the
+  exact security-key channel wire encoding). It only stores, activates,
+  and tracks generations of whatever `SecretMaterial` bytes a caller
+  supplies.
+
+## Audit record shape
+
+[`SecretsLifecycleAuditFields`] (schema version 1) is a path-free,
+material-free JSON-serializable record: `vm_id`, `kind`, `action`
+(`provision`/`rotate`/`rollback`/`retire`), `base_dir_hash`, `result`
+(`created`/`rotated`/`rolled_back`/`retired`/`verified_clean`/`denied`/
+`failed_closed`), `marker_result`
+(`created`/`verified`/`tombstoned`/`unchanged`/`failed_closed`), an
+optional `generation`, a bounded `retained_generations` list (at most
+`MAX_AUDITED_RETAINED_GENERATIONS`, currently 8), an optional
+`material_digest_hex` (present only for `provision`/`rotate`), and an
+optional `fail_reason` (present exactly for `denied`/`failed_closed`
+results). `SecretsLifecycleAuditFields::validate` enforces every
+cross-field invariant listed above; every constructor
+(`provisioned`/`rotated`/`rolled_back`/`retired`/`verified_clean`/
+`denied`/`failed`) returns an already-valid record.
+
+## Marker and path layout
+
+```
+<per_vm_state_root>/secrets/<kind-slug>/
+  generations/
+    <n>/material          # 0600, expected_uid:expected_gid
+  current -> generations/<n>
+
+/var/lib/d2b/secrets-lifecycle-markers/<vm_id>/<kind-slug>   # 0600 JSON marker
+```
+
+`<kind-slug>` is one of `tpm-bound-credential`, `guest-signing-key`,
+`security-key-channel-state` ([`SecretKind::as_slug`]).
+
+## Integration wiring points (not performed by this component)
+
+This component's public functions are ready to call but are not wired
+into any shared sink. An integrator still needs to:
+
+1. Add `pub mod secrets_lifecycle;` and
+   `pub mod secrets_rotation_audit;` to
+   `packages/d2b-priv-broker/src/ops/mod.rs`.
+2. Add an
+   `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
+   variant (and matching `from_operation_value` arm) to
+   `packages/d2b-priv-broker/src/ops/audit_op.rs`.
+3. Add new wire request/response DTOs (in `d2b-contracts`) and a
+   `runtime.rs` dispatch path calling
+   `provision`/`rotate`/`rollback`/`retire` and emitting the returned
+   audit record via `crate::audit::AuditLog`. The plan text for this
+   component explicitly forbids adding a new broker op enum family
+   from within it, so this step is deliberately deferred.
+4. Decide what bundle-resolved field supplies `per_vm_state_root` for
+   `derive_paths` (mirrors `swtpm_dir::derive_paths`'s
+   `&SpawnRunnerPlan` parameter).
+5. Decide whether `SecretKind::GuestSigningKey` material comes from
+   `exec_reconcile::run_ssh_keygen` output fed into `rotate`'s
+   `material` parameter, or stays separate.
+6. Decide the exact coupling between `SecretKind::TpmBoundCredential`
+   rotation and `swtpm_dir.rs`'s physical NVRAM (e.g. whether a rotate
+   here should also trigger a swtpm reseal) — a product/security
+   decision beyond this component's scope.
+7. Add `pub mod secrets_channel;` to `packages/d2b-sk-frontend/src/lib.rs`,
+   and wire `services/security_key/mod.rs`'s `SessionConfig` to source
+   its `channel_binding`/`reconnect_generation` from
+   `ChannelState::current`/`ChannelMaterial::into_session_config_args`
+   instead of the static `D2B_SK_CHANNEL_BINDING_HEX`/
+   `D2B_SK_RECONNECT_GENERATION` environment variables it reads today.
+8. Confirm or replace `ChannelMaterial::from_wire_bytes`'s proposed
+   32-byte-binding + 8-byte-big-endian-generation wire format against
+   whatever the future broker dispatch arm for
+   `SecretKind::SecurityKeyChannelState` actually serializes — it is a
+   proposal, not a settled contract.
+9. Run `gen-nix-unit-pins.sh` after this component lands so
+   `tests/unit/nix/pinned/*.txt` picks up the new
+   `w8-secrets-lifecycle-eval.nix` case names (not run here since the
+   pinned files are not owned by this component).
+
+## See also
+
+- [How to rotate secrets](../how-to/rotate-secrets.md)
+- [`docs/reference/cgroup-delegation.md`](./cgroup-delegation.md) —
+  sibling reference doc style this page follows.
+- `packages/d2b-priv-broker/src/ops/swtpm_dir.rs` — the physical TPM
+  NVRAM state this component's `TpmBoundCredential` kind layers atop
+  without editing.
+- `packages/d2b-priv-broker/src/ops/store_sync_audit.rs` — the
+  existing standalone-audit-schema precedent this component's
+  `secrets_rotation_audit.rs` mirrors.

--- a/docs/reference/secrets-lifecycle.md
+++ b/docs/reference/secrets-lifecycle.md
@@ -61,20 +61,35 @@ already been activated.**
 ### Cross-process locking and the durable transaction log
 
 Every mutating action first opens (or creates)
-`<kind_root>/lock` and takes an exclusive, blocking-with-timeout
-`flock(2)` on it (`acquire_lock`, bounded by
+`<kind_root>/lock` and takes an exclusive, poll-with-timeout **open
+file description (OFD)** lock on it via `F_OFD_SETLK`
+(`acquire_lock`/`try_ofd_lock_exclusive`, bounded by
 `SecretsLifecycleConfig::lock_max_wait`/`lock_poll_interval`, failing
 closed with `FailReason::LockUnavailable` on timeout — this is the
 cross-process, per-`(vm, kind)` exclusive lock finding (1) asked for).
-Before trusting the lock, `acquire_lock` verifies: the anchored parent
-(`kind_root`) is a trusted-broker-owned directory of the expected mode
+This module deliberately uses the repository's established `F_OFD_SETLK`
+convention (mirroring `d2bd::audio_dispatch::ofd_lock`/`ofd_unlock`)
+rather than BSD `flock(2)`: an OFD lock is associated with the *open
+file description*, not the owning process, so it composes correctly
+with a single process holding multiple independent fds on the same
+lock file, where `flock`'s whole-process association would let two
+unrelated fds silently share one lock. Before trusting the lock,
+`acquire_lock` verifies: the anchored parent (`kind_root`) is a
+trusted-broker-owned directory of the expected mode
 (`verify_broker_owned`); the lock file itself is a trusted-broker-owned
 regular file of the expected mode with exactly one hard link (never a
-hard-link plant); and, immediately after `flock` succeeds, that the
-`lock` directory entry still resolves — by `(dev, ino)` — to the exact
-file this call opened and locked, closing the classic
-unlink-and-recreate-between-open-and-flock race. Any mismatch is
-`FailReason::BrokerOwnershipViolation`. "Broker-owned" here means
+hard-link plant); and, immediately after the OFD lock succeeds, that
+the `lock` directory entry still resolves — by `(dev, ino)` — to the
+exact file this call opened and locked, closing the classic
+unlink-and-recreate-between-open-and-lock race. Any mismatch is
+`FailReason::BrokerOwnershipViolation`. `LockGuard` is an opaque RAII
+token with no public/forgeable "is locked" proof; releasing the lock
+is simply closing its owned fd (the kernel drops an OFD lock exactly
+when every fd referencing its open file description is closed — no
+separate unlock call is needed). A full generated-sync-row
+`d2b-state::LockSet`/`AuthorityRef` integration remains an explicit
+integrator-owned wiring point (see "Integration wiring points" below).
+"Broker-owned" here means
 "owned by this process's own effective uid/gid" (`broker_identity`):
 metadata directories (`kind_root`, `generations/`) and the lock file
 are never `cfg.owner_uid`/`cfg.owner_gid`-owned — that consumer-facing
@@ -282,10 +297,18 @@ A dedicated marker file per `(vm, kind)` at `<kind_root>/marker.json`
 
 Every public action (`provision`/`rotate`/`rollback`/`retire`) routes
 through the single shared `open_and_recover` entry point, which — right
-after loading the marker and whenever it records an active generation —
-runs one central pre-mutation check, `verify_marker_against_live_state`,
-rather than four separately-maintained call sites. This is the one
-reachable trigger for `FailReason::IdentityCurrentTargetMismatch`: it
+after loading the marker — runs one central pre-mutation check,
+`verify_marker_against_live_state`, rather than four separately-
+maintained call sites. This validates **both** marker shapes, not just
+the active one: for an *active* marker it is the live-generation check
+described below; for an *inactive* (retired/never-provisioned) marker
+it independently verifies `previous == None`, that `high_water_epoch`
+and the marker's own bookkeeping are internally coherent for a
+never-active lineage, and — via `current_is_genuinely_absent` — that
+`current` does not resolve to anything at all (never merely that it
+"looks retired"); a stale or foreign `current` entry surviving over an
+inactive marker is rejected the same way a live-state mismatch is. This
+is the one reachable trigger for `FailReason::IdentityCurrentTargetMismatch`: it
 confirms that `current` resolves, by **exact literal symlink text**, to
 `generations/<active.epoch>` — a path that merely *ends* in the right
 epoch number (an absolute path, a foreign-rooted relative path, or any
@@ -513,7 +536,7 @@ cross-field invariant listed above; every constructor
     <epoch>/material        # 0600, expected_uid:expected_gid
   current -> generations/<epoch>
   marker.json                # 0600 JSON, schema v2
-  lock                        # 0600, flock(2) target, never contains data
+  lock                        # 0600, F_OFD_SETLK target, never contains data
   txlog                       # 0600 JSON, present only mid-transaction
 ```
 
@@ -544,7 +567,22 @@ into any shared sink. An integrator still needs to:
    already exist** with a non-world-writable mode before this module
    is called; this module only creates `state_root/<vm_id>/<kind-slug>`
    beneath it, never `state_root` itself — and the real owner
-   uid/gid for each kind.
+   uid/gid for each kind. This module's public functions still take
+   `vm_id: &str` and derive `kind_root` via `state_root.join(vm_id)`,
+   matching the existing `vm: &str`/label-derived-path convention this
+   repository already uses for this class of op (e.g.
+   `swtpm_dir.rs::paths`); this is **not** the same thing as this
+   component's own audit surface, which is already opaque-ID-bound
+   (`SecretsLifecycleAuditFields::vm_id` is a `d2b_contracts::types::VmId`,
+   never a raw path or label). If/when the ADR 0034 storage contract
+   exposes a generated, caller-resolved opaque storage-id →
+   pre-opened-anchored-dirfd mapping, this module's path-derivation
+   helpers (`derive_paths`/`kind_root`) are the exact integration
+   point to replace with that typed authority instead of a
+   `state_root.join(vm_id)` join; until that resolver exists as a
+   stable, generated contract this component cannot consume, this
+   remains an explicit integrator-owned wiring point rather than
+   something this component can close unilaterally.
 5. Decide whether `SecretKind::GuestSigningKey` material comes from
    `exec_reconcile::run_ssh_keygen` output fed into `rotate`'s
    `material` parameter, or stays separate.
@@ -579,6 +617,16 @@ into any shared sink. An integrator still needs to:
     `tests/unit/nix/pinned/*.txt` picks up the new
     `w8-secrets-lifecycle-eval.nix` case names (not run here since the
     pinned files are not owned by this component).
+12. `acquire_lock` uses this module's own `F_OFD_SETLK` primitive
+    (mirroring `d2bd::audio_dispatch::ofd_lock`/`ofd_unlock`) rather
+    than inventing a new lock namespace, but it does not yet register
+    with any shared `d2b-state::LockSet`/`AuthorityRef` lock registry —
+    no such generated, cross-component lock-row contract exists for
+    this module to consume today. If/when one lands, the integrator
+    should either replace `acquire_lock`'s standalone OFD lock with a
+    caller-supplied typed held-lock/lease token from that registry, or
+    confirm this module's private per-`(vm, kind)` lock file is exempt
+    because nothing outside this module ever contends for it.
 
 ## See also
 

--- a/docs/reference/secrets-lifecycle.md
+++ b/docs/reference/secrets-lifecycle.md
@@ -66,56 +66,123 @@ Every mutating action first opens (or creates)
 `SecretsLifecycleConfig::lock_max_wait`/`lock_poll_interval`, failing
 closed with `FailReason::LockUnavailable` on timeout — this is the
 cross-process, per-`(vm, kind)` exclusive lock finding (1) asked for).
+Before trusting the lock, `acquire_lock` verifies: the anchored parent
+(`kind_root`) is a trusted-broker-owned directory of the expected mode
+(`verify_broker_owned`); the lock file itself is a trusted-broker-owned
+regular file of the expected mode with exactly one hard link (never a
+hard-link plant); and, immediately after `flock` succeeds, that the
+`lock` directory entry still resolves — by `(dev, ino)` — to the exact
+file this call opened and locked, closing the classic
+unlink-and-recreate-between-open-and-flock race. Any mismatch is
+`FailReason::BrokerOwnershipViolation`. "Broker-owned" here means
+"owned by this process's own effective uid/gid" (`broker_identity`):
+metadata directories (`kind_root`, `generations/`) and the lock file
+are never `cfg.owner_uid`/`cfg.owner_gid`-owned — that consumer-facing
+identity applies only to the `material` file leaf a generation
+directory contains.
+
 While holding that lock, every promote-shaped action
 (`provision`/`rotate`/`rollback`) and `retire` runs through one of two
 shared phase-machine engines:
 
-- **Promote** ([`PromotePhase`]): `Planned` → material staged and
-  fsynced → `CurrentPromoted` → `current` atomically repointed at the
-  new generation → marker durably rewritten (fsynced) →
-  `MarkerCommitted` → old generation pruned on a best-effort basis →
-  transaction log removed.
-- **Retire** ([`RetirePhase`]): `Planned` → generation tree
-  enumerated/validated → entries deleted one at a time → phase advances
-  to `CurrentRemoved` once the tree is provably empty → marker
-  tombstoned → transaction log removed.
+- **Promote** ([`PromotePhase`]): `Planned` (material staged into a
+  fresh `.stage-*` directory, or a rollback's already-existing target
+  generation tamper-verified) → `EpochReady` (the target generation is
+  materialised at its final `generations/<epoch>` name, fsynced) →
+  `CurrentPromoted` (`current` atomically repointed at the new
+  generation, fsynced) → `MarkerCommitted` (marker durably rewritten,
+  fsynced; superseded generation pruned best-effort; any leftover
+  `.stage-*` directory enumerated/validated/deleted with every failure
+  propagated) → transaction log removed.
+- **Retire** ([`RetirePhase`]): `Enumerated` (the physical
+  `generations/` tree anchored-enumerated and validated) →
+  `CurrentRemoved` (`current` unlinked, then every recorded generation
+  *and* every recorded `.stage-*` directory deleted, each re-validated
+  immediately before its own deletion) → `EpochsRemoved` (a fresh
+  re-enumeration must observe the tree fully empty) → `ProvenEmpty`
+  (marker tombstoned) → transaction log removed.
 
-Before each phase transition that cannot be trivially undone, the
-*current phase* is written to `<kind_root>/txlog` (JSON, fsynced) —
-this is the durable transaction/recovery state machine finding (1)
-asked for. [`recover_if_needed`] is called at the start of every
-action (and by the standalone [`recover_in_flight_transaction`] entry
-point) and, if a leftover `txlog` is found:
+Before each phase transition, the *current phase* is written to
+`<kind_root>/txlog` (JSON, fsynced) — this is the durable
+transaction/recovery state machine finding (1) asked for. Every fsync
+in this module (`fsync_fd`) returns `Result<(), FailReason::FsyncFailed>`;
+a failed sync at any phase transition — material write, staging
+directory, epoch rename, `current` swap, marker write, txlog write,
+generation/stage deletion — propagates immediately and blocks that
+phase from ever being recorded as advanced. No phase transition is
+ever considered committed on an unsynced write, so a crash immediately
+after a failed sync is always safely re-driveable by a later recovery
+pass; nothing is ever left activated with only a *possible* failure to
+persist it durably.
+
+Immediately on read, before any recovery attempt acts on it, a leftover
+`txlog` undergoes full semantic validation
+(`validate_txlog_semantics`/`validate_promote_intent_semantics`/
+`validate_retire_intent_semantics`) bound to the exact `(vm_id, kind)`
+directory it was found in: the recorded `vm`/`kind` must match the
+directory; the action/`create_epoch`/`stage_name`/`expected_identity`
+combination must be one this module can legally have written;
+epoch/high-water/prune-epoch/carry-previous relationships must be
+internally consistent; `RetireIntent.epochs`/`stage_names` must be
+sorted, deduplicated, in-bounds, and correctly prefixed. Any violation
+is `FailReason::IntentCorrupt` — a hand-edited or otherwise corrupted
+txlog is never handed to the recovery engine to interpret.
+[`recover_if_needed`] is called at the start of every action (and by
+the standalone [`recover_in_flight_transaction`] entry point) and, once
+the txlog passes semantic validation:
 
 - if the phase recorded is at or before the point where an external
-  observer could see any change (`Planned` for promote; `Planned` or
-  mid-enumeration for retire), the leftover state is safely discarded
-  — nothing was ever activated, so there is nothing to complete;
+  observer could see any change (`Planned` for promote; `Enumerated`
+  for retire), the leftover state is safely discarded or completed —
+  nothing was ever activated, so a fresh re-drive is always safe;
+- `Planned`-phase promote recovery never abandons or silently
+  re-stages a target epoch that a prior crashed attempt already
+  renamed into place: if `generations/<to_epoch>` already exists with
+  content whose digest matches the intent's `expected_digest_hex`, the
+  engine treats it as already-materialised and continues forward
+  without needing the original material again; if content already
+  occupies that epoch number with a **different** digest, recovery
+  fails closed (`RecoveryContentMismatch`) rather than ever adopting or
+  overwriting a stale, foreign, or previously-aborted generation;
 - if the phase recorded is at or after the commit point
   (`CurrentPromoted`/`MarkerCommitted` for promote,
-  `CurrentRemoved` for retire), recovery **only ever moves forward** —
-  it re-verifies the already-activated content against what the log
-  recorded and completes the remaining steps (marker write, pruning,
-  tombstoning); it never reverts an already-swapped `current` or
-  resurrects an already-deleted generation. A verification mismatch at
-  this stage fails closed (`RecoveryContentMismatch`/
-  `RecoveryAmbiguous`) without touching anything further — it does not
-  silently re-diverge storage, and it does not clear the txlog (so a
-  subsequent recovery attempt, e.g. after fixing the anomaly by hand,
-  gets another chance).
+  `CurrentRemoved`/`EpochsRemoved`/`ProvenEmpty` for retire), recovery
+  **only ever moves forward** — it re-verifies the already-activated
+  content against what the log recorded and completes the remaining
+  steps; it never reverts an already-swapped `current` or resurrects an
+  already-deleted generation. A verification mismatch at this stage
+  fails closed (`RecoveryContentMismatch`/`RecoveryAmbiguous`) without
+  touching anything further — it does not silently re-diverge storage,
+  and it does not clear the txlog (so a subsequent recovery attempt,
+  e.g. after fixing the anomaly by hand, gets another chance).
 
 `provision`, `rotate`, and `rollback` share the same
 [`execute_promote`] codepath (parameterized by a [`PromoteIntent`]) for
 both a fresh call and for completing a leftover recovery — there is no
 separate "recovery-only" branch that could drift out of sync with the
 normal path. `retire` and its own recovery both run through
-[`execute_retire`] the same way.
+[`execute_retire`] the same way. Every generation deletion inside
+`execute_retire` is preceded by `revalidate_generation_before_delete`:
+an immediate, anchored, nofollow re-stat/re-validate of that exact
+generation directory right before it is removed, so a tamper injected
+between the original enumeration and the delete (not merely between
+process restarts) is still caught rather than trusted from a stale
+snapshot.
 
-Staging directory/file names use [`allocate_staging_name`]: a
-collision-resistant name mixing the process id, a per-process atomic
-monotonic counter, wall-clock nanoseconds, and a `RandomState`-seeded
-hash, retried up to `MAX_STAGE_NAME_ATTEMPTS` times before failing
-closed with `FailReason::StagingNameExhausted`.
+Staging directory names use `random_stage_name`: a collision-resistant
+name mixing the process id, a per-process atomic monotonic counter,
+wall-clock nanoseconds, and a `RandomState`-seeded hash folded through
+SHA-256. Staged entries are **real secret-tree contents**, never a
+separately-swept, best-effort concern: `enumerate_and_validate_generation_tree`
+collects `.stage-*` directories exactly like generation epochs
+(`validate_stage_dir_contents` refuses anything but at most one
+regular, single-hard-link entry inside), and every deletion path
+(`remove_stage_dir`, used by promote's post-commit leftover sweep and
+by retire's `CurrentRemoved` phase) fully enumerates, deletes,
+positively proves empty, and fsyncs — propagating every failure rather
+than ignoring it. A stage directory is included in the final
+provably-empty proof retirement requires before tombstoning the
+marker.
 
 ### Marker identity (v2)
 
@@ -131,17 +198,28 @@ A dedicated marker file per `(vm, kind)` at `<kind_root>/marker.json`
   - owner `uid`/`gid`, permission `mode` bits, hard-link count, and
     whether an extended POSIX ACL is present;
   - a SHA-256 content digest.
-- `previous_epoch`: the immediately-prior retained generation's epoch,
-  if any (used by `rollback`).
+- `previous`: the immediately-prior retained generation's full identity,
+  if any (used by `rollback`). `previous.epoch` need not be numerically
+  less than `active.epoch` — a `rollback` swaps the pair, so `previous`
+  can legitimately be the *larger* epoch just rolled back away from;
+  what always holds is that it is a distinct, real, never-exceeding-
+  high-water epoch.
 
-`rotate`, `rollback`, and `retire` all re-derive this same identity
-tuple from the **live** filesystem state and compare it field-by-field
-against the marker before mutating anything, and separately verify
-that `current` **literally resolves by name** to the epoch the marker
-claims is active (`FailReason::IdentityCurrentTargetMismatch`) — a
-coincidentally-matching `stat()` result on some other path is not
-accepted as proof. Each mismatch axis has its own closed
-[`FailReason`] variant so a hard-link plant
+Every public action (`provision`/`rotate`/`rollback`/`retire`) routes
+through the single shared `open_and_recover` entry point, which — right
+after loading the marker and whenever it records an active generation —
+runs one central pre-mutation check, `verify_marker_against_live_state`,
+rather than four separately-maintained call sites. This is the one
+reachable trigger for `FailReason::IdentityCurrentTargetMismatch`: it
+confirms that `current` resolves, by **exact literal symlink text**, to
+`generations/<active.epoch>` — a path that merely *ends* in the right
+epoch number (an absolute path, a foreign-rooted relative path, or any
+text other than that precise relative form) is never accepted as a
+match, even when a naive `stat()`-based comparison would otherwise
+agree. It then re-derives the active (and, if present, previous)
+generation's identity tuple from the **live** filesystem state and
+compares it field-by-field against the marker. Each mismatch axis has
+its own closed [`FailReason`] variant so a hard-link plant
 (`IdentityLinkCountMismatch`, or `IdentityInodeMismatch` when the
 digest happens to match but the physical inode does not — the case
 byte-content comparison alone cannot see), a digest-preserving
@@ -162,9 +240,12 @@ Mirroring the `swtpm_dir.rs` philosophy:
   the marker says active but the generation vanished;
 - `provision` fails closed (`GenerationConflict`) if material exists on
   disk with **no** matching active marker — never silently adopted;
-- `rotate`/`rollback` fail closed on any [`MaterialIdentity`] mismatch
-  axis (above) rather than proceeding against a live generation that
-  does not match what the marker recorded.
+- `rotate`/`rollback`/`retire` all fail closed on any
+  [`MaterialIdentity`] mismatch axis (above), on any
+  `IdentityCurrentTargetMismatch`, and on any internally-inconsistent
+  marker (mutually exclusive `retired`/`active`, out-of-bounds epoch)
+  via the shared central validation — rather than proceeding against a
+  live generation that does not match what the marker recorded.
 
 ### Retirement never trusts the marker's word alone
 
@@ -176,15 +257,19 @@ before looking at what the marker says, regardless of marker state:
   already empty is a hard-fail anomaly
   (`PreviouslyProvisionedMaterialMissing`) — a missing marker, or an
   empty tree, never by itself implies "already cleanly retired";
-- a tree with any unrecognised entry name, unexpected file type, or a
-  `material` file whose link count is not exactly `1` aborts the
-  entire retirement with **zero deletions**
-  (`FailReason::RetirementTreeAnomaly`);
-- otherwise every validated entry is deleted one at a time, each
-  containing directory is fsynced after its deletions, and the tree is
-  positively re-verified empty
-  (`FailReason::RetirementNotProvablyEmpty` if not) before the marker
-  is tombstoned;
+- a tree with any unrecognised entry name, unexpected file type, a
+  `material` file whose link count is not exactly `1`, or a `.stage-*`
+  directory containing anything other than at most one regular,
+  single-hard-link entry aborts the entire retirement with **zero
+  deletions** (`FailReason::RetirementTreeAnomaly`);
+- otherwise every validated generation *and* every validated stage
+  directory is deleted, each re-validated immediately before its own
+  deletion (`revalidate_generation_before_delete`) so a tamper injected
+  after enumeration is still caught; each containing directory is
+  fsynced after its deletions (with any sync failure blocking further
+  progress, never silently ignored); the tree is then positively
+  re-verified empty (`FailReason::RetirementNotProvablyEmpty` if not)
+  before the marker is tombstoned;
 - retiring an already-retired or never-provisioned kind (empty tree,
   no active marker) is idempotent and reports `verified_clean`, not an
   error.
@@ -200,7 +285,7 @@ the newer epoch's generation directory is left physically in place
 (pruned only after the new marker is durably committed) but its epoch
 number is never reissued. `rollback` itself never grows
 `high_water_epoch` and prunes nothing (it just re-points `current` at
-the retained `previous_epoch`, subject to the same identity-tamper
+the retained `previous`, subject to the same identity-tamper
 verification as any other promote). `provision` always allocates epoch
 `1` and resets `high_water_epoch` to `1` for a fresh lineage — this is
 sound (not a numbering collision risk) specifically because `retire()`

--- a/docs/reference/secrets-lifecycle.md
+++ b/docs/reference/secrets-lifecycle.md
@@ -6,6 +6,15 @@
 > `packages/d2b-sk-frontend/src/secrets_channel.rs`. This is the
 > storage/atomicity/rotation-state layer only — see "Non-goals" below
 > for what it deliberately does not do.
+>
+> **Status: not wired into any live broker dispatch path or guest
+> transport.** Every function this page documents is a tested,
+> standalone Rust API reachable only from this component's own
+> `#[cfg(test)]` modules today. See
+> [Integration wiring points](#integration-wiring-points-not-performed-by-this-component)
+> for the exact remaining steps and
+> [How to rotate secrets](../how-to/rotate-secrets.md) for what a
+> reviewer can verify in the meantime.
 
 This page is the contract for the provision/rotate/rollback/retire
 engine that tracks per-realm secrets material: TPM-bound credentials,
@@ -15,6 +24,14 @@ anchored, atomic, identity-bound, fail-closed conventions (the same
 family as `swtpm_dir.rs`'s hardening step and `store_sync_audit.rs`'s
 typed audit schema), applied generically across all three secret
 kinds through one shared engine rather than three separate ones.
+
+This document describes the **second, redesigned** iteration of this
+engine (superseding an earlier draft that an external security review
+found was not crash-safe). The redesign's driving property, repeated
+throughout this page, is: **a process crash must never leave storage
+in a state where recovery is forced to either silently activate
+something unverified, or return an error while unrecoverable state has
+already been activated.**
 
 ## Scope and invariants
 
@@ -26,70 +43,254 @@ kinds through one shared engine rather than three separate ones.
   `derive_paths`). Generating the raw material itself — running
   `ssh-keygen`, deriving a TPM attestation blob, or producing
   channel-binding wire material — stays the caller's concern; this
-  engine only owns storage, atomicity, and rotation-state tracking.
+  engine only owns storage, atomicity, rotation-state tracking, and
+  crash recovery.
 - **Fd-relative and anchored.** Every filesystem mutation goes through
   `crate::sys::path_safe`'s existing primitives (`ensure_dir`,
   `open_at`, `mkdir_at_exclusive`, `create_file_at_safe`,
   `atomic_replace_fd_with_owner`, `remove_path_safe`, `fstat_fd`,
-  `fstatat_nofollow`) — no bare `std::fs` path-string call ever
-  touches a role-writable directory.
-- **Atomic generation activation.** Each `(vm, kind)` has an on-disk
-  layout of `<per_vm_state_root>/secrets/<kind-slug>/generations/<n>/material`
-  plus a `current` symlink, atomically swapped with a hidden-name
-  symlink-then-`renameat` sequence directly against the already-open
-  `secrets_dir` fd (the same rename-based atomic-swap idiom used
-  elsewhere in the broker/host, reimplemented locally here rather than
-  reusing `d2b_host::hardlink_farm::swap_current_symlink`, which is
-  coupled to that module's own `marker.json` schema).
-- **Identity-bound tamper guard.** A dedicated marker file per
-  `(vm, kind)` under `/var/lib/d2b/secrets-lifecycle-markers/<vm_id>/<kind-slug>`
-  (root-owned, `0600`, JSON) records the active generation number plus
-  the active generation directory's `st_dev`/`st_ino`. `rotate`,
-  `rollback`, and `retire` all re-verify that identity against the
-  live directory before mutating, so a TOCTOU replacement of the
-  active generation's content is caught rather than silently rotated
-  or retired forward. This marker tree is independent of
-  `swtpm_dir.rs`'s own per-VM marker
-  (`/var/lib/d2b/swtpm-markers/<vm>`) — this component never reads or
-  writes that file.
-- **Fail-closed on drift, not just on error.** Mirroring the
-  `swtpm_dir.rs` philosophy:
-  - `provision` refuses (`already-provisioned`) if active material
-    already exists;
-  - `provision` fails closed (`previously-provisioned-material-missing`)
-    if the marker says active but the generation vanished;
-  - `provision` fails closed (`marker-tampered-or-missing-material`) if
-    material exists on disk with **no** matching active marker — never
-    silently adopted;
-  - `rotate`/`rollback`/`retire` all fail closed
-    (`marker-tampered-or-missing-material`) if the live active
-    generation's identity does not match the marker.
-- **Bounded retention.** Exactly one previous generation is retained
-  at a time (tracked by the marker's `generation`/`previous_generation`
-  pair, never by directory enumeration). `rotate` prunes anything older
-  than the immediately-prior generation on a best-effort basis (a
-  prune failure never rolls back an already-committed rotate).
-  `rollback` restores the immediately-prior generation and fails
-  closed (`no-rollback-target`) if none is tracked. `retire` is
-  idempotent and removes every generation the marker still tracks.
-- **Redaction.** No public function in this module ever returns or
-  logs a raw path, a raw secret byte, or a raw `io::Error` message.
-  Errors are a closed-set `&'static str` reason slug
-  (`secrets_lifecycle::reasons::*`) plus a fully-formed
-  [`SecretsLifecycleAuditFields`] record. That record itself never
-  carries a path (only an FNV1a-64 `base_dir_hash`, parity with
-  `crate::ops::hosts::stable_hash_str`) or raw material (only a
-  SHA-256 `material_digest_hex` fingerprint). [`SecretMaterial`]'s
-  `Debug` impl never prints its bytes, and the bytes are held in a
-  `zeroize::Zeroizing<Vec<u8>>` so they are wiped on drop.
-- **Guest-side channel state** (`secrets_channel.rs`, in
-  `d2b-sk-frontend`) mirrors the same lifecycle shape in memory only:
-  [`ChannelState::provision`]/`rotate`/`retire`/`current`, with
-  `rotate` refusing a non-strictly-increasing generation
-  (`stale-reconnect-generation`) as a replay/rollback defense. It is a
-  standalone module with zero dependency on the rest of that crate
-  (only `std`), so it can be validated independently of the guest
-  session/transport wiring.
+  `fstatat_nofollow`, `fd_extended_acl_present`) — no bare `std::fs`
+  path-string call ever touches a role-writable directory. `state_root`
+  itself is treated as an externally-established precondition (opened
+  read-only via `open_dir_path_safe`, never `ensure_dir`'d): only
+  `state_root/<vm_id>` and `state_root/<vm_id>/<kind-slug>` are created
+  by this module, since a bare `ensure_dir` on `state_root` itself would
+  fail closed under `path_safe::refuse_world_writable_parent` for any
+  `state_root` whose own parent is world-writable.
+
+### Cross-process locking and the durable transaction log
+
+Every mutating action first opens (or creates)
+`<kind_root>/lock` and takes an exclusive, blocking-with-timeout
+`flock(2)` on it (`acquire_lock`, bounded by
+`SecretsLifecycleConfig::lock_max_wait`/`lock_poll_interval`, failing
+closed with `FailReason::LockUnavailable` on timeout — this is the
+cross-process, per-`(vm, kind)` exclusive lock finding (1) asked for).
+While holding that lock, every promote-shaped action
+(`provision`/`rotate`/`rollback`) and `retire` runs through one of two
+shared phase-machine engines:
+
+- **Promote** ([`PromotePhase`]): `Planned` → material staged and
+  fsynced → `CurrentPromoted` → `current` atomically repointed at the
+  new generation → marker durably rewritten (fsynced) →
+  `MarkerCommitted` → old generation pruned on a best-effort basis →
+  transaction log removed.
+- **Retire** ([`RetirePhase`]): `Planned` → generation tree
+  enumerated/validated → entries deleted one at a time → phase advances
+  to `CurrentRemoved` once the tree is provably empty → marker
+  tombstoned → transaction log removed.
+
+Before each phase transition that cannot be trivially undone, the
+*current phase* is written to `<kind_root>/txlog` (JSON, fsynced) —
+this is the durable transaction/recovery state machine finding (1)
+asked for. [`recover_if_needed`] is called at the start of every
+action (and by the standalone [`recover_in_flight_transaction`] entry
+point) and, if a leftover `txlog` is found:
+
+- if the phase recorded is at or before the point where an external
+  observer could see any change (`Planned` for promote; `Planned` or
+  mid-enumeration for retire), the leftover state is safely discarded
+  — nothing was ever activated, so there is nothing to complete;
+- if the phase recorded is at or after the commit point
+  (`CurrentPromoted`/`MarkerCommitted` for promote,
+  `CurrentRemoved` for retire), recovery **only ever moves forward** —
+  it re-verifies the already-activated content against what the log
+  recorded and completes the remaining steps (marker write, pruning,
+  tombstoning); it never reverts an already-swapped `current` or
+  resurrects an already-deleted generation. A verification mismatch at
+  this stage fails closed (`RecoveryContentMismatch`/
+  `RecoveryAmbiguous`) without touching anything further — it does not
+  silently re-diverge storage, and it does not clear the txlog (so a
+  subsequent recovery attempt, e.g. after fixing the anomaly by hand,
+  gets another chance).
+
+`provision`, `rotate`, and `rollback` share the same
+[`execute_promote`] codepath (parameterized by a [`PromoteIntent`]) for
+both a fresh call and for completing a leftover recovery — there is no
+separate "recovery-only" branch that could drift out of sync with the
+normal path. `retire` and its own recovery both run through
+[`execute_retire`] the same way.
+
+Staging directory/file names use [`allocate_staging_name`]: a
+collision-resistant name mixing the process id, a per-process atomic
+monotonic counter, wall-clock nanoseconds, and a `RandomState`-seeded
+hash, retried up to `MAX_STAGE_NAME_ATTEMPTS` times before failing
+closed with `FailReason::StagingNameExhausted`.
+
+### Marker identity (v2)
+
+A dedicated marker file per `(vm, kind)` at `<kind_root>/marker.json`
+(root-owned, `0600`, JSON, `MARKER_SCHEMA_VERSION = 2`) records:
+
+- `high_water_epoch`: the monotonic generation high-water mark (see
+  below);
+- `active`: `None` if retired/never-provisioned, or `Some(`[`MaterialIdentity`]`)` binding the active generation's:
+  - `epoch` (the lineage epoch number);
+  - `dev`/`ino` of the material file, captured via a `nofollow`-safe fd
+    open (never a path re-resolution that could be raced);
+  - owner `uid`/`gid`, permission `mode` bits, hard-link count, and
+    whether an extended POSIX ACL is present;
+  - a SHA-256 content digest.
+- `previous_epoch`: the immediately-prior retained generation's epoch,
+  if any (used by `rollback`).
+
+`rotate`, `rollback`, and `retire` all re-derive this same identity
+tuple from the **live** filesystem state and compare it field-by-field
+against the marker before mutating anything, and separately verify
+that `current` **literally resolves by name** to the epoch the marker
+claims is active (`FailReason::IdentityCurrentTargetMismatch`) — a
+coincidentally-matching `stat()` result on some other path is not
+accepted as proof. Each mismatch axis has its own closed
+[`FailReason`] variant so a hard-link plant
+(`IdentityLinkCountMismatch`, or `IdentityInodeMismatch` when the
+digest happens to match but the physical inode does not — the case
+byte-content comparison alone cannot see), a digest-preserving
+directory swap (`IdentityInodeMismatch`), an ownership drift
+(`IdentityOwnerMismatch`), a mode drift (`IdentityModeMismatch`), an
+ACL drift (`IdentityAclMismatch`), or a content drift
+(`IdentityDigestMismatch`) are independently distinguishable on the
+audit surface rather than collapsed into one generic "tampered"
+reason.
+
+### Fail-closed on drift, not just on error
+
+Mirroring the `swtpm_dir.rs` philosophy:
+
+- `provision` refuses (`AlreadyProvisioned`) if active material
+  already exists;
+- `provision` fails closed (`PreviouslyProvisionedMaterialMissing`) if
+  the marker says active but the generation vanished;
+- `provision` fails closed (`GenerationConflict`) if material exists on
+  disk with **no** matching active marker — never silently adopted;
+- `rotate`/`rollback` fail closed on any [`MaterialIdentity`] mismatch
+  axis (above) rather than proceeding against a live generation that
+  does not match what the marker recorded.
+
+### Retirement never trusts the marker's word alone
+
+`retire()` always **enumerates and strictly validates the entire
+physical `generations/` tree** ([`enumerate_and_validate_generation_tree`])
+before looking at what the marker says, regardless of marker state:
+
+- an *active* marker over a tree that anchored-enumeration finds
+  already empty is a hard-fail anomaly
+  (`PreviouslyProvisionedMaterialMissing`) — a missing marker, or an
+  empty tree, never by itself implies "already cleanly retired";
+- a tree with any unrecognised entry name, unexpected file type, or a
+  `material` file whose link count is not exactly `1` aborts the
+  entire retirement with **zero deletions**
+  (`FailReason::RetirementTreeAnomaly`);
+- otherwise every validated entry is deleted one at a time, each
+  containing directory is fsynced after its deletions, and the tree is
+  positively re-verified empty
+  (`FailReason::RetirementNotProvablyEmpty` if not) before the marker
+  is tombstoned;
+- retiring an already-retired or never-provisioned kind (empty tree,
+  no active marker) is idempotent and reports `verified_clean`, not an
+  error.
+
+### Monotonic generation numbering, survivable across rollback
+
+`MarkerData::high_water_epoch` is a monotonic high-water mark, not
+`current_epoch + 1`: `rotate` always allocates
+`high_water_epoch + 1`. This means a `rotate` issued **after** a
+`rollback` can never collide with (or silently resurrect) a
+still-materialised newer epoch that the rollback moved away from —
+the newer epoch's generation directory is left physically in place
+(pruned only after the new marker is durably committed) but its epoch
+number is never reissued. `rollback` itself never grows
+`high_water_epoch` and prunes nothing (it just re-points `current` at
+the retained `previous_epoch`, subject to the same identity-tamper
+verification as any other promote). `provision` always allocates epoch
+`1` and resets `high_water_epoch` to `1` for a fresh lineage — this is
+sound (not a numbering collision risk) specifically because `retire()`
+physically empties and proves-empty the entire `generations/` tree
+before the marker is tombstoned; the monotonic high-water invariant
+only needs to hold *within* one non-retired lineage.
+
+### Redaction
+
+No public function in this module ever returns or logs a raw path, a
+raw secret byte, or a raw `io::Error` message. Errors are a closed-set
+[`FailReason`] enum plus a fully-formed
+[`SecretsLifecycleAuditFields`] record. That record itself never
+carries a path (only an FNV1a-64 `base_dir_hash`, parity with
+`crate::ops::hosts::stable_hash_str`) or raw material (only a SHA-256
+`material_digest_hex` fingerprint, present only for
+`provision`/`rotate`). [`SecretMaterial`]:
+
+- derives neither `Copy` nor `Clone`;
+- wraps caller-supplied bytes in `zeroize::Zeroizing<Vec<u8>>`
+  **before** the length/emptiness validation check runs, so a
+  rejected (empty or oversized) buffer is zeroized on drop just like an
+  accepted one — there is no code path where a rejected buffer is
+  dropped without zeroization;
+- has a `Debug` impl that never prints its bytes.
+
+## Guest-side channel state (`secrets_channel.rs`, protocol v2)
+
+The guest-side counterpart (`d2b-sk-frontend::secrets_channel`) is a
+standalone, zero-internal-dependency module (only `std`) mirroring the
+same lifecycle shape in memory. Its own redesign (superseding the
+first draft's single conflated `ChannelGeneration` counter) splits
+three previously-conflated concepts:
+
+- [`LineageEpoch`]: the broker-side active generation identity.
+  **Rollbackable** — a legitimate `Rollback` action moves it backwards.
+  This module enforces no monotonicity on it; the broker/authenticator
+  is the authority for whether a given epoch transition is legitimate.
+- [`DeliveryCounter`]: a strictly-monotonic anti-replay sequence
+  number, checked first (before any other validation) on every
+  [`ChannelState::apply`] call, **independent of** and **separate
+  from** `LineageEpoch`. Critically, its high-water mark is a property
+  of the in-memory [`ChannelState`] object's lifetime, not of the
+  rollbackable storage generation: it is **never reset by `Retire` or
+  a subsequent `Provision`**, unlike `LineageEpoch` (which legitimately
+  restarts at a fresh baseline after a retire, mirroring the broker's
+  own storage-generation restart). A stale or repeated
+  `DeliveryCounter` is rejected
+  (`ChannelStateError::StaleDeliveryCounter`) regardless of which
+  [`ChannelAction`] it is attached to, including across a
+  retire-then-reprovision boundary.
+- [`ChannelAction`]: an explicit four-way discriminator
+  (`Provision`/`Rotate`/`Rollback`/`Retire`) carried alongside the
+  epoch and counter, rather than inferred from whether the epoch went
+  up or down.
+
+[`ChannelUpdate`] is the only way to apply a transition; its fields are
+private and only constructible through named constructors
+(`provision`/`rotate`/`rollback`/`retire`) that guarantee the
+action/epoch/material combination is always internally consistent (for
+example, `retire()` can never accidentally carry material). It is not
+`Clone`/`Copy`: an update owns its [`ChannelBinding`] (when present)
+and consumes it exactly once via `apply`; on rejection, the update
+(and any embedded material) is simply dropped at the end of that call,
+which zeroizes it through `ChannelBinding`'s `Drop` impl — there is no
+separate "zeroize on rejection" code path to keep in sync.
+[`ChannelBinding`] itself derives neither `Copy` nor `Clone`, wraps its
+candidate bytes **before** validating them (so the rejection path also
+zeroizes on drop), and exposes its raw bytes only through an explicit,
+one-shot `expose_bytes()` call for final external handoff (e.g. to
+`SessionConfig::new`) rather than through any implicit
+copy/clone. Zeroization here is implemented without the `zeroize`
+crate — `d2b-sk-frontend` has no such dependency, and adding one would
+require a `Cargo.toml` edit this component does not own — using a
+`#![forbid(unsafe_code)]`-compatible `std::hint::black_box`-guarded
+best-effort overwrite instead of the `zeroize` crate's own
+volatile-write internals.
+
+**This module deliberately does not define or parse a wire byte
+format.** A prior draft proposed a concrete 40-byte layout
+(`from_wire_bytes`); that was exactly the kind of ad-hoc format
+finalized without closed validation against the broker's actual
+(nonexistent, today) `SecretKind::SecurityKeyChannelState` dispatch
+serialization that this redesign was asked to remove. The integrator
+must define the real wire schema (likely in `d2b-contracts`, out of
+scope here), authenticate incoming messages against it, and translate
+the result into a [`ChannelUpdate`] — never the other way around. This
+module also does not authenticate messages itself: by the time a
+`ChannelUpdate` reaches `apply`, it is assumed to already have been
+authenticated (signature/MAC verified, origin checked) by the caller.
 
 ## Non-goals
 
@@ -104,22 +305,31 @@ kinds through one shared engine rather than three separate ones.
 - This component does not decide *how* material is generated for any
   kind (ssh-keygen invocation, TPM attestation derivation, or the
   exact security-key channel wire encoding). It only stores, activates,
-  and tracks generations of whatever `SecretMaterial` bytes a caller
+  and tracks generations of whatever [`SecretMaterial`] bytes a caller
   supplies.
+- This component does not implement message authentication or a
+  concrete wire byte format for the guest channel. See "Guest-side
+  channel state" above.
 
 ## Audit record shape
 
-[`SecretsLifecycleAuditFields`] (schema version 1) is a path-free,
+[`SecretsLifecycleAuditFields`] (schema version 2) is a path-free,
 material-free JSON-serializable record: `vm_id`, `kind`, `action`
 (`provision`/`rotate`/`rollback`/`retire`), `base_dir_hash`, `result`
 (`created`/`rotated`/`rolled_back`/`retired`/`verified_clean`/`denied`/
 `failed_closed`), `marker_result`
 (`created`/`verified`/`tombstoned`/`unchanged`/`failed_closed`), an
-optional `generation`, a bounded `retained_generations` list (at most
-`MAX_AUDITED_RETAINED_GENERATIONS`, currently 8), an optional
-`material_digest_hex` (present only for `provision`/`rotate`), and an
-optional `fail_reason` (present exactly for `denied`/`failed_closed`
-results). `SecretsLifecycleAuditFields::validate` enforces every
+optional `lineage_epoch` (the active generation's epoch; never present
+for `retired`), an optional `high_water_epoch`, a bounded
+`retained_generations` list (nonzero whenever present, at most
+`MAX_AUDITED_RETAINED_GENERATIONS`, and always excluding the active
+epoch), an optional `material_digest_hex` (present only for
+`provision`/`rotate`, a lowercase 64-hex-digit SHA-256 string), a
+`recovered_prior_transaction` flag (set whenever the action first had
+to drain a leftover crash-interrupted transaction), and an optional
+`fail_reason` (present exactly for `denied`/`failed_closed` results,
+drawn only from the closed [`FailReason`] enum — never an arbitrary
+string or path). `SecretsLifecycleAuditFields::validate` enforces every
 cross-field invariant listed above; every constructor
 (`provisioned`/`rotated`/`rolled_back`/`retired`/`verified_clean`/
 `denied`/`failed`) returns an already-valid record.
@@ -127,12 +337,13 @@ cross-field invariant listed above; every constructor
 ## Marker and path layout
 
 ```
-<per_vm_state_root>/secrets/<kind-slug>/
+<state_root>/<vm_id>/<kind-slug>/
   generations/
-    <n>/material          # 0600, expected_uid:expected_gid
-  current -> generations/<n>
-
-/var/lib/d2b/secrets-lifecycle-markers/<vm_id>/<kind-slug>   # 0600 JSON marker
+    <epoch>/material        # 0600, expected_uid:expected_gid
+  current -> generations/<epoch>
+  marker.json                # 0600 JSON, schema v2
+  lock                        # 0600, flock(2) target, never contains data
+  txlog                       # 0600 JSON, present only mid-transaction
 ```
 
 `<kind-slug>` is one of `tpm-bound-credential`, `guest-signing-key`,
@@ -149,38 +360,54 @@ into any shared sink. An integrator still needs to:
 2. Add an
    `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
    variant (and matching `from_operation_value` arm) to
-   `packages/d2b-priv-broker/src/ops/audit_op.rs`.
+   `packages/d2b-priv-broker/src/ops/audit_op.rs`, and wire the
+   returned record into `crate::audit::AuditLog`.
 3. Add new wire request/response DTOs (in `d2b-contracts`) and a
    `runtime.rs` dispatch path calling
-   `provision`/`rotate`/`rollback`/`retire` and emitting the returned
-   audit record via `crate::audit::AuditLog`. The plan text for this
+   `provision`/`rotate`/`rollback`/`retire`. The plan text for this
    component explicitly forbids adding a new broker op enum family
    from within it, so this step is deliberately deferred.
-4. Decide what bundle-resolved field supplies `per_vm_state_root` for
-   `derive_paths` (mirrors `swtpm_dir::derive_paths`'s
-   `&SpawnRunnerPlan` parameter).
+4. Decide the real `SecretsLifecycleConfig::state_root` source
+   (candidate: a subdirectory of the per-realm state root established
+   by the ADR 0034 storage-lifecycle contract) — **this path must
+   already exist** with a non-world-writable mode before this module
+   is called; this module only creates `state_root/<vm_id>/<kind-slug>`
+   beneath it, never `state_root` itself — and the real owner
+   uid/gid for each kind.
 5. Decide whether `SecretKind::GuestSigningKey` material comes from
    `exec_reconcile::run_ssh_keygen` output fed into `rotate`'s
    `material` parameter, or stays separate.
 6. Decide the exact coupling between `SecretKind::TpmBoundCredential`
-   rotation and `swtpm_dir.rs`'s physical NVRAM (e.g. whether a rotate
-   here should also trigger a swtpm reseal) — a product/security
+   rotation here and `swtpm_dir.rs`'s physical NVRAM (e.g. whether a
+   rotate here should also trigger a swtpm reseal) — a product/security
    decision beyond this component's scope.
-7. Add `pub mod secrets_channel;` to `packages/d2b-sk-frontend/src/lib.rs`,
-   and wire `services/security_key/mod.rs`'s `SessionConfig` to source
-   its `channel_binding`/`reconnect_generation` from
-   `ChannelState::current`/`ChannelMaterial::into_session_config_args`
-   instead of the static `D2B_SK_CHANNEL_BINDING_HEX`/
-   `D2B_SK_RECONNECT_GENERATION` environment variables it reads today.
-8. Confirm or replace `ChannelMaterial::from_wire_bytes`'s proposed
-   32-byte-binding + 8-byte-big-endian-generation wire format against
-   whatever the future broker dispatch arm for
-   `SecretKind::SecurityKeyChannelState` actually serializes — it is a
-   proposal, not a settled contract.
-9. Run `gen-nix-unit-pins.sh` after this component lands so
-   `tests/unit/nix/pinned/*.txt` picks up the new
-   `w8-secrets-lifecycle-eval.nix` case names (not run here since the
-   pinned files are not owned by this component).
+7. Call [`recover_in_flight_transaction`] once at controller/broker
+   startup for every known `(vm, kind)` pair before dispatching any
+   live request, so a leftover transaction from a prior crash is
+   drained proactively rather than only on the next incoming request
+   for that exact pair.
+8. Add `pub mod secrets_channel;` to
+   `packages/d2b-sk-frontend/src/lib.rs`, and wire
+   `services/security_key/mod.rs`'s `SessionConfig` to source its
+   `channel_binding`/`reconnect_generation` from
+   `ChannelState::with_current` instead of the static
+   `D2B_SK_CHANNEL_BINDING_HEX`/`D2B_SK_RECONNECT_GENERATION`
+   environment variables it reads today.
+9. Define the real wire schema for the message that carries
+   `SecretKind::SecurityKeyChannelState` material to the guest (likely
+   in `d2b-contracts`), including how it is authenticated, and
+   translate it into a [`ChannelUpdate`] — this module has no wire
+   format or authentication logic of its own by design (see "Guest-side
+   channel state" above).
+10. If replay protection must also survive a guest process restart
+    (not just a broker-side retire/reprovision), persist
+    [`ChannelState::delivery_high_water`] to guest-local storage and
+    restore it before the first `apply` call after startup — this
+    in-memory module does not do so itself.
+11. Run `gen-nix-unit-pins.sh` after this component lands so
+    `tests/unit/nix/pinned/*.txt` picks up the new
+    `w8-secrets-lifecycle-eval.nix` case names (not run here since the
+    pinned files are not owned by this component).
 
 ## See also
 

--- a/docs/reference/secrets-lifecycle.md
+++ b/docs/reference/secrets-lifecycle.md
@@ -4,12 +4,12 @@
 > `packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs`,
 > `packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs`, and
 > `packages/d2b-sk-frontend/src/secrets_channel.rs`. This is the
-> storage/atomicity/rotation-state layer only — see "Non-goals" below
-> for what it deliberately does not do.
+> storage-agnostic transaction/rotation-state layer only — see
+> "Non-goals" below for what it deliberately does not do.
 >
-> **Status: not wired into any live broker dispatch path or guest
-> transport.** Every function this page documents is a tested,
-> standalone Rust API reachable only from this component's own
+> **Status: not wired into any live broker dispatch path, audit sink,
+> or guest transport.** Every function this page documents is a
+> tested, standalone Rust API reachable only from this component's own
 > `#[cfg(test)]` modules today. See
 > [Integration wiring points](#integration-wiring-points-not-performed-by-this-component)
 > for the exact remaining steps and
@@ -19,19 +19,143 @@
 This page is the contract for the provision/rotate/rollback/retire
 engine that tracks per-realm secrets material: TPM-bound credentials,
 guest signing keys, and security-key channel state (the closed
-[`SecretKind`] set). It follows the broker's existing fd-relative,
-anchored, atomic, identity-bound, fail-closed conventions (the same
-family as `swtpm_dir.rs`'s hardening step and `store_sync_audit.rs`'s
-typed audit schema), applied generically across all three secret
-kinds through one shared engine rather than three separate ones.
+[`SecretKind`] set). It follows the broker's existing identity-bound,
+fail-closed, redaction-safe conventions (the same family as
+`swtpm_dir.rs`'s hardening step and `store_sync_audit.rs`'s typed audit
+schema), applied generically across all three secret kinds through one
+shared engine rather than three separate ones.
 
-This document describes the **second, redesigned** iteration of this
-engine (superseding an earlier draft that an external security review
-found was not crash-safe). The redesign's driving property, repeated
-throughout this page, is: **a process crash must never leave storage
-in a state where recovery is forced to either silently activate
-something unverified, or return an error while unrecoverable state has
-already been activated.**
+## W8fu6: a pure transaction core behind an injected port
+
+This document describes the **third** iteration of this engine.
+
+- Rounds 1-5 (superseded) built a **filesystem-anchored** engine: raw
+  fd-relative paths (`crate::sys::path_safe`), a private `F_OFD_SETLK`
+  cross-process lock, a durable on-disk JSON marker + transaction log,
+  fsync-heavy crash recovery, and an anchored enumerate-then-delete
+  retirement walk.
+- **This round (W8fu6, current) replaces all of that** with a **pure
+  transaction core** that has zero side effects of its own: no
+  filesystem access, no locking, no process spawning, no JSON
+  serialization of its own state. Every stateful effect goes through
+  one injected trait, [`SecretsAuthorityPort`], and every
+  crash/fault/concurrency/tamper test in `secrets_lifecycle.rs` runs
+  entirely against an in-memory `FakeAuthorityPort` test double defined
+  in that file's own `#[cfg(test)] mod fake_port` — there is no test in
+  this component that spins up a real directory tree, a real lock, or
+  touches a real filesystem.
+
+The redesign's driving property, unchanged from earlier rounds and
+still the standard every change below is held to, is: **a crash, a
+concurrent writer, or a tampered read must never leave this module
+having silently activated something unverified, and must never force
+a caller to see an error after unrecoverable state has already been
+durably activated.**
+
+### Why a compare-and-swap fencing token instead of a lock + txlog
+
+The prior design's lock (mutual exclusion) and transaction log (crash
+recovery) both existed to make a *sequence* of raw filesystem writes
+durable and atomic despite crashes and concurrent callers. A storage
+substrate that already offers atomic compare-and-swap (etcd's
+`mod_revision`, ZooKeeper's `version`, a database row's optimistic-lock
+column, or — for a filesystem adapter of the integrator's own design —
+a `rename(2)`-based scheme) makes both unnecessary *from this module's
+point of view*: every action below reads a [`DurableState`] plus an
+opaque [`OwnershipEpoch`] fencing token via
+[`SecretsAuthorityPort::read_state`], computes the next state, and
+calls [`SecretsAuthorityPort::cas_commit`] with the token it read.
+Either the CAS succeeds (this call was the only writer the whole time)
+or it is fenced (some other writer's transition is now current; this
+call fails cleanly with [`FailReason::OwnershipFenced`] and has mutated
+nothing). This module never acquires or holds a lock, and never writes
+a transaction log of its own — whatever recovery a concrete adapter
+needs for its own commit primitive is the adapter's problem, entirely
+hidden behind `cas_commit` returning `Ok`/`Err` atomically.
+
+### What "forward recovery" means without a txlog
+
+There is no separate "recovery mode": a caller that observes
+`FailReason::OwnershipFenced` simply re-reads the current state and
+retries (or gives up) — there is no crashed, half-applied transaction
+to detect or unwind, because `cas_commit` is defined to be atomic
+(all-or-nothing) from this module's point of view. "Forward recovery"
+instead applies to *pruning*: a transition that supersedes a generation
+(`rotate` superseding the old `previous`, `retire` superseding both
+`active` and `previous`) commits the superseding [`DurableState`]
+**first** and only then attempts to synchronously prune the superseded
+material via [`SecretsAuthorityPort::prune_material`]. If that
+synchronous prune does not fully succeed, the still-owed epochs are
+recorded in the *already-durably-committed* state's
+[`DurableState::pending_prune`] list (bounded at [`MAX_PENDING_PRUNE`])
+rather than being lost or blocking the caller's success — every
+subsequent action for that `(workload, kind)` resolves any outstanding
+debt (via the shared `read_and_verify` helper) before doing its own
+work, so the debt is self-healing and monotonically shrinks. This is
+the module's concrete answer to "never return an error after silently
+activating unrecoverable state": the CAS commit that activates a new
+generation and the best-effort prune of the old one are two separate
+steps, and a failure in the second step is recorded as durable,
+retriable debt — never swallowed, and never allowed to turn a
+successful activation into a reported failure.
+
+### Why deterministic, high-water-keyed epoch allocation
+
+A new generation's epoch number is always `state.high_water_epoch + 1`
+— never "current epoch + 1" — so a `rotate` issued after a `rollback`
+can never collide with (or silently resurrect) a still-materialized,
+newer-numbered epoch the rollback moved away from. Because the next
+epoch number is a pure function of the last *durably committed*
+high-water mark, staging is naturally idempotent by epoch: two calls
+that stage the same not-yet-committed epoch number simply race on
+whose bytes are staged last (closed by the post-commit
+re-verification described next), and there is never a need for the
+collision-resistant random staging-name scheme rounds 1-5 required.
+
+### Closing the "last stage wins" race
+
+`stage_material` is defined to run *before* `cas_commit`, so two
+concurrent callers that both read the same pre-commit state and
+compute the same next epoch number can each call `stage_material` for
+that epoch before either of them calls `cas_commit`. Only one of the
+two `cas_commit` calls can win the race, but the *order* of the two
+`stage_material` calls relative to the winning `cas_commit` is not
+itself CAS-serialized — the loser's `stage_material` call could still
+run (and overwrite the winner's staged bytes) *after* the winner's
+`cas_commit` succeeds, silently corrupting the now-durably-active
+generation's material without ever going through `cas_commit` again.
+[`provision`] and [`rotate`] close this window by **immediately
+re-reading the live digest of the epoch they just committed** and
+comparing it against the digest they themselves staged: a mismatch
+means some other writer's `stage_material` call landed after this
+call's `cas_commit`, so this call quarantines the authority and fails
+closed with `FailReason::ChecksumMismatch` rather than certifying
+success over corrupted, no-longer-trusted material. `rollback` and
+`retire` never stage material, so neither is exposed to this race; both
+still independently re-verify every generation identity they read
+before mutating (via the shared `read_and_verify` helper and, for
+`rollback`, an additional call-site re-check immediately before its own
+mutation).
+
+### Canonical typed identity, no legacy VM-name string
+
+Every function below takes a
+[`d2b_contracts::v2_identity::WorkloadId`] — the same canonical v2
+identity type already used elsewhere in this crate
+(`guest_session_material.rs`, `child_realm_guest_material.rs`) —
+rather than a bare `vm_id: &str` or the legacy
+`d2b_contracts::types::VmId` human-label newtype rounds 1-5 used.
+`WorkloadId`'s own `parse`/`FromStr` already enforces the canonical
+bounded-opaque-string shape, so this module has no `valid_vm_id`-style
+runtime string check of its own to maintain — an invalid identity
+simply cannot exist as a `WorkloadId` value in the first place. Every
+[`SecretsAuthorityPort`] method is scoped by `(&WorkloadId,
+SecretKind)`; how (or whether) an adapter maps that pair onto any
+underlying storage location — a path, a database key, a KV-store
+prefix — is entirely the adapter's concern and never observable here.
+The audit surface (`SecretsLifecycleAuditFields::workload_id`) carries
+the same typed, opaque `WorkloadId` — never a human-readable label or a
+filesystem path.
 
 ## Scope and invariants
 
@@ -39,400 +163,146 @@ already been activated.**
   [`SecretKind::GuestSigningKey`], and
   [`SecretKind::SecurityKeyChannelState`] all flow through the same
   `provision`/`rotate`/`rollback`/`retire` functions, parameterized by
-  [`SecretsLifecyclePaths`] (derived per `(vm_id, kind)` via
-  `derive_paths`). Generating the raw material itself — running
-  `ssh-keygen`, deriving a TPM attestation blob, or producing
-  channel-binding wire material — stays the caller's concern; this
-  engine only owns storage, atomicity, rotation-state tracking, and
-  crash recovery.
-- **Fd-relative and anchored.** Every filesystem mutation goes through
-  `crate::sys::path_safe`'s existing primitives (`ensure_dir`,
-  `open_at`, `mkdir_at_exclusive`, `create_file_at_safe`,
-  `atomic_replace_fd_with_owner`, `remove_path_safe`, `fstat_fd`,
-  `fstatat_nofollow`, `fd_extended_acl_present`) — no bare `std::fs`
-  path-string call ever touches a role-writable directory. `state_root`
-  itself is treated as an externally-established precondition (opened
-  read-only via `open_dir_path_safe`, never `ensure_dir`'d): only
-  `state_root/<vm_id>` and `state_root/<vm_id>/<kind-slug>` are created
-  by this module, since a bare `ensure_dir` on `state_root` itself would
-  fail closed under `path_safe::refuse_world_writable_parent` for any
-  `state_root` whose own parent is world-writable.
+  `(workload: &WorkloadId, kind: SecretKind)`. Generating the raw
+  material itself — running `ssh-keygen`, deriving a TPM attestation
+  blob, or producing channel-binding wire material — stays the
+  caller's concern; this engine only owns durable-state transitions,
+  CAS fencing, digest re-verification, and forward-recovery pruning.
+- **Zero side effects of its own.** No filesystem access, no locking,
+  no process spawning. Every mutating effect is a call through the
+  injected [`SecretsAuthorityPort`] trait; this module has no opinion
+  on, and no dependency on, whatever real storage/locking/CAS
+  substrate a concrete adapter chooses.
+- **Never silently activates unverified state.** See "W8fu6" above:
+  CAS fencing, post-commit digest re-verification, and
+  self-consistency validation on every read together mean a caller
+  either sees a durably committed, independently re-verified success,
+  or a loud, fail-closed error — never a quiet partial mutation.
 
-### Cross-process locking and the durable transaction log
+### Durable state (`DurableState`)
 
-Every mutating action first opens (or creates)
-`<kind_root>/lock` and takes an exclusive, poll-with-timeout **open
-file description (OFD)** lock on it via `F_OFD_SETLK`
-(`acquire_lock`/`try_ofd_lock_exclusive`, bounded by
-`SecretsLifecycleConfig::lock_max_wait`/`lock_poll_interval`, failing
-closed with `FailReason::LockUnavailable` on timeout — this is the
-cross-process, per-`(vm, kind)` exclusive lock finding (1) asked for).
-This module deliberately uses the repository's established `F_OFD_SETLK`
-convention (mirroring `d2bd::audio_dispatch::ofd_lock`/`ofd_unlock`)
-rather than BSD `flock(2)`: an OFD lock is associated with the *open
-file description*, not the owning process, so it composes correctly
-with a single process holding multiple independent fds on the same
-lock file, where `flock`'s whole-process association would let two
-unrelated fds silently share one lock. Before trusting the lock,
-`acquire_lock` verifies: the anchored parent (`kind_root`) is a
-trusted-broker-owned directory of the expected mode
-(`verify_broker_owned`); the lock file itself is a trusted-broker-owned
-regular file of the expected mode with exactly one hard link (never a
-hard-link plant); and, immediately after the OFD lock succeeds, that
-the `lock` directory entry still resolves — by `(dev, ino)` — to the
-exact file this call opened and locked, closing the classic
-unlink-and-recreate-between-open-and-lock race. Any mismatch is
-`FailReason::BrokerOwnershipViolation`. `LockGuard` is an opaque RAII
-token with no public/forgeable "is locked" proof; releasing the lock
-is simply closing its owned fd (the kernel drops an OFD lock exactly
-when every fd referencing its open file description is closed — no
-separate unlock call is needed). A full generated-sync-row
-`d2b-state::LockSet`/`AuthorityRef` integration remains an explicit
-integrator-owned wiring point (see "Integration wiring points" below).
-"Broker-owned" here means
-"owned by this process's own effective uid/gid" (`broker_identity`):
-metadata directories (`kind_root`, `generations/`) and the lock file
-are never `cfg.owner_uid`/`cfg.owner_gid`-owned — that consumer-facing
-identity applies only to the `material` file leaf a generation
-directory contains.
+[`DurableState`] is the *entire* payload [`SecretsAuthorityPort::cas_commit`]
+ever writes for one `(workload, kind)` pair — there is no separate
+marker, transaction log, or lock-state object:
 
-While holding that lock, every promote-shaped action
-(`provision`/`rotate`/`rollback`) and `retire` runs through one of two
-shared phase-machine engines:
+- `high_water_epoch: u64` — monotonic high-water mark: the highest
+  epoch number the current, unbroken lineage (since the last
+  `provision`) has committed as active. Never decreases within one
+  such lineage. `provision` deliberately resets this to `1` for a
+  fresh lineage: the shared read helper unconditionally requires any
+  `pending_prune` debt from a prior `retire` to be fully drained
+  (every previously-live epoch confirmed pruned by the authority)
+  before `provision` may run at all, so reusing epoch `1`'s key can
+  never resurrect a prior lineage's leftover bytes.
+- `active: Option<GenerationRecord>` — the currently active
+  generation (`epoch` + SHA-256 hex `digest_hex`), when one exists.
+  `None` for a never-provisioned or freshly retired pair.
+- `previous: Option<GenerationRecord>` — the most recently superseded
+  generation still retained for a possible `rollback`, when one
+  exists. Always `None` when `active` is `None`.
+- `retired: bool` — `true` exactly for a pair that has been retired
+  and not since re-provisioned. A retired pair always has
+  `active: None, previous: None`.
+- `pending_prune: Vec<Epoch>` — epochs a prior committed transition
+  determined are superseded and safe to prune, but whose synchronous
+  best-effort prune attempt did not fully succeed. Bounded at
+  [`MAX_PENDING_PRUNE`] (`2`); never contains the current `active` or
+  `previous` epoch; always strictly ascending and duplicate-free.
 
-- **Promote** ([`PromotePhase`]): `Planned` (material staged into a
-  fresh `.stage-*` directory, or a rollback's already-existing target
-  generation tamper-verified) → `EpochReady` (the target generation is
-  materialised at its final `generations/<epoch>` name, fsynced) →
-  `CurrentPromoted` (`current` atomically repointed at the new
-  generation, fsynced) → `MarkerCommitted` (marker durably rewritten,
-  fsynced; superseded generation pruned best-effort; any leftover
-  `.stage-*` directory enumerated/validated/deleted with every failure
-  propagated) → transaction log removed.
-- **Retire** ([`RetirePhase`]): `Enumerated` (the physical
-  `generations/` tree anchored-enumerated and validated) →
-  `CurrentRemoved` (`current` unlinked, then every recorded generation
-  *and* every recorded `.stage-*` directory deleted, each re-validated
-  immediately before its own deletion) → `EpochsRemoved` (a fresh
-  re-enumeration must observe the tree fully empty) → `ProvenEmpty`
-  (marker tombstoned) → transaction log removed.
+`DurableState::validate_self_consistent` checks every one of the above
+cross-field invariants (bound, ascending/duplicate-free order,
+retired-implies-empty, digest-hex shape, epoch-vs-high-water bounds,
+no overlap between `pending_prune` and the live generations) before
+this module trusts a value read from the authority. This is
+deliberately independent of live digest re-verification (which the
+shared read helper performs separately by calling
+`SecretsAuthorityPort::material_digest`) — `validate_self_consistent`
+only checks that the state's *own* fields are mutually consistent.
 
-Before each phase transition, the *current phase* is written to
-`<kind_root>/txlog` (JSON, fsynced) — this is the durable
-transaction/recovery state machine finding (1) asked for. Every fsync
-in this module (`fsync_fd`) returns `Result<(), FailReason::FsyncFailed>`;
-a failed sync at any phase transition — material write, staging
-directory, epoch rename, `current` swap, marker write, txlog write,
-generation/stage deletion — propagates immediately and blocks that
-phase from ever being recorded as advanced. No phase transition is
-ever considered committed on an unsynced write, so a crash immediately
-after a failed sync is always safely re-driveable by a later recovery
-pass; nothing is ever left activated with only a *possible* failure to
-persist it durably.
+### The authority port (`SecretsAuthorityPort`)
 
-Immediately on read, before any recovery attempt acts on it, a leftover
-`txlog` undergoes full semantic validation
-(`validate_txlog_semantics`/`validate_promote_intent_semantics`/
-`validate_retire_intent_semantics`) bound to the exact `(vm_id, kind)`
-directory it was found in: the recorded `vm`/`kind` must match the
-directory; the action/`create_epoch`/`stage_name`/`expected_identity`
-combination must be one this module can legally have written;
-epoch/high-water/prune-epoch/carry-previous relationships must be
-internally consistent; `RetireIntent.epochs`/`stage_names` must be
-sorted, deduplicated, in-bounds, and correctly prefixed. Any violation
-is `FailReason::IntentCorrupt` — a hand-edited or otherwise corrupted
-txlog is never handed to the recovery engine to interpret.
-[`recover_if_needed`] is called at the start of every action (and by
-the standalone [`recover_in_flight_transaction`] entry point) and, once
-the txlog passes semantic validation:
+The single seam this pure transaction core depends on. An
+integrator-owned adapter implements this against whatever real
+storage/locking/CAS substrate lands (a filesystem tree with its own
+`rename(2)`-based scheme, a KV store with native CAS, a database row
+with an optimistic-lock column, etc). Every method is "guarded":
+scoped to exactly one `(workload, kind)` pair, taking and returning
+only this module's own typed values — never a raw path, file
+descriptor, lock handle, or adapter-internal error detail.
 
-- if the phase recorded is at or before the point where an external
-  observer could see any change (`Planned` for promote; `Enumerated`
-  for retire), the leftover state is safely discarded or completed —
-  nothing was ever activated, so a fresh re-drive is always safe;
-- `Planned`-phase promote recovery never abandons or silently
-  re-stages a target epoch that a prior crashed attempt already
-  renamed into place: if `generations/<to_epoch>` already exists with
-  content whose digest matches the intent's `expected_digest_hex`, the
-  engine treats it as already-materialised, **retries the
-  `generations_fd` durability barrier** (the prior attempt's own
-  trailing fsync may be exactly what crashed it) before advancing, and
-  continues forward without needing the original material again; if
-  content already occupies that epoch number with a **different**
-  digest, recovery fails closed (`RecoveryContentMismatch`) rather than
-  ever adopting or overwriting a stale, foreign, or previously-aborted
-  generation;
-- a `Planned`-phase abort with no leftover material to complete the
-  transaction (`PromoteOutcome::AbortedNoMaterial`) never leaves an
-  orphan wedge: `discard_partial_stage_if_present` validates and
-  deletes any partial `.stage-*` directory the crashed attempt left
-  behind (propagating any deletion error) before the txlog is cleared;
-  if that partial stage cannot be safely validated (an unrecognised
-  on-disk shape), the abort fails closed and **retains** the txlog
-  instead, so a future recovery attempt still has the record needed to
-  reason about it — the transaction is never silently dropped over
-  unrecognised on-disk state;
-- if the phase recorded is at or after the commit point
-  (`CurrentPromoted`/`MarkerCommitted` for promote,
-  `CurrentRemoved`/`EpochsRemoved`/`ProvenEmpty` for retire), recovery
-  **only ever moves forward** — it re-verifies the already-activated
-  content against what the log recorded and completes the remaining
-  steps; it never reverts an already-swapped `current` or resurrects an
-  already-deleted generation. A verification mismatch at this stage
-  fails closed (`RecoveryContentMismatch`/`RecoveryAmbiguous`) without
-  touching anything further — it does not silently re-diverge storage,
-  and it does not clear the txlog (so a subsequent recovery attempt,
-  e.g. after fixing the anomaly by hand, gets another chance).
+| Method | Contract |
+| --- | --- |
+| `read_state(workload, kind) -> Result<(DurableState, OwnershipEpoch), PortError>` | A pair never committed to returns `DurableState::never_provisioned()` paired with `OwnershipEpoch::NEVER_COMMITTED`. |
+| `stage_material(workload, kind, epoch, material) -> Result<String, PortError>` | Durably stores `material`'s bytes as the candidate content for `epoch`, returning the digest the adapter actually stored. May be called more than once for an epoch not yet referenced as `active`/`previous` by the currently committed state; MUST refuse (`PortError::EpochAlreadyCommitted`) a stage call for an epoch already so referenced. |
+| `material_digest(workload, kind, epoch) -> Result<String, PortError>` | Re-derives the digest of whatever is currently stored for `epoch`, without ever handing the raw bytes back to this module. |
+| `cas_commit(workload, kind, expected, next) -> Result<OwnershipEpoch, PortError>` | Atomically replaces the committed state with `next` iff the adapter's currently stored fencing token equals `expected` — all or nothing. On success returns a new, different token. On a lost race returns `PortError::OwnershipFenced` and mutates nothing. |
+| `prune_material(workload, kind, epoch) -> Result<(), PortError>` | Durably discards the material for `epoch`. Idempotent: already absent is `Ok(())`. Never called for an epoch still referenced as `active`/`previous` by the last-known committed state — the superseding transition is always committed first, then pruned. |
+| `quarantine(workload, kind, reason) -> Result<(), PortError>` | Durably marks the pair quarantined: every subsequent call of any method above for this pair must fail closed with `PortError::Quarantined` until an out-of-band, integrator-owned clearing operation (this module exposes none) resets it. Idempotent. |
 
-`provision`, `rotate`, and `rollback` share the same
-[`execute_promote`] codepath (parameterized by a [`PromoteIntent`]) for
-both a fresh call and for completing a leftover recovery — there is no
-separate "recovery-only" branch that could drift out of sync with the
-normal path. `retire` and its own recovery both run through
-[`execute_retire`] the same way. Every generation deletion inside
-`execute_retire` is preceded by `revalidate_generation_before_delete`:
-an immediate, anchored, nofollow re-stat/re-validate of that exact
-generation directory right before it is removed, so a tamper injected
-between the original enumeration and the delete (not merely between
-process restarts) is still caught rather than trusted from a stale
-snapshot. `revalidate_generation_before_delete` accepts exactly two
-directory shapes: the fully-materialized generation
-`enumerate_and_validate_generation_tree` originally validated, or the
-one legitimate mid-deletion crash checkpoint `remove_generation` can
-leave behind — `material` already unlinked, the epoch directory itself
-not yet removed. Recognizing that checkpoint requires every one of: the
-entry is still a directory (not a symlink, file, or anything else
-swapped into the name); it is still trusted-broker-owned at the
-expected `cfg.dir_mode` (a foreign owner or any other mode means the
-directory was replaced, not left behind by this module's own deletion
-sequence); and it contains **zero** entries other than `.`/`..` (an
-unrecognized leftover entry, or a `material` entry of the wrong type or
-link-count, still fails closed rather than being swept away). This
-acceptance is reachable **only** from `execute_retire`'s
-`CurrentRemoved` phase deletion loop, always acting on a `RetireIntent`
-that has already passed `validate_retire_intent_semantics` — never from
-`enumerate_and_validate_generation_tree`, which fresh pre-retirement
-planning (`retire`'s initial enumeration) and the final `EpochsRemoved`
-prove-empty check both still call, and which remains exactly as strict
-as before: an empty generation directory encountered there is still
-`FailReason::RetirementTreeAnomaly`, not a silently-accepted "nothing
-here yet" state. A missing marker, or a marker that still claims the
-epoch active over that same physically-empty directory, is likewise
-never treated as clean storage by the fresh path — it fails closed on
-the more specific `PreviouslyProvisionedMaterialMissing` reason raised
-while re-verifying the marker's claimed active generation identity,
-before enumeration is even reached. Both `execute_promote`'s post-commit
-stage cleanup and
-`execute_retire`'s `CurrentRemoved` phase likewise call
-`revalidate_stage_before_delete` on each `.stage-*` directory
-immediately before its own deletion. `CurrentPromoted` and
-`MarkerCommitted` recovery/completion each re-verify, before any
-further mutation or txlog removal, that `current` still resolves by
-exact literal symlink text to the intended target epoch
-(`current_resolves_exactly_to`) — and `MarkerCommitted` additionally
-re-reads and checks the marker's `active` fields against the intent —
-so a phase is never advanced, and the txlog never cleared, over a
-`current`/marker state that does not match what that phase's own
-identity contract requires. A missing generation or stage directory
-encountered while `retire` is retried still retries the
-`generations_fd` durability barrier before the retirement phase
-advances, so an unsynced prior deletion can never reappear (e.g. via a
-crash-induced write-back) after the marker has already been
-tombstoned.
+Implementations MUST provide the exact atomicity/idempotency
+guarantees documented on each method; this module's correctness (in
+particular "never return an error after silently activating
+unrecoverable state") depends on `cas_commit` being genuinely atomic
+and `prune_material`/`quarantine` being genuinely idempotent.
 
-Staging directory names use `random_stage_name`: a collision-resistant
-name mixing the process id, a per-process atomic monotonic counter,
-wall-clock nanoseconds, and a `RandomState`-seeded hash folded through
-SHA-256, always exactly `STAGE_PREFIX` (`.stage-`) followed by 32
-lowercase-hex characters. `is_well_formed_stage_name` closes the
-syntax to exactly that shape — no path separator, no `..`, no
-alternate length or alphabet — and every stage name recorded in a
-txlog intent is checked against it (`validate_promote_intent_semantics`/
-`validate_retire_intent_semantics`) before that intent is ever written
-or acted on, in addition to `enumerate_and_validate_generation_tree`'s
-own defense-in-depth check over whatever names are physically present
-on disk. Staged entries are **real secret-tree contents**, never a
-separately-swept, best-effort concern: `enumerate_and_validate_generation_tree`
-collects `.stage-*` directories exactly like generation epochs
-(`validate_stage_dir_contents` refuses anything but at most one
-regular, single-hard-link entry inside), and every deletion path
-(`remove_stage_dir`, used by promote's post-commit leftover sweep and
-by retire's `CurrentRemoved` phase) fully enumerates, deletes,
-positively proves empty, and fsyncs — propagating every failure rather
-than ignoring it, including a `fsync` that must run even when the
-directory to remove already appears absent (`remove_generation`'s and
-`remove_stage_dir`'s own `NotFound` fast paths still retry the
-containing directory's durability barrier rather than skipping it, so
-a deletion whose fsync had not yet landed cannot silently resurface
-after the transaction is considered complete). A stage directory is
-included in the final provably-empty proof retirement requires before
-tombstoning the marker. The transient `current`-swap staging entry
-(`CURRENT_SWAP_STAGE_NAME`) is never removed via the generic
-symlink-refusing `remove_path_safe` helper — `atomic_swap_current`
-verifies by anchored `nofollow` stat that it is exactly a symlink
-before an anchored `unlinkat`, and fails closed
-(`FailReason::CurrentSwapFailed`) without deleting anything if it ever
-finds something else occupying that name.
+`PortError` is a closed, four-variant enum (`OwnershipFenced`,
+`Quarantined`, `EpochAlreadyCommitted`, `Unavailable`) — this module
+never inspects or forwards an adapter's own internal error detail;
+every variant is meaningful to *this* module's own algorithm, and
+`map_port_error` collapses each onto the audit-facing [`FailReason`]
+set (`Unavailable` maps to the single opaque `FailReason::PortUnavailable`
+bucket, never an adapter-specific string).
 
-### Marker identity (v2)
+### Secret material (`SecretMaterial`)
 
-A dedicated marker file per `(vm, kind)` at `<kind_root>/marker.json`
-(root-owned, `0600`, JSON, `MARKER_SCHEMA_VERSION = 2`) records:
+Caller-supplied secret bytes. Deliberately **not** `Copy` or `Clone`:
+every holder of an owned `SecretMaterial` is a distinct, independently
+zeroized buffer. The bytes are wrapped in `zeroize::Zeroizing` *before*
+validation, so a rejected (empty or oversized) buffer is still zeroized
+on drop rather than discarded as a plain `Vec<u8>`. Capped at
+`SecretMaterial::MAX_LEN` (1 MiB) — generous for TPM-bound credential
+blobs, guest signing keys, and security-key channel state, while
+preventing an unbounded allocation/hash from a misbehaving caller. Its
+`Debug` impl reports only a byte length (`finish_non_exhaustive`),
+never the material itself.
 
-- `high_water_epoch`: the monotonic generation high-water mark (see
-  below);
-- `active`: `None` if retired/never-provisioned, or `Some(`[`MaterialIdentity`]`)` binding the active generation's:
-  - `epoch` (the lineage epoch number);
-  - `dev`/`ino` of the material file, captured via a `nofollow`-safe fd
-    open (never a path re-resolution that could be raced);
-  - owner `uid`/`gid`, permission `mode` bits, hard-link count, and
-    whether an extended POSIX ACL is present;
-  - a SHA-256 content digest.
-- `previous`: the immediately-prior retained generation's full identity,
-  if any (used by `rollback`). `previous.epoch` need not be numerically
-  less than `active.epoch` — a `rollback` swaps the pair, so `previous`
-  can legitimately be the *larger* epoch just rolled back away from;
-  what always holds is that it is a distinct, real, never-exceeding-
-  high-water epoch.
+### Quarantine
 
-Every public action (`provision`/`rotate`/`rollback`/`retire`) routes
-through the single shared `open_and_recover` entry point, which — right
-after loading the marker — runs one central pre-mutation check,
-`verify_marker_against_live_state`, rather than four separately-
-maintained call sites. This validates **both** marker shapes, not just
-the active one: for an *active* marker it is the live-generation check
-described below; for an *inactive* (retired/never-provisioned) marker
-it independently verifies `previous == None`, that `high_water_epoch`
-and the marker's own bookkeeping are internally coherent for a
-never-active lineage, and — via `current_is_genuinely_absent` — that
-`current` does not resolve to anything at all (never merely that it
-"looks retired"); a stale or foreign `current` entry surviving over an
-inactive marker is rejected the same way a live-state mismatch is. This
-is the one reachable trigger for `FailReason::IdentityCurrentTargetMismatch`: it
-confirms that `current` resolves, by **exact literal symlink text**, to
-`generations/<active.epoch>` — a path that merely *ends* in the right
-epoch number (an absolute path, a foreign-rooted relative path, or any
-text other than that precise relative form) is never accepted as a
-match, even when a naive `stat()`-based comparison would otherwise
-agree. It then re-derives the active (and, if present, previous)
-generation's identity tuple from the **live** filesystem state and
-compares it field-by-field against the marker. Each mismatch axis has
-its own closed [`FailReason`] variant so a hard-link plant
-(`IdentityLinkCountMismatch`, or `IdentityInodeMismatch` when the
-digest happens to match but the physical inode does not — the case
-byte-content comparison alone cannot see), a digest-preserving
-directory swap (`IdentityInodeMismatch`), an ownership drift
-(`IdentityOwnerMismatch`), a mode drift (`IdentityModeMismatch`), an
-ACL drift (`IdentityAclMismatch`), or a content drift
-(`IdentityDigestMismatch`) are independently distinguishable on the
-audit surface rather than collapsed into one generic "tampered"
-reason.
-
-Beyond that live-state check, every freshly constructed intent is also
-run through `validate_promote_intent_semantics`/
-`validate_retire_intent_semantics` immediately before it is durably
-logged (`write_txlog`) in `provision`/`rotate`/`rollback`/`retire` —
-not only when a leftover txlog is re-read during recovery. In
-particular, a `rollback`'s intent must satisfy
-`expected_digest_hex == expected_identity.digest_hex` before it is
-ever acted on: the rollback target's claimed content digest and its
-claimed full on-disk identity must agree with each other at
-construction time, not merely be independently plausible.
-
-### Fail-closed on drift, not just on error
-
-Mirroring the `swtpm_dir.rs` philosophy:
-
-- `provision` refuses (`AlreadyProvisioned`) if active material
-  already exists;
-- `provision` fails closed (`PreviouslyProvisionedMaterialMissing`) if
-  the marker says active but the generation vanished;
-- `provision` fails closed (`GenerationConflict`) if material exists on
-  disk with **no** matching active marker — never silently adopted;
-- `rotate`/`rollback`/`retire` all fail closed on any
-  [`MaterialIdentity`] mismatch axis (above), on any
-  `IdentityCurrentTargetMismatch`, and on any internally-inconsistent
-  marker (mutually exclusive `retired`/`active`, out-of-bounds epoch)
-  via the shared central validation — rather than proceeding against a
-  live generation that does not match what the marker recorded.
-
-### Retirement never trusts the marker's word alone
-
-`retire()` always **enumerates and strictly validates the entire
-physical `generations/` tree** ([`enumerate_and_validate_generation_tree`])
-before looking at what the marker says, regardless of marker state:
-
-- an *active* marker over a tree that anchored-enumeration finds
-  already empty is a hard-fail anomaly
-  (`PreviouslyProvisionedMaterialMissing`) — a missing marker, or an
-  empty tree, never by itself implies "already cleanly retired";
-- a tree with any unrecognised entry name, unexpected file type, a
-  `material` file whose link count is not exactly `1`, or a `.stage-*`
-  directory containing anything other than at most one regular,
-  single-hard-link entry aborts the entire retirement with **zero
-  deletions** (`FailReason::RetirementTreeAnomaly`);
-- otherwise every validated generation *and* every validated stage
-  directory is deleted, each re-validated immediately before its own
-  deletion (`revalidate_generation_before_delete`) so a tamper injected
-  after enumeration is still caught; each containing directory is
-  fsynced after its deletions (with any sync failure blocking further
-  progress, never silently ignored); the tree is then positively
-  re-verified empty (`FailReason::RetirementNotProvablyEmpty` if not)
-  before the marker is tombstoned;
-- retiring an already-retired or never-provisioned kind (empty tree,
-  no active marker) is idempotent and reports `verified_clean`, not an
-  error.
-
-### Monotonic generation numbering, survivable across rollback
-
-`MarkerData::high_water_epoch` is a monotonic high-water mark, not
-`current_epoch + 1`: `rotate` always allocates
-`high_water_epoch + 1`. This means a `rotate` issued **after** a
-`rollback` can never collide with (or silently resurrect) a
-still-materialised newer epoch that the rollback moved away from —
-the newer epoch's generation directory is left physically in place
-(pruned only after the new marker is durably committed) but its epoch
-number is never reissued. `rollback` itself never grows
-`high_water_epoch` and prunes nothing (it just re-points `current` at
-the retained `previous`, subject to the same identity-tamper
-verification as any other promote). `provision` always allocates epoch
-`1` and resets `high_water_epoch` to `1` for a fresh lineage — this is
-sound (not a numbering collision risk) specifically because `retire()`
-physically empties and proves-empty the entire `generations/` tree
-before the marker is tombstoned; the monotonic high-water invariant
-only needs to hold *within* one non-retired lineage.
+Quarantine is a one-way, fail-closed door from this module's point of
+view: there is no "un-quarantine" call. [`QuarantineReason`] is a
+closed three-variant enum (`ActiveChecksumMismatch`,
+`PreviousChecksumMismatch`, `StateSelfInconsistent`) recording exactly
+why this module chose to quarantine — never an arbitrary string. See
+"Integration wiring points" § 3 for the operator-facing clearing path
+this component deliberately does not implement.
 
 ### Redaction
 
-No public function in this module ever returns or logs a raw path, a
-raw secret byte, or a raw `io::Error` message. Errors are a closed-set
-[`FailReason`] enum plus a fully-formed
-[`SecretsLifecycleAuditFields`] record. That record itself never
-carries a path (only an FNV1a-64 `base_dir_hash`, parity with
-`crate::ops::hosts::stable_hash_str`) or raw material (only a SHA-256
-`material_digest_hex` fingerprint, present only for
-`provision`/`rotate`). [`SecretMaterial`]:
+No public function, error type, or `Debug` impl in this module ever
+exposes secret bytes or a raw path:
 
-- derives neither `Copy` nor `Clone`;
-- wraps caller-supplied bytes in `zeroize::Zeroizing<Vec<u8>>`
-  **before** the length/emptiness validation check runs, so a
-  rejected (empty or oversized) buffer is zeroized on drop just like an
-  accepted one — there is no code path where a rejected buffer is
-  dropped without zeroization;
-- has a `Debug` impl that never prints its bytes.
+- [`SecretsLifecycleError`] carries only a [`FailReason`] and an
+  already-redacted [`SecretsLifecycleAuditFields`] value.
+- [`SecretMaterial`]'s `Debug` impl reports only a byte length.
+- [`SecretsAuthorityPort`] itself never receives or returns a path, fd,
+  or lock handle — only `WorkloadId`, `SecretKind`, `Epoch`,
+  `DurableState`, digests (hex strings), and this module's own closed
+  error/reason enums.
 
 ## Guest-side channel state (`secrets_channel.rs`, protocol v2)
 
 The guest-side counterpart (`d2b-sk-frontend::secrets_channel`) is a
 standalone, zero-internal-dependency module (only `std`) mirroring the
-same lifecycle shape in memory. Its own redesign (superseding the
-first draft's single conflated `ChannelGeneration` counter) splits
-three previously-conflated concepts:
+same lifecycle shape in memory, already aligned with the W8fu6
+broker-side model (no functional change was needed this round beyond a
+doc-comment update to stop referencing the removed on-disk
+`MarkerData::active` field). It splits three independent concepts:
 
-- [`LineageEpoch`]: the broker-side active generation identity.
-  **Rollbackable** — a legitimate `Rollback` action moves it backwards.
-  This module enforces no monotonicity on it; the broker/authenticator
-  is the authority for whether a given epoch transition is legitimate.
+- [`LineageEpoch`]: mirrors the broker-side
+  `DurableState::active`'s `GenerationRecord::epoch`. **Rollbackable**
+  — a legitimate `Rollback` action moves it backwards. This module
+  enforces no monotonicity on it; the broker/authenticator is the
+  authority for whether a given epoch transition is legitimate.
 - [`DeliveryCounter`]: a strictly-monotonic anti-replay sequence
   number, checked first (before any other validation) on every
   [`ChannelState::apply`] call, **independent of** and **separate
@@ -441,15 +311,15 @@ three previously-conflated concepts:
   rollbackable storage generation: it is **never reset by `Retire` or
   a subsequent `Provision`**, unlike `LineageEpoch` (which legitimately
   restarts at a fresh baseline after a retire, mirroring the broker's
-  own storage-generation restart). A stale or repeated
-  `DeliveryCounter` is rejected
-  (`ChannelStateError::StaleDeliveryCounter`) regardless of which
-  [`ChannelAction`] it is attached to, including across a
-  retire-then-reprovision boundary.
+  own `DurableState::high_water_epoch` restart). A stale or repeated
+  `DeliveryCounter` is rejected (`ChannelStateError::StaleDeliveryCounter`)
+  regardless of which [`ChannelAction`] it is attached to, including
+  across a retire-then-reprovision boundary.
 - [`ChannelAction`]: an explicit four-way discriminator
   (`Provision`/`Rotate`/`Rollback`/`Retire`) carried alongside the
   epoch and counter, rather than inferred from whether the epoch went
-  up or down.
+  up or down — the same four actions [`LifecycleAction`] models on the
+  broker side.
 
 [`ChannelUpdate`] is the only way to apply a transition; its fields are
 private and only constructible through named constructors
@@ -465,10 +335,10 @@ separate "zeroize on rejection" code path to keep in sync.
 candidate bytes **before** validating them (so the rejection path also
 zeroizes on drop), and exposes its raw bytes only through an explicit,
 one-shot `expose_bytes()` call for final external handoff (e.g. to
-`SessionConfig::new`) rather than through any implicit
-copy/clone. Zeroization here is implemented without the `zeroize`
-crate — `d2b-sk-frontend` has no such dependency, and adding one would
-require a `Cargo.toml` edit this component does not own — using a
+`SessionConfig::new`) rather than through any implicit copy/clone.
+Zeroization here is implemented without the `zeroize` crate —
+`d2b-sk-frontend` has no such dependency, and adding one would require
+a `Cargo.toml` edit this component does not own — using a
 `#![forbid(unsafe_code)]`-compatible `std::hint::black_box`-guarded
 best-effort overwrite instead of the `zeroize` crate's own
 volatile-write internals.
@@ -498,18 +368,24 @@ authenticated (signature/MAC verified, origin checked) by the caller.
   identity; it is not a replacement for `swtpm_dir.rs`.
 - This component does not decide *how* material is generated for any
   kind (ssh-keygen invocation, TPM attestation derivation, or the
-  exact security-key channel wire encoding). It only stores, activates,
-  and tracks generations of whatever [`SecretMaterial`] bytes a caller
-  supplies.
+  exact security-key channel wire encoding). It only tracks durable
+  state transitions and CAS commits for whatever [`SecretMaterial`]
+  bytes a caller supplies.
 - This component does not implement message authentication or a
   concrete wire byte format for the guest channel. See "Guest-side
   channel state" above.
+- This component does not implement a `SecretsAuthorityPort` adapter
+  over any real storage substrate. It is a pure library with an
+  in-memory fault-injecting test double used only by its own
+  `#[cfg(test)]` suite; a real adapter is entirely integrator-owned
+  (see "Integration wiring points" § 1).
 
 ## Audit record shape
 
-[`SecretsLifecycleAuditFields`] (schema version 2) is a path-free,
-material-free JSON-serializable record: `vm_id`, `kind`, `action`
-(`provision`/`rotate`/`rollback`/`retire`), `base_dir_hash`, `result`
+[`SecretsLifecycleAuditFields`] (schema version 3) is a path-free,
+material-free JSON-serializable record: `workload_id` (canonical typed
+`WorkloadId`, never a human-readable label or path), `kind`, `action`
+(`provision`/`rotate`/`rollback`/`retire`), `result`
 (`created`/`rotated`/`rolled_back`/`retired`/`verified_clean`/`denied`/
 `failed_closed`), `marker_result`
 (`created`/`verified`/`tombstoned`/`unchanged`/`failed_closed`), an
@@ -519,82 +395,80 @@ for `retired`), an optional `high_water_epoch`, a bounded
 `MAX_AUDITED_RETAINED_GENERATIONS`, and always excluding the active
 epoch), an optional `material_digest_hex` (present only for
 `provision`/`rotate`, a lowercase 64-hex-digit SHA-256 string), a
-`recovered_prior_transaction` flag (set whenever the action first had
-to drain a leftover crash-interrupted transaction), and an optional
-`fail_reason` (present exactly for `denied`/`failed_closed` results,
-drawn only from the closed [`FailReason`] enum — never an arbitrary
-string or path). `SecretsLifecycleAuditFields::validate` enforces every
-cross-field invariant listed above; every constructor
-(`provisioned`/`rotated`/`rolled_back`/`retired`/`verified_clean`/
-`denied`/`failed`) returns an already-valid record.
+`prune_deferred` flag (only reachable when `result` is `Rotated` or
+`Retired` — set exactly when this action's own successful commit left
+at least one superseded generation not yet synchronously pruned, i.e.
+recorded in `DurableState::pending_prune` for a future action to
+resolve), and an optional `fail_reason` (present exactly for
+`denied`/`failed_closed` results, drawn only from the closed
+[`FailReason`] enum — never an arbitrary string or path).
+`SecretsLifecycleAuditFields::validate` enforces a **complete**
+`action` x `result` x `marker_result` compatibility matrix (not just
+per-field presence checks) — every combination not actually reachable
+from `secrets_lifecycle.rs`'s own call sites is rejected too. Every
+constructor (`provisioned`/`rotated`/`rolled_back`/`retired`/
+`verified_clean`/`denied`/`failed`) returns an already-valid record;
+`failed` in particular hardcodes `MarkerResult::FailedClosed` rather
+than accepting a caller-supplied `MarkerResult`, so it can never be
+called into producing a schema-invalid combination.
 
-## Marker and path layout
-
-```
-<state_root>/<vm_id>/<kind-slug>/
-  generations/
-    <epoch>/material        # 0600, expected_uid:expected_gid
-  current -> generations/<epoch>
-  marker.json                # 0600 JSON, schema v2
-  lock                        # 0600, F_OFD_SETLK target, never contains data
-  txlog                       # 0600 JSON, present only mid-transaction
-```
-
-`<kind-slug>` is one of `tpm-bound-credential`, `guest-signing-key`,
-`security-key-channel-state` ([`SecretKind::as_slug`]).
+This is a substantially smaller, storage-agnostic set than the rounds
+1-5 filesystem-anchored engine's 27-variant `FailReason` enum: every
+variant naming a raw path/lock/fsync/txlog/ACL/inode/link-count concept
+was a property of that engine's *own* filesystem adapter, never
+observable by the W8fu6 pure transaction core, which only ever calls
+the six guarded, typed `SecretsAuthorityPort` methods. All of that
+fine-grained tamper/I/O detail is now the adapter's own internal
+concern, hidden behind `PortError` and reported to this audit surface,
+when it must be, only via the single opaque `FailReason::PortUnavailable`
+bucket.
 
 ## Integration wiring points (not performed by this component)
 
-This component's public functions are ready to call but are not wired
-into any shared sink. An integrator still needs to:
+This module is a pure library with **zero** side effects of its own —
+no filesystem access, no locking, no process spawning. A future
+integrator must, in follow-up commits **outside this component's
+ownership**:
 
-1. Add `pub mod secrets_lifecycle;` and
-   `pub mod secrets_rotation_audit;` to
-   `packages/d2b-priv-broker/src/ops/mod.rs`.
-2. Add an
+1. Implement a concrete [`SecretsAuthorityPort`] adapter over whatever
+   real durable storage/CAS substrate lands for the broker (e.g. the
+   ADR 0034 storage/lock contract once it exists, or a dedicated KV
+   store). This is now the **single dominant** wiring blocker — rounds
+   1-5's many fine-grained filesystem wiring points (lock file
+   placement, `dir_mode`/`file_mode`, owner uid/gid, `state_root`) are
+   superseded by this one seam.
+2. Add exactly one new
    `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
-   variant (and matching `from_operation_value` arm) to
-   `packages/d2b-priv-broker/src/ops/audit_op.rs`, and wire the
-   returned record into `crate::audit::AuditLog`.
-3. Add new wire request/response DTOs (in `d2b-contracts`) and a
-   `runtime.rs` dispatch path calling
-   `provision`/`rotate`/`rollback`/`retire`. The plan text for this
-   component explicitly forbids adding a new broker op enum family
-   from within it, so this step is deliberately deferred.
-4. Decide the real `SecretsLifecycleConfig::state_root` source
-   (candidate: a subdirectory of the per-realm state root established
-   by the ADR 0034 storage-lifecycle contract) — **this path must
-   already exist** with a non-world-writable mode before this module
-   is called; this module only creates `state_root/<vm_id>/<kind-slug>`
-   beneath it, never `state_root` itself — and the real owner
-   uid/gid for each kind. This module's public functions still take
-   `vm_id: &str` and derive `kind_root` via `state_root.join(vm_id)`,
-   matching the existing `vm: &str`/label-derived-path convention this
-   repository already uses for this class of op (e.g.
-   `swtpm_dir.rs::paths`); this is **not** the same thing as this
-   component's own audit surface, which is already opaque-ID-bound
-   (`SecretsLifecycleAuditFields::vm_id` is a `d2b_contracts::types::VmId`,
-   never a raw path or label). If/when the ADR 0034 storage contract
-   exposes a generated, caller-resolved opaque storage-id →
-   pre-opened-anchored-dirfd mapping, this module's path-derivation
-   helpers (`derive_paths`/`kind_root`) are the exact integration
-   point to replace with that typed authority instead of a
-   `state_root.join(vm_id)` join; until that resolver exists as a
-   stable, generated contract this component cannot consume, this
-   remains an explicit integrator-owned wiring point rather than
-   something this component can close unilaterally.
-5. Decide whether `SecretKind::GuestSigningKey` material comes from
+   variant to `crate::ops::audit_op::OperationFields` (and a matching
+   `from_operation_value` arm), and route each
+   `Ok`/`Err(SecretsLifecycleError)` returned by [`provision`],
+   [`rotate`], [`rollback`], [`retire`] into `crate::audit::AuditLog`
+   via that new variant.
+3. Add a broker dispatch path (an existing operation-request enum's
+   new variant, or a new one, per the integrator's chosen RPC shape)
+   that resolves a caller's `(realm, workload label)` into a
+   [`d2b_contracts::v2_identity::WorkloadId`] (e.g. via
+   `WorkloadId::derive`) and a [`SecretMaterial`] payload, then calls
+   the four public functions below against the concrete
+   `SecretsAuthorityPort` adapter from (1).
+4. Decide and implement whatever real quarantine-clearing operation
+   exists for [`QuarantineReason`] — this module deliberately exposes
+   no "un-quarantine" call (quarantine is a one-way, fail-closed door
+   from this module's own point of view), so an operator-facing clear
+   path is an adapter/broker-level concern.
+5. For `SecretKind::SecurityKeyChannelState`, wire the four public
+   functions to whatever calls into `d2b-sk-frontend`'s
+   `secrets_channel.rs` need this lifecycle — see that module's own
+   "Integration wiring points" note for its side of the seam (session
+   config wiring, wire schema/authentication, broker dispatch mapping,
+   delivery-counter persistence).
+6. Decide whether `SecretKind::GuestSigningKey` material comes from
    `exec_reconcile::run_ssh_keygen` output fed into `rotate`'s
    `material` parameter, or stays separate.
-6. Decide the exact coupling between `SecretKind::TpmBoundCredential`
+7. Decide the exact coupling between `SecretKind::TpmBoundCredential`
    rotation here and `swtpm_dir.rs`'s physical NVRAM (e.g. whether a
    rotate here should also trigger a swtpm reseal) — a product/security
    decision beyond this component's scope.
-7. Call [`recover_in_flight_transaction`] once at controller/broker
-   startup for every known `(vm, kind)` pair before dispatching any
-   live request, so a leftover transaction from a prior crash is
-   drained proactively rather than only on the next incoming request
-   for that exact pair.
 8. Add `pub mod secrets_channel;` to
    `packages/d2b-sk-frontend/src/lib.rs`, and wire
    `services/security_key/mod.rs`'s `SessionConfig` to source its
@@ -617,16 +491,11 @@ into any shared sink. An integrator still needs to:
     `tests/unit/nix/pinned/*.txt` picks up the new
     `w8-secrets-lifecycle-eval.nix` case names (not run here since the
     pinned files are not owned by this component).
-12. `acquire_lock` uses this module's own `F_OFD_SETLK` primitive
-    (mirroring `d2bd::audio_dispatch::ofd_lock`/`ofd_unlock`) rather
-    than inventing a new lock namespace, but it does not yet register
-    with any shared `d2b-state::LockSet`/`AuthorityRef` lock registry —
-    no such generated, cross-component lock-row contract exists for
-    this module to consume today. If/when one lands, the integrator
-    should either replace `acquire_lock`'s standalone OFD lock with a
-    caller-supplied typed held-lock/lease token from that registry, or
-    confirm this module's private per-`(vm, kind)` lock file is exempt
-    because nothing outside this module ever contends for it.
+12. Add `pub mod secrets_lifecycle;` and `pub mod secrets_rotation_audit;`
+    to `packages/d2b-priv-broker/src/ops/mod.rs` once (1)-(3) above are
+    ready to consume them — this component deliberately never adds
+    that declaration itself, since doing so without a real adapter or
+    dispatch path would compile a component with no reachable caller.
 
 ## See also
 

--- a/docs/reference/secrets-lifecycle.md
+++ b/docs/reference/secrets-lifecycle.md
@@ -180,7 +180,34 @@ an immediate, anchored, nofollow re-stat/re-validate of that exact
 generation directory right before it is removed, so a tamper injected
 between the original enumeration and the delete (not merely between
 process restarts) is still caught rather than trusted from a stale
-snapshot. Both `execute_promote`'s post-commit stage cleanup and
+snapshot. `revalidate_generation_before_delete` accepts exactly two
+directory shapes: the fully-materialized generation
+`enumerate_and_validate_generation_tree` originally validated, or the
+one legitimate mid-deletion crash checkpoint `remove_generation` can
+leave behind — `material` already unlinked, the epoch directory itself
+not yet removed. Recognizing that checkpoint requires every one of: the
+entry is still a directory (not a symlink, file, or anything else
+swapped into the name); it is still trusted-broker-owned at the
+expected `cfg.dir_mode` (a foreign owner or any other mode means the
+directory was replaced, not left behind by this module's own deletion
+sequence); and it contains **zero** entries other than `.`/`..` (an
+unrecognized leftover entry, or a `material` entry of the wrong type or
+link-count, still fails closed rather than being swept away). This
+acceptance is reachable **only** from `execute_retire`'s
+`CurrentRemoved` phase deletion loop, always acting on a `RetireIntent`
+that has already passed `validate_retire_intent_semantics` — never from
+`enumerate_and_validate_generation_tree`, which fresh pre-retirement
+planning (`retire`'s initial enumeration) and the final `EpochsRemoved`
+prove-empty check both still call, and which remains exactly as strict
+as before: an empty generation directory encountered there is still
+`FailReason::RetirementTreeAnomaly`, not a silently-accepted "nothing
+here yet" state. A missing marker, or a marker that still claims the
+epoch active over that same physically-empty directory, is likewise
+never treated as clean storage by the fresh path — it fails closed on
+the more specific `PreviouslyProvisionedMaterialMissing` reason raised
+while re-verifying the marker's claimed active generation identity,
+before enumeration is even reached. Both `execute_promote`'s post-commit
+stage cleanup and
 `execute_retire`'s `CurrentRemoved` phase likewise call
 `revalidate_stage_before_delete` on each `.stage-*` directory
 immediately before its own deletion. `CurrentPromoted` and

--- a/docs/reference/secrets-lifecycle.md
+++ b/docs/reference/secrets-lifecycle.md
@@ -139,11 +139,24 @@ the txlog passes semantic validation:
   re-stages a target epoch that a prior crashed attempt already
   renamed into place: if `generations/<to_epoch>` already exists with
   content whose digest matches the intent's `expected_digest_hex`, the
-  engine treats it as already-materialised and continues forward
-  without needing the original material again; if content already
-  occupies that epoch number with a **different** digest, recovery
-  fails closed (`RecoveryContentMismatch`) rather than ever adopting or
-  overwriting a stale, foreign, or previously-aborted generation;
+  engine treats it as already-materialised, **retries the
+  `generations_fd` durability barrier** (the prior attempt's own
+  trailing fsync may be exactly what crashed it) before advancing, and
+  continues forward without needing the original material again; if
+  content already occupies that epoch number with a **different**
+  digest, recovery fails closed (`RecoveryContentMismatch`) rather than
+  ever adopting or overwriting a stale, foreign, or previously-aborted
+  generation;
+- a `Planned`-phase abort with no leftover material to complete the
+  transaction (`PromoteOutcome::AbortedNoMaterial`) never leaves an
+  orphan wedge: `discard_partial_stage_if_present` validates and
+  deletes any partial `.stage-*` directory the crashed attempt left
+  behind (propagating any deletion error) before the txlog is cleared;
+  if that partial stage cannot be safely validated (an unrecognised
+  on-disk shape), the abort fails closed and **retains** the txlog
+  instead, so a future recovery attempt still has the record needed to
+  reason about it — the transaction is never silently dropped over
+  unrecognised on-disk state;
 - if the phase recorded is at or after the commit point
   (`CurrentPromoted`/`MarkerCommitted` for promote,
   `CurrentRemoved`/`EpochsRemoved`/`ProvenEmpty` for retire), recovery
@@ -167,12 +180,36 @@ an immediate, anchored, nofollow re-stat/re-validate of that exact
 generation directory right before it is removed, so a tamper injected
 between the original enumeration and the delete (not merely between
 process restarts) is still caught rather than trusted from a stale
-snapshot.
+snapshot. Both `execute_promote`'s post-commit stage cleanup and
+`execute_retire`'s `CurrentRemoved` phase likewise call
+`revalidate_stage_before_delete` on each `.stage-*` directory
+immediately before its own deletion. `CurrentPromoted` and
+`MarkerCommitted` recovery/completion each re-verify, before any
+further mutation or txlog removal, that `current` still resolves by
+exact literal symlink text to the intended target epoch
+(`current_resolves_exactly_to`) — and `MarkerCommitted` additionally
+re-reads and checks the marker's `active` fields against the intent —
+so a phase is never advanced, and the txlog never cleared, over a
+`current`/marker state that does not match what that phase's own
+identity contract requires. A missing generation or stage directory
+encountered while `retire` is retried still retries the
+`generations_fd` durability barrier before the retirement phase
+advances, so an unsynced prior deletion can never reappear (e.g. via a
+crash-induced write-back) after the marker has already been
+tombstoned.
 
 Staging directory names use `random_stage_name`: a collision-resistant
 name mixing the process id, a per-process atomic monotonic counter,
 wall-clock nanoseconds, and a `RandomState`-seeded hash folded through
-SHA-256. Staged entries are **real secret-tree contents**, never a
+SHA-256, always exactly `STAGE_PREFIX` (`.stage-`) followed by 32
+lowercase-hex characters. `is_well_formed_stage_name` closes the
+syntax to exactly that shape — no path separator, no `..`, no
+alternate length or alphabet — and every stage name recorded in a
+txlog intent is checked against it (`validate_promote_intent_semantics`/
+`validate_retire_intent_semantics`) before that intent is ever written
+or acted on, in addition to `enumerate_and_validate_generation_tree`'s
+own defense-in-depth check over whatever names are physically present
+on disk. Staged entries are **real secret-tree contents**, never a
 separately-swept, best-effort concern: `enumerate_and_validate_generation_tree`
 collects `.stage-*` directories exactly like generation epochs
 (`validate_stage_dir_contents` refuses anything but at most one
@@ -180,9 +217,20 @@ regular, single-hard-link entry inside), and every deletion path
 (`remove_stage_dir`, used by promote's post-commit leftover sweep and
 by retire's `CurrentRemoved` phase) fully enumerates, deletes,
 positively proves empty, and fsyncs — propagating every failure rather
-than ignoring it. A stage directory is included in the final
-provably-empty proof retirement requires before tombstoning the
-marker.
+than ignoring it, including a `fsync` that must run even when the
+directory to remove already appears absent (`remove_generation`'s and
+`remove_stage_dir`'s own `NotFound` fast paths still retry the
+containing directory's durability barrier rather than skipping it, so
+a deletion whose fsync had not yet landed cannot silently resurface
+after the transaction is considered complete). A stage directory is
+included in the final provably-empty proof retirement requires before
+tombstoning the marker. The transient `current`-swap staging entry
+(`CURRENT_SWAP_STAGE_NAME`) is never removed via the generic
+symlink-refusing `remove_path_safe` helper — `atomic_swap_current`
+verifies by anchored `nofollow` stat that it is exactly a symlink
+before an anchored `unlinkat`, and fails closed
+(`FailReason::CurrentSwapFailed`) without deleting anything if it ever
+finds something else occupying that name.
 
 ### Marker identity (v2)
 
@@ -229,6 +277,17 @@ ACL drift (`IdentityAclMismatch`), or a content drift
 (`IdentityDigestMismatch`) are independently distinguishable on the
 audit surface rather than collapsed into one generic "tampered"
 reason.
+
+Beyond that live-state check, every freshly constructed intent is also
+run through `validate_promote_intent_semantics`/
+`validate_retire_intent_semantics` immediately before it is durably
+logged (`write_txlog`) in `provision`/`rotate`/`rollback`/`retire` —
+not only when a leftover txlog is re-read during recovery. In
+particular, a `rollback`'s intent must satisfy
+`expected_digest_hex == expected_identity.digest_hex` before it is
+ever acted on: the rollback target's claimed content digest and its
+claimed full on-disk identity must agree with each other at
+construction time, not merely be independently plausible.
 
 ### Fail-closed on drift, not just on error
 

--- a/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
@@ -1707,23 +1707,98 @@ fn verify_marker_against_live_state(
 
 /// Immediately before deleting a generation directory as part of
 /// retirement, re-stat it (nofollow, anchored) and confirm it is
-/// still exactly a validated material directory. A missing entry is
+/// still either a validated material directory, or the exact
+/// legitimate mid-deletion crash checkpoint `remove_generation` can
+/// leave behind: `material` already unlinked, but the (now-empty)
+/// epoch directory itself not yet removed. A missing entry is
 /// tolerated (another recovery pass, or this same pass on retry,
-/// already removed it); any other anomaly -- wrong type, extra
-/// entries, a hard-linked material file -- fails closed rather than
-/// deleting a directory that no longer matches what enumeration
-/// originally validated.
+/// already removed it entirely).
+///
+/// Recognizing the empty-directory checkpoint is reachable **only**
+/// from here -- i.e. only from `execute_retire`'s `CurrentRemoved`
+/// phase, always acting on a `RetireIntent` that has already passed
+/// `validate_retire_intent_semantics` (checked both when the intent is
+/// first written and every time a leftover txlog is re-read before
+/// recovery acts on it). Fresh, pre-retirement planning never goes
+/// through this function: `enumerate_and_validate_generation_tree`
+/// (used to build a brand-new retirement plan, and again to prove the
+/// tree fully empty once `EpochsRemoved` is reached) always calls the
+/// strict `verify_generation_dir_is_exactly_material` and remains
+/// exactly as strict as before -- an empty generation directory
+/// encountered there is still `FailReason::RetirementTreeAnomaly`, not
+/// a silently-accepted "nothing here yet" state.
+///
+/// To accept the directory as the empty checkpoint (rather than any
+/// other empty-directory shape an attacker could construct in its
+/// place) every one of these must hold:
+/// - the entry is still a directory (never a symlink, regular file, or
+///   any other type swapped into the same name -- that is a
+///   replacement, not a partially-deleted survivor, and fails closed);
+/// - it is still trusted-broker-owned at the expected `cfg.dir_mode`
+///   (a foreign owner, or any other mode, means the directory itself
+///   was replaced rather than left behind by this module's own
+///   deletion sequence, and fails closed);
+/// - it contains **zero** entries other than `.`/`..` -- any
+///   unrecognised leftover entry, or a `material` entry of the wrong
+///   type or link-count, fails closed rather than being swept away as
+///   part of "finishing" the deletion.
+///
+/// Any other anomaly -- wrong type, an unexpected extra entry, a
+/// hard-linked material file -- fails closed rather than deleting a
+/// directory that no longer matches what enumeration originally
+/// validated.
 fn revalidate_generation_before_delete(
     generations_fd: BorrowedFd<'_>,
     epoch: u64,
+    cfg: &SecretsLifecycleConfig,
 ) -> Result<(), FailReason> {
     let epoch_name = epoch.to_string();
     let generations_owned = borrowed_to_owned(generations_fd)?;
-    match path_safe::fstatat_nofollow(&generations_owned, &epoch_name) {
-        Ok(Some(_)) => verify_generation_dir_is_exactly_material(&generations_owned, &epoch_name),
-        Ok(None) => Ok(()),
-        Err(_) => Err(FailReason::RetirementTreeAnomaly),
+    let stat = match path_safe::fstatat_nofollow(&generations_owned, &epoch_name) {
+        Ok(Some(stat)) => stat,
+        Ok(None) => return Ok(()),
+        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
+    };
+    if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFDIR {
+        return Err(FailReason::RetirementTreeAnomaly);
     }
+    match verify_generation_dir_is_exactly_material(&generations_owned, &epoch_name) {
+        Ok(()) => return Ok(()),
+        Err(FailReason::RetirementTreeAnomaly) => {}
+        Err(other) => return Err(other),
+    }
+    // Not a fully-materialized generation: the only other shape this
+    // retire deletion loop may ever accept is the exact
+    // post-material-unlink, pre-directory-removal checkpoint, and only
+    // over a directory that is still verifiably this module's own
+    // trusted-broker-owned metadata directory.
+    verify_broker_owned(&stat, nix::libc::S_IFDIR, cfg.dir_mode)
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let dir_fd = path_safe::open_at(
+        generations_owned.as_fd(),
+        Path::new(&epoch_name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )
+    .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let inner = rustix::fs::Dir::read_from(dir_fd.as_fd())
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    for entry in inner {
+        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
+        let ename = entry
+            .file_name()
+            .to_str()
+            .map_err(|_| FailReason::RetirementTreeAnomaly)?
+            .to_owned();
+        if ename != "." && ename != ".." {
+            // A genuinely empty checkpoint has zero entries; anything
+            // else here (an unrelated leftover, or a `material` entry
+            // that `verify_generation_dir_is_exactly_material` already
+            // rejected above as the wrong type/link-count) is an
+            // anomaly, never silently accepted.
+            return Err(FailReason::RetirementTreeAnomaly);
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------
@@ -1931,6 +2006,7 @@ fn execute_promote(
 fn execute_retire(
     secrets_fd: BorrowedFd<'_>,
     generations_fd: BorrowedFd<'_>,
+    cfg: &SecretsLifecycleConfig,
     mut intent: RetireIntent,
 ) -> Result<(), FailReason> {
     loop {
@@ -1951,7 +2027,7 @@ fn execute_retire(
             }
             RetirePhase::CurrentRemoved => {
                 for &epoch in &intent.epochs {
-                    revalidate_generation_before_delete(generations_fd, epoch)?;
+                    revalidate_generation_before_delete(generations_fd, epoch, cfg)?;
                     remove_generation(generations_fd, epoch)?;
                 }
                 for stage_name in &intent.stage_names {
@@ -2030,7 +2106,7 @@ fn recover_if_needed(
                 }),
             }
         }
-        TxLog::Retire(intent) => match execute_retire(secrets_fd, generations_fd, intent) {
+        TxLog::Retire(intent) => match execute_retire(secrets_fd, generations_fd, cfg, intent) {
             Ok(()) => Ok(true),
             Err(reason) => Err(RecoveryError {
                 action: Some(LifecycleAction::Retire),
@@ -2443,7 +2519,7 @@ pub fn retire(
         .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent.clone()))
         .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
-    match execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), intent) {
+    match execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), cfg, intent) {
         Ok(()) => Ok(SecretsLifecycleAuditFields::retired(
             &ctx,
             high_water_epoch,
@@ -3716,13 +3792,13 @@ mod tests {
             .unwrap();
 
         // Absent generation is tolerated (idempotent replay).
-        revalidate_generation_before_delete(generations_fd.as_fd(), 2).unwrap();
+        revalidate_generation_before_delete(generations_fd.as_fd(), 2, &cfg).unwrap();
 
         // Tamper: hard-link a second name into the generation just
         // before deletion would occur.
         let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
         std::fs::hard_link(gen_dir.join(MATERIAL_FILE_NAME), gen_dir.join("planted")).unwrap();
-        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1).unwrap_err();
+        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1, &cfg).unwrap_err();
         assert_eq!(err, FailReason::RetirementTreeAnomaly);
     }
 
@@ -4642,5 +4718,232 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.reason, FailReason::NotProvisioned);
         assert!(!err.audit.recovered_prior_transaction);
+    }
+
+    // -------------------------------------------------------------
+    // Round-5 finding: txlog-backed retirement recovery must accept
+    // the legitimate "material already unlinked, epoch directory not
+    // yet removed" crash checkpoint -- but only from the retire
+    // txlog-recovery deletion loop, and only over a directory that
+    // still proves out as this module's own trusted-broker-owned,
+    // fully empty metadata directory. Fresh pre-retirement planning
+    // (`retire()`'s initial enumeration) must remain exactly as
+    // strict as before.
+    // -------------------------------------------------------------
+
+    #[test]
+    fn execute_retire_finishes_a_generation_crashed_immediately_after_material_unlink() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "crash-after-material-unlink";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        // Simulate the crash: `remove_generation` already unlinked
+        // `material` but the process died before it removed the
+        // now-empty epoch directory entry itself.
+        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
+        assert_eq!(std::fs::read_dir(&gen_dir).unwrap().count(), 0);
+
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        remove_current_symlink(secrets_fd.as_fd()).unwrap();
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: vec![],
+            high_water_epoch: 1,
+            phase: RetirePhase::CurrentRemoved,
+        };
+        execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap();
+
+        assert!(!gen_dir.exists());
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert!(marker.retired);
+        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_none());
+    }
+
+    #[test]
+    fn execute_retire_cleans_up_mixed_crashed_and_still_materialized_generations() {
+        // A multi-generation retry: one epoch was left in the empty
+        // post-material-unlink checkpoint by a prior crashed attempt,
+        // another is still fully materialized and was never touched.
+        // Both must be correctly removed in one pass.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "mixed-crash-retry";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        let gen1_dir = generations_dir.join("1");
+        let gen2_dir = generations_dir.join("2");
+        // Epoch 1: crashed mid-deletion (material unlinked, directory
+        // left behind). Epoch 2: untouched, still fully materialized.
+        std::fs::remove_file(gen1_dir.join(MATERIAL_FILE_NAME)).unwrap();
+        assert_eq!(std::fs::read_dir(&gen1_dir).unwrap().count(), 0);
+        assert!(gen2_dir.join(MATERIAL_FILE_NAME).exists());
+
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        remove_current_symlink(secrets_fd.as_fd()).unwrap();
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1, 2],
+            stage_names: vec![],
+            high_water_epoch: 2,
+            phase: RetirePhase::CurrentRemoved,
+        };
+        execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap();
+
+        assert!(!gen1_dir.exists());
+        assert!(!gen2_dir.exists());
+        assert_eq!(std::fs::read_dir(&generations_dir).unwrap().count(), 0);
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert!(marker.retired);
+    }
+
+    #[test]
+    fn resumed_generation_deletion_retries_a_failed_directory_fsync() {
+        // Fault-inject the trailing `fsync_fd(generations_fd)` barrier
+        // specifically while finishing a crash-left empty checkpoint:
+        // the failure must block phase advancement rather than being
+        // silently swallowed, and a bare retry (no other mutation)
+        // must complete the whole retirement.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "resumed-deletion-fsync-fault";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
+
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        remove_current_symlink(secrets_fd.as_fd()).unwrap();
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: vec![],
+            high_water_epoch: 1,
+            phase: RetirePhase::CurrentRemoved,
+        };
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = execute_retire(
+                secrets_fd.as_fd(),
+                generations_fd.as_fd(),
+                &cfg,
+                intent.clone(),
+            )
+            .unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // The directory entry itself was already removed by
+        // `remove_generation` before the fsync it retried failed; the
+        // retry below must not require the entry to still be present.
+        assert!(!gen_dir.exists());
+        execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap();
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert!(marker.retired);
+    }
+
+    #[test]
+    fn revalidate_generation_before_delete_rejects_a_fake_empty_directory_with_wrong_mode() {
+        // An empty directory alone is not sufficient: it must also
+        // still be trusted-broker-owned at the expected mode. A
+        // foreign/incorrectly-moded replacement fails closed rather
+        // than being swept away as "finishing" a legitimate deletion.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths =
+            derive_paths("fake-empty-wrong-mode", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
+        assert_eq!(std::fs::read_dir(&gen_dir).unwrap().count(), 0);
+        let mut perms = std::fs::metadata(&gen_dir).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&gen_dir, perms).unwrap();
+
+        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1, &cfg).unwrap_err();
+        assert_eq!(err, FailReason::RetirementTreeAnomaly);
+        // Nothing was deleted: the anomaly is detected, not swept.
+        assert!(gen_dir.exists());
+    }
+
+    #[test]
+    fn revalidate_generation_before_delete_rejects_an_empty_looking_directory_with_a_stray_entry() {
+        // Zero *recognized* entries is required, not merely "no
+        // `material`". An unrelated leftover entry alongside a
+        // missing `material` must still fail closed.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths =
+            derive_paths("fake-empty-stray-entry", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
+        std::fs::write(gen_dir.join("rogue"), b"unexpected").unwrap();
+
+        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1, &cfg).unwrap_err();
+        assert_eq!(err, FailReason::RetirementTreeAnomaly);
+        assert!(gen_dir.exists());
+    }
+
+    #[test]
+    fn fresh_retire_over_a_crashed_generation_checkpoint_still_fails_closed() {
+        // The empty-checkpoint acceptance is reachable *only* from the
+        // retire txlog-recovery deletion loop. A brand-new, fresh call
+        // to `retire()` (no leftover txlog) must still go through the
+        // strict initial enumeration and fail closed over the exact
+        // same on-disk state the crash-recovery tests above complete
+        // successfully.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "fresh-retire-over-crash-state";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
+
+        let err = retire(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::PreviouslyProvisionedMaterialMissing);
+        // Fails closed without deleting anything.
+        assert!(gen_dir.exists());
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
@@ -1,76 +1,151 @@
-//! Provision / rotate / rollback / retire engine for per-realm secrets
-//! material (TPM-bound credentials, guest signing keys, and
-//! security-key channel state — see [`SecretKind`]).
+//! Per-realm secrets lifecycle engine: provision / rotate / rollback /
+//! retire for TPM-bound credentials, guest signing keys, and
+//! security-key channel state, anchored under a per-`(vm, kind)`
+//! directory via fd-relative, `openat2(RESOLVE_BENEATH)`-safe
+//! primitives from [`crate::sys::path_safe`].
 //!
-//! This module is the storage/atomicity/rotation-state layer only. It
-//! never generates raw secret material itself (that stays a caller
-//! concern — e.g. calling `ssh-keygen` for a [`SecretKind::GuestSigningKey`],
-//! or deriving a TPM attestation blob for a [`SecretKind::TpmBoundCredential`]),
-//! and it never touches `swtpm_dir.rs`'s physical NVRAM state or
-//! `security_key.rs`'s CTAPHID transport directly. It provides one
-//! generic, fd-relative, fail-closed engine that every secret kind
-//! shares for:
+//! # Design summary (W8fu1 redesign)
 //!
-//!   - laying out `<per_vm_state_root>/secrets/<kind-slug>/generations/<n>/material`
-//!     plus a `current` symlink, atomically swapped with a
-//!     rename-based two-step (mirrors the broker's other atomic-swap
-//!     idioms, e.g. `d2b_host::hardlink_farm::swap_current_symlink`,
-//!     but implemented directly against an fd-anchored `secrets_dir`
-//!     rather than reusing that store-view-specific helper);
-//!   - an identity-bound tamper-guard marker (dev/ino of the active
-//!     generation directory) under a dedicated marker tree, kept
-//!     independent of `swtpm_dir.rs`'s own per-VM marker so this
-//!     component never touches that file;
-//!   - fail-closed behaviour for every drift/tamper condition,
-//!     mirroring the `swtpm_dir.rs` philosophy: a previously-active
-//!     marker whose material vanished, or on-disk material with no
-//!     matching active marker, both abort rather than silently adopt
-//!     or silently reprovision.
+//! This is a from-scratch redesign of the original `36d9dcf8` engine,
+//! addressing an external review that found the first draft's marker
+//! identity, retirement enumeration, and generation numbering were not
+//! crash-safe. The core structural change is a **durable
+//! transaction/recovery log** (`txlog`, JSON, written beside the
+//! marker) plus a **cross-process advisory `flock` lock** so:
 //!
-//! # Integration wiring points (deliberately NOT performed here)
+//! * every mutating action (`provision`/`rotate`/`rollback`/`retire`)
+//!   is modelled as a small phase machine (see [`PromotePhase`] /
+//!   [`RetirePhase`]) whose *current phase* is durably persisted
+//!   before each side effect that cannot be trivially undone;
+//! * a process crash at any point can be resumed by the *next* caller
+//!   (or by the standalone [`recover_in_flight_transaction`] entry
+//!   point) re-entering the exact same phase-driven state machine —
+//!   [`execute_promote`] and [`execute_retire`] are single codepaths
+//!   used for both a fresh action and crash recovery of a leftover
+//!   one;
+//! * the invariant that makes this safe is **forward-only commitment**:
+//!   before `current` is swapped (promote) or the physical generation
+//!   tree is proven empty (retire), recovery is free to safely discard
+//!   the leftover transaction (nothing observable changed yet); once
+//!   that point is passed, recovery may only ever complete the
+//!   transaction forward to its terminal, marker-durable state — it
+//!   never reverts a swap or resurrects a deleted generation. This is
+//!   the property finding (1) called out as missing: "never return an
+//!   error after silently activating unrecoverable state".
 //!
-//! Per the W8 `secrets-lifecycle` component scope, this module is not
-//! wired into any shared sink. The integrator still needs to:
+//! Marker identity (finding 2) is strengthened from the original
+//! draft's bare `(dev, ino)` pair to [`MaterialIdentity`]: lineage
+//! epoch, `(dev, ino)`, owner uid/gid, permission bits, link count,
+//! POSIX-ACL presence, and a SHA-256 content digest — captured via a
+//! `nofollow`-safe fd open (never a path re-resolution), and verified
+//! against `current`'s *literal* name resolution (not just a
+//! coincidentally-matching stat), so a hard-link plant, a
+//! digest-preserving directory swap, or a permission/ownership/ACL
+//! drift are each independently detected and separately named in the
+//! closed [`super::secrets_rotation_audit::FailReason`] enum.
 //!
-//!   1. Add `pub mod secrets_lifecycle;` and
-//!      `pub mod secrets_rotation_audit;` to
-//!      `packages/d2b-priv-broker/src/ops/mod.rs`.
-//!   2. Add an `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
-//!      variant (and a matching `from_operation_value` arm) to
-//!      `packages/d2b-priv-broker/src/ops/audit_op.rs`.
-//!   3. Add new wire request/response DTOs (in `d2b-contracts`) and a
-//!      dispatch path in `packages/d2b-priv-broker/src/runtime.rs` that
-//!      calls [`provision`]/[`rotate`]/[`rollback`]/[`retire`] and
-//!      emits the returned [`SecretsLifecycleAuditFields`] through
-//!      `crate::audit::AuditLog`. The plan text explicitly forbids
-//!      adding a new broker op enum family from within this component,
-//!      so this wiring is out of scope here.
-//!   4. Decide, at the integration site, what bundle-resolved field
-//!      supplies `per_vm_state_root` for [`derive_paths`] (mirrors how
-//!      `swtpm_dir::derive_paths` takes a `&SpawnRunnerPlan`).
-//!   5. Decide whether `SecretKind::GuestSigningKey` material comes
-//!      from `exec_reconcile::run_ssh_keygen` output fed into
-//!      [`rotate`]'s `material` parameter, or stays separate.
-//!   6. Decide the exact coupling between `SecretKind::TpmBoundCredential`
-//!      rotation and `swtpm_dir.rs`'s physical NVRAM (e.g. whether a
-//!      rotate here should also trigger a swtpm reseal) — this is a
-//!      product/security decision beyond this component's scope.
-//!   7. Wire `packages/d2b-sk-frontend/src/secrets_channel.rs`'s
-//!      `ChannelState` into `services/security_key/mod.rs`'s
-//!      `SessionConfig` so a `SecretKind::SecurityKeyChannelState`
-//!      rotation on the broker side can propagate a fresh
-//!      `channel_binding`/`reconnect_generation` to the guest session
-//!      (neither file is owned by this component).
-//!   8. Run `gen-nix-unit-pins.sh` after this component lands so
-//!      `tests/unit/nix/pinned/*.txt` picks up the new
-//!      `w8-secrets-lifecycle-eval.nix` case names (not run here since
-//!      the pinned files are not owned by this component).
+//! Retirement (finding 3) never trusts the marker's word that storage
+//! is clean: every `retire()` call first anchored-enumerates and
+//! strictly validates the *entire* physical `generations/` tree
+//! ([`enumerate_and_validate_generation_tree`]) regardless of what the
+//! marker says. An absent/tombstoned marker over a *non-empty* tree is
+//! treated as leftover material that retirement must still clean up
+//! (not as evidence of a clean state); an *active* marker over an
+//! *empty* tree is treated as a hard-fail anomaly rather than a silent
+//! "already retired". Any unrecognised entry, wrong file type, or a
+//! `material` file with a link count other than 1 aborts retirement
+//! with zero deletions.
+//!
+//! Generation numbering (finding 4) is a monotonic high-water mark
+//! (`MarkerData::high_water_epoch`) carried in the marker, not
+//! `current epoch + 1`: `rotate` always allocates
+//! `high_water_epoch + 1`, so a `rotate` issued after a `rollback` can
+//! never collide with (or silently resurrect) a still-materialised
+//! newer epoch that the rollback moved away from. Physical pruning of
+//! a superseded generation only ever happens strictly after the new
+//! marker has been durably committed.
+//!
+//! `provision()` always allocates epoch `1` and resets
+//! `high_water_epoch` to `1` — this is intentionally **not** a
+//! monotonic baseline carried across a full retire/re-provision cycle.
+//! It is sound only because `retire()` physically empties the entire
+//! `generations/` tree (enumerated and proven empty) before the
+//! marker is tombstoned, so there is no physical collision risk in
+//! restarting numbering at `1` for a fresh lineage. The monotonic
+//! high-water invariant matters strictly *within* one non-retired
+//! lineage (i.e. for `rotate`-after-`rollback` collision avoidance).
+//!
+//! [`SecretMaterial`] (finding 6) wraps caller-supplied bytes in
+//! [`zeroize::Zeroizing`] **before** the length/emptiness validation
+//! check (the original draft validated the raw `Vec<u8>` first and
+//! only wrapped it in `Zeroizing` on the success path, so a rejected
+//! empty/oversized buffer was dropped without zeroization). It derives
+//! neither `Copy` nor `Clone`.
+//!
+//! # Status: not wired into any live broker dispatch path
+//!
+//! Nothing in this module is reachable from a running broker today.
+//! An integrator must, in follow-up commits that this component does
+//! **not** own:
+//!
+//! 1. Add a `SecretsLifecycle { .. }` request/response shape to the
+//!    broker's private wire contract and a matching
+//!    `runtime.rs` dispatch arm that calls
+//!    [`provision`]/[`rotate`]/[`rollback`]/[`retire`].
+//! 2. Add exactly one new
+//!    `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
+//!    variant (and its `from_operation_value` arm) to
+//!    `ops::audit_op`, and wire the returned
+//!    [`super::secrets_rotation_audit::SecretsLifecycleAuditFields`]
+//!    into the broker's `crate::audit::AuditLog` sink.
+//! 3. Add a matching `ops::mod` `pub mod secrets_lifecycle;` /
+//!    `pub mod secrets_rotation_audit;` declaration (this component
+//!    intentionally does not edit `ops/mod.rs`).
+//! 4. Decide the real `SecretsLifecycleConfig::state_root` source
+//!    (candidate: a subdirectory of the per-realm state root established
+//!    by the ADR 0034 storage-lifecycle contract) and the real
+//!    owner uid/gid for `TpmBoundCredential` vs `GuestSigningKey` vs
+//!    `SecurityKeyChannelState` — this module takes them as
+//!    caller-supplied configuration and asserts nothing about their
+//!    real-world values. **`state_root` itself must already exist**
+//!    with a non-world-writable mode before this module is called
+//!    (mirrors `ensure_dir_preserve_existing`'s host-activation-owns-
+//!    the-root convention elsewhere in the broker): this module only
+//!    creates `state_root/<vm_id>/<kind-slug>` beneath it, never
+//!    `state_root` itself.
+//! 5. Decide how `TpmBoundCredential` rotation here relates to the
+//!    swtpm NVRAM state `swtpm_dir.rs` already owns: this module
+//!    tracks a rotation *lineage* layered on top of, and never
+//!    mutates, the physical swtpm state directory.
+//! 6. Decide the real `GuestSigningKey` material source (this module
+//!    accepts already-generated bytes via [`SecretMaterial::new`]; it
+//!    does not generate key material itself).
+//! 7. Wire `d2b-sk-frontend`'s `security_key.rs` /
+//!    `ComponentSession` channel policy to
+//!    `d2b-sk-frontend::secrets_channel` (see that module's own
+//!    "Integration wiring points" doc section).
+//! 8. Regenerate the W8 wave-plan nix-unit pin after any of the above
+//!    lands, per `tests/AGENTS.md`.
+//! 9. Call [`recover_in_flight_transaction`] once at controller/broker
+//!    startup for every known `(vm, kind)` pair before dispatching any
+//!    live request, so a leftover transaction from a prior crash is
+//!    drained proactively rather than only on the next incoming
+//!    request for that exact pair.
+//!
+//! Everything above is exactly why this module's tests exercise the
+//! engine directly (`#[cfg(test)]`, in-process, real temp
+//! directories) rather than through any dispatch path — there is no
+//! dispatch path yet.
 
-use std::fmt;
-use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use nix::libc;
+use nix::fcntl::{FlockArg, flock};
 use rustix::fs::OFlags;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -78,1143 +153,2093 @@ use zeroize::Zeroizing;
 
 use crate::ops::hosts::stable_hash_str;
 use crate::ops::secrets_rotation_audit::{
-    LifecycleAction, MarkerResult, SecretKind, SecretsLifecycleAuditContext,
+    FailReason, LifecycleAction, MarkerResult, SecretKind, SecretsLifecycleAuditContext,
     SecretsLifecycleAuditFields,
 };
 use crate::sys::path_safe;
 
-/// Root of the dedicated per-kind tamper-guard marker tree. Kept
-/// distinct from `swtpm_dir.rs`'s own per-VM marker tree
-/// (`/var/lib/d2b/swtpm-markers/<vm>`) so this component never reads
-/// or writes that file.
-pub const MARKER_TREE_ROOT: &str = "/var/lib/d2b/secrets-lifecycle-markers";
+// ---------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------
 
-/// On-disk schema version for the marker JSON body.
-const MARKER_SCHEMA_VERSION: u32 = 1;
+/// Bumped whenever [`MarkerData`]'s on-disk shape changes
+/// incompatibly. `read_marker` fails closed
+/// (`MarkerTamperedOrMissingMaterial`) on any other version.
+const MARKER_SCHEMA_VERSION: u32 = 2;
 
-const SECRETS_ROOT_DIR_MODE: u32 = 0o750;
-const SECRETS_KIND_DIR_MODE: u32 = 0o700;
-const GENERATION_DIR_MODE: u32 = 0o700;
-const MATERIAL_FILE_MODE: u32 = 0o600;
-const MARKER_DIR_MODE: u32 = 0o700;
-const MARKER_FILE_MODE: u32 = 0o600;
+const GENERATIONS_DIR_NAME: &str = "generations";
+const MARKER_FILE_NAME: &str = "marker.json";
+const CURRENT_LINK_NAME: &str = "current";
+const CURRENT_SWAP_STAGE_NAME: &str = ".current.stage";
+const MATERIAL_FILE_NAME: &str = "material";
+const LOCK_FILE_NAME: &str = "lock";
+const TXLOG_FILE_NAME: &str = "txlog";
+const STAGE_PREFIX: &str = ".stage-";
 
-/// Closed set of path-free, redaction-safe failure reason slugs. Every
-/// public function in this module only ever surfaces one of these —
-/// never a raw `io::Error` message, which could embed a path.
-pub mod reasons {
-    pub const INVALID_VM_ID: &str = "invalid-vm-id";
-    pub const DERIVATION_FAILED: &str = "path-derivation-failed";
-    pub const PARENT_OPEN_FAILED: &str = "secrets-dir-open-failed";
-    pub const MARKER_TREE_FAILED: &str = "marker-tree-open-failed";
-    pub const MARKER_WRITE_FAILED: &str = "marker-write-failed";
-    pub const MARKER_TAMPERED: &str = "marker-tampered-or-missing-material";
-    pub const ALREADY_PROVISIONED: &str = "already-provisioned";
-    pub const ALREADY_RETIRED: &str = "already-retired";
-    pub const NOT_PROVISIONED: &str = "not-provisioned";
-    pub const NO_ROLLBACK_TARGET: &str = "no-rollback-target";
-    pub const PREVIOUSLY_PROVISIONED_MATERIAL_MISSING: &str =
-        "previously-provisioned-material-missing";
-    pub const GENERATION_CONFLICT: &str = "generation-conflict";
-    pub const MATERIAL_WRITE_FAILED: &str = "material-write-failed";
-    pub const CURRENT_SWAP_FAILED: &str = "current-swap-failed";
-    pub const INVALID_MATERIAL: &str = "invalid-material";
-}
+const DIR_MODE_DEFAULT: u32 = 0o700;
+const FILE_MODE_DEFAULT: u32 = 0o600;
 
-/// Runtime configuration for a single lifecycle call. Kept separate
-/// from [`SecretsLifecyclePaths`] so tests can point ownership/enforcement
-/// at scratch-safe values without touching the derived path shape.
-#[derive(Debug, Clone, Copy)]
+/// Bound on retries when allocating a collision-resistant staging
+/// directory name. Each attempt mixes fresh entropy (pid + monotonic
+/// counter + wall-clock nanos + `RandomState`-seeded hash); observing
+/// exhaustion here would indicate a broken randomness source, not
+/// ordinary contention.
+const MAX_STAGE_NAME_ATTEMPTS: u32 = 32;
+
+// ---------------------------------------------------------------------
+// Config / paths
+// ---------------------------------------------------------------------
+
+/// Caller-supplied configuration. See the module doc's "Integration
+/// wiring points" §4 for the real-world `state_root` /
+/// `owner_uid`/`owner_gid` source this component does not decide.
+#[derive(Debug, Clone)]
 pub struct SecretsLifecycleConfig {
-    /// Expected owner of the secrets-state tree (typically the
-    /// broker's own uid/gid; per-kind consumers never get direct
-    /// filesystem access).
-    pub expected_uid: u32,
-    pub expected_gid: u32,
-    /// Owner of the tamper-guard marker file/dir. Usually identical to
-    /// `expected_uid`/`expected_gid`, but kept distinct in case a
-    /// future policy roots the marker tree under a narrower principal.
-    pub marker_owner_uid: u32,
-    pub marker_owner_gid: u32,
-    /// Monotonic wall-clock milliseconds used to stamp the marker.
-    /// Caller-supplied (not read from the system clock in this
-    /// module) so tests are deterministic.
-    pub now_ms: u64,
-    /// When `true`, refuse a world-writable parent directory on
-    /// production-looking paths (`/var/lib/d2b/...`). Tests targeting
-    /// a scratch tempdir set this to `false`.
-    pub enforce_root_parents: bool,
+    /// Anchored root directory beneath which `<vm_id>/<kind-slug>/` is
+    /// derived. Must be an absolute path.
+    pub state_root: PathBuf,
+    pub dir_mode: u32,
+    pub file_mode: u32,
+    pub owner_uid: Option<u32>,
+    pub owner_gid: Option<u32>,
+    /// Upper bound on how long [`acquire_lock`] polls for the
+    /// cross-process exclusive lock before failing closed with
+    /// [`FailReason::LockUnavailable`].
+    pub lock_max_wait: Duration,
+    pub lock_poll_interval: Duration,
 }
 
-/// Derived, path-bearing (but never logged) locations for one
-/// `(vm, kind)` pair.
+impl Default for SecretsLifecycleConfig {
+    fn default() -> Self {
+        Self {
+            state_root: PathBuf::from("/var/lib/d2b/secrets"),
+            dir_mode: DIR_MODE_DEFAULT,
+            file_mode: FILE_MODE_DEFAULT,
+            owner_uid: None,
+            owner_gid: None,
+            lock_max_wait: Duration::from_secs(10),
+            lock_poll_interval: Duration::from_millis(20),
+        }
+    }
+}
+
+/// Derived, redaction-safe path bundle for one `(vm, kind)` pair.
 #[derive(Debug, Clone)]
 pub struct SecretsLifecyclePaths {
-    pub vm_id: String,
-    pub kind: SecretKind,
-    /// `<per_vm_state_root>/secrets/<kind-slug>`
-    pub secrets_dir: PathBuf,
-    /// `<MARKER_TREE_ROOT>/<vm_id>`
-    pub marker_dir: PathBuf,
+    pub kind_root: PathBuf,
+    /// FNV1a-64 hex fingerprint of `kind_root`, safe to place on the
+    /// audit surface (parity with [`stable_hash_str`]).
+    pub base_dir_hash: String,
 }
 
 fn valid_vm_id(vm_id: &str) -> bool {
+    // Mirrors the framework-wide VM name contract
+    // (`^[a-z][a-z0-9-]*$`, see `nixos-modules/assertions.nix`): used
+    // here purely as a path-component safety gate, not to duplicate
+    // that eval-time assertion.
     let mut chars = vm_id.chars();
     match chars.next() {
-        Some(first) if first.is_ascii_lowercase() => {}
+        Some(c) if c.is_ascii_lowercase() => {}
         _ => return false,
     }
     chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
 }
 
-/// Derive the paths this component owns for `(vm_id, kind)` beneath
-/// `per_vm_state_root`. `per_vm_state_root` is expected to already
-/// exist (established by the caller's own per-VM state-dir prepare
-/// step); this function does not create it.
+/// Derive the anchored per-`(vm, kind)` directory. Fails closed on an
+/// invalid `vm_id` before any filesystem access.
 pub fn derive_paths(
-    per_vm_state_root: &Path,
     vm_id: &str,
     kind: SecretKind,
-) -> Result<SecretsLifecyclePaths, &'static str> {
-    if !valid_vm_id(vm_id) {
-        return Err(reasons::INVALID_VM_ID);
+    cfg: &SecretsLifecycleConfig,
+) -> Result<SecretsLifecyclePaths, FailReason> {
+    if !valid_vm_id(vm_id) || !cfg.state_root.is_absolute() {
+        return Err(FailReason::InvalidVmId);
     }
-    if !per_vm_state_root.is_absolute() {
-        return Err(reasons::DERIVATION_FAILED);
-    }
+    let kind_root = cfg.state_root.join(vm_id).join(kind.as_slug());
+    let base_dir_hash = stable_hash_str(&kind_root.to_string_lossy());
     Ok(SecretsLifecyclePaths {
-        vm_id: vm_id.to_owned(),
-        kind,
-        secrets_dir: per_vm_state_root.join("secrets").join(kind.as_slug()),
-        marker_dir: PathBuf::from(MARKER_TREE_ROOT).join(vm_id),
+        kind_root,
+        base_dir_hash,
     })
 }
 
-/// Zeroizing, digest-only-Debug wrapper around raw secret material
-/// bytes. Never implements a byte-exposing `Display`, and `Debug`
-/// never prints the bytes or their length-derived shape beyond a
-/// fixed placeholder.
-pub struct SecretMaterial(Zeroizing<Vec<u8>>);
+fn context(
+    vm_id: &str,
+    kind: SecretKind,
+    action: LifecycleAction,
+    paths: &SecretsLifecyclePaths,
+) -> SecretsLifecycleAuditContext {
+    SecretsLifecycleAuditContext {
+        vm_id: vm_id.to_owned(),
+        kind,
+        action,
+        base_dir_hash: paths.base_dir_hash.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Secret material
+// ---------------------------------------------------------------------
+
+/// Caller-supplied secret bytes. Deliberately **not** `Copy` or
+/// `Clone`: every holder of an owned `SecretMaterial` is a distinct,
+/// independently zeroized buffer. The bytes are wrapped in
+/// [`Zeroizing`] *before* validation, so a rejected (empty or
+/// oversized) buffer is still zeroized on drop rather than discarded
+/// as a plain `Vec<u8>`.
+pub struct SecretMaterial {
+    bytes: Zeroizing<Vec<u8>>,
+}
 
 impl SecretMaterial {
-    /// Generous but bounded ceiling so a single material blob can
-    /// never grow unbounded (a 1 MiB budget comfortably covers a TPM
-    /// attestation blob, an SSH host key bundle, or channel-binding
-    /// wire material with headroom).
+    /// 1 MiB. Generous for TPM-bound credential blobs, guest signing
+    /// keys, and security-key channel state; prevents an unbounded
+    /// allocation/hash from a misbehaving caller.
     pub const MAX_LEN: usize = 1 << 20;
 
-    pub fn new(bytes: Vec<u8>) -> Result<Self, &'static str> {
+    pub fn new(bytes: Vec<u8>) -> Result<Self, FailReason> {
+        // Wrap FIRST: a validation-rejected buffer is zeroized on
+        // drop here, not silently dropped as a plain `Vec<u8>`.
+        let bytes = Zeroizing::new(bytes);
         if bytes.is_empty() || bytes.len() > Self::MAX_LEN {
-            return Err(reasons::INVALID_MATERIAL);
+            return Err(FailReason::InvalidMaterial);
         }
-        Ok(Self(Zeroizing::new(bytes)))
+        Ok(Self { bytes })
     }
 
-    fn as_bytes(&self) -> &[u8] {
-        &self.0
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
     }
 
-    /// SHA-256 hex digest of the material. Safe to audit/log — the
-    /// raw bytes never are.
     pub fn digest_hex(&self) -> String {
         let mut hasher = Sha256::new();
-        hasher.update(self.as_bytes());
-        let digest = hasher.finalize();
-        let mut out = String::with_capacity(64);
-        for byte in digest {
-            out.push_str(&format!("{byte:02x}"));
-        }
-        out
+        hasher.update(&*self.bytes);
+        hex_encode(&hasher.finalize())
     }
 }
 
-impl fmt::Debug for SecretMaterial {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("SecretMaterial")
-            .field(&"<redacted>")
-            .finish()
+impl std::fmt::Debug for SecretMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SecretMaterial")
+            .field("len", &self.bytes.len())
+            .finish_non_exhaustive()
     }
 }
 
-/// Path-free, material-free error returned by every public function
-/// in this module. Carries the fully-formed audit record so a caller
-/// need not reconstruct it.
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------
+// Marker identity
+// ---------------------------------------------------------------------
+
+/// Full tamper-detecting identity of one generation's `material` file,
+/// captured via a `nofollow`-safe fd open (never a path
+/// re-resolution).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MaterialIdentity {
+    pub epoch: u64,
+    pub dev: u64,
+    pub ino: u64,
+    pub uid: u32,
+    pub gid: u32,
+    /// Permission bits only (`st_mode & 0o7777`).
+    pub mode: u32,
+    pub nlink: u64,
+    pub has_acl: bool,
+    pub digest_hex: String,
+}
+
+/// On-disk marker (`marker.json`), schema v2.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MarkerData {
+    pub v: u32,
+    pub vm: String,
+    pub kind: String,
+    pub retired: bool,
+    pub high_water_epoch: u64,
+    pub active: Option<MaterialIdentity>,
+    pub previous: Option<MaterialIdentity>,
+    pub first_provisioned_ms: u64,
+    pub updated_ms: u64,
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------
+// Transaction / recovery log
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotePhase {
+    /// Intent recorded; the target generation may or may not be
+    /// staged/created yet. Nothing observable (`current`/marker) has
+    /// changed. Safe to discard.
+    Planned,
+    /// `generations/<to_epoch>/material` exists and is durable
+    /// (fsynced), verified against `expected_digest_hex`. `current`
+    /// still points elsewhere (or nowhere). Still safe to discard.
+    EpochReady,
+    /// `current` now resolves to `generations/<to_epoch>/`, durable.
+    /// This is the activation point: recovery may only move forward
+    /// from here.
+    CurrentPromoted,
+    /// `marker.json` durably reflects the new active/previous/
+    /// high-water state. Only pruning + txlog removal remain
+    /// (idempotent).
+    MarkerCommitted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetirePhase {
+    /// The physical generation tree has been anchored-enumerated and
+    /// validated; `intent.epochs` is the recorded deletion plan.
+    /// `current` may still be present. Nothing has been deleted yet.
+    Enumerated,
+    /// `current` has been removed. No generation has been deleted
+    /// yet.
+    CurrentRemoved,
+    /// Every recorded epoch has been removed (idempotently — already-
+    /// removed entries are tolerated).
+    EpochsRemoved,
+    /// A fresh re-enumeration proved the tree is empty. Only the
+    /// tombstone marker write + txlog removal remain.
+    ProvenEmpty,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromoteIntent {
+    pub vm: String,
+    pub kind: String,
+    pub action: LifecycleAction,
+    pub to_epoch: u64,
+    pub create_epoch: bool,
+    /// Name of the staging directory used for a freshly-created
+    /// epoch. Empty when `create_epoch` is `false` (rollback).
+    pub stage_name: String,
+    pub expected_digest_hex: String,
+    /// Full recorded identity of the rollback target, used to
+    /// tamper-verify the pre-existing generation before promoting it.
+    /// `None` when `create_epoch` is `true`.
+    pub expected_identity: Option<MaterialIdentity>,
+    /// The identity that becomes the new `previous` once this action
+    /// commits.
+    pub carry_previous: Option<MaterialIdentity>,
+    /// A generation to prune strictly after the new marker is
+    /// durably committed. `None` when nothing is superseded.
+    pub prune_epoch: Option<u64>,
+    pub new_high_water_epoch: u64,
+    pub first_provisioned_ms: u64,
+    pub phase: PromotePhase,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetireIntent {
+    pub vm: String,
+    pub kind: String,
+    /// The recorded deletion plan from the enumeration that started
+    /// this transaction. Recovery re-enumerates fresh and requires the
+    /// fresh result to be a subset of this plan.
+    pub epochs: Vec<u64>,
+    pub high_water_epoch: u64,
+    pub phase: RetirePhase,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "tx_variant", rename_all = "snake_case", deny_unknown_fields)]
+pub enum TxLog {
+    Promote(PromoteIntent),
+    Retire(RetireIntent),
+}
+
+// ---------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecretsLifecycleError {
-    pub reason: &'static str,
+    pub reason: FailReason,
     pub audit: SecretsLifecycleAuditFields,
 }
 
-impl fmt::Display for SecretsLifecycleError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "secrets-lifecycle {:?} failed: {}",
-            self.audit.action, self.reason
-        )
+impl std::fmt::Display for SecretsLifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "secrets-lifecycle: {}", self.reason)
     }
 }
 
 impl std::error::Error for SecretsLifecycleError {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct MarkerData {
-    v: u32,
-    vm: String,
-    kind: String,
-    retired: bool,
-    generation: Option<u32>,
-    previous_generation: Option<u32>,
-    active_dev: Option<u64>,
-    active_ino: Option<u64>,
-    first_provisioned_ms: u64,
-    updated_ms: u64,
-}
-
-fn io_from_rustix(err: rustix::io::Errno) -> std::io::Error {
-    std::io::Error::from_raw_os_error(err.raw_os_error())
-}
-
-fn production_path(path: &Path) -> bool {
-    path.starts_with("/var/lib/d2b")
-}
-
-fn context(paths: &SecretsLifecyclePaths, action: LifecycleAction) -> SecretsLifecycleAuditContext {
-    SecretsLifecycleAuditContext {
-        vm_id: paths.vm_id.clone(),
-        kind: paths.kind,
-        action,
-        base_dir_hash: stable_hash_str(&paths.secrets_dir.display().to_string()),
+fn denied(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> SecretsLifecycleError {
+    SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::denied(ctx, reason),
     }
 }
 
-fn ensure_marker_tree(
-    paths: &SecretsLifecyclePaths,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<OwnedFd, &'static str> {
-    if cfg.enforce_root_parents && production_path(&paths.marker_dir) {
-        path_safe::refuse_world_writable_parent(&paths.marker_dir)
-            .map_err(|_| reasons::MARKER_TREE_FAILED)?;
+fn failed_closed(
+    ctx: &SecretsLifecycleAuditContext,
+    marker_result: MarkerResult,
+    reason: FailReason,
+) -> SecretsLifecycleError {
+    SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(ctx, marker_result, reason),
     }
-    // `paths.marker_dir` is `<marker_tree_root>/<vm_id>`. Unlike the
-    // per-VM secrets root (established by an earlier, out-of-scope
-    // state-dir prepare step), the marker tree root itself is a
-    // fresh top-level directory this module owns end-to-end, so it
-    // is not safe to assume it already exists. Create it first (a
-    // no-op once any VM has provisioned once) before creating the
-    // per-VM leaf beneath it.
-    let marker_root = paths
-        .marker_dir
-        .parent()
-        .ok_or(reasons::MARKER_TREE_FAILED)?;
-    path_safe::ensure_dir(
-        marker_root,
-        MARKER_DIR_MODE,
-        Some(cfg.marker_owner_uid),
-        Some(cfg.marker_owner_gid),
-    )
-    .map_err(|_| reasons::MARKER_TREE_FAILED)?;
-    path_safe::ensure_dir(
-        &paths.marker_dir,
-        MARKER_DIR_MODE,
-        Some(cfg.marker_owner_uid),
-        Some(cfg.marker_owner_gid),
-    )
-    .map_err(|_| reasons::MARKER_TREE_FAILED)?;
-    path_safe::open_dir_path_safe(&paths.marker_dir).map_err(|_| reasons::MARKER_TREE_FAILED)
 }
 
-fn read_marker(
-    marker_dir_fd: &OwnedFd,
-    paths: &SecretsLifecyclePaths,
-) -> Result<Option<MarkerData>, &'static str> {
-    let name = paths.kind.as_slug();
-    let stat = match path_safe::fstatat_nofollow(marker_dir_fd, name) {
-        Ok(Some(stat)) => stat,
-        Ok(None) => return Ok(None),
-        Err(_) => return Err(reasons::MARKER_TAMPERED),
-    };
-    if (stat.st_mode & libc::S_IFMT) != libc::S_IFREG {
-        return Err(reasons::MARKER_TAMPERED);
-    }
-    let fd = path_safe::open_file_at_safe(marker_dir_fd, name, libc::O_RDONLY)
-        .map_err(|_| reasons::MARKER_TAMPERED)?;
-    let mut file = std::fs::File::from(fd);
-    let mut buf = String::new();
-    {
-        use std::io::Read;
-        file.read_to_string(&mut buf)
-            .map_err(|_| reasons::MARKER_TAMPERED)?;
-    }
-    let data: MarkerData = serde_json::from_str(&buf).map_err(|_| reasons::MARKER_TAMPERED)?;
-    if data.v != MARKER_SCHEMA_VERSION || data.vm != paths.vm_id || data.kind != name {
-        return Err(reasons::MARKER_TAMPERED);
-    }
-    Ok(Some(data))
+fn io_to_reason(_err: io::Error, on_failure: FailReason) -> FailReason {
+    on_failure
 }
 
-fn write_marker(
-    marker_dir_fd: &OwnedFd,
-    paths: &SecretsLifecyclePaths,
-    cfg: &SecretsLifecycleConfig,
-    data: &MarkerData,
-) -> Result<(), &'static str> {
-    let body = serde_json::to_vec(data).map_err(|_| reasons::MARKER_WRITE_FAILED)?;
-    path_safe::atomic_replace_fd_with_owner(
-        marker_dir_fd,
-        paths.kind.as_slug(),
-        &body,
-        MARKER_FILE_MODE,
-        Some(cfg.marker_owner_uid),
-        Some(cfg.marker_owner_gid),
-    )
-    .map_err(|_| reasons::MARKER_WRITE_FAILED)
-}
+// ---------------------------------------------------------------------
+// Directory / marker / txlog primitives
+// ---------------------------------------------------------------------
 
+/// Open (creating if absent) the anchored `kind_root` directory and
+/// its `generations/` child, returning both fds. Every subsequent
+/// operation is fd-relative from here.
+///
+/// `cfg.state_root` itself is a precondition, not something this
+/// component creates: [`path_safe::ensure_dir`] refuses to operate
+/// under a world-writable parent, and the real deployment's secrets
+/// root is expected to be established (with the correct non-world-
+/// writable mode) by host activation before the broker ever calls
+/// into this module — see the module doc's "Integration wiring
+/// points" §4. `open_dir_path_safe` (no world-writable-parent check)
+/// only verifies it exists. `vm_dir` and `kind_root` are created
+/// on demand beneath it via `ensure_dir`, which is safe here because
+/// their immediate parent (`state_root`, then `vm_dir`) is never
+/// world-writable once `state_root` itself is correctly established.
 fn open_or_create_secrets_dir(
     paths: &SecretsLifecyclePaths,
     cfg: &SecretsLifecycleConfig,
-) -> Result<OwnedFd, &'static str> {
-    let secrets_root = paths
-        .secrets_dir
+) -> Result<(OwnedFd, OwnedFd), FailReason> {
+    let vm_dir = paths
+        .kind_root
         .parent()
-        .ok_or(reasons::DERIVATION_FAILED)?;
-    path_safe::ensure_dir(
-        secrets_root,
-        SECRETS_ROOT_DIR_MODE,
-        Some(cfg.expected_uid),
-        Some(cfg.expected_gid),
+        .ok_or(FailReason::SecretsDirOpenFailed)?;
+    path_safe::open_dir_path_safe(&cfg.state_root).map_err(|_| FailReason::SecretsDirOpenFailed)?;
+    path_safe::ensure_dir(vm_dir, cfg.dir_mode, cfg.owner_uid, cfg.owner_gid)
+        .map_err(|_| FailReason::SecretsDirOpenFailed)?;
+    path_safe::ensure_dir(&paths.kind_root, cfg.dir_mode, cfg.owner_uid, cfg.owner_gid)
+        .map_err(|_| FailReason::SecretsDirOpenFailed)?;
+    let secrets_fd = path_safe::open_dir_path_safe(&paths.kind_root)
+        .map_err(|_| FailReason::SecretsDirOpenFailed)?;
+    path_safe::mkdir_at(
+        secrets_fd.as_fd(),
+        Path::new(GENERATIONS_DIR_NAME),
+        cfg.dir_mode,
     )
-    .map_err(|_| reasons::PARENT_OPEN_FAILED)?;
-    path_safe::ensure_dir(
-        &paths.secrets_dir,
-        SECRETS_KIND_DIR_MODE,
-        Some(cfg.expected_uid),
-        Some(cfg.expected_gid),
+    .map_err(|_| FailReason::MarkerTreeOpenFailed)?;
+    let generations_fd = path_safe::open_at(
+        secrets_fd.as_fd(),
+        Path::new(GENERATIONS_DIR_NAME),
+        OFlags::RDONLY | OFlags::DIRECTORY,
     )
-    .map_err(|_| reasons::PARENT_OPEN_FAILED)?;
-    path_safe::ensure_dir(
-        &paths.secrets_dir.join("generations"),
-        SECRETS_KIND_DIR_MODE,
-        Some(cfg.expected_uid),
-        Some(cfg.expected_gid),
-    )
-    .map_err(|_| reasons::PARENT_OPEN_FAILED)?;
-    path_safe::open_dir_path_safe(&paths.secrets_dir).map_err(|_| reasons::PARENT_OPEN_FAILED)
+    .map_err(|_| FailReason::MarkerTreeOpenFailed)?;
+    Ok((secrets_fd, generations_fd))
 }
 
-fn open_generations_dir(secrets_dir_fd: &OwnedFd) -> Result<OwnedFd, &'static str> {
+fn open_generations_dir(secrets_fd: BorrowedFd<'_>) -> Result<OwnedFd, FailReason> {
     path_safe::open_at(
-        secrets_dir_fd.as_fd(),
-        Path::new("generations"),
+        secrets_fd,
+        Path::new(GENERATIONS_DIR_NAME),
         OFlags::RDONLY | OFlags::DIRECTORY,
     )
-    .map_err(|_| reasons::PARENT_OPEN_FAILED)
+    .map_err(|_| FailReason::MarkerTreeOpenFailed)
 }
 
-fn write_generation(
-    secrets_dir_fd: &OwnedFd,
-    generation: u32,
-    material: &SecretMaterial,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<libc::stat, &'static str> {
-    let generations_fd = open_generations_dir(secrets_dir_fd)?;
-    let name = generation.to_string();
-    path_safe::mkdir_at_exclusive(
-        generations_fd.as_fd(),
-        Path::new(&name),
-        GENERATION_DIR_MODE,
-    )
-    .map_err(|err| {
-        if err.kind() == std::io::ErrorKind::AlreadyExists {
-            reasons::GENERATION_CONFLICT
-        } else {
-            reasons::MATERIAL_WRITE_FAILED
-        }
-    })?;
-    let generation_fd = path_safe::open_at(
-        generations_fd.as_fd(),
-        Path::new(&name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
-    path_safe::fchmod(generation_fd.as_fd(), GENERATION_DIR_MODE)
-        .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
-    path_safe::fchown(
-        generation_fd.as_fd(),
-        Some(cfg.expected_uid),
-        Some(cfg.expected_gid),
-    )
-    .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
-
-    let file_fd = path_safe::create_file_at_safe(
-        &generation_fd,
-        "material",
-        libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL,
-        MATERIAL_FILE_MODE,
-    )
-    .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
-    {
-        use std::io::Write;
-        let mut file = std::fs::File::from(file_fd);
-        file.write_all(material.as_bytes())
-            .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
-        file.sync_all()
-            .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
+fn read_marker(secrets_fd: BorrowedFd<'_>) -> Result<Option<MarkerData>, FailReason> {
+    let fd = match path_safe::open_file_at_safe(
+        &borrowed_to_owned(secrets_fd)?,
+        MARKER_FILE_NAME,
+        nix::libc::O_RDONLY,
+    ) {
+        Ok(fd) => fd,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(FailReason::MarkerTreeOpenFailed),
+    };
+    let bytes = read_fd_to_end(fd.as_fd()).map_err(|_| FailReason::MarkerTreeOpenFailed)?;
+    let marker: MarkerData =
+        serde_json::from_slice(&bytes).map_err(|_| FailReason::MarkerTamperedOrMissingMaterial)?;
+    if marker.v != MARKER_SCHEMA_VERSION {
+        return Err(FailReason::MarkerTamperedOrMissingMaterial);
     }
-    path_safe::fstat_fd(generation_fd.as_fd()).map_err(|_| reasons::MATERIAL_WRITE_FAILED)
+    Ok(Some(marker))
 }
 
-fn stat_generation(secrets_dir_fd: &OwnedFd, generation: u32) -> Result<libc::stat, &'static str> {
-    let generations_fd = open_generations_dir(secrets_dir_fd)?;
-    let name = generation.to_string();
-    let fd = path_safe::open_at(
-        generations_fd.as_fd(),
-        Path::new(&name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
+fn write_marker(secrets_fd: BorrowedFd<'_>, marker: &MarkerData) -> Result<(), FailReason> {
+    let body = serde_json::to_vec(marker).map_err(|_| FailReason::MarkerWriteFailed)?;
+    let owned = borrowed_to_owned(secrets_fd)?;
+    path_safe::atomic_replace_fd_with_owner(
+        &owned,
+        MARKER_FILE_NAME,
+        &body,
+        FILE_MODE_DEFAULT,
+        None,
+        None,
     )
-    .map_err(|_| reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING)?;
-    path_safe::fstat_fd(fd.as_fd()).map_err(|_| reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING)
+    .map_err(|_| FailReason::MarkerWriteFailed)?;
+    fsync_fd(secrets_fd);
+    Ok(())
 }
 
-/// Best-effort removal of one generation directory's `material` file
-/// and the directory itself. Never fails the caller: a stale
-/// generation left behind after a crash is picked up by the next
-/// rotate/retire's own retention bookkeeping, never silently trusted
-/// as current.
-fn remove_generation(secrets_dir_fd: &OwnedFd, generation: u32) {
-    let Ok(generations_fd) = open_generations_dir(secrets_dir_fd) else {
+fn read_txlog(secrets_fd: BorrowedFd<'_>) -> Result<Option<TxLog>, FailReason> {
+    let owned = borrowed_to_owned(secrets_fd)?;
+    let fd = match path_safe::open_file_at_safe(&owned, TXLOG_FILE_NAME, nix::libc::O_RDONLY) {
+        Ok(fd) => fd,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(FailReason::IntentCorrupt),
+    };
+    let bytes = read_fd_to_end(fd.as_fd()).map_err(|_| FailReason::IntentCorrupt)?;
+    let log: TxLog = serde_json::from_slice(&bytes).map_err(|_| FailReason::IntentCorrupt)?;
+    Ok(Some(log))
+}
+
+fn write_txlog(secrets_fd: BorrowedFd<'_>, log: &TxLog) -> Result<(), FailReason> {
+    let body = serde_json::to_vec(log).map_err(|_| FailReason::IntentWriteFailed)?;
+    let owned = borrowed_to_owned(secrets_fd)?;
+    path_safe::atomic_replace_fd_with_owner(
+        &owned,
+        TXLOG_FILE_NAME,
+        &body,
+        FILE_MODE_DEFAULT,
+        None,
+        None,
+    )
+    .map_err(|_| FailReason::IntentWriteFailed)?;
+    fsync_fd(secrets_fd);
+    Ok(())
+}
+
+fn remove_txlog(secrets_fd: BorrowedFd<'_>) -> Result<(), FailReason> {
+    let owned = borrowed_to_owned(secrets_fd)?;
+    match path_safe::remove_path_safe(&owned, TXLOG_FILE_NAME) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => return Err(FailReason::IntentWriteFailed),
+    }
+    fsync_fd(secrets_fd);
+    Ok(())
+}
+
+/// `BorrowedFd` -> `OwnedFd` without taking ownership of the original
+/// descriptor: dups via `openat2(".")`-equivalent semantics through
+/// [`path_safe::open_at`]. Needed because several `path_safe` helpers
+/// take `&OwnedFd`, while callers here hold a `BorrowedFd` (e.g. from
+/// a `LockGuard` or a caller-held directory fd) for the duration of a
+/// single call.
+fn borrowed_to_owned(fd: BorrowedFd<'_>) -> Result<OwnedFd, FailReason> {
+    path_safe::open_at(fd, Path::new("."), OFlags::RDONLY | OFlags::DIRECTORY)
+        .map_err(|_| FailReason::MarkerTreeOpenFailed)
+}
+
+fn read_fd_to_end(fd: BorrowedFd<'_>) -> io::Result<Vec<u8>> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd as _;
+    // SAFETY-free: build a short-lived `File` view over the fd without
+    // taking ownership, restoring the raw fd afterward via
+    // `into_raw_fd` on a duplicated descriptor so the original isn't
+    // double-closed.
+    let dup = rustix::fs::fcntl_dupfd_cloexec(fd, 0).map_err(io_from_rustix)?;
+    let mut file: std::fs::File = dup.into();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let _ = fd.as_raw_fd();
+    Ok(buf)
+}
+
+fn fsync_fd(fd: BorrowedFd<'_>) {
+    let _ = rustix::fs::fsync(fd);
+}
+
+fn io_from_rustix(err: rustix::io::Errno) -> io::Error {
+    io::Error::from_raw_os_error(err.raw_os_error())
+}
+
+// ---------------------------------------------------------------------
+// Cross-process lock
+// ---------------------------------------------------------------------
+
+pub struct LockGuard {
+    _file: std::fs::File,
+}
+
+fn acquire_lock(
+    secrets_fd: BorrowedFd<'_>,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<LockGuard, FailReason> {
+    let owned = borrowed_to_owned(secrets_fd)?;
+    let fd = path_safe::create_file_at_safe(
+        &owned,
+        LOCK_FILE_NAME,
+        nix::libc::O_RDWR | nix::libc::O_CREAT,
+        FILE_MODE_DEFAULT,
+    )
+    .map_err(|_| FailReason::LockUnavailable)?;
+    let file: std::fs::File = fd.into();
+    let deadline = Instant::now() + cfg.lock_max_wait;
+    loop {
+        match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
+            Ok(()) => return Ok(LockGuard { _file: file }),
+            Err(nix::errno::Errno::EWOULDBLOCK) => {
+                if Instant::now() >= deadline {
+                    return Err(FailReason::LockUnavailable);
+                }
+                std::thread::sleep(cfg.lock_poll_interval);
+            }
+            Err(_) => return Err(FailReason::LockUnavailable),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Staging / generation helpers
+// ---------------------------------------------------------------------
+
+fn random_stage_name() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id() as u64;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let mut hasher = RandomState::new().build_hasher();
+    hasher.write_u64(pid);
+    hasher.write_u64(counter);
+    hasher.write_u64(nanos);
+    let entropy = hasher.finish();
+
+    let mut mix = Sha256::new();
+    mix.update(pid.to_le_bytes());
+    mix.update(counter.to_le_bytes());
+    mix.update(nanos.to_le_bytes());
+    mix.update(entropy.to_le_bytes());
+    let digest = mix.finalize();
+    format!("{STAGE_PREFIX}{}", hex_encode(&digest[..16]))
+}
+
+fn parse_strict_epoch(name: &str) -> Option<u64> {
+    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if name.len() > 1 && name.starts_with('0') {
+        return None;
+    }
+    name.parse::<u64>().ok()
+}
+
+/// Sweep any leftover `.stage-*` directories (from a crash before a
+/// stage was ever recorded in a txlog, or one already superseded).
+/// Best-effort: failures are ignored, since a stray stage dir has no
+/// bearing on correctness (it is never referenced by `current` or the
+/// marker).
+fn sweep_stale_stage_dirs(generations_fd: BorrowedFd<'_>, keep: Option<&str>) {
+    let owned = match borrowed_to_owned(generations_fd) {
+        Ok(fd) => fd,
+        Err(_) => return,
+    };
+    let Ok(dir) = rustix::fs::Dir::read_from(generations_fd) else {
         return;
     };
-    let name = generation.to_string();
-    if let Ok(generation_fd) = path_safe::open_at(
-        generations_fd.as_fd(),
-        Path::new(&name),
+    for entry in dir.flatten() {
+        let Ok(name) = entry.file_name().to_str() else {
+            continue;
+        };
+        if name == "." || name == ".." {
+            continue;
+        }
+        if !name.starts_with(STAGE_PREFIX) {
+            continue;
+        }
+        if keep == Some(name) {
+            continue;
+        }
+        let _ = remove_dir_tree_one_level(&owned, name);
+    }
+}
+
+/// Remove a one-level directory (a stage dir contains at most one
+/// `material` file) via `remove_path_safe` on each child then the
+/// directory itself.
+fn remove_dir_tree_one_level(parent_fd: &OwnedFd, name: &str) -> io::Result<()> {
+    if let Ok(child_fd) = path_safe::open_at(
+        parent_fd.as_fd(),
+        Path::new(name),
         OFlags::RDONLY | OFlags::DIRECTORY,
-    ) {
-        let _ = path_safe::remove_path_safe(&generation_fd, "material");
-    }
-    let _ = path_safe::remove_path_safe(&generations_fd, &name);
-}
-
-/// Best-effort removal of the `current` symlink itself. `current` is
-/// always a symlink by construction (see [`atomic_swap_current`]), so
-/// unlike [`path_safe::remove_path_safe`] (which deliberately refuses
-/// to operate on a symlink as a generic anti-planting guard for
-/// contexts where a symlink would be unexpected) this removes the
-/// link entry directly without following it. Never fails the caller.
-fn remove_current_symlink(secrets_dir_fd: &OwnedFd) {
-    let _ = rustix::fs::unlinkat(
-        secrets_dir_fd.as_fd(),
-        "current",
-        rustix::fs::AtFlags::empty(),
-    );
-}
-
-/// Atomically point the `current` symlink at `generations/<generation>`
-/// using a hidden-name symlink-then-rename swap against the already
-/// fd-anchored `secrets_dir`, so no window ever exposes a half-written
-/// or dangling `current`.
-fn atomic_swap_current(
-    secrets_dir_fd: BorrowedFd<'_>,
-    generation: u32,
-) -> Result<(), &'static str> {
-    let target = format!("generations/{generation}");
-    let tmp_name = format!(".current.tmp.{}", std::process::id());
-    let _ = rustix::fs::unlinkat(
-        secrets_dir_fd,
-        tmp_name.as_str(),
-        rustix::fs::AtFlags::empty(),
-    );
-    rustix::fs::symlinkat(target.as_str(), secrets_dir_fd, tmp_name.as_str())
-        .map_err(io_from_rustix)
-        .map_err(|_| reasons::CURRENT_SWAP_FAILED)?;
-    match rustix::fs::renameat(secrets_dir_fd, tmp_name.as_str(), secrets_dir_fd, "current") {
-        Ok(()) => {
-            let _ = rustix::fs::fsync(secrets_dir_fd);
-            Ok(())
-        }
-        Err(_) => {
-            let _ = rustix::fs::unlinkat(
-                secrets_dir_fd,
-                tmp_name.as_str(),
-                rustix::fs::AtFlags::empty(),
-            );
-            Err(reasons::CURRENT_SWAP_FAILED)
+    ) && let Ok(dir) = rustix::fs::Dir::read_from(child_fd.as_fd())
+    {
+        let child_owned = borrowed_to_owned_io(child_fd.as_fd())?;
+        for entry in dir.flatten() {
+            if let Ok(cname) = entry.file_name().to_str()
+                && cname != "."
+                && cname != ".."
+            {
+                let _ = path_safe::remove_path_safe(&child_owned, cname);
+            }
         }
     }
+    path_safe::remove_path_safe(parent_fd, name)
 }
 
-fn current_present(secrets_dir_fd: &OwnedFd) -> Result<bool, &'static str> {
-    path_safe::fstatat_nofollow(secrets_dir_fd, "current")
-        .map(|stat| stat.is_some())
-        .map_err(|_| reasons::MARKER_TAMPERED)
+fn borrowed_to_owned_io(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
+    path_safe::open_at(fd, Path::new("."), OFlags::RDONLY | OFlags::DIRECTORY)
 }
 
-fn verify_active_identity(
-    secrets_dir_fd: &OwnedFd,
-    marker: &MarkerData,
-) -> Result<(), &'static str> {
-    let generation = marker.generation.ok_or(reasons::MARKER_TAMPERED)?;
-    let (expected_dev, expected_ino) = match (marker.active_dev, marker.active_ino) {
-        (Some(dev), Some(ino)) => (dev, ino),
-        _ => return Err(reasons::MARKER_TAMPERED),
+/// Stage `material` bytes into a fresh, collision-resistant directory
+/// beneath `generations/`, fsyncing the material file and the stage
+/// directory before returning. Idempotent with respect to
+/// `stage_name`: if a directory of that name already exists with a
+/// matching digest, this is a no-op (crash-recovery re-entry).
+fn ensure_staged(
+    generations_fd: BorrowedFd<'_>,
+    cfg: &SecretsLifecycleConfig,
+    stage_name: &str,
+    expected_digest_hex: &str,
+    material: Option<&SecretMaterial>,
+) -> Result<bool, FailReason> {
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    if let Ok(existing_digest) = digest_of_material_dir(&generations_owned, stage_name) {
+        if existing_digest == expected_digest_hex {
+            return Ok(true);
+        }
+        // Tampered/partial stage from a previous crash: nothing has
+        // been activated yet (we are still pre-EpochReady), so it is
+        // safe to discard and let the caller decide (abort/retry).
+        let _ = remove_dir_tree_one_level(&generations_owned, stage_name);
+        return Err(FailReason::RecoveryContentMismatch);
+    }
+
+    let Some(material) = material else {
+        return Ok(false);
     };
-    let stat = stat_generation(secrets_dir_fd, generation)?;
-    if stat.st_dev != expected_dev || stat.st_ino != expected_ino {
-        return Err(reasons::MARKER_TAMPERED);
+
+    path_safe::mkdir_at_exclusive(generations_fd, Path::new(stage_name), cfg.dir_mode)
+        .map_err(|_| FailReason::MaterialWriteFailed)?;
+    let stage_fd = path_safe::open_at(
+        generations_fd,
+        Path::new(stage_name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )
+    .map_err(|_| FailReason::MaterialWriteFailed)?;
+    let stage_owned = borrowed_to_owned(stage_fd.as_fd())?;
+    path_safe::atomic_replace_fd_with_owner(
+        &stage_owned,
+        MATERIAL_FILE_NAME,
+        material.as_bytes(),
+        cfg.file_mode,
+        cfg.owner_uid,
+        cfg.owner_gid,
+    )
+    .map_err(|_| FailReason::MaterialWriteFailed)?;
+    fsync_fd(stage_fd.as_fd());
+    fsync_fd(generations_fd);
+    Ok(true)
+}
+
+fn digest_of_material_dir(generations_fd: &OwnedFd, dir_name: &str) -> io::Result<String> {
+    let dir_fd = path_safe::open_at(
+        generations_fd.as_fd(),
+        Path::new(dir_name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )?;
+    let material_fd = path_safe::open_file_at_safe(
+        &borrowed_to_owned_io(dir_fd.as_fd())?,
+        MATERIAL_FILE_NAME,
+        nix::libc::O_RDONLY,
+    )?;
+    let bytes = Zeroizing::new(read_fd_to_end(material_fd.as_fd())?);
+    let mut hasher = Sha256::new();
+    hasher.update(&*bytes);
+    Ok(hex_encode(&hasher.finalize()))
+}
+
+/// Rename the stage directory into its final numeric epoch name.
+/// Idempotent: if the final directory already exists with a matching
+/// digest (a previous crash-recovery pass already renamed it), this
+/// is a no-op.
+fn promote_stage_to_generation(
+    generations_fd: BorrowedFd<'_>,
+    stage_name: &str,
+    to_epoch: u64,
+) -> Result<(), FailReason> {
+    let epoch_name = to_epoch.to_string();
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    if digest_of_material_dir(&generations_owned, &epoch_name).is_ok() {
+        return Ok(());
+    }
+    rustix::fs::renameat(
+        generations_fd,
+        Path::new(stage_name),
+        generations_fd,
+        Path::new(&epoch_name),
+    )
+    .map_err(|_| FailReason::GenerationConflict)?;
+    fsync_fd(generations_fd);
+    Ok(())
+}
+
+fn capture_identity(
+    generations_fd: BorrowedFd<'_>,
+    epoch: u64,
+) -> Result<MaterialIdentity, FailReason> {
+    let epoch_name = epoch.to_string();
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    let dir_fd = path_safe::open_at(
+        generations_fd,
+        Path::new(&epoch_name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )
+    .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
+    let material_fd =
+        path_safe::open_file_at_safe(&dir_owned, MATERIAL_FILE_NAME, nix::libc::O_RDONLY)
+            .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    let stat = path_safe::fstat_fd(material_fd.as_fd())
+        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    let (has_acl, _) = path_safe::fd_extended_acl_present(material_fd.as_fd())
+        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    let bytes = Zeroizing::new(
+        read_fd_to_end(material_fd.as_fd())
+            .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?,
+    );
+    let mut hasher = Sha256::new();
+    hasher.update(&*bytes);
+    let digest_hex = hex_encode(&hasher.finalize());
+    let _ = generations_owned;
+    Ok(MaterialIdentity {
+        epoch,
+        dev: stat.st_dev as u64,
+        ino: stat.st_ino as u64,
+        uid: stat.st_uid,
+        gid: stat.st_gid,
+        mode: (stat.st_mode as u32) & 0o7777,
+        nlink: stat.st_nlink as u64,
+        has_acl,
+        digest_hex,
+    })
+}
+
+/// Tamper-verify a live generation against a recorded identity
+/// (used by rollback's Planned phase to confirm the retained
+/// generation has not drifted since it was recorded).
+fn verify_existing_generation_identity(
+    generations_fd: BorrowedFd<'_>,
+    expected: &MaterialIdentity,
+) -> Result<(), FailReason> {
+    let live = capture_identity(generations_fd, expected.epoch)?;
+    if live.uid != expected.uid || live.gid != expected.gid {
+        return Err(FailReason::IdentityOwnerMismatch);
+    }
+    if live.mode != expected.mode {
+        return Err(FailReason::IdentityModeMismatch);
+    }
+    if live.has_acl != expected.has_acl {
+        return Err(FailReason::IdentityAclMismatch);
+    }
+    if live.nlink != expected.nlink {
+        return Err(FailReason::IdentityLinkCountMismatch);
+    }
+    if live.digest_hex != expected.digest_hex {
+        return Err(FailReason::IdentityDigestMismatch);
+    }
+    if live.dev != expected.dev || live.ino != expected.ino {
+        return Err(FailReason::IdentityInodeMismatch);
     }
     Ok(())
 }
 
-/// Provision fresh (generation 1) material for `(vm, kind)`.
-///
-/// Fails closed with [`reasons::ALREADY_PROVISIONED`] if active
-/// material already exists (callers should use [`rotate`] instead).
-/// Fails closed with [`reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING`]
-/// if the marker records active material but the generation vanished.
-/// Fails closed with [`reasons::MARKER_TAMPERED`] if material exists on
-/// disk with no matching active marker (never silently adopted).
-/// Succeeds (fresh generation 1) when never provisioned, or when the
-/// prior provisioning was cleanly retired.
+/// Read the literal name `current` resolves to (its symlink target's
+/// final component), without following the link past that.
+fn read_current_target(secrets_fd: BorrowedFd<'_>) -> Option<u64> {
+    let target = rustix::fs::readlinkat(secrets_fd, Path::new(CURRENT_LINK_NAME), Vec::new())
+        .ok()?
+        .into_string()
+        .ok()?;
+    let name = Path::new(&target).file_name()?.to_str()?;
+    parse_strict_epoch(name)
+}
+
+/// Atomically swap `current` to point at `generations/<epoch>` using a
+/// hidden-name-then-rename swap so there is never a moment `current`
+/// is absent. Idempotent: if `current` already resolves to `epoch`,
+/// this is a no-op.
+fn atomic_swap_current(secrets_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), FailReason> {
+    if read_current_target(secrets_fd) == Some(epoch) {
+        return Ok(());
+    }
+    let owned = borrowed_to_owned(secrets_fd)?;
+    let target = PathBuf::from(GENERATIONS_DIR_NAME).join(epoch.to_string());
+    // Best-effort cleanup of a leftover stage symlink from a previous
+    // crash between symlink-creation and rename.
+    let _ = path_safe::remove_path_safe(&owned, CURRENT_SWAP_STAGE_NAME);
+    rustix::fs::symlinkat(&target, secrets_fd, Path::new(CURRENT_SWAP_STAGE_NAME))
+        .map_err(|_| FailReason::CurrentSwapFailed)?;
+    rustix::fs::renameat(
+        secrets_fd,
+        Path::new(CURRENT_SWAP_STAGE_NAME),
+        secrets_fd,
+        Path::new(CURRENT_LINK_NAME),
+    )
+    .map_err(|_| FailReason::CurrentSwapFailed)?;
+    fsync_fd(secrets_fd);
+    Ok(())
+}
+
+/// `current` is always a symlink; [`path_safe::remove_path_safe`]
+/// refuses to operate on symlinks by design, so removal goes through
+/// a raw `unlinkat` instead. Tolerates absence (idempotent).
+fn remove_current_symlink(secrets_fd: BorrowedFd<'_>) -> Result<(), FailReason> {
+    match rustix::fs::unlinkat(
+        secrets_fd,
+        Path::new(CURRENT_LINK_NAME),
+        rustix::fs::AtFlags::empty(),
+    ) {
+        Ok(()) => {
+            fsync_fd(secrets_fd);
+            Ok(())
+        }
+        Err(rustix::io::Errno::NOENT) => Ok(()),
+        Err(_) => Err(FailReason::CurrentSwapFailed),
+    }
+}
+
+/// Remove one already-validated generation directory
+/// (`generations/<epoch>/material` then `generations/<epoch>/`).
+/// Tolerates the directory already being absent (idempotent
+/// crash-recovery replay). Any other failure is propagated: the
+/// caller must fail the whole retirement closed rather than continue
+/// past a partial deletion.
+fn remove_generation(generations_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), FailReason> {
+    let epoch_name = epoch.to_string();
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    let dir_fd = match path_safe::open_at(
+        generations_fd,
+        Path::new(&epoch_name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    ) {
+        Ok(fd) => fd,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
+    };
+    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
+    match path_safe::remove_path_safe(&dir_owned, MATERIAL_FILE_NAME) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
+    }
+    drop(dir_fd);
+    path_safe::remove_path_safe(&generations_owned, &epoch_name)
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    fsync_fd(generations_fd);
+    Ok(())
+}
+
+/// Anchored enumeration of `generations/`, failing closed on any
+/// entry this cannot fully account for. Deletes nothing; a caller
+/// invokes this to *plan* retirement, never as part of deleting.
+fn enumerate_and_validate_generation_tree(
+    generations_fd: BorrowedFd<'_>,
+) -> Result<Vec<u64>, FailReason> {
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    let dir = rustix::fs::Dir::read_from(generations_fd)
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let mut epochs = Vec::new();
+    for entry in dir {
+        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
+        let name = entry
+            .file_name()
+            .to_str()
+            .map_err(|_| FailReason::RetirementTreeAnomaly)?
+            .to_owned();
+        if name == "." || name == ".." {
+            continue;
+        }
+        if name.starts_with(STAGE_PREFIX) {
+            // Stage dirs are swept separately, never part of the
+            // retirement plan; their presence does not block
+            // retirement, but they must not be miscounted as a
+            // generation either.
+            continue;
+        }
+        let Some(epoch) = parse_strict_epoch(&name) else {
+            return Err(FailReason::RetirementTreeAnomaly);
+        };
+        verify_generation_dir_is_exactly_material(&generations_owned, &name)?;
+        epochs.push(epoch);
+    }
+    epochs.sort_unstable();
+    Ok(epochs)
+}
+
+fn verify_generation_dir_is_exactly_material(
+    generations_fd: &OwnedFd,
+    name: &str,
+) -> Result<(), FailReason> {
+    let stat = path_safe::fstatat_nofollow(generations_fd, name)
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?
+        .ok_or(FailReason::RetirementTreeAnomaly)?;
+    if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFDIR {
+        return Err(FailReason::RetirementTreeAnomaly);
+    }
+    let dir_fd = path_safe::open_at(
+        generations_fd.as_fd(),
+        Path::new(name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )
+    .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
+    let inner = rustix::fs::Dir::read_from(dir_fd.as_fd())
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let mut saw_material = false;
+    for entry in inner {
+        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
+        let ename = entry
+            .file_name()
+            .to_str()
+            .map_err(|_| FailReason::RetirementTreeAnomaly)?
+            .to_owned();
+        if ename == "." || ename == ".." {
+            continue;
+        }
+        if ename != MATERIAL_FILE_NAME {
+            return Err(FailReason::RetirementTreeAnomaly);
+        }
+        saw_material = true;
+    }
+    if !saw_material {
+        return Err(FailReason::RetirementTreeAnomaly);
+    }
+    let material_stat = path_safe::fstatat_nofollow(&dir_owned, MATERIAL_FILE_NAME)
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?
+        .ok_or(FailReason::RetirementTreeAnomaly)?;
+    if (material_stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFREG {
+        return Err(FailReason::RetirementTreeAnomaly);
+    }
+    if material_stat.st_nlink != 1 {
+        return Err(FailReason::RetirementTreeAnomaly);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// Unified promote engine (fresh action + crash recovery)
+// ---------------------------------------------------------------------
+
+enum PromoteOutcome {
+    Completed(MarkerData),
+    /// Only reachable when recovering a crash that occurred before
+    /// any material was ever staged for a `create_epoch` intent —
+    /// i.e. nothing was ever activated. Discarding is safe.
+    AbortedNoMaterial,
+}
+
+fn execute_promote(
+    secrets_fd: BorrowedFd<'_>,
+    generations_fd: BorrowedFd<'_>,
+    cfg: &SecretsLifecycleConfig,
+    mut intent: PromoteIntent,
+    mut material: Option<&SecretMaterial>,
+) -> Result<PromoteOutcome, FailReason> {
+    loop {
+        match intent.phase {
+            PromotePhase::Planned => {
+                if intent.create_epoch {
+                    let staged = ensure_staged(
+                        generations_fd,
+                        cfg,
+                        &intent.stage_name,
+                        &intent.expected_digest_hex,
+                        material,
+                    )?;
+                    if !staged {
+                        remove_txlog(secrets_fd)?;
+                        return Ok(PromoteOutcome::AbortedNoMaterial);
+                    }
+                    promote_stage_to_generation(
+                        generations_fd,
+                        &intent.stage_name,
+                        intent.to_epoch,
+                    )?;
+                } else {
+                    let expected = intent
+                        .expected_identity
+                        .as_ref()
+                        .ok_or(FailReason::RecoveryAmbiguous)?;
+                    verify_existing_generation_identity(generations_fd, expected)?;
+                }
+                material = None;
+                intent.phase = PromotePhase::EpochReady;
+                write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
+            }
+            PromotePhase::EpochReady => {
+                atomic_swap_current(secrets_fd, intent.to_epoch)?;
+                intent.phase = PromotePhase::CurrentPromoted;
+                write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
+            }
+            PromotePhase::CurrentPromoted => {
+                let identity = capture_identity(generations_fd, intent.to_epoch)?;
+                if identity.digest_hex != intent.expected_digest_hex {
+                    // `current` already points at this epoch; we must
+                    // never revert it. This can only mean the intent
+                    // itself was corrupted (e.g. hand-edited txlog) —
+                    // fail closed without touching current/marker.
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
+                if intent.new_high_water_epoch < intent.to_epoch {
+                    return Err(FailReason::HighWaterRegressed);
+                }
+                let marker = MarkerData {
+                    v: MARKER_SCHEMA_VERSION,
+                    vm: intent.vm.clone(),
+                    kind: intent.kind.clone(),
+                    retired: false,
+                    high_water_epoch: intent.new_high_water_epoch,
+                    active: Some(identity),
+                    previous: intent.carry_previous.clone(),
+                    first_provisioned_ms: intent.first_provisioned_ms,
+                    updated_ms: now_ms(),
+                };
+                write_marker(secrets_fd, &marker)?;
+                intent.phase = PromotePhase::MarkerCommitted;
+                write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
+            }
+            PromotePhase::MarkerCommitted => {
+                if let Some(prune) = intent.prune_epoch {
+                    // Best-effort: pruning failure does not fail the
+                    // action (the marker already durably reflects the
+                    // correct active/previous state); it only leaves
+                    // an orphaned generation directory for a future
+                    // retire() to clean up via its full-tree
+                    // enumeration.
+                    let _ = remove_generation(generations_fd, prune);
+                }
+                sweep_stale_stage_dirs(generations_fd, None);
+                remove_txlog(secrets_fd)?;
+                let marker = read_marker(secrets_fd)?.ok_or(FailReason::MarkerWriteFailed)?;
+                return Ok(PromoteOutcome::Completed(marker));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Unified retire engine (fresh action + crash recovery)
+// ---------------------------------------------------------------------
+
+fn execute_retire(
+    secrets_fd: BorrowedFd<'_>,
+    generations_fd: BorrowedFd<'_>,
+    mut intent: RetireIntent,
+) -> Result<(), FailReason> {
+    loop {
+        match intent.phase {
+            RetirePhase::Enumerated => {
+                let fresh = enumerate_and_validate_generation_tree(generations_fd)?;
+                if !fresh.iter().all(|e| intent.epochs.contains(e)) {
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
+                remove_current_symlink(secrets_fd)?;
+                intent.phase = RetirePhase::CurrentRemoved;
+                write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
+            }
+            RetirePhase::CurrentRemoved => {
+                for &epoch in &intent.epochs {
+                    remove_generation(generations_fd, epoch)?;
+                }
+                intent.phase = RetirePhase::EpochsRemoved;
+                write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
+            }
+            RetirePhase::EpochsRemoved => {
+                let remaining = enumerate_and_validate_generation_tree(generations_fd)?;
+                if !remaining.is_empty() {
+                    return Err(FailReason::RetirementNotProvablyEmpty);
+                }
+                intent.phase = RetirePhase::ProvenEmpty;
+                write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
+            }
+            RetirePhase::ProvenEmpty => {
+                sweep_stale_stage_dirs(generations_fd, None);
+                let marker = MarkerData {
+                    v: MARKER_SCHEMA_VERSION,
+                    vm: intent.vm.clone(),
+                    kind: intent.kind.clone(),
+                    retired: true,
+                    high_water_epoch: intent.high_water_epoch,
+                    active: None,
+                    previous: None,
+                    first_provisioned_ms: 0,
+                    updated_ms: now_ms(),
+                };
+                write_marker(secrets_fd, &marker)?;
+                remove_txlog(secrets_fd)?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Recovery dispatch
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecoveryError {
+    pub action: Option<LifecycleAction>,
+    pub reason: FailReason,
+}
+
+fn recover_if_needed(
+    secrets_fd: BorrowedFd<'_>,
+    generations_fd: BorrowedFd<'_>,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<bool, RecoveryError> {
+    let txlog = read_txlog(secrets_fd).map_err(|reason| RecoveryError {
+        action: None,
+        reason,
+    })?;
+    let Some(txlog) = txlog else {
+        return Ok(false);
+    };
+    match txlog {
+        TxLog::Promote(intent) => {
+            let action = intent.action;
+            match execute_promote(secrets_fd, generations_fd, cfg, intent, None) {
+                Ok(_) => Ok(true),
+                Err(reason) => Err(RecoveryError {
+                    action: Some(action),
+                    reason,
+                }),
+            }
+        }
+        TxLog::Retire(intent) => match execute_retire(secrets_fd, generations_fd, intent) {
+            Ok(()) => Ok(true),
+            Err(reason) => Err(RecoveryError {
+                action: Some(LifecycleAction::Retire),
+                reason,
+            }),
+        },
+    }
+}
+
+/// Standalone entry point for draining a leftover crash-interrupted
+/// transaction independent of issuing a new lifecycle action (e.g. at
+/// realm controller/broker startup, per the module doc's wiring point
+/// §9). Returns `Ok(true)` if a leftover transaction was found and
+/// completed/discarded, `Ok(false)` if there was nothing to recover.
+pub fn recover_in_flight_transaction(
+    vm_id: &str,
+    kind: SecretKind,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<bool, SecretsLifecycleError> {
+    let paths = derive_paths(vm_id, kind, cfg).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::denied(
+            &SecretsLifecycleAuditContext {
+                vm_id: vm_id.to_owned(),
+                kind,
+                action: LifecycleAction::Provision,
+                base_dir_hash: String::new(),
+            },
+            reason,
+        ),
+    })?;
+    let (secrets_fd, generations_fd) =
+        open_or_create_secrets_dir(&paths, cfg).map_err(|reason| {
+            let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
+            denied(&ctx, reason)
+        })?;
+    let _lock = acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| {
+        let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
+        denied(&ctx, reason)
+    })?;
+    match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), cfg) {
+        Ok(recovered) => Ok(recovered),
+        Err(err) => {
+            let ctx = context(
+                vm_id,
+                kind,
+                err.action.unwrap_or(LifecycleAction::Provision),
+                &paths,
+            );
+            Err(failed_closed(&ctx, MarkerResult::FailedClosed, err.reason))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Public lifecycle actions
+// ---------------------------------------------------------------------
+
+/// `(paths, secrets_fd, generations_fd, lock, recovered_prior_transaction, marker)`.
+type OpenAndRecoverOk = (
+    SecretsLifecyclePaths,
+    OwnedFd,
+    OwnedFd,
+    LockGuard,
+    bool,
+    Option<MarkerData>,
+);
+
+fn open_and_recover(
+    vm_id: &str,
+    kind: SecretKind,
+    action: LifecycleAction,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<OpenAndRecoverOk, SecretsLifecycleError> {
+    let paths = derive_paths(vm_id, kind, cfg).map_err(|reason| {
+        let ctx = SecretsLifecycleAuditContext {
+            vm_id: vm_id.to_owned(),
+            kind,
+            action,
+            base_dir_hash: String::new(),
+        };
+        denied(&ctx, reason)
+    })?;
+    let ctx = context(vm_id, kind, action, &paths);
+    let (secrets_fd, generations_fd) =
+        open_or_create_secrets_dir(&paths, cfg).map_err(|reason| denied(&ctx, reason))?;
+    let lock = acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| denied(&ctx, reason))?;
+    let recovered = match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), cfg) {
+        Ok(recovered) => recovered,
+        Err(err) => {
+            let recovered_ctx = context(vm_id, kind, err.action.unwrap_or(action), &paths);
+            return Err(failed_closed(
+                &recovered_ctx,
+                MarkerResult::FailedClosed,
+                err.reason,
+            ));
+        }
+    };
+    let marker = read_marker(secrets_fd.as_fd()).map_err(|reason| denied(&ctx, reason))?;
+    Ok((paths, secrets_fd, generations_fd, lock, recovered, marker))
+}
+
+/// Provision fresh generation-1 material. Fails closed
+/// ([`FailReason::AlreadyProvisioned`], denied) if the marker already
+/// records an active (non-retired) generation, and
+/// ([`FailReason::GenerationConflict`], failed) if the physical tree
+/// is non-empty without a matching active marker (an anomaly this
+/// module refuses to silently adopt).
 pub fn provision(
-    paths: &SecretsLifecyclePaths,
+    vm_id: &str,
+    kind: SecretKind,
+    material: SecretMaterial,
     cfg: &SecretsLifecycleConfig,
-    material: &SecretMaterial,
 ) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let ctx = context(paths, LifecycleAction::Provision);
-    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-    let existing = read_marker(&marker_dir_fd, paths).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-    let secrets_dir_fd =
-        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        })?;
-    let has_current = current_present(&secrets_dir_fd).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-    let marker_active = existing.as_ref().map(|m| !m.retired).unwrap_or(false);
+    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
+        open_and_recover(vm_id, kind, LifecycleAction::Provision, cfg)?;
+    let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
 
-    match (marker_active, has_current) {
-        (true, true) => {
-            return Err(SecretsLifecycleError {
-                reason: reasons::ALREADY_PROVISIONED,
-                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::ALREADY_PROVISIONED),
-            });
-        }
-        (true, false) => {
-            return Err(SecretsLifecycleError {
-                reason: reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING,
-                ),
-            });
-        }
-        (false, true) => {
-            // Material present with no active marker backing it: a
-            // planted or drifted directory. Never silently adopted.
-            return Err(SecretsLifecycleError {
-                reason: reasons::MARKER_TAMPERED,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reasons::MARKER_TAMPERED,
-                ),
-            });
-        }
-        (false, false) => {}
+    if let Some(marker) = &marker
+        && marker.active.is_some()
+        && !marker.retired
+    {
+        return Err(denied(&ctx, FailReason::AlreadyProvisioned));
+    }
+    let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
+        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+    if !existing.is_empty() {
+        return Err(failed_closed(
+            &ctx,
+            MarkerResult::FailedClosed,
+            FailReason::GenerationConflict,
+        ));
     }
 
-    let stat = write_generation(&secrets_dir_fd, 1, material, cfg).map_err(|reason| {
-        SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        }
-    })?;
-    atomic_swap_current(secrets_dir_fd.as_fd(), 1).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-
-    let marker = MarkerData {
-        v: MARKER_SCHEMA_VERSION,
-        vm: paths.vm_id.clone(),
-        kind: paths.kind.as_slug().to_owned(),
-        retired: false,
-        generation: Some(1),
-        previous_generation: None,
-        active_dev: Some(stat.st_dev),
-        active_ino: Some(stat.st_ino),
-        first_provisioned_ms: cfg.now_ms,
-        updated_ms: cfg.now_ms,
+    let digest_hex = material.digest_hex();
+    let intent = PromoteIntent {
+        vm: vm_id.to_owned(),
+        kind: kind.as_slug().to_owned(),
+        action: LifecycleAction::Provision,
+        to_epoch: 1,
+        create_epoch: true,
+        stage_name: random_stage_name(),
+        expected_digest_hex: digest_hex.clone(),
+        expected_identity: None,
+        carry_previous: None,
+        prune_epoch: None,
+        new_high_water_epoch: 1,
+        first_provisioned_ms: now_ms(),
+        phase: PromotePhase::Planned,
     };
-    write_marker(&marker_dir_fd, paths, cfg, &marker).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-
-    Ok(SecretsLifecycleAuditFields::provisioned(
-        &ctx,
-        material.digest_hex(),
-    ))
+    write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
+        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+    match execute_promote(
+        secrets_fd.as_fd(),
+        generations_fd.as_fd(),
+        cfg,
+        intent,
+        Some(&material),
+    ) {
+        Ok(PromoteOutcome::Completed(new_marker)) => Ok(SecretsLifecycleAuditFields::provisioned(
+            &ctx,
+            new_marker.high_water_epoch,
+            digest_hex,
+            recovered,
+        )),
+        Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
+            &ctx,
+            MarkerResult::FailedClosed,
+            FailReason::MaterialWriteFailed,
+        )),
+        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
+    }
 }
 
-/// Rotate `(vm, kind)` to a new generation, retaining exactly the
-/// immediately-prior generation for [`rollback`].
-///
-/// Requires an active (non-retired) marker; verifies the marker's
-/// recorded active generation identity against the live directory
-/// before mutating, so a TOCTOU swap of the active generation's
-/// content is caught rather than silently rotated forward from an
-/// attacker-controlled base.
+/// Retained generations after a successful rotate/rollback: exactly
+/// `previous`'s epoch, when one exists.
+fn retained_from_previous(previous: &Option<MaterialIdentity>) -> Vec<u64> {
+    previous.as_ref().map(|p| vec![p.epoch]).unwrap_or_default()
+}
+
+/// Create and activate a new generation. Requires an active,
+/// non-retired marker (else [`FailReason::NotProvisioned`], denied).
+/// Allocates `to_epoch = high_water_epoch + 1` — never
+/// `current_epoch + 1` — so a rotate issued after a rollback can
+/// never collide with a still-materialised newer epoch the rollback
+/// moved away from.
 pub fn rotate(
-    paths: &SecretsLifecyclePaths,
+    vm_id: &str,
+    kind: SecretKind,
+    material: SecretMaterial,
     cfg: &SecretsLifecycleConfig,
-    material: &SecretMaterial,
 ) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let ctx = context(paths, LifecycleAction::Rotate);
-    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-    let marker = match read_marker(&marker_dir_fd, paths) {
-        Ok(Some(marker)) if !marker.retired => marker,
-        Ok(Some(_)) => {
-            return Err(SecretsLifecycleError {
-                reason: reasons::ALREADY_RETIRED,
-                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::ALREADY_RETIRED),
-            });
-        }
-        Ok(None) => {
-            return Err(SecretsLifecycleError {
-                reason: reasons::NOT_PROVISIONED,
-                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::NOT_PROVISIONED),
-            });
-        }
-        Err(reason) => {
-            return Err(SecretsLifecycleError {
-                reason,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reason,
-                ),
-            });
-        }
+    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
+        open_and_recover(vm_id, kind, LifecycleAction::Rotate, cfg)?;
+    let ctx = context(vm_id, kind, LifecycleAction::Rotate, &paths);
+
+    let marker = match marker {
+        Some(marker) if marker.active.is_some() && !marker.retired => marker,
+        _ => return Err(denied(&ctx, FailReason::NotProvisioned)),
     };
-
-    let secrets_dir_fd =
-        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        })?;
-    verify_active_identity(&secrets_dir_fd, &marker).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-
-    let current_generation = marker.generation.ok_or_else(|| SecretsLifecycleError {
-        reason: reasons::MARKER_TAMPERED,
-        audit: SecretsLifecycleAuditFields::failed(
+    let active = marker.active.clone().expect("checked above");
+    let to_epoch = marker.high_water_epoch + 1;
+    let digest_hex = material.digest_hex();
+    let intent = PromoteIntent {
+        vm: vm_id.to_owned(),
+        kind: kind.as_slug().to_owned(),
+        action: LifecycleAction::Rotate,
+        to_epoch,
+        create_epoch: true,
+        stage_name: random_stage_name(),
+        expected_digest_hex: digest_hex.clone(),
+        expected_identity: None,
+        carry_previous: Some(active),
+        prune_epoch: marker.previous.as_ref().map(|p| p.epoch),
+        new_high_water_epoch: to_epoch,
+        first_provisioned_ms: marker.first_provisioned_ms,
+        phase: PromotePhase::Planned,
+    };
+    write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
+        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+    match execute_promote(
+        secrets_fd.as_fd(),
+        generations_fd.as_fd(),
+        cfg,
+        intent,
+        Some(&material),
+    ) {
+        Ok(PromoteOutcome::Completed(new_marker)) => Ok(SecretsLifecycleAuditFields::rotated(
+            &ctx,
+            new_marker.active.as_ref().map(|i| i.epoch).unwrap_or(0),
+            new_marker.high_water_epoch,
+            retained_from_previous(&new_marker.previous),
+            digest_hex,
+            recovered,
+        )),
+        Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
             MarkerResult::FailedClosed,
-            reasons::MARKER_TAMPERED,
-        ),
-    })?;
-    let new_generation =
-        current_generation
-            .checked_add(1)
-            .ok_or_else(|| SecretsLifecycleError {
-                reason: reasons::GENERATION_CONFLICT,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reasons::GENERATION_CONFLICT,
-                ),
-            })?;
-
-    let stat =
-        write_generation(&secrets_dir_fd, new_generation, material, cfg).map_err(|reason| {
-            SecretsLifecycleError {
-                reason,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reason,
-                ),
-            }
-        })?;
-    atomic_swap_current(secrets_dir_fd.as_fd(), new_generation).map_err(|reason| {
-        SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        }
-    })?;
-
-    // Retention policy: keep exactly the generation we just rotated
-    // away from; prune anything older. Best-effort — a prune failure
-    // never rolls back the already-committed rotate.
-    if let Some(stale) = marker.previous_generation {
-        remove_generation(&secrets_dir_fd, stale);
+            FailReason::MaterialWriteFailed,
+        )),
+        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
     }
-
-    let updated_marker = MarkerData {
-        v: MARKER_SCHEMA_VERSION,
-        vm: paths.vm_id.clone(),
-        kind: paths.kind.as_slug().to_owned(),
-        retired: false,
-        generation: Some(new_generation),
-        previous_generation: Some(current_generation),
-        active_dev: Some(stat.st_dev),
-        active_ino: Some(stat.st_ino),
-        first_provisioned_ms: marker.first_provisioned_ms,
-        updated_ms: cfg.now_ms,
-    };
-    write_marker(&marker_dir_fd, paths, cfg, &updated_marker).map_err(|reason| {
-        SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        }
-    })?;
-
-    Ok(SecretsLifecycleAuditFields::rotated(
-        &ctx,
-        new_generation,
-        vec![current_generation],
-        material.digest_hex(),
-    ))
 }
 
-/// Swap `current` back to the immediately-prior generation recorded
-/// by the marker. Fails closed with [`reasons::NO_ROLLBACK_TARGET`] if
-/// no previous generation is tracked (either never rotated, or the
-/// retained generation was already pruned by a later action).
+/// Swap `current` back to the retained `previous` generation.
+/// Requires a `previous` entry (else [`FailReason::NoRollbackTarget`],
+/// denied). Tamper-verifies the retained generation's full recorded
+/// identity before promoting it. The generation being rolled back
+/// *from* becomes the new `previous` (so a rollback may itself be
+/// rolled back / "rolled forward"); `high_water_epoch` is unchanged
+/// (rollback never grows the monotonic mark) and nothing is pruned.
 pub fn rollback(
-    paths: &SecretsLifecyclePaths,
+    vm_id: &str,
+    kind: SecretKind,
     cfg: &SecretsLifecycleConfig,
 ) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let ctx = context(paths, LifecycleAction::Rollback);
-    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-    let marker = match read_marker(&marker_dir_fd, paths) {
-        Ok(Some(marker)) if !marker.retired => marker,
-        Ok(Some(_)) => {
-            return Err(SecretsLifecycleError {
-                reason: reasons::ALREADY_RETIRED,
-                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::ALREADY_RETIRED),
-            });
-        }
-        Ok(None) => {
-            return Err(SecretsLifecycleError {
-                reason: reasons::NOT_PROVISIONED,
-                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::NOT_PROVISIONED),
-            });
-        }
-        Err(reason) => {
-            return Err(SecretsLifecycleError {
-                reason,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reason,
-                ),
-            });
-        }
-    };
-    let Some(previous_generation) = marker.previous_generation else {
-        return Err(SecretsLifecycleError {
-            reason: reasons::NO_ROLLBACK_TARGET,
-            audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::NO_ROLLBACK_TARGET),
-        });
-    };
+    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
+        open_and_recover(vm_id, kind, LifecycleAction::Rollback, cfg)?;
+    let ctx = context(vm_id, kind, LifecycleAction::Rollback, &paths);
 
-    let secrets_dir_fd =
-        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        })?;
-    verify_active_identity(&secrets_dir_fd, &marker).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-    let previous_stat =
-        stat_generation(&secrets_dir_fd, previous_generation).map_err(|reason| {
-            SecretsLifecycleError {
-                reason,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reason,
-                ),
-            }
-        })?;
-
-    let current_generation = marker.generation.ok_or_else(|| SecretsLifecycleError {
-        reason: reasons::MARKER_TAMPERED,
-        audit: SecretsLifecycleAuditFields::failed(
+    let marker = match marker {
+        Some(marker) if marker.active.is_some() && !marker.retired => marker,
+        _ => return Err(denied(&ctx, FailReason::NotProvisioned)),
+    };
+    let Some(previous) = marker.previous.clone() else {
+        return Err(denied(&ctx, FailReason::NoRollbackTarget));
+    };
+    let active = marker.active.clone().expect("checked above");
+    let intent = PromoteIntent {
+        vm: vm_id.to_owned(),
+        kind: kind.as_slug().to_owned(),
+        action: LifecycleAction::Rollback,
+        to_epoch: previous.epoch,
+        create_epoch: false,
+        stage_name: String::new(),
+        expected_digest_hex: previous.digest_hex.clone(),
+        expected_identity: Some(previous),
+        carry_previous: Some(active),
+        prune_epoch: None,
+        new_high_water_epoch: marker.high_water_epoch,
+        first_provisioned_ms: marker.first_provisioned_ms,
+        phase: PromotePhase::Planned,
+    };
+    write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
+        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+    match execute_promote(
+        secrets_fd.as_fd(),
+        generations_fd.as_fd(),
+        cfg,
+        intent,
+        None,
+    ) {
+        Ok(PromoteOutcome::Completed(new_marker)) => Ok(SecretsLifecycleAuditFields::rolled_back(
+            &ctx,
+            new_marker.active.as_ref().map(|i| i.epoch).unwrap_or(0),
+            new_marker.high_water_epoch,
+            retained_from_previous(&new_marker.previous),
+            recovered,
+        )),
+        Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
             MarkerResult::FailedClosed,
-            reasons::MARKER_TAMPERED,
-        ),
-    })?;
-
-    atomic_swap_current(secrets_dir_fd.as_fd(), previous_generation).map_err(|reason| {
-        SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        }
-    })?;
-
-    let updated_marker = MarkerData {
-        v: MARKER_SCHEMA_VERSION,
-        vm: paths.vm_id.clone(),
-        kind: paths.kind.as_slug().to_owned(),
-        retired: false,
-        generation: Some(previous_generation),
-        previous_generation: Some(current_generation),
-        active_dev: Some(previous_stat.st_dev),
-        active_ino: Some(previous_stat.st_ino),
-        first_provisioned_ms: marker.first_provisioned_ms,
-        updated_ms: cfg.now_ms,
-    };
-    write_marker(&marker_dir_fd, paths, cfg, &updated_marker).map_err(|reason| {
-        SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        }
-    })?;
-
-    Ok(SecretsLifecycleAuditFields::rolled_back(
-        &ctx,
-        previous_generation,
-        vec![current_generation],
-    ))
+            FailReason::RecoveryAmbiguous,
+        )),
+        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
+    }
 }
 
-/// Retire `(vm, kind)`: remove all tracked generations, the `current`
-/// symlink, and tombstone the marker. Idempotent — retiring an
-/// already-retired or never-provisioned kind returns
-/// [`crate::ops::secrets_rotation_audit::LifecycleResult::VerifiedClean`]
-/// rather than an error.
-///
-/// Fails closed (rather than proceeding to tombstone) if the marker
-/// records active material that has already vanished from disk — an
-/// operator must investigate the drift before this component treats
-/// the kind as cleanly retired.
+/// Remove every generation and tombstone the marker. Always
+/// anchored-enumerates and validates the *entire physical*
+/// `generations/` tree first, regardless of what the marker claims —
+/// an absent/tombstoned marker over non-empty storage is still fully
+/// retired (never treated as already-clean), and an active marker
+/// over empty storage fails closed
+/// ([`FailReason::PreviouslyProvisionedMaterialMissing`]) rather than
+/// silently accepting the discrepancy.
 pub fn retire(
-    paths: &SecretsLifecyclePaths,
+    vm_id: &str,
+    kind: SecretKind,
     cfg: &SecretsLifecycleConfig,
 ) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let ctx = context(paths, LifecycleAction::Retire);
-    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
-    let marker = match read_marker(&marker_dir_fd, paths) {
-        Ok(None) => return Ok(SecretsLifecycleAuditFields::verified_clean(&ctx, None)),
-        Ok(Some(marker)) if marker.retired => {
-            return Ok(SecretsLifecycleAuditFields::verified_clean(&ctx, None));
-        }
-        Ok(Some(marker)) => marker,
-        Err(reason) => {
-            return Err(SecretsLifecycleError {
-                reason,
-                audit: SecretsLifecycleAuditFields::failed(
-                    &ctx,
-                    MarkerResult::FailedClosed,
-                    reason,
-                ),
-            });
-        }
-    };
+    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
+        open_and_recover(vm_id, kind, LifecycleAction::Retire, cfg)?;
+    let ctx = context(vm_id, kind, LifecycleAction::Retire, &paths);
 
-    let secrets_dir_fd =
-        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        })?;
-    verify_active_identity(&secrets_dir_fd, &marker).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-    })?;
+    sweep_stale_stage_dirs(generations_fd.as_fd(), None);
+    let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
+        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
 
-    remove_current_symlink(&secrets_dir_fd);
-    if let Some(generation) = marker.generation {
-        remove_generation(&secrets_dir_fd, generation);
-    }
-    if let Some(previous) = marker.previous_generation {
-        remove_generation(&secrets_dir_fd, previous);
+    let recorded_high_water = marker.as_ref().map(|m| m.high_water_epoch).unwrap_or(0);
+    let marker_claims_active = marker
+        .as_ref()
+        .map(|m| m.active.is_some() && !m.retired)
+        .unwrap_or(false);
+
+    if existing.is_empty() {
+        if marker_claims_active {
+            // Marker says material should exist; the physical tree
+            // disagrees. Fail closed rather than silently accepting
+            // "clean" over an unexplained discrepancy.
+            return Err(failed_closed(
+                &ctx,
+                MarkerResult::FailedClosed,
+                FailReason::PreviouslyProvisionedMaterialMissing,
+            ));
+        }
+        return Ok(SecretsLifecycleAuditFields::verified_clean(
+            &ctx,
+            recorded_high_water,
+        ));
     }
 
-    let tombstoned_marker = MarkerData {
-        v: MARKER_SCHEMA_VERSION,
-        vm: paths.vm_id.clone(),
-        kind: paths.kind.as_slug().to_owned(),
-        retired: true,
-        generation: None,
-        previous_generation: None,
-        active_dev: None,
-        active_ino: None,
-        first_provisioned_ms: marker.first_provisioned_ms,
-        updated_ms: cfg.now_ms,
+    let high_water_epoch = recorded_high_water.max(existing.iter().copied().max().unwrap_or(0));
+    let intent = RetireIntent {
+        vm: vm_id.to_owned(),
+        kind: kind.as_slug().to_owned(),
+        epochs: existing,
+        high_water_epoch,
+        phase: RetirePhase::Enumerated,
     };
-    write_marker(&marker_dir_fd, paths, cfg, &tombstoned_marker).map_err(|reason| {
-        SecretsLifecycleError {
-            reason,
-            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
-        }
-    })?;
-
-    Ok(SecretsLifecycleAuditFields::retired(&ctx))
+    write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent.clone()))
+        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+    match execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), intent) {
+        Ok(()) => Ok(SecretsLifecycleAuditFields::retired(
+            &ctx,
+            high_water_epoch,
+            recovered,
+        )),
+        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
+    }
 }
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ops::secrets_rotation_audit::LifecycleResult;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
 
-    fn test_cfg(now_ms: u64) -> SecretsLifecycleConfig {
-        let uid = nix::unistd::getuid().as_raw();
-        let gid = nix::unistd::getgid().as_raw();
+    fn cfg_at(root: &std::path::Path) -> SecretsLifecycleConfig {
         SecretsLifecycleConfig {
-            expected_uid: uid,
-            expected_gid: gid,
-            marker_owner_uid: uid,
-            marker_owner_gid: gid,
-            now_ms,
-            enforce_root_parents: false,
+            state_root: root.to_path_buf(),
+            dir_mode: 0o700,
+            file_mode: 0o600,
+            owner_uid: None,
+            owner_gid: None,
+            lock_max_wait: Duration::from_millis(500),
+            lock_poll_interval: Duration::from_millis(5),
         }
     }
 
-    /// Build test paths that mirror `derive_paths`'s real contract:
-    /// `secrets_dir` sits beneath a `per_vm_state_root` that the
-    /// (out-of-scope) state-dir prepare step is assumed to have
-    /// already created, so this helper creates that stand-in root
-    /// itself. `marker_dir`'s parent (the marker tree root) is
-    /// deliberately left uncreated so tests exercise this module's
-    /// own first-use creation of it.
-    fn test_paths(root: &Path, vm: &str, kind: SecretKind) -> SecretsLifecyclePaths {
-        let per_vm_state_root = root.join("state").join(vm);
-        std::fs::create_dir_all(&per_vm_state_root).expect("stand-in per-vm root");
-        SecretsLifecyclePaths {
-            vm_id: vm.to_owned(),
-            kind,
-            secrets_dir: per_vm_state_root.join("secrets").join(kind.as_slug()),
-            marker_dir: root.join("markers").join(vm),
-        }
+    fn material(bytes: &[u8]) -> SecretMaterial {
+        SecretMaterial::new(bytes.to_vec()).expect("valid material")
     }
 
-    fn material(byte: u8) -> SecretMaterial {
-        SecretMaterial::new(vec![byte; 32]).expect("valid material")
+    fn assert_valid(fields: &SecretsLifecycleAuditFields) {
+        fields.validate().unwrap_or_else(|err| {
+            panic!("audit fields failed validation: {err}\nfields: {fields:?}")
+        });
     }
+
+    // -------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------
 
     #[test]
-    fn valid_vm_id_accepts_and_rejects_expected_shapes() {
-        assert!(valid_vm_id("work"));
-        assert!(valid_vm_id("corp-vm-1"));
-        assert!(!valid_vm_id(""));
-        assert!(!valid_vm_id("Work"));
-        assert!(!valid_vm_id("1work"));
-        assert!(!valid_vm_id("work/etc"));
-    }
+    fn provision_rotate_rollback_retire_happy_path() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "alice";
+        let kind = SecretKind::GuestSigningKey;
 
-    #[test]
-    fn derive_paths_rejects_invalid_vm_id_and_relative_root() {
-        assert!(
-            derive_paths(
-                Path::new("/var/lib/d2b/vms/work"),
-                "Bad",
-                SecretKind::GuestSigningKey
-            )
-            .is_err()
-        );
-        assert!(derive_paths(Path::new("relative"), "work", SecretKind::GuestSigningKey).is_err());
-        let paths = derive_paths(
-            Path::new("/var/lib/d2b/vms/work"),
-            "work",
-            SecretKind::GuestSigningKey,
-        )
-        .expect("valid derivation");
-        assert_eq!(
-            paths.secrets_dir,
-            Path::new("/var/lib/d2b/vms/work/secrets/guest-signing-key")
-        );
-        assert_eq!(paths.marker_dir, Path::new(MARKER_TREE_ROOT).join("work"));
-    }
+        let provisioned = provision(vm, kind, material(b"gen-1"), &cfg).unwrap();
+        assert_valid(&provisioned);
+        assert_eq!(provisioned.lineage_epoch, Some(1));
+        assert_eq!(provisioned.high_water_epoch, Some(1));
 
-    #[test]
-    fn secret_material_rejects_empty_and_oversized() {
-        assert!(SecretMaterial::new(Vec::new()).is_err());
-        assert!(SecretMaterial::new(vec![0u8; SecretMaterial::MAX_LEN + 1]).is_err());
-        assert!(SecretMaterial::new(vec![1u8; 4]).is_ok());
-    }
+        // Duplicate provision on an active lineage is denied.
+        let err = provision(vm, kind, material(b"gen-1-again"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::AlreadyProvisioned);
 
-    #[test]
-    fn secret_material_debug_never_prints_bytes() {
-        let m = material(0xAB);
-        let debug = format!("{m:?}");
-        assert!(!debug.contains("171"));
-        assert!(debug.contains("redacted"));
-    }
-
-    #[test]
-    fn provision_then_rotate_then_rollback_then_retire_round_trip() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
-        let cfg = test_cfg(1_000);
-
-        let provisioned = provision(&paths, &cfg, &material(1)).expect("provision succeeds");
-        assert_eq!(provisioned.result, LifecycleResult::Created);
-        assert_eq!(provisioned.generation, Some(1));
-
-        let rotated = rotate(&paths, &test_cfg(2_000), &material(2)).expect("rotate succeeds");
-        assert_eq!(rotated.result, LifecycleResult::Rotated);
-        assert_eq!(rotated.generation, Some(2));
+        let rotated = rotate(vm, kind, material(b"gen-2"), &cfg).unwrap();
+        assert_valid(&rotated);
+        assert_eq!(rotated.lineage_epoch, Some(2));
+        assert_eq!(rotated.high_water_epoch, Some(2));
         assert_eq!(rotated.retained_generations, vec![1]);
 
-        let rolled_back = rollback(&paths, &test_cfg(3_000)).expect("rollback succeeds");
-        assert_eq!(rolled_back.result, LifecycleResult::RolledBack);
-        assert_eq!(rolled_back.generation, Some(1));
-        assert_eq!(rolled_back.retained_generations, vec![2]);
+        let rotated_again = rotate(vm, kind, material(b"gen-3"), &cfg).unwrap();
+        assert_valid(&rotated_again);
+        assert_eq!(rotated_again.lineage_epoch, Some(3));
+        assert_eq!(rotated_again.high_water_epoch, Some(3));
+        // Rotation prunes everything but the immediately-previous
+        // generation; epoch 1 is gone once epoch 3 supersedes epoch 2.
+        assert_eq!(rotated_again.retained_generations, vec![2]);
 
-        let retired = retire(&paths, &test_cfg(4_000)).expect("retire succeeds");
-        assert_eq!(retired.result, LifecycleResult::Retired);
+        let rolled_back = rollback(vm, kind, &cfg).unwrap();
+        assert_valid(&rolled_back);
+        assert_eq!(rolled_back.lineage_epoch, Some(2));
+        // Rollback never grows the monotonic high-water mark.
+        assert_eq!(rolled_back.high_water_epoch, Some(3));
+        assert_eq!(rolled_back.retained_generations, vec![3]);
 
-        // Idempotent retire.
-        let retired_again = retire(&paths, &test_cfg(5_000)).expect("retire is idempotent");
-        assert_eq!(retired_again.result, LifecycleResult::VerifiedClean);
-    }
+        // Rolling back again ("redo") returns to epoch 3.
+        let redo = rollback(vm, kind, &cfg).unwrap();
+        assert_valid(&redo);
+        assert_eq!(redo.lineage_epoch, Some(3));
+        assert_eq!(redo.high_water_epoch, Some(3));
+        assert_eq!(redo.retained_generations, vec![2]);
 
-    #[test]
-    fn provision_twice_without_retire_is_denied() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::TpmBoundCredential);
-        let cfg = test_cfg(1_000);
-        provision(&paths, &cfg, &material(1)).expect("first provision succeeds");
-        let err = provision(&paths, &cfg, &material(2)).expect_err("second provision denied");
-        assert_eq!(err.reason, reasons::ALREADY_PROVISIONED);
-        assert_eq!(err.audit.result, LifecycleResult::Denied);
+        let retired = retire(vm, kind, &cfg).unwrap();
+        assert_valid(&retired);
+        assert_eq!(retired.high_water_epoch, Some(3));
+
+        // Retiring an already-retired (never re-provisioned) lineage
+        // is a clean no-op, not an error.
+        let verified = retire(vm, kind, &cfg).unwrap();
+        assert_valid(&verified);
     }
 
     #[test]
     fn rotate_without_provision_is_denied() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::SecurityKeyChannelState);
-        let cfg = test_cfg(1_000);
-        let err = rotate(&paths, &cfg, &material(1)).expect_err("rotate without provision denied");
-        assert_eq!(err.reason, reasons::NOT_PROVISIONED);
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let err = rotate("bob", SecretKind::TpmBoundCredential, material(b"x"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::NotProvisioned);
     }
 
     #[test]
-    fn rollback_without_prior_rotate_has_no_target() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
-        let cfg = test_cfg(1_000);
-        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
-        let err = rollback(&paths, &test_cfg(2_000)).expect_err("no rollback target");
-        assert_eq!(err.reason, reasons::NO_ROLLBACK_TARGET);
+    fn rollback_without_previous_generation_is_denied() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "carol";
+        let kind = SecretKind::SecurityKeyChannelState;
+        provision(vm, kind, material(b"only-gen"), &cfg).unwrap();
+        let err = rollback(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::NoRollbackTarget);
     }
 
     #[test]
-    fn provision_after_clean_retire_succeeds_at_generation_one() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
-        let cfg = test_cfg(1_000);
-        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
-        retire(&paths, &test_cfg(2_000)).expect("retire succeeds");
-        let reprovisioned =
-            provision(&paths, &test_cfg(3_000), &material(3)).expect("re-provision succeeds");
-        assert_eq!(reprovisioned.generation, Some(1));
+    fn retire_never_provisioned_is_verified_clean() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let fields = retire("never-provisioned", SecretKind::GuestSigningKey, &cfg).unwrap();
+        assert_valid(&fields);
+        assert_eq!(fields.high_water_epoch, Some(0));
     }
 
     #[test]
-    fn provision_fails_closed_when_marker_missing_but_current_exists() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
-        let cfg = test_cfg(1_000);
-        // Simulate drift: the secrets tree exists (with a `current`
-        // symlink and a generation) but the marker was never written
-        // (or was removed out of band).
-        let secrets_dir_fd = open_or_create_secrets_dir(&paths, &cfg).expect("dir created");
-        write_generation(&secrets_dir_fd, 1, &material(9), &cfg).expect("material written");
-        atomic_swap_current(secrets_dir_fd.as_fd(), 1).expect("swap succeeds");
+    fn rotate_after_rollback_never_reuses_a_still_materialised_epoch() {
+        // Monotonic high-water allocation: rotate() must allocate
+        // strictly past every epoch the marker has ever recorded,
+        // even one a rollback moved *away* from and which therefore
+        // still physically exists on disk.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "dana";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+        // Now: active=2, previous=1, high_water=2.
+        let after_rollback = rollback(vm, kind, &cfg).unwrap();
+        assert_eq!(after_rollback.lineage_epoch, Some(1));
+        // active=1, previous=2 (still on disk, unpruned), high_water=2.
+        let after_rotate = rotate(vm, kind, material(b"e3"), &cfg).unwrap();
+        // Must allocate epoch 3, never epoch 2 (which is still the
+        // `previous` generation's live directory at this point).
+        assert_eq!(after_rotate.lineage_epoch, Some(3));
+        assert_eq!(after_rotate.high_water_epoch, Some(3));
+    }
 
-        let err = provision(&paths, &cfg, &material(1)).expect_err("must fail closed");
-        assert_eq!(err.reason, reasons::MARKER_TAMPERED);
+    // -------------------------------------------------------------
+    // Crash recovery
+    // -------------------------------------------------------------
+
+    #[test]
+    fn recovery_completes_a_promote_left_at_planned() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "erin";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name: random_stage_name(),
+            expected_digest_hex: material(b"e2").digest_hex(),
+            expected_identity: None,
+            carry_previous: read_marker(secrets_fd.as_fd())
+                .unwrap()
+                .and_then(|m| m.active),
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
+        drop(secrets_fd);
+        drop(generations_fd);
+
+        // No material handed to recovery: a `Planned` promote with no
+        // staged bytes yet must abort (discard) rather than fabricate
+        // material out of thin air.
+        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
+        assert!(recovered);
+        let fields = rotate(vm, kind, material(b"e2-redo"), &cfg).unwrap();
+        assert_valid(&fields);
+        assert_eq!(fields.lineage_epoch, Some(2));
     }
 
     #[test]
-    fn provision_fails_closed_when_marker_active_but_material_vanished() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
-        let cfg = test_cfg(1_000);
-        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
+    fn recovery_forward_completes_a_promote_left_at_current_promoted() {
+        // Once `current` has been swapped, recovery must always
+        // complete forward to a durable marker — never revert.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "frank";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
 
-        // Simulate an out-of-band deletion of the material tree while
-        // the marker still claims it is active. `current` is a
-        // symlink by construction, so simulate a manual/out-of-band
-        // unlink directly rather than through the safe wrapper (which
-        // deliberately refuses to touch symlinks elsewhere).
-        let secrets_dir_fd = open_or_create_secrets_dir(&paths, &cfg).expect("dir reopened");
-        remove_current_symlink(&secrets_dir_fd);
-        remove_generation(&secrets_dir_fd, 1);
-
-        let err = provision(&paths, &cfg, &material(2)).expect_err("must fail closed");
-        assert_eq!(err.reason, reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING);
-    }
-
-    #[test]
-    fn rotate_fails_closed_when_active_generation_content_swapped() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
-        let cfg = test_cfg(1_000);
-        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
-
-        // Simulate a TOCTOU swap by directly corrupting the marker's
-        // recorded identity rather than deleting/recreating the
-        // generation directory: on some filesystems a freed inode
-        // number can be reused immediately, which would make a
-        // delete-then-recreate swap non-deterministic to detect here
-        // even though the same dev/ino check still fails closed in
-        // practice against a genuinely different backing inode.
-        let marker_dir_fd = ensure_marker_tree(&paths, &cfg).expect("marker tree");
-        let mut marker = read_marker(&marker_dir_fd, &paths)
-            .expect("marker read")
-            .expect("marker present");
-        marker.active_ino = Some(
-            marker
-                .active_ino
-                .expect("active ino recorded")
-                .wrapping_add(1),
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e2");
+        let stage_name = random_stage_name();
+        assert!(
+            ensure_staged(
+                generations_fd.as_fd(),
+                &cfg,
+                &stage_name,
+                &mat.digest_hex(),
+                Some(&mat),
+            )
+            .unwrap()
         );
-        write_marker(&marker_dir_fd, &paths, &cfg, &marker).expect("marker corrupted");
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2).unwrap();
+        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
+        let prior_active = read_marker(secrets_fd.as_fd())
+            .unwrap()
+            .and_then(|m| m.active);
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: prior_active,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::CurrentPromoted,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
+        drop(secrets_fd);
+        drop(generations_fd);
 
-        let err = rotate(&paths, &test_cfg(2_000), &material(2)).expect_err("must fail closed");
-        assert_eq!(err.reason, reasons::MARKER_TAMPERED);
+        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
+        assert!(recovered);
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert_eq!(marker.active.unwrap().epoch, 2);
+        assert!(read_txlog(secrets_fd.as_fd()).unwrap().is_none());
     }
 
     #[test]
-    fn multiple_kinds_for_same_vm_are_independent() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let tpm_paths = test_paths(tmp.path(), "work", SecretKind::TpmBoundCredential);
-        let signing_paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
-        let cfg = test_cfg(1_000);
+    fn recovery_completes_a_retire_left_at_current_removed() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "gina";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
 
-        provision(&tpm_paths, &cfg, &material(1)).expect("tpm provision succeeds");
-        // The other kind for the same VM must still report not-provisioned.
-        let err =
-            rotate(&signing_paths, &cfg, &material(2)).expect_err("independent kind is untouched");
-        assert_eq!(err.reason, reasons::NOT_PROVISIONED);
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        remove_current_symlink(secrets_fd.as_fd()).unwrap();
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            high_water_epoch: 1,
+            phase: RetirePhase::CurrentRemoved,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent)).unwrap();
+        drop(secrets_fd);
+        drop(generations_fd);
+
+        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
+        assert!(recovered);
+        let fields = retire(vm, kind, &cfg).unwrap();
+        assert_valid(&fields);
+    }
+
+    #[test]
+    fn planned_promote_recovery_never_activates_partial_state_then_error() {
+        // Regression guard for "never return error after silently
+        // activating unrecoverable state": force recovery to fail
+        // *after* `current` has already moved (a corrupted intent at
+        // `CurrentPromoted`) and confirm the swap is never reverted —
+        // the on-disk `current` link must keep resolving to the
+        // (verifiably durable) epoch it was swapped to even though
+        // the recovery call itself returns an error.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "harold";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e2");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2).unwrap();
+        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
+        // Corrupt the recorded digest so `CurrentPromoted`'s identity
+        // check cannot match — this must fail closed, not silently
+        // re-swap `current` back to epoch 1.
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: "0".repeat(64),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::CurrentPromoted,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
+        let target_before = read_current_target(secrets_fd.as_fd());
+        drop(secrets_fd);
+        drop(generations_fd);
+
+        let err = recover_in_flight_transaction(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::RecoveryAmbiguous);
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // `current` must still point at epoch 2 — the activation that
+        // already happened is never rolled back by a failed recovery.
+        assert_eq!(read_current_target(secrets_fd.as_fd()), target_before);
+        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(2));
+    }
+
+    // -------------------------------------------------------------
+    // Tamper detection
+    // -------------------------------------------------------------
+
+    #[test]
+    fn rollback_detects_owner_mode_and_digest_tampering() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "iris";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let material_path = paths
+            .kind_root
+            .join(GENERATIONS_DIR_NAME)
+            .join("1")
+            .join(MATERIAL_FILE_NAME);
+
+        // Digest tamper: overwrite the retained generation's bytes.
+        std::fs::write(&material_path, b"tampered-bytes").unwrap();
+        let err = rollback(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::IdentityDigestMismatch);
+
+        // Restore then tamper the mode instead.
+        std::fs::write(&material_path, b"e1").unwrap();
+        let mut perms = std::fs::metadata(&material_path).unwrap().permissions();
+        perms.set_mode(0o666);
+        std::fs::set_permissions(&material_path, perms).unwrap();
+        let err = rollback(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::IdentityModeMismatch);
+    }
+
+    #[test]
+    fn rollback_detects_hardlinked_material() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "jack";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        let material_path = gen_dir.join(MATERIAL_FILE_NAME);
+        let extra_link = gen_dir.join("extra-hardlink");
+        std::fs::hard_link(&material_path, &extra_link).unwrap();
+
+        let err = rollback(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::IdentityLinkCountMismatch);
+    }
+
+    // -------------------------------------------------------------
+    // Retirement tree anomaly / fail-closed enumeration
+    // -------------------------------------------------------------
+
+    #[test]
+    fn retire_fails_closed_on_unexpected_entry_and_deletes_nothing() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "karen";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        std::fs::write(generations_dir.join("not-an-epoch"), b"bogus").unwrap();
+
+        let err = retire(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::RetirementTreeAnomaly);
+        // Nothing was deleted: the legitimate generation is intact.
+        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
+        assert!(generations_dir.join("not-an-epoch").is_file());
+    }
+
+    #[test]
+    fn retire_fails_closed_on_hardlinked_material_in_tree() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "leo";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::hard_link(
+            gen_dir.join(MATERIAL_FILE_NAME),
+            gen_dir.join("extra-hardlink"),
+        )
+        .unwrap();
+
+        let err = retire(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::RetirementTreeAnomaly);
+    }
+
+    #[test]
+    fn retire_fails_closed_when_marker_active_but_tree_already_empty() {
+        // "Missing marker never implies clean storage" — and
+        // symmetrically, an active marker over physically-empty
+        // storage must never be silently accepted as clean either.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "mabel";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
+        std::fs::remove_dir(&gen_dir).unwrap();
+
+        let err = retire(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::PreviouslyProvisionedMaterialMissing);
+    }
+
+    #[test]
+    fn retire_on_nonempty_tree_with_missing_marker_still_retires() {
+        // A missing marker file must never be interpreted as "already
+        // clean" when the physical generation tree is non-empty.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "nate";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        std::fs::remove_file(paths.kind_root.join(MARKER_FILE_NAME)).unwrap();
+
+        let fields = retire(vm, kind, &cfg).unwrap();
+        assert_valid(&fields);
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        assert_eq!(std::fs::read_dir(&generations_dir).unwrap().count(), 0);
+    }
+
+    // -------------------------------------------------------------
+    // Locking / concurrency
+    // -------------------------------------------------------------
+
+    #[test]
+    fn concurrent_holder_blocks_a_second_lock_attempt() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "olive";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Hold the exclusive lock open across the whole scope below.
+        let _held = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap();
+
+        let short_wait_cfg = SecretsLifecycleConfig {
+            lock_max_wait: Duration::from_millis(60),
+            lock_poll_interval: Duration::from_millis(5),
+            ..cfg.clone()
+        };
+        let err = rotate(vm, kind, material(b"e2"), &short_wait_cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::LockUnavailable);
+    }
+
+    // -------------------------------------------------------------
+    // Zeroization / material hygiene
+    // -------------------------------------------------------------
+
+    #[test]
+    fn secret_material_rejects_empty_and_oversized_input() {
+        assert_eq!(
+            SecretMaterial::new(Vec::new()).unwrap_err(),
+            FailReason::InvalidMaterial
+        );
+        assert_eq!(
+            SecretMaterial::new(vec![0u8; SecretMaterial::MAX_LEN + 1]).unwrap_err(),
+            FailReason::InvalidMaterial
+        );
+    }
+
+    #[test]
+    fn secret_material_debug_never_prints_bytes() {
+        let mat = material(b"super-secret-bytes");
+        let rendered = format!("{mat:?}");
+        assert!(!rendered.contains("super-secret-bytes"));
+        assert!(rendered.contains("len"));
+    }
+
+    // -------------------------------------------------------------
+    // Path / vm-id validation
+    // -------------------------------------------------------------
+
+    #[test]
+    fn invalid_vm_id_is_rejected_before_any_filesystem_access() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let err = provision(
+            "Not-Valid!",
+            SecretKind::GuestSigningKey,
+            material(b"x"),
+            &cfg,
+        )
+        .unwrap_err();
+        assert_eq!(err.reason, FailReason::InvalidVmId);
+        // Nothing was created under the state root.
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
@@ -1,279 +1,403 @@
-//! Per-realm secrets lifecycle engine: provision / rotate / rollback /
-//! retire for TPM-bound credentials, guest signing keys, and
-//! security-key channel state, anchored under a per-`(vm, kind)`
-//! directory via fd-relative, `openat2(RESOLVE_BENEATH)`-safe
-//! primitives from [`crate::sys::path_safe`].
+//! Per-realm secrets lifecycle: a **pure transaction core** for
+//! provision / rotate / rollback / retire, decoupled from any storage
+//! or locking adapter via the injected [`SecretsAuthorityPort`] trait.
 //!
-//! # Design summary (W8fu1 redesign)
+//! # W8fu6: ports-and-adapters rewrite
 //!
-//! This is a from-scratch redesign of the original `36d9dcf8` engine,
-//! addressing an external review that found the first draft's marker
-//! identity, retirement enumeration, and generation numbering were not
-//! crash-safe. The core structural change is a **durable
-//! transaction/recovery log** (`txlog`, JSON, written beside the
-//! marker) plus a **cross-process advisory `flock` lock** so:
+//! Rounds 1-5 of this component built a **filesystem-anchored**
+//! engine: raw fd-relative paths (`crate::sys::path_safe`), a private
+//! `F_OFD_SETLK` cross-process lock, a durable on-disk JSON marker +
+//! `txlog`, fsync-heavy crash recovery, and an anchored
+//! enumerate-then-delete retirement walk. This round replaces all of
+//! that with a **pure transaction core** that never touches a
+//! filesystem primitive, a lock, or a byte of JSON directly. Every
+//! stateful effect goes through the injected [`SecretsAuthorityPort`]
+//! trait, and every crash/fault/concurrency/tamper test in this file
+//! runs entirely against the in-memory [`FakeAuthorityPort`] test
+//! double below -- there is no integration test in this file that
+//! spins up a real directory tree, a real lock, or a real filesystem.
 //!
-//! * every mutating action (`provision`/`rotate`/`rollback`/`retire`)
-//!   is modelled as a small phase machine (see [`PromotePhase`] /
-//!   [`RetirePhase`]) whose *current phase* is durably persisted
-//!   before each side effect that cannot be trivially undone;
-//! * a process crash at any point can be resumed by the *next* caller
-//!   (or by the standalone [`recover_in_flight_transaction`] entry
-//!   point) re-entering the exact same phase-driven state machine —
-//!   [`execute_promote`] and [`execute_retire`] are single codepaths
-//!   used for both a fresh action and crash recovery of a leftover
-//!   one;
-//! * the invariant that makes this safe is **forward-only commitment**:
-//!   before `current` is swapped (promote) or the physical generation
-//!   tree is proven empty (retire), recovery is free to safely discard
-//!   the leftover transaction (nothing observable changed yet); once
-//!   that point is passed, recovery may only ever complete the
-//!   transaction forward to its terminal, marker-durable state — it
-//!   never reverts a swap or resurrects a deleted generation. This is
-//!   the property finding (1) called out as missing: "never return an
-//!   error after silently activating unrecoverable state".
+//! ## Why a compare-and-swap fencing token instead of a lock + txlog
 //!
-//! Marker identity (finding 2) is strengthened from the original
-//! draft's bare `(dev, ino)` pair to [`MaterialIdentity`]: lineage
-//! epoch, `(dev, ino)`, owner uid/gid, permission bits, link count,
-//! POSIX-ACL presence, and a SHA-256 content digest — captured via a
-//! `nofollow`-safe fd open (never a path re-resolution), and verified
-//! against `current`'s *literal* name resolution (not just a
-//! coincidentally-matching stat), so a hard-link plant, a
-//! digest-preserving directory swap, or a permission/ownership/ACL
-//! drift are each independently detected and separately named in the
-//! closed [`super::secrets_rotation_audit::FailReason`] enum.
+//! The prior design's lock (mutual exclusion) and txlog (crash
+//! recovery) both existed to make a *sequence* of raw filesystem
+//! writes durable and atomic despite crashes and concurrent callers.
+//! A storage substrate that already offers atomic compare-and-swap
+//! (etcd's `mod_revision`, ZooKeeper's `version`, a database row's
+//! optimistic-lock column, or -- for a filesystem adapter of the
+//! integrator's own design -- a `rename(2)`-based scheme) makes both
+//! unnecessary *from this module's point of view*: every action below
+//! reads a [`DurableState`] plus an opaque [`OwnershipEpoch`] fencing
+//! token via [`SecretsAuthorityPort::read_state`], computes the next
+//! state, and calls [`SecretsAuthorityPort::cas_commit`] with the
+//! token it read. Either the CAS succeeds (this call was the only
+//! writer the whole time) or it is fenced (some other writer's
+//! transition is now current; this call fails cleanly with
+//! [`FailReason::OwnershipFenced`] and has mutated nothing). This
+//! module never acquires or holds a lock, and never writes a txlog --
+//! whatever recovery a concrete adapter needs for its own commit
+//! primitive is the adapter's problem, entirely hidden behind
+//! [`SecretsAuthorityPort::cas_commit`] returning `Ok`/`Err`
+//! atomically.
 //!
-//! Retirement (finding 3) never trusts the marker's word that storage
-//! is clean: every `retire()` call first anchored-enumerates and
-//! strictly validates the *entire* physical `generations/` tree
-//! ([`enumerate_and_validate_generation_tree`]) regardless of what the
-//! marker says. An absent/tombstoned marker over a *non-empty* tree is
-//! treated as leftover material that retirement must still clean up
-//! (not as evidence of a clean state); an *active* marker over an
-//! *empty* tree is treated as a hard-fail anomaly rather than a silent
-//! "already retired". Any unrecognised entry, wrong file type, or a
-//! `material` file with a link count other than 1 aborts retirement
-//! with zero deletions.
+//! ## What "forward recovery" means without a txlog
 //!
-//! Generation numbering (finding 4) is a monotonic high-water mark
-//! (`MarkerData::high_water_epoch`) carried in the marker, not
-//! `current epoch + 1`: `rotate` always allocates
-//! `high_water_epoch + 1`, so a `rotate` issued after a `rollback` can
-//! never collide with (or silently resurrect) a still-materialised
-//! newer epoch that the rollback moved away from. Physical pruning of
-//! a superseded generation only ever happens strictly after the new
-//! marker has been durably committed.
+//! There is no separate "recovery mode": a caller that observes
+//! [`FailReason::OwnershipFenced`] simply re-reads the current state
+//! and retries (or gives up) -- there is no crashed, half-applied
+//! transaction to detect or unwind, because [`SecretsAuthorityPort::cas_commit`]
+//! is defined to be atomic (all-or-nothing) from this module's point
+//! of view. "Forward recovery" instead applies to *pruning*: a
+//! transition that supersedes a generation (`rotate` superseding the
+//! old `previous`, `retire` superseding both `active` and `previous`)
+//! commits the superseding [`DurableState`] first and only then
+//! attempts to synchronously prune the superseded material via
+//! [`SecretsAuthorityPort::prune_material`]. If that synchronous prune
+//! does not fully succeed, the still-owed epochs are recorded in the
+//! *already-durably-committed* state's [`DurableState::pending_prune`]
+//! list (bounded at [`MAX_PENDING_PRUNE`]) rather than being lost or
+//! blocking the caller's success -- every subsequent action for that
+//! `(workload, kind)` resolves any outstanding debt (via
+//! [`read_and_verify`]) before doing its own work, so the debt is
+//! self-healing and monotonically shrinks. This is the module's
+//! concrete answer to "never return an error after silently
+//! activating unrecoverable state": the CAS commit that activates a
+//! new generation and the best-effort prune of the old one are two
+//! separate steps, and a failure in the second step is recorded as
+//! durable, retriable debt -- never swallowed, and never allowed to
+//! turn a successful activation into a reported failure.
 //!
-//! `provision()` always allocates epoch `1` and resets
-//! `high_water_epoch` to `1` — this is intentionally **not** a
-//! monotonic baseline carried across a full retire/re-provision cycle.
-//! It is sound only because `retire()` physically empties the entire
-//! `generations/` tree (enumerated and proven empty) before the
-//! marker is tombstoned, so there is no physical collision risk in
-//! restarting numbering at `1` for a fresh lineage. The monotonic
-//! high-water invariant matters strictly *within* one non-retired
-//! lineage (i.e. for `rotate`-after-`rollback` collision avoidance).
+//! ## Why deterministic, high-water-keyed epoch allocation
 //!
-//! [`SecretMaterial`] (finding 6) wraps caller-supplied bytes in
-//! [`zeroize::Zeroizing`] **before** the length/emptiness validation
-//! check (the original draft validated the raw `Vec<u8>` first and
-//! only wrapped it in `Zeroizing` on the success path, so a rejected
-//! empty/oversized buffer was dropped without zeroization). It derives
-//! neither `Copy` nor `Clone`.
+//! A new generation's epoch number is always
+//! `state.high_water_epoch + 1` -- never "current epoch + 1" -- so a
+//! `rotate` issued after a `rollback` can never collide with (or
+//! silently resurrect) a still-materialized, newer-numbered epoch the
+//! rollback moved away from. Because the next epoch number is a pure
+//! function of the last *durably committed* high-water mark, staging
+//! is naturally idempotent by epoch: two calls that stage the same
+//! not-yet-committed epoch number simply race on whose bytes are
+//! staged last (closed by the post-commit re-verification described
+//! below), and there is never a need for the collision-resistant
+//! random staging-name scheme rounds 1-5 required.
 //!
-//! # Status: not wired into any live broker dispatch path
+//! ## Closing the "last stage wins" race
 //!
-//! Nothing in this module is reachable from a running broker today.
-//! An integrator must, in follow-up commits that this component does
-//! **not** own:
+//! [`SecretsAuthorityPort::stage_material`] is defined to run *before*
+//! [`SecretsAuthorityPort::cas_commit`], so two concurrent callers
+//! that both read the same pre-commit state and compute the same next
+//! epoch number can each call `stage_material` for that epoch before
+//! either of them calls `cas_commit`. Only one of the two `cas_commit`
+//! calls can win the race, but the *order* of the two `stage_material`
+//! calls relative to the winning `cas_commit` is not itself
+//! CAS-serialized -- the loser's `stage_material` call could still run
+//! (and overwrite the winner's staged bytes) *after* the winner's
+//! `cas_commit` succeeds, silently corrupting the now-durably-active
+//! generation's material without ever going through `cas_commit`
+//! again. [`provision`] and [`rotate`] close this window by
+//! **immediately re-reading the live digest of the epoch they just
+//! committed** and comparing it against the digest they themselves
+//! staged: a mismatch means some other writer's `stage_material` call
+//! landed after this call's `cas_commit`, so this call quarantines the
+//! authority and fails closed with [`FailReason::ChecksumMismatch`]
+//! rather than certifying success over corrupted, no-longer-trusted
+//! material.
 //!
-//! 1. Add a `SecretsLifecycle { .. }` request/response shape to the
-//!    broker's private wire contract and a matching
-//!    `runtime.rs` dispatch arm that calls
-//!    [`provision`]/[`rotate`]/[`rollback`]/[`retire`].
-//! 2. Add exactly one new
-//!    `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
-//!    variant (and its `from_operation_value` arm) to
-//!    `ops::audit_op`, and wire the returned
-//!    [`super::secrets_rotation_audit::SecretsLifecycleAuditFields`]
-//!    into the broker's `crate::audit::AuditLog` sink.
-//! 3. Add a matching `ops::mod` `pub mod secrets_lifecycle;` /
-//!    `pub mod secrets_rotation_audit;` declaration (this component
-//!    intentionally does not edit `ops/mod.rs`).
-//! 4. Decide the real `SecretsLifecycleConfig::state_root` source
-//!    (candidate: a subdirectory of the per-realm state root established
-//!    by the ADR 0034 storage-lifecycle contract) and the real
-//!    owner uid/gid for `TpmBoundCredential` vs `GuestSigningKey` vs
-//!    `SecurityKeyChannelState` — this module takes them as
-//!    caller-supplied configuration and asserts nothing about their
-//!    real-world values. **`state_root` itself must already exist**
-//!    with a non-world-writable mode before this module is called
-//!    (mirrors `ensure_dir_preserve_existing`'s host-activation-owns-
-//!    the-root convention elsewhere in the broker): this module only
-//!    creates `state_root/<vm_id>/<kind-slug>` beneath it, never
-//!    `state_root` itself.
-//! 5. Decide how `TpmBoundCredential` rotation here relates to the
-//!    swtpm NVRAM state `swtpm_dir.rs` already owns: this module
-//!    tracks a rotation *lineage* layered on top of, and never
-//!    mutates, the physical swtpm state directory.
-//! 6. Decide the real `GuestSigningKey` material source (this module
-//!    accepts already-generated bytes via [`SecretMaterial::new`]; it
-//!    does not generate key material itself).
-//! 7. Wire `d2b-sk-frontend`'s `security_key.rs` /
-//!    `ComponentSession` channel policy to
-//!    `d2b-sk-frontend::secrets_channel` (see that module's own
-//!    "Integration wiring points" doc section).
-//! 8. Regenerate the W8 wave-plan nix-unit pin after any of the above
-//!    lands, per `tests/AGENTS.md`.
-//! 9. Call [`recover_in_flight_transaction`] once at controller/broker
-//!    startup for every known `(vm, kind)` pair before dispatching any
-//!    live request, so a leftover transaction from a prior crash is
-//!    drained proactively rather than only on the next incoming
-//!    request for that exact pair.
+//! ## Canonical typed identity, no legacy VM-name string
 //!
-//! Everything above is exactly why this module's tests exercise the
-//! engine directly (`#[cfg(test)]`, in-process, real temp
-//! directories) rather than through any dispatch path — there is no
-//! dispatch path yet.
+//! Every function below takes a [`d2b_contracts::v2_identity::WorkloadId`]
+//! -- the same canonical v2 identity type already used elsewhere in
+//! this crate (`guest_session_material.rs`,
+//! `child_realm_guest_material.rs`) -- rather than a bare `vm_id: &str`
+//! or the legacy `d2b_contracts::types::VmId` human-label newtype
+//! rounds 1-5 used. `WorkloadId`'s own `parse`/`FromStr` already
+//! enforces the canonical bounded-opaque-string shape, so this module
+//! has no `valid_vm_id`-style runtime string check of its own to
+//! maintain -- an invalid identity simply cannot exist as a
+//! `WorkloadId` value in the first place. Every `SecretsAuthorityPort`
+//! method is scoped by `(&WorkloadId, SecretKind)`; how (or whether) an
+//! adapter maps that pair onto any underlying storage location -- a
+//! path, a database key, a KV-store prefix -- is entirely the
+//! adapter's concern and never observable here.
+//!
+//! # Integration wiring points (explicit, not yet performed)
+//!
+//! This module is a pure library with **zero** side effects of its
+//! own -- no filesystem access, no locking, no process spawning. A
+//! future integrator must, in follow-up commits **outside this
+//! component's ownership**:
+//!
+//! 1. Implement a concrete [`SecretsAuthorityPort`] adapter over
+//!    whatever real durable storage/CAS substrate lands for the
+//!    broker (e.g. the ADR 0034 storage/lock contract once it exists,
+//!    or a dedicated KV store). This is now the **single dominant**
+//!    wiring blocker -- rounds 1-5's many fine-grained filesystem
+//!    wiring points (lock file placement, `dir_mode`/`file_mode`,
+//!    owner uid/gid, `state_root`) are superseded by this one seam.
+//! 2. Add exactly one new `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
+//!    variant to `crate::ops::audit_op::OperationFields` (and a
+//!    matching `from_operation_value` arm), and route each
+//!    `Ok`/`Err(SecretsLifecycleError)` returned by [`provision`],
+//!    [`rotate`], [`rollback`], [`retire`] into `crate::audit::AuditLog`
+//!    via that new variant.
+//! 3. Add a broker dispatch path (an existing operation-request
+//!    enum's new variant, or a new one, per the integrator's chosen
+//!    RPC shape) that resolves a caller's `(realm, workload label)`
+//!    into a [`d2b_contracts::v2_identity::WorkloadId`] (e.g. via
+//!    `WorkloadId::derive`) and a [`SecretMaterial`] payload, then
+//!    calls the four public functions below against the concrete
+//!    `SecretsAuthorityPort` adapter from (1).
+//! 4. Decide and implement whatever real quarantine-clearing
+//!    operation exists for [`QuarantineReason`] -- this module
+//!    deliberately exposes no "un-quarantine" call (quarantine is a
+//!    one-way, fail-closed door from this module's own point of view),
+//!    so an operator-facing clear path is an adapter/broker-level
+//!    concern.
+//! 5. For `SecretKind::SecurityKeyChannelState`, wire the four public
+//!    functions to whatever calls into `d2b-sk-frontend`'s
+//!    `secrets_channel.rs` need this lifecycle -- see that module's
+//!    own "Integration wiring points" note for its side of the seam
+//!    (session config wiring, wire schema/authentication, broker
+//!    dispatch mapping, delivery-counter persistence).
 
-use std::collections::hash_map::RandomState;
-use std::hash::{BuildHasher, Hasher};
-use std::io;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::fmt;
 
-use rustix::fs::OFlags;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
-use crate::ops::hosts::stable_hash_str;
+#[cfg(test)]
+use crate::ops::secrets_rotation_audit::LifecycleResult;
 use crate::ops::secrets_rotation_audit::{
     FailReason, LifecycleAction, SecretKind, SecretsLifecycleAuditContext,
     SecretsLifecycleAuditFields,
 };
-use crate::sys::path_safe;
-use d2b_contracts::types::VmId;
+use d2b_contracts::v2_identity::WorkloadId;
 
 // ---------------------------------------------------------------------
-// Constants
+// Epoch / fencing primitives
 // ---------------------------------------------------------------------
 
-/// Bumped whenever [`MarkerData`]'s on-disk shape changes
-/// incompatibly. `read_marker` fails closed
-/// (`MarkerTamperedOrMissingMaterial`) on any other version.
-const MARKER_SCHEMA_VERSION: u32 = 2;
+/// A 1-based generation number within one `(workload, kind)` lineage.
+/// `0` is reserved and never a valid [`Epoch`] value -- this is the
+/// same "epochs start at 1" convention the audit schema's
+/// `LineageEpochIsZero` check enforces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Epoch(u64);
 
-const GENERATIONS_DIR_NAME: &str = "generations";
-const MARKER_FILE_NAME: &str = "marker.json";
-const CURRENT_LINK_NAME: &str = "current";
-const CURRENT_SWAP_STAGE_NAME: &str = ".current.stage";
-const MATERIAL_FILE_NAME: &str = "material";
-const LOCK_FILE_NAME: &str = "lock";
-const TXLOG_FILE_NAME: &str = "txlog";
-const STAGE_PREFIX: &str = ".stage-";
+impl Epoch {
+    pub const FIRST: Epoch = Epoch(1);
 
-const DIR_MODE_DEFAULT: u32 = 0o700;
-const FILE_MODE_DEFAULT: u32 = 0o600;
+    /// `None` for `0`; every other value is a valid epoch.
+    pub fn from_raw(value: u64) -> Option<Self> {
+        if value == 0 { None } else { Some(Self(value)) }
+    }
 
-/// Bound on retries when allocating a collision-resistant staging
-/// directory name. Each attempt mixes fresh entropy (pid + monotonic
-/// counter + wall-clock nanos + `RandomState`-seeded hash); observing
-/// exhaustion here would indicate a broken randomness source, not
-/// ordinary contention.
-const MAX_STAGE_NAME_ATTEMPTS: u32 = 32;
-
-// ---------------------------------------------------------------------
-// Config / paths
-// ---------------------------------------------------------------------
-
-/// Caller-supplied configuration. See the module doc's "Integration
-/// wiring points" §4 for the real-world `state_root` /
-/// `owner_uid`/`owner_gid` source this component does not decide.
-#[derive(Debug, Clone)]
-pub struct SecretsLifecycleConfig {
-    /// Anchored root directory beneath which `<vm_id>/<kind-slug>/` is
-    /// derived. Must be an absolute path.
-    pub state_root: PathBuf,
-    pub dir_mode: u32,
-    pub file_mode: u32,
-    pub owner_uid: Option<u32>,
-    pub owner_gid: Option<u32>,
-    /// Upper bound on how long [`acquire_lock`] polls for the
-    /// cross-process exclusive lock before failing closed with
-    /// [`FailReason::LockUnavailable`].
-    pub lock_max_wait: Duration,
-    pub lock_poll_interval: Duration,
+    pub fn get(self) -> u64 {
+        self.0
+    }
 }
 
-impl Default for SecretsLifecycleConfig {
-    fn default() -> Self {
+impl fmt::Display for Epoch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// An opaque compare-and-swap fencing token returned by
+/// [`SecretsAuthorityPort::read_state`] and required (by exact value)
+/// by [`SecretsAuthorityPort::cas_commit`]. Distinct from [`Epoch`]:
+/// this counts **every** accepted commit for a `(workload, kind)` pair
+/// (including `rollback`, which never advances the lineage high-water
+/// mark), while [`Epoch`] only counts materialized generations. This
+/// module never inspects an [`OwnershipEpoch`]'s value -- it only ever
+/// passes back exactly what it was given by the same port instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OwnershipEpoch(u64);
+
+impl OwnershipEpoch {
+    /// The fencing token a port must return from `read_state` for a
+    /// `(workload, kind)` pair it has never accepted a commit for.
+    pub const NEVER_COMMITTED: OwnershipEpoch = OwnershipEpoch(0);
+
+    pub fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Bound on [`DurableState::pending_prune`]. `retire` can orphan at
+/// most two generations (the former `active` and the former
+/// `previous`) in a single transition, and every other action either
+/// orphans at most one (`rotate`, superseding the outgoing `previous`)
+/// or none (`provision`, `rollback`) -- and [`read_and_verify`] always
+/// fully drains any pre-existing debt before an action computes its
+/// own transition, so this bound is never exceeded in practice. It
+/// exists as a defensive, checked invariant, not a soft guideline.
+pub const MAX_PENDING_PRUNE: usize = 2;
+
+fn valid_digest_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+// ---------------------------------------------------------------------
+// Durable state
+// ---------------------------------------------------------------------
+
+/// One materialized generation's identity as recorded in
+/// [`DurableState`]: its epoch number and the SHA-256 hex digest of
+/// its material. This module always independently re-verifies this
+/// digest against the live authority (via
+/// [`SecretsAuthorityPort::material_digest`]) before trusting it for
+/// any mutation -- a [`GenerationRecord`] by itself is a claim, not
+/// proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationRecord {
+    pub epoch: Epoch,
+    pub digest_hex: String,
+}
+
+impl GenerationRecord {
+    pub fn new(epoch: Epoch, digest_hex: impl Into<String>) -> Self {
         Self {
-            state_root: PathBuf::from("/var/lib/d2b/secrets"),
-            dir_mode: DIR_MODE_DEFAULT,
-            file_mode: FILE_MODE_DEFAULT,
-            owner_uid: None,
-            owner_gid: None,
-            lock_max_wait: Duration::from_secs(10),
-            lock_poll_interval: Duration::from_millis(20),
+            epoch,
+            digest_hex: digest_hex.into(),
         }
     }
 }
 
-/// Derived, redaction-safe path bundle for one `(vm, kind)` pair.
-#[derive(Debug, Clone)]
-pub struct SecretsLifecyclePaths {
-    pub kind_root: PathBuf,
-    /// FNV1a-64 hex fingerprint of `kind_root`, safe to place on the
-    /// audit surface (parity with [`stable_hash_str`]).
-    pub base_dir_hash: String,
+/// The complete durable state this module ever needs for one
+/// `(workload, kind)` pair. This is the *entire* payload
+/// [`SecretsAuthorityPort::cas_commit`] ever writes -- there is no
+/// separate marker, txlog, or lock-state object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DurableState {
+    /// Monotonic high-water mark: the highest epoch number the
+    /// *current, unbroken* lineage (since the last `provision`) has
+    /// committed as active. Never decreases within one such lineage --
+    /// in particular, `rotate` always allocates `high_water_epoch + 1`
+    /// (never `active.epoch + 1`), so a rotate issued after a
+    /// `rollback` can never collide with a still-materialized, newer
+    /// epoch the rollback moved away from. [`provision`] deliberately
+    /// resets this to `1` for a *fresh* lineage: [`read_and_verify`]
+    /// unconditionally requires any `pending_prune` debt from a prior
+    /// `retire` to be fully drained (every previously-live epoch
+    /// confirmed pruned by the authority) before `provision` may run
+    /// at all, so reusing epoch `1`'s key can never resurrect a prior
+    /// lineage's leftover bytes.
+    pub high_water_epoch: u64,
+    /// The currently active generation, when one exists. `None` for a
+    /// never-provisioned or freshly-retired pair.
+    pub active: Option<GenerationRecord>,
+    /// The most recently superseded generation still retained for a
+    /// possible `rollback`, when one exists. Always `None` when
+    /// `active` is `None`.
+    pub previous: Option<GenerationRecord>,
+    /// `true` exactly for a pair that has been retired and not since
+    /// re-provisioned. A retired pair always has `active: None,
+    /// previous: None`.
+    pub retired: bool,
+    /// Epochs this pair's own prior committed transition determined
+    /// are superseded and safe to prune, but whose synchronous
+    /// best-effort prune attempt (at commit time) did not fully
+    /// succeed. Bounded at [`MAX_PENDING_PRUNE`]; never contains the
+    /// current `active` or `previous` epoch. See the module doc's
+    /// "What forward recovery means" section.
+    pub pending_prune: Vec<Epoch>,
 }
 
-fn valid_vm_id(vm_id: &str) -> bool {
-    // Mirrors the framework-wide VM name contract
-    // (`^[a-z][a-z0-9-]*$`, see `nixos-modules/assertions.nix`): used
-    // here purely as a path-component safety gate, not to duplicate
-    // that eval-time assertion.
-    let mut chars = vm_id.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_lowercase() => {}
-        _ => return false,
+impl DurableState {
+    /// The state a `(workload, kind)` pair that has never been
+    /// committed to is defined to have.
+    pub fn never_provisioned() -> Self {
+        Self {
+            high_water_epoch: 0,
+            active: None,
+            previous: None,
+            retired: false,
+            pending_prune: Vec::new(),
+        }
     }
-    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-}
 
-/// Derive the anchored per-`(vm, kind)` directory. Fails closed on an
-/// invalid `vm_id` before any filesystem access.
-pub fn derive_paths(
-    vm_id: &str,
-    kind: SecretKind,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<SecretsLifecyclePaths, FailReason> {
-    if !valid_vm_id(vm_id) || !cfg.state_root.is_absolute() {
-        return Err(FailReason::InvalidVmId);
-    }
-    let kind_root = cfg.state_root.join(vm_id).join(kind.as_slug());
-    let base_dir_hash = stable_hash_str(&kind_root.to_string_lossy());
-    Ok(SecretsLifecyclePaths {
-        kind_root,
-        base_dir_hash,
-    })
-}
+    /// Check every structural invariant this module relies on before
+    /// trusting a [`DurableState`] value read from the authority.
+    /// This is deliberately independent of any live digest
+    /// re-verification (that happens separately in
+    /// [`read_and_verify`]) -- this only checks that the state's
+    /// *own* fields are mutually consistent.
+    pub fn validate_self_consistent(&self) -> Result<(), FailReason> {
+        if self.pending_prune.len() > MAX_PENDING_PRUNE {
+            return Err(FailReason::StateCorrupt);
+        }
+        {
+            // Must already be strictly ascending AND duplicate-free --
+            // comparing against a freshly sorted+deduped copy catches
+            // both an out-of-order list and a list with repeats in one
+            // check (a length-only comparison, as an earlier draft of
+            // this check did, would miss a merely-reordered list: e.g.
+            // `[2, 1]` sorts+dedups to `[1, 2]`, same length as the
+            // original, but the original was never valid).
+            let mut sorted = self.pending_prune.clone();
+            sorted.sort_unstable();
+            sorted.dedup();
+            if sorted != self.pending_prune {
+                return Err(FailReason::StateCorrupt);
+            }
+        }
 
-fn context(
-    vm_id: &str,
-    kind: SecretKind,
-    action: LifecycleAction,
-    paths: &SecretsLifecyclePaths,
-) -> SecretsLifecycleAuditContext {
-    SecretsLifecycleAuditContext {
-        vm_id: VmId::new(vm_id),
-        kind,
-        action,
-        base_dir_hash: paths.base_dir_hash.clone(),
+        if self.retired {
+            if self.active.is_some() || self.previous.is_some() {
+                return Err(FailReason::StateCorrupt);
+            }
+            if self.high_water_epoch == 0 {
+                // A pair cannot be retired without ever having been
+                // provisioned.
+                return Err(FailReason::StateCorrupt);
+            }
+        } else if self.active.is_none() {
+            // Never-provisioned: nothing else may be set either.
+            if self.previous.is_some() || self.high_water_epoch != 0 {
+                return Err(FailReason::StateCorrupt);
+            }
+        }
+
+        if let Some(active) = &self.active {
+            if !valid_digest_hex(&active.digest_hex) {
+                return Err(FailReason::StateCorrupt);
+            }
+            if active.epoch.get() == 0 || active.epoch.get() > self.high_water_epoch {
+                return Err(FailReason::StateCorrupt);
+            }
+            if self.pending_prune.contains(&active.epoch) {
+                return Err(FailReason::StateCorrupt);
+            }
+        }
+        if let Some(previous) = &self.previous {
+            if !valid_digest_hex(&previous.digest_hex) {
+                return Err(FailReason::StateCorrupt);
+            }
+            let Some(active) = &self.active else {
+                // `previous` without `active` is never valid.
+                return Err(FailReason::StateCorrupt);
+            };
+            if previous.epoch == active.epoch {
+                return Err(FailReason::StateCorrupt);
+            }
+            if previous.epoch.get() == 0 || previous.epoch.get() > self.high_water_epoch {
+                return Err(FailReason::StateCorrupt);
+            }
+            if self.pending_prune.contains(&previous.epoch) {
+                return Err(FailReason::StateCorrupt);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -282,7 +406,7 @@ fn context(
 // ---------------------------------------------------------------------
 
 /// Caller-supplied secret bytes. Deliberately **not** `Copy` or
-/// `Clone`: every holder of an owned `SecretMaterial` is a distinct,
+/// `Clone`: every holder of an owned [`SecretMaterial`] is a distinct,
 /// independently zeroized buffer. The bytes are wrapped in
 /// [`Zeroizing`] *before* validation, so a rejected (empty or
 /// oversized) buffer is still zeroized on drop rather than discarded
@@ -318,8 +442,8 @@ impl SecretMaterial {
     }
 }
 
-impl std::fmt::Debug for SecretMaterial {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for SecretMaterial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SecretMaterial")
             .field("len", &self.bytes.len())
             .finish_non_exhaustive()
@@ -327,152 +451,165 @@ impl std::fmt::Debug for SecretMaterial {
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut out = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        out.push_str(&format!("{b:02x}"));
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
     }
     out
 }
 
 // ---------------------------------------------------------------------
-// Marker identity
+// The authority port
 // ---------------------------------------------------------------------
 
-/// Full tamper-detecting identity of one generation's `material` file,
-/// captured via a `nofollow`-safe fd open (never a path
-/// re-resolution).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct MaterialIdentity {
-    pub epoch: u64,
-    pub dev: u64,
-    pub ino: u64,
-    pub uid: u32,
-    pub gid: u32,
-    /// Permission bits only (`st_mode & 0o7777`).
-    pub mode: u32,
-    pub nlink: u64,
-    pub has_acl: bool,
-    pub digest_hex: String,
+/// Closed set of errors a [`SecretsAuthorityPort`] adapter may report.
+/// This module never inspects or forwards an adapter's own internal
+/// error detail -- every variant here is meaningful to *this* module's
+/// own algorithm, not a leak of the adapter's internals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortError {
+    /// [`SecretsAuthorityPort::cas_commit`]'s `expected` token did not
+    /// match the authority's current token; nothing was mutated.
+    OwnershipFenced,
+    /// The authority has quarantined this `(workload, kind)` pair; no
+    /// operation may proceed.
+    Quarantined,
+    /// [`SecretsAuthorityPort::stage_material`] was called for an
+    /// epoch already referenced as `active` or `previous` by the
+    /// authority's currently committed [`DurableState`]. This module
+    /// never calls `stage_material` for an epoch it can determine is
+    /// already committed, so this is only reachable via a
+    /// concurrently racing writer or a fault-injecting test double.
+    EpochAlreadyCommitted,
+    /// An adapter-internal failure (I/O, its own locking/storage
+    /// substrate, etc) unrelated to this module's own protocol.
+    Unavailable,
 }
 
-/// On-disk marker (`marker.json`), schema v2.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct MarkerData {
-    pub v: u32,
-    pub vm: String,
-    pub kind: String,
-    pub retired: bool,
-    pub high_water_epoch: u64,
-    pub active: Option<MaterialIdentity>,
-    pub previous: Option<MaterialIdentity>,
-    pub first_provisioned_ms: u64,
-    pub updated_ms: u64,
+/// Closed set of reasons this module quarantines a `(workload, kind)`
+/// pair. Quarantine is a one-way, fail-closed door from this module's
+/// point of view: there is no "un-quarantine" call here (see the
+/// module doc's "Integration wiring points" § 4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuarantineReason {
+    /// The live digest of the `active` generation did not match the
+    /// digest recorded in the last-read [`DurableState`].
+    ActiveChecksumMismatch,
+    /// The live digest of the `previous` generation did not match the
+    /// digest recorded in the last-read [`DurableState`].
+    PreviousChecksumMismatch,
+    /// The [`DurableState`] read from the authority failed its own
+    /// [`DurableState::validate_self_consistent`] check.
+    StateSelfInconsistent,
 }
 
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+/// The single seam this pure transaction core depends on. An
+/// integrator-owned adapter implements this against whatever real
+/// storage/locking/CAS substrate lands (a filesystem tree with its own
+/// `rename(2)`-based scheme, a KV store with native CAS, a database
+/// row with an optimistic-lock column, etc) -- this module has no
+/// opinion on, and no dependency on, that choice. Every method is
+/// "guarded": scoped to exactly one `(workload, kind)` pair, taking
+/// and returning only this module's own typed values -- never a raw
+/// path, file descriptor, lock handle, or adapter-internal error
+/// detail.
+///
+/// Implementations MUST provide the exact atomicity/idempotency
+/// guarantees documented on each method; this module's correctness
+/// (in particular "never return an error after silently activating
+/// unrecoverable state") depends on `cas_commit` being genuinely
+/// atomic and `prune_material`/`quarantine` being genuinely idempotent.
+pub trait SecretsAuthorityPort {
+    /// Load the current durable state and its CAS fencing token. A
+    /// `(workload, kind)` pair that has never been committed to
+    /// returns [`DurableState::never_provisioned`] paired with
+    /// [`OwnershipEpoch::NEVER_COMMITTED`].
+    fn read_state(
+        &self,
+        workload: &WorkloadId,
+        kind: SecretKind,
+    ) -> Result<(DurableState, OwnershipEpoch), PortError>;
+
+    /// Durably store `material`'s bytes as the candidate content for
+    /// `epoch`, returning the digest the adapter actually stored (the
+    /// caller compares this against its own independently computed
+    /// digest as an immediate defense-in-depth check that the adapter
+    /// stored exactly what was asked). May be called more than once
+    /// for an epoch not yet referenced as `active`/`previous` by the
+    /// currently committed [`DurableState`] (each call's bytes
+    /// supersede the previous, so re-staging after an interrupted
+    /// attempt is always safe) -- but the adapter MUST refuse
+    /// ([`PortError::EpochAlreadyCommitted`]) a stage call for an
+    /// epoch already so referenced.
+    fn stage_material(
+        &self,
+        workload: &WorkloadId,
+        kind: SecretKind,
+        epoch: Epoch,
+        material: &SecretMaterial,
+    ) -> Result<String, PortError>;
+
+    /// Re-derive the digest of whatever is currently stored for
+    /// `epoch`, without ever handing the raw bytes back to this
+    /// module. Used to re-verify `active`/`previous` before any
+    /// mutation, and to close the "last stage wins" race described in
+    /// the module doc by re-checking a just-committed epoch.
+    fn material_digest(
+        &self,
+        workload: &WorkloadId,
+        kind: SecretKind,
+        epoch: Epoch,
+    ) -> Result<String, PortError>;
+
+    /// Atomically replace the committed [`DurableState`] with `next`
+    /// if and only if the adapter's currently stored fencing token
+    /// equals `expected` -- all or nothing, exactly like a classic
+    /// CAS/etcd transaction. On success returns the new fencing token
+    /// (always different from `expected`). On a lost race returns
+    /// [`PortError::OwnershipFenced`] and the adapter's own state is
+    /// left completely unchanged.
+    fn cas_commit(
+        &self,
+        workload: &WorkloadId,
+        kind: SecretKind,
+        expected: OwnershipEpoch,
+        next: DurableState,
+    ) -> Result<OwnershipEpoch, PortError>;
+
+    /// Durably discard the material for `epoch`. Idempotent: already
+    /// absent is `Ok(())`, not an error. This module never calls this
+    /// for an epoch still referenced as `active` or `previous` by the
+    /// last-known committed [`DurableState`] -- the superseding
+    /// transition is always committed first, then pruned.
+    fn prune_material(
+        &self,
+        workload: &WorkloadId,
+        kind: SecretKind,
+        epoch: Epoch,
+    ) -> Result<(), PortError>;
+
+    /// Durably mark `(workload, kind)` as quarantined: every
+    /// subsequent call of any method above for this pair must fail
+    /// closed with [`PortError::Quarantined`] until an out-of-band,
+    /// integrator-owned clearing operation (this module exposes none)
+    /// resets it. Idempotent.
+    fn quarantine(
+        &self,
+        workload: &WorkloadId,
+        kind: SecretKind,
+        reason: QuarantineReason,
+    ) -> Result<(), PortError>;
 }
 
-// ---------------------------------------------------------------------
-// Transaction / recovery log
-// ---------------------------------------------------------------------
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PromotePhase {
-    /// Intent recorded; the target generation may or may not be
-    /// staged/created yet. Nothing observable (`current`/marker) has
-    /// changed. Safe to discard.
-    Planned,
-    /// `generations/<to_epoch>/material` exists and is durable
-    /// (fsynced), verified against `expected_digest_hex`. `current`
-    /// still points elsewhere (or nowhere). Still safe to discard.
-    EpochReady,
-    /// `current` now resolves to `generations/<to_epoch>/`, durable.
-    /// This is the activation point: recovery may only move forward
-    /// from here.
-    CurrentPromoted,
-    /// `marker.json` durably reflects the new active/previous/
-    /// high-water state. Only pruning + txlog removal remain
-    /// (idempotent).
-    MarkerCommitted,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum RetirePhase {
-    /// The physical generation tree has been anchored-enumerated and
-    /// validated; `intent.epochs` is the recorded deletion plan.
-    /// `current` may still be present. Nothing has been deleted yet.
-    Enumerated,
-    /// `current` has been removed. No generation has been deleted
-    /// yet.
-    CurrentRemoved,
-    /// Every recorded epoch has been removed (idempotently — already-
-    /// removed entries are tolerated).
-    EpochsRemoved,
-    /// A fresh re-enumeration proved the tree is empty. Only the
-    /// tombstone marker write + txlog removal remain.
-    ProvenEmpty,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PromoteIntent {
-    pub vm: String,
-    pub kind: String,
-    pub action: LifecycleAction,
-    pub to_epoch: u64,
-    pub create_epoch: bool,
-    /// Name of the staging directory used for a freshly-created
-    /// epoch. Empty when `create_epoch` is `false` (rollback).
-    pub stage_name: String,
-    pub expected_digest_hex: String,
-    /// Full recorded identity of the rollback target, used to
-    /// tamper-verify the pre-existing generation before promoting it.
-    /// `None` when `create_epoch` is `true`.
-    pub expected_identity: Option<MaterialIdentity>,
-    /// The identity that becomes the new `previous` once this action
-    /// commits.
-    pub carry_previous: Option<MaterialIdentity>,
-    /// A generation to prune strictly after the new marker is
-    /// durably committed. `None` when nothing is superseded.
-    pub prune_epoch: Option<u64>,
-    pub new_high_water_epoch: u64,
-    pub first_provisioned_ms: u64,
-    pub phase: PromotePhase,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RetireIntent {
-    pub vm: String,
-    pub kind: String,
-    /// The recorded deletion plan from the enumeration that started
-    /// this transaction. Recovery re-enumerates fresh and requires the
-    /// fresh result to be a subset of this plan.
-    pub epochs: Vec<u64>,
-    /// Every `.stage-*` staging directory found in the same
-    /// enumeration. Staged entries are real secret-tree contents (a
-    /// stage dir contains, or is about to contain, a copy of
-    /// caller-supplied material bytes): they are deleted exactly like
-    /// `epochs`, with every failure propagated, never as a
-    /// best-effort sweep.
-    pub stage_names: Vec<String>,
-    pub high_water_epoch: u64,
-    pub phase: RetirePhase,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "tx_variant", rename_all = "snake_case", deny_unknown_fields)]
-pub enum TxLog {
-    Promote(PromoteIntent),
-    Retire(RetireIntent),
+fn map_port_error(err: PortError) -> FailReason {
+    match err {
+        PortError::OwnershipFenced => FailReason::OwnershipFenced,
+        PortError::Quarantined => FailReason::Quarantined,
+        PortError::EpochAlreadyCommitted => FailReason::StateCorrupt,
+        PortError::Unavailable => FailReason::PortUnavailable,
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -485,5575 +622,1567 @@ pub struct SecretsLifecycleError {
     pub audit: SecretsLifecycleAuditFields,
 }
 
-impl std::fmt::Display for SecretsLifecycleError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for SecretsLifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "secrets-lifecycle: {}", self.reason)
     }
 }
 
 impl std::error::Error for SecretsLifecycleError {}
 
-/// `recovered` must reflect whether this call already successfully
-/// drained a leftover crashed transaction (via [`open_and_recover`])
-/// before reaching this denial — see
-/// [`SecretsLifecycleAuditFields::denied`].
-fn denied(
-    ctx: &SecretsLifecycleAuditContext,
-    recovered: bool,
-    reason: FailReason,
-) -> SecretsLifecycleError {
+fn denied(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> SecretsLifecycleError {
     SecretsLifecycleError {
         reason,
-        audit: SecretsLifecycleAuditFields::denied(ctx, recovered, reason),
+        audit: SecretsLifecycleAuditFields::denied(ctx, reason),
     }
 }
 
-/// `recovered` must reflect whether this call already successfully
-/// drained a leftover crashed transaction before this failure — see
-/// [`SecretsLifecycleAuditFields::failed`]. There is no
-/// caller-supplied `MarkerResult` here: `failed` itself always
-/// records `MarkerResult::FailedClosed`.
-fn failed_closed(
-    ctx: &SecretsLifecycleAuditContext,
-    recovered: bool,
-    reason: FailReason,
-) -> SecretsLifecycleError {
+/// There is no caller-supplied `MarkerResult` here: `failed` itself
+/// always records `MarkerResult::FailedClosed` (see that constructor's
+/// own doc comment for why accepting one would be dead flexibility).
+fn failed_closed(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> SecretsLifecycleError {
     SecretsLifecycleError {
         reason,
-        audit: SecretsLifecycleAuditFields::failed(ctx, recovered, reason),
+        audit: SecretsLifecycleAuditFields::failed(ctx, reason),
     }
 }
 
-fn io_to_reason(_err: io::Error, on_failure: FailReason) -> FailReason {
-    on_failure
-}
-
-// ---------------------------------------------------------------------
-// Directory / marker / txlog primitives
-// ---------------------------------------------------------------------
-
-/// Open (creating if absent) the anchored `kind_root` directory and
-/// its `generations/` child, returning both fds. Every subsequent
-/// operation is fd-relative from here.
-///
-/// `cfg.state_root` itself is a precondition, not something this
-/// component creates: [`path_safe::ensure_dir`] refuses to operate
-/// under a world-writable parent, and the real deployment's secrets
-/// root is expected to be established (with the correct non-world-
-/// writable mode) by host activation before the broker ever calls
-/// into this module — see the module doc's "Integration wiring
-/// points" §4. `open_dir_path_safe` (no world-writable-parent check)
-/// only verifies it exists. `vm_dir` and `kind_root` are created
-/// on demand beneath it via `ensure_dir`, which is safe here because
-/// their immediate parent (`state_root`, then `vm_dir`) is never
-/// world-writable once `state_root` itself is correctly established.
-fn open_or_create_secrets_dir(
-    paths: &SecretsLifecyclePaths,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<(OwnedFd, OwnedFd), FailReason> {
-    let vm_dir = paths
-        .kind_root
-        .parent()
-        .ok_or(FailReason::SecretsDirOpenFailed)?;
-    path_safe::open_dir_path_safe(&cfg.state_root).map_err(|_| FailReason::SecretsDirOpenFailed)?;
-    // Metadata directories (the per-VM directory, the per-kind
-    // secrets root, and `generations/`) are trusted-broker-owned
-    // bookkeeping, never a consumer-owned material leaf: `cfg.
-    // owner_uid`/`owner_gid` apply only to the `material` file
-    // written by `ensure_staged`. `ensure_dir` only reasserts mode on
-    // every call (it does not re-`chown` when passed `None, None`),
-    // so ownership drift is independently verified here rather than
-    // trusted from construction alone.
-    path_safe::ensure_dir(vm_dir, cfg.dir_mode, None, None)
-        .map_err(|_| FailReason::SecretsDirOpenFailed)?;
-    let vm_dir_fd =
-        path_safe::open_dir_path_safe(vm_dir).map_err(|_| FailReason::SecretsDirOpenFailed)?;
-    let vm_dir_stat =
-        path_safe::fstat_fd(vm_dir_fd.as_fd()).map_err(|_| FailReason::BrokerOwnershipViolation)?;
-    verify_broker_owned(&vm_dir_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
-    drop(vm_dir_fd);
-
-    path_safe::ensure_dir(&paths.kind_root, cfg.dir_mode, None, None)
-        .map_err(|_| FailReason::SecretsDirOpenFailed)?;
-    let secrets_fd = path_safe::open_dir_path_safe(&paths.kind_root)
-        .map_err(|_| FailReason::SecretsDirOpenFailed)?;
-    let secrets_stat = path_safe::fstat_fd(secrets_fd.as_fd())
-        .map_err(|_| FailReason::BrokerOwnershipViolation)?;
-    verify_broker_owned(&secrets_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
-    path_safe::mkdir_at(
-        secrets_fd.as_fd(),
-        Path::new(GENERATIONS_DIR_NAME),
-        cfg.dir_mode,
-    )
-    .map_err(|_| FailReason::MarkerTreeOpenFailed)?;
-    let generations_fd = path_safe::open_at(
-        secrets_fd.as_fd(),
-        Path::new(GENERATIONS_DIR_NAME),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| FailReason::MarkerTreeOpenFailed)?;
-    let generations_stat = path_safe::fstat_fd(generations_fd.as_fd())
-        .map_err(|_| FailReason::BrokerOwnershipViolation)?;
-    verify_broker_owned(&generations_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
-    Ok((secrets_fd, generations_fd))
-}
-
-fn open_generations_dir(secrets_fd: BorrowedFd<'_>) -> Result<OwnedFd, FailReason> {
-    path_safe::open_at(
-        secrets_fd,
-        Path::new(GENERATIONS_DIR_NAME),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| FailReason::MarkerTreeOpenFailed)
-}
-
-fn read_marker(secrets_fd: BorrowedFd<'_>) -> Result<Option<MarkerData>, FailReason> {
-    let fd = match path_safe::open_file_at_safe(
-        &borrowed_to_owned(secrets_fd)?,
-        MARKER_FILE_NAME,
-        nix::libc::O_RDONLY,
-    ) {
-        Ok(fd) => fd,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(_) => return Err(FailReason::MarkerTreeOpenFailed),
-    };
-    let bytes = read_fd_to_end(fd.as_fd()).map_err(|_| FailReason::MarkerTreeOpenFailed)?;
-    let marker: MarkerData =
-        serde_json::from_slice(&bytes).map_err(|_| FailReason::MarkerTamperedOrMissingMaterial)?;
-    if marker.v != MARKER_SCHEMA_VERSION {
-        return Err(FailReason::MarkerTamperedOrMissingMaterial);
-    }
-    Ok(Some(marker))
-}
-
-fn write_marker(secrets_fd: BorrowedFd<'_>, marker: &MarkerData) -> Result<(), FailReason> {
-    let body = serde_json::to_vec(marker).map_err(|_| FailReason::MarkerWriteFailed)?;
-    let owned = borrowed_to_owned(secrets_fd)?;
-    path_safe::atomic_replace_fd_with_owner(
-        &owned,
-        MARKER_FILE_NAME,
-        &body,
-        FILE_MODE_DEFAULT,
-        None,
-        None,
-    )
-    .map_err(|_| FailReason::MarkerWriteFailed)?;
-    fsync_fd(secrets_fd)?;
-    Ok(())
-}
-
-/// Cross-field semantic validation of a leftover `txlog`, bound to the
-/// exact `(vm, kind)` directory it was found in. Run immediately on
-/// read, *before* any recovery attempt: a txlog naming a different
-/// `(vm, kind)`, an internally inconsistent phase/epoch/stage/
-/// high-water combination, or an action a `PromoteIntent` cannot
-/// legally carry is [`FailReason::IntentCorrupt`] rather than
-/// something recovery tries to interpret.
-fn validate_txlog_semantics(log: &TxLog, vm_id: &str, kind: SecretKind) -> Result<(), FailReason> {
-    match log {
-        TxLog::Promote(intent) => validate_promote_intent_semantics(intent, vm_id, kind),
-        TxLog::Retire(intent) => validate_retire_intent_semantics(intent, vm_id, kind),
-    }
-}
-
-fn validate_promote_intent_semantics(
-    intent: &PromoteIntent,
-    vm_id: &str,
-    kind: SecretKind,
-) -> Result<(), FailReason> {
-    if intent.vm != vm_id || intent.kind != kind.as_slug() {
-        return Err(FailReason::IntentCorrupt);
-    }
-    if intent.to_epoch == 0 {
-        return Err(FailReason::IntentCorrupt);
-    }
-    let action_wants_create = match intent.action {
-        LifecycleAction::Provision | LifecycleAction::Rotate => true,
-        LifecycleAction::Rollback => false,
-        LifecycleAction::Retire => return Err(FailReason::IntentCorrupt),
-    };
-    if intent.create_epoch != action_wants_create {
-        return Err(FailReason::IntentCorrupt);
-    }
-    if intent.create_epoch {
-        if intent.stage_name.is_empty() || !is_well_formed_stage_name(&intent.stage_name) {
-            return Err(FailReason::IntentCorrupt);
-        }
-        if intent.expected_identity.is_some() {
-            return Err(FailReason::IntentCorrupt);
-        }
-    } else {
-        if !intent.stage_name.is_empty() {
-            return Err(FailReason::IntentCorrupt);
-        }
-        match &intent.expected_identity {
-            Some(identity)
-                if identity.epoch == intent.to_epoch
-                    && identity.digest_hex == intent.expected_digest_hex => {}
-            _ => return Err(FailReason::IntentCorrupt),
-        }
-    }
-    if intent.new_high_water_epoch < intent.to_epoch {
-        return Err(FailReason::IntentCorrupt);
-    }
-    if let Some(previous) = &intent.carry_previous
-        && previous.epoch == intent.to_epoch
-    {
-        return Err(FailReason::IntentCorrupt);
-    }
-    if let Some(prune) = intent.prune_epoch
-        && (prune == intent.to_epoch
-            || intent
-                .carry_previous
-                .as_ref()
-                .is_some_and(|p| p.epoch == prune))
-    {
-        return Err(FailReason::IntentCorrupt);
-    }
-    Ok(())
-}
-
-fn validate_retire_intent_semantics(
-    intent: &RetireIntent,
-    vm_id: &str,
-    kind: SecretKind,
-) -> Result<(), FailReason> {
-    if intent.vm != vm_id || intent.kind != kind.as_slug() {
-        return Err(FailReason::IntentCorrupt);
-    }
-    let mut sorted_epochs = intent.epochs.clone();
-    sorted_epochs.sort_unstable();
-    sorted_epochs.dedup();
-    if sorted_epochs != intent.epochs {
-        return Err(FailReason::IntentCorrupt);
-    }
-    if intent
-        .epochs
-        .iter()
-        .any(|&e| e == 0 || e > intent.high_water_epoch)
-    {
-        return Err(FailReason::IntentCorrupt);
-    }
-    let mut sorted_stage_names = intent.stage_names.clone();
-    sorted_stage_names.sort();
-    sorted_stage_names.dedup();
-    if sorted_stage_names != intent.stage_names
-        || intent
-            .stage_names
-            .iter()
-            .any(|s| !is_well_formed_stage_name(s))
-    {
-        return Err(FailReason::IntentCorrupt);
-    }
-    Ok(())
-}
-
-fn read_txlog(
-    secrets_fd: BorrowedFd<'_>,
-    vm_id: &str,
-    kind: SecretKind,
-) -> Result<Option<TxLog>, FailReason> {
-    let owned = borrowed_to_owned(secrets_fd)?;
-    let fd = match path_safe::open_file_at_safe(&owned, TXLOG_FILE_NAME, nix::libc::O_RDONLY) {
-        Ok(fd) => fd,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(_) => return Err(FailReason::IntentCorrupt),
-    };
-    let bytes = read_fd_to_end(fd.as_fd()).map_err(|_| FailReason::IntentCorrupt)?;
-    let log: TxLog = serde_json::from_slice(&bytes).map_err(|_| FailReason::IntentCorrupt)?;
-    validate_txlog_semantics(&log, vm_id, kind)?;
-    Ok(Some(log))
-}
-
-fn write_txlog(secrets_fd: BorrowedFd<'_>, log: &TxLog) -> Result<(), FailReason> {
-    let body = serde_json::to_vec(log).map_err(|_| FailReason::IntentWriteFailed)?;
-    let owned = borrowed_to_owned(secrets_fd)?;
-    path_safe::atomic_replace_fd_with_owner(
-        &owned,
-        TXLOG_FILE_NAME,
-        &body,
-        FILE_MODE_DEFAULT,
-        None,
-        None,
-    )
-    .map_err(|_| FailReason::IntentWriteFailed)?;
-    fsync_fd(secrets_fd)?;
-    Ok(())
-}
-
-fn remove_txlog(secrets_fd: BorrowedFd<'_>) -> Result<(), FailReason> {
-    let owned = borrowed_to_owned(secrets_fd)?;
-    match path_safe::remove_path_safe(&owned, TXLOG_FILE_NAME) {
-        Ok(()) => {}
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-        Err(_) => return Err(FailReason::IntentWriteFailed),
-    }
-    fsync_fd(secrets_fd)?;
-    Ok(())
-}
-
-/// `BorrowedFd` -> `OwnedFd` without taking ownership of the original
-/// descriptor: dups via `openat2(".")`-equivalent semantics through
-/// [`path_safe::open_at`]. Needed because several `path_safe` helpers
-/// take `&OwnedFd`, while callers here hold a `BorrowedFd` (e.g. from
-/// a `LockGuard` or a caller-held directory fd) for the duration of a
-/// single call.
-fn borrowed_to_owned(fd: BorrowedFd<'_>) -> Result<OwnedFd, FailReason> {
-    path_safe::open_at(fd, Path::new("."), OFlags::RDONLY | OFlags::DIRECTORY)
-        .map_err(|_| FailReason::MarkerTreeOpenFailed)
-}
-
-fn read_fd_to_end(fd: BorrowedFd<'_>) -> io::Result<Vec<u8>> {
-    use std::io::Read;
-    use std::os::fd::AsRawFd as _;
-    // SAFETY-free: build a short-lived `File` view over the fd without
-    // taking ownership, restoring the raw fd afterward via
-    // `into_raw_fd` on a duplicated descriptor so the original isn't
-    // double-closed.
-    let dup = rustix::fs::fcntl_dupfd_cloexec(fd, 0).map_err(io_from_rustix)?;
-    let mut file: std::fs::File = dup.into();
-    let mut buf = Vec::new();
-    file.read_to_end(&mut buf)?;
-    let _ = fd.as_raw_fd();
-    Ok(buf)
-}
-
-/// One byte more than [`SecretMaterial::MAX_LEN`]: large enough to
-/// distinguish "at the maximum permitted size" from "oversized",
-/// small enough that a read against this cap can never be unbounded.
-const MATERIAL_READ_CAP: u64 = SecretMaterial::MAX_LEN as u64 + 1;
-
-/// Read up to `cap` bytes from `fd` directly into a
-/// `Zeroizing<Vec<u8>>` -- never through an intermediate plain
-/// `Vec<u8>` -- so a partial-read-then-error buffer is zeroized on
-/// drop rather than silently dropped as ordinary heap memory. Returns
-/// an error (without ever exceeding `cap` bytes of allocation) if the
-/// stream still has unread data past `cap`, so a file that grows
-/// between `fstat` and `read` can never be read past the cap either.
-fn read_fd_to_end_capped(fd: BorrowedFd<'_>, cap: u64) -> io::Result<Zeroizing<Vec<u8>>> {
-    use std::io::Read;
-    use std::os::fd::AsRawFd as _;
-    let dup = rustix::fs::fcntl_dupfd_cloexec(fd, 0).map_err(io_from_rustix)?;
-    let file: std::fs::File = dup.into();
-    // Cap the reader at `cap + 1`: reading exactly `cap + 1` bytes
-    // successfully proves the underlying stream is oversized, which
-    // we reject below, while never allocating more than `cap + 1`
-    // bytes regardless of how large the real stream actually is.
-    let mut limited = file.take(cap + 1);
-    let mut buf = Zeroizing::new(Vec::new());
-    limited.read_to_end(&mut buf)?;
-    let _ = fd.as_raw_fd();
-    if buf.len() as u64 > cap {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "material file exceeds the closed read cap",
-        ));
-    }
-    Ok(buf)
-}
-
-/// Safely open, type/size-verify, and read an on-disk material file
-/// beneath `dir_fd`, returning the opened fd (for any further
-/// fd-based checks the caller needs, e.g. an ACL probe), its `fstat`
-/// result, and its full contents in a buffer that is *never*
-/// observable as a plain, unwrapped `Vec<u8>`.
-///
-/// - Opens with `O_RDONLY | O_NONBLOCK`: nofollow / no-magiclink /
-///   beneath-only resolution is already enforced unconditionally by
-///   [`path_safe::open_file_at_safe`]; `O_NONBLOCK` additionally
-///   guarantees this call can never block indefinitely if a FIFO has
-///   been planted at the material path instead of a regular file.
-/// - Rejects, before reading a single byte, anything that is not a
-///   regular file or whose reported size exceeds
-///   [`MATERIAL_READ_CAP`] -- a device, FIFO, or corrupt/oversized
-///   on-disk entry is never read.
-/// - Reads directly into a `Zeroizing<Vec<u8>>` via
-///   [`read_fd_to_end_capped`] (never through an intermediate plain
-///   `Vec<u8>`).
-///
-/// Callers that need to compare *owner/mode/nlink* identity against
-/// an expected value (e.g. tamper detection across a rollback) do so
-/// on the returned `stat` themselves, using the existing per-field
-/// `FailReason` variants (`IdentityOwnerMismatch`,
-/// `IdentityModeMismatch`, `IdentityLinkCountMismatch`, ...) -- this
-/// function only enforces the type/size invariants that must hold
-/// before *any* read is safe to attempt; it deliberately does not
-/// reject on nlink so that identity capture can still surface the
-/// precise mismatch reason downstream.
-fn read_material_file_capped(
-    dir_fd: &OwnedFd,
-) -> Result<(OwnedFd, nix::libc::stat, Zeroizing<Vec<u8>>), FailReason> {
-    let file_fd = path_safe::open_file_at_safe(
-        dir_fd,
-        MATERIAL_FILE_NAME,
-        nix::libc::O_RDONLY | nix::libc::O_NONBLOCK,
-    )
-    .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
-    let stat = path_safe::fstat_fd(file_fd.as_fd())
-        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
-    if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFREG {
-        return Err(FailReason::PreviouslyProvisionedMaterialMissing);
-    }
-    if stat.st_size < 0 || stat.st_size as u64 > MATERIAL_READ_CAP {
-        return Err(FailReason::PreviouslyProvisionedMaterialMissing);
-    }
-    let bytes = read_fd_to_end_capped(file_fd.as_fd(), MATERIAL_READ_CAP)
-        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
-    Ok((file_fd, stat, bytes))
-}
-
-// Test-only fault injection seam: when enabled (see
-// `tests::FsyncFaultGuard`), every `fsync_fd` call fails with
-// `FailReason::FsyncFailed` instead of touching the filesystem, so
-// tests can prove each phase-advancement point genuinely blocks on a
-// durable sync rather than merely calling `fsync` and ignoring the
-// result.
-#[cfg(test)]
-thread_local! {
-    static FSYNC_SHOULD_FAIL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-}
-
-fn fsync_fd(fd: BorrowedFd<'_>) -> Result<(), FailReason> {
-    #[cfg(test)]
-    if FSYNC_SHOULD_FAIL.with(|c| c.get()) {
-        return Err(FailReason::FsyncFailed);
-    }
-    rustix::fs::fsync(fd).map_err(|_| FailReason::FsyncFailed)
-}
-
-fn io_from_rustix(err: rustix::io::Errno) -> io::Error {
-    io::Error::from_raw_os_error(err.raw_os_error())
-}
-
-// ---------------------------------------------------------------------
-// Broker-trusted ownership (metadata dirs, lock file)
-// ---------------------------------------------------------------------
-
-/// The trusted "broker owner" identity for every path this module
-/// manages *except* a `material` file leaf: metadata directories
-/// (`kind_root`, `generations/`), the marker, the txlog, and the lock
-/// file. Since this module only ever runs inside the broker process,
-/// "owned by the broker" and "owned by this process's effective
-/// uid/gid" are the same statement — a path this module is about to
-/// trust for locking or transaction bookkeeping that reports some
-/// *other* owner was not created by this code path and must never be
-/// trusted, regardless of what `cfg.owner_uid`/`cfg.owner_gid` (the
-/// separate, *consumer*-facing identity applied only to material file
-/// leaves — see [`ensure_staged`]) say.
-fn broker_identity() -> (u32, u32) {
-    (
-        rustix::process::geteuid().as_raw(),
-        rustix::process::getegid().as_raw(),
-    )
-}
-
-/// Verify `stat` is exactly `expected_type` (`S_IFDIR`/`S_IFREG`),
-/// owned by the trusted broker identity, has exactly `expected_mode`
-/// permission bits, and (for a regular file) exactly one hard link.
-/// Any mismatch is [`FailReason::BrokerOwnershipViolation`] — this is
-/// the check that makes broker-owned metadata/lock paths
-/// "non-replaceable": a foreign-owned or hard-linked stand-in is
-/// refused rather than silently trusted.
-fn verify_broker_owned(
-    stat: &nix::libc::stat,
-    expected_type: nix::libc::mode_t,
-    expected_mode: u32,
-) -> Result<(), FailReason> {
-    let (uid, gid) = broker_identity();
-    if (stat.st_mode & nix::libc::S_IFMT) != expected_type {
-        return Err(FailReason::BrokerOwnershipViolation);
-    }
-    if stat.st_uid != uid || stat.st_gid != gid {
-        return Err(FailReason::BrokerOwnershipViolation);
-    }
-    if (stat.st_mode & 0o7777) != expected_mode {
-        return Err(FailReason::BrokerOwnershipViolation);
-    }
-    if expected_type == nix::libc::S_IFREG && stat.st_nlink != 1 {
-        return Err(FailReason::BrokerOwnershipViolation);
-    }
-    Ok(())
-}
-
-/// Build a whole-file (`l_len == 0`, `l_start == 0`, `l_whence ==
-/// SEEK_SET`) `libc::flock` descriptor for an OFD lock/unlock
-/// operation. `l_pid` is left `0`: the kernel ignores it for
-/// `F_OFD_*` commands (it is only meaningful for the classic
-/// process-associated `F_SETLK`/`F_GETLK`).
-fn whole_file_flock(l_type: nix::libc::c_short) -> nix::libc::flock {
-    nix::libc::flock {
-        l_type,
-        l_whence: nix::libc::SEEK_SET as nix::libc::c_short,
-        l_start: 0,
-        l_len: 0,
-        l_pid: 0,
-    }
-}
-
-/// Attempt to acquire a non-blocking, whole-file, exclusive **open
-/// file description** (OFD) lock on `fd` via `F_OFD_SETLK`
-/// (`F_OFD_SETLKW`'s non-blocking sibling). This is the repository's
-/// established cross-process advisory-lock primitive (mirroring
-/// `d2bd::audio_dispatch::ofd_lock`/`ofd_unlock`'s `F_OFD_SETLK{,W}`
-/// pattern) rather than BSD `flock(2)`: an OFD lock is associated
-/// with the *open file description*, not the owning process, so it
-/// composes correctly with `fork`/exec and with a single process
-/// holding multiple independent fds on the same lock file — unlike
-/// BSD `flock`, whose whole-process association would let two
-/// unrelated fds opened by the same process silently share one lock.
-///
-/// Returns `Ok(true)` if the lock was acquired, `Ok(false)` if it is
-/// currently held by another open file description (the caller should
-/// retry), and `Err` for any other failure. Both `EAGAIN` and `EACCES`
-/// are treated as "held elsewhere" per the Linux `fcntl(2)` manual
-/// page, which documents either errno as possible for a conflicting
-/// `F_SETLK`-family lock request depending on lock type.
-fn try_ofd_lock_exclusive(fd: BorrowedFd<'_>) -> Result<bool, FailReason> {
-    let fl = whole_file_flock(nix::libc::F_WRLCK as nix::libc::c_short);
-    match nix::fcntl::fcntl(fd.as_raw_fd(), nix::fcntl::FcntlArg::F_OFD_SETLK(&fl)) {
-        Ok(_) => Ok(true),
-        Err(nix::errno::Errno::EAGAIN) | Err(nix::errno::Errno::EACCES) => Ok(false),
-        Err(_) => Err(FailReason::LockUnavailable),
-    }
-}
-
-// ---------------------------------------------------------------------
-// Cross-process lock
-// ---------------------------------------------------------------------
-
-#[derive(Debug)]
-pub struct LockGuard {
-    _file: std::fs::File,
-}
-
-/// Acquire the cross-process exclusive lock for one `(vm, kind)`
-/// directory. Before trusting the OFD lock, this verifies: the
-/// anchored parent (`secrets_fd`, i.e. `kind_root`) is a trusted-
-/// broker-owned directory with the expected mode; the lock file
-/// itself is a trusted-broker-owned regular file with the expected
-/// mode and exactly one hard link (never a hard-link plant); and,
-/// immediately after the lock succeeds, that the directory entry
-/// named `lock` still resolves (by `(dev, ino)`) to the exact file
-/// this call opened and locked — guarding against the classic
-/// lock-via-path race where another actor unlinks-and-recreates the
-/// lock file between this call's `open` and its lock attempt, which
-/// would let two callers each hold an uncontended lock on two
-/// different, now-unlinked-vs-live inodes of the same name. The
-/// underlying primitive is the repository's `F_OFD_SETLK` convention
-/// (see [`try_ofd_lock_exclusive`]), not BSD `flock`; releasing the
-/// lock is simply closing `LockGuard`'s owned fd (the kernel drops an
-/// OFD lock exactly when every fd referencing its open file
-/// description is closed — no separate unlock call is needed, and
-/// [`LockGuard`] deliberately exposes no public/forgeable "is locked"
-/// proof, only an opaque RAII token).
-///
-/// A full generated-sync-row `d2b-state::LockSet`/`AuthorityRef`
-/// integration remains an explicit integrator-owned wiring point: see
-/// the module doc's "Integration wiring points" §5.
-fn acquire_lock(
-    secrets_fd: BorrowedFd<'_>,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<LockGuard, FailReason> {
-    let owned = borrowed_to_owned(secrets_fd)?;
-    let parent_stat =
-        path_safe::fstat_fd(secrets_fd).map_err(|_| FailReason::BrokerOwnershipViolation)?;
-    verify_broker_owned(&parent_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
-
-    let fd = path_safe::create_file_at_safe(
-        &owned,
-        LOCK_FILE_NAME,
-        nix::libc::O_RDWR | nix::libc::O_CREAT,
-        FILE_MODE_DEFAULT,
-    )
-    .map_err(|_| FailReason::LockUnavailable)?;
-    let lock_stat =
-        path_safe::fstat_fd(fd.as_fd()).map_err(|_| FailReason::BrokerOwnershipViolation)?;
-    verify_broker_owned(&lock_stat, nix::libc::S_IFREG, FILE_MODE_DEFAULT)?;
-
-    let file: std::fs::File = fd.into();
-    let deadline = Instant::now() + cfg.lock_max_wait;
-    loop {
-        match try_ofd_lock_exclusive(file.as_fd())? {
-            true => {
-                // Re-stat by name (anchored beneath the already-
-                // verified `secrets_fd` parent) and compare `(dev,
-                // ino)` against the fd we just locked: if another
-                // actor swapped the `lock` entry between our open and
-                // our successful lock, the identity will differ and
-                // we must not trust this lock.
-                let by_name = path_safe::fstatat_nofollow(&owned, LOCK_FILE_NAME)
-                    .map_err(|_| FailReason::BrokerOwnershipViolation)?
-                    .ok_or(FailReason::BrokerOwnershipViolation)?;
-                let by_fd = path_safe::fstat_fd(file.as_fd())
-                    .map_err(|_| FailReason::BrokerOwnershipViolation)?;
-                if by_name.st_dev != by_fd.st_dev || by_name.st_ino != by_fd.st_ino {
-                    return Err(FailReason::BrokerOwnershipViolation);
-                }
-                return Ok(LockGuard { _file: file });
-            }
-            false => {
-                if Instant::now() >= deadline {
-                    return Err(FailReason::LockUnavailable);
-                }
-                std::thread::sleep(cfg.lock_poll_interval);
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------
-// Staging / generation helpers
-// ---------------------------------------------------------------------
-
-fn random_stage_name() -> String {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id() as u64;
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(0);
-    let mut hasher = RandomState::new().build_hasher();
-    hasher.write_u64(pid);
-    hasher.write_u64(counter);
-    hasher.write_u64(nanos);
-    let entropy = hasher.finish();
-
-    let mut mix = Sha256::new();
-    mix.update(pid.to_le_bytes());
-    mix.update(counter.to_le_bytes());
-    mix.update(nanos.to_le_bytes());
-    mix.update(entropy.to_le_bytes());
-    let digest = mix.finalize();
-    format!("{STAGE_PREFIX}{}", hex_encode(&digest[..16]))
-}
-
-/// The exact closed syntax [`random_stage_name`] always produces:
-/// `STAGE_PREFIX` followed by exactly 32 lowercase-hex characters, as
-/// one single path component with no separator or parent-reference
-/// syntax. Used to validate every stage name that originates from a
-/// txlog (fresh construction *and* recovery reload) before it is ever
-/// used as an anchored path component -- a corrupted or hand-edited
-/// txlog containing `/`, `..`, or any other value must never reach an
-/// `openat`-family call.
-fn is_well_formed_stage_name(name: &str) -> bool {
-    if name.contains('/') || name.contains("..") {
-        return false;
-    }
-    let Some(suffix) = name.strip_prefix(STAGE_PREFIX) else {
-        return false;
-    };
-    suffix.len() == 32
-        && suffix
-            .bytes()
-            .all(|b| b.is_ascii_digit() || (b.is_ascii_lowercase() && b.is_ascii_hexdigit()))
-}
-
-fn parse_strict_epoch(name: &str) -> Option<u64> {
-    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_digit()) {
-        return None;
-    }
-    if name.len() > 1 && name.starts_with('0') {
-        return None;
-    }
-    name.parse::<u64>().ok()
-}
-
-/// Validate a `.stage-*` directory's contents are consistent with an
-/// in-progress or superseded staging attempt: at most one entry,
-/// which (if present) must be a regular file with exactly one hard
-/// link (either the final `material` name, or a stray hidden
-/// temp-file name a crash left behind mid-write via
-/// `path_safe::atomic_replace_fd_with_owner`'s named-stage fallback).
-/// Anything else (a subdirectory, a symlink, more than one entry, or
-/// a hard-linked file) is an anomaly this refuses to silently delete.
-fn validate_stage_dir_contents(generations_fd: &OwnedFd, name: &str) -> Result<(), FailReason> {
-    let dir_fd = path_safe::open_at(
-        generations_fd.as_fd(),
-        Path::new(name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
-    let inner = rustix::fs::Dir::read_from(dir_fd.as_fd())
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let mut seen: Option<String> = None;
-    for entry in inner {
-        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
-        let ename = entry
-            .file_name()
-            .to_str()
-            .map_err(|_| FailReason::RetirementTreeAnomaly)?
-            .to_owned();
-        if ename == "." || ename == ".." {
-            continue;
-        }
-        if seen.is_some() {
-            return Err(FailReason::RetirementTreeAnomaly);
-        }
-        seen = Some(ename);
-    }
-    if let Some(ename) = seen {
-        let stat = path_safe::fstatat_nofollow(&dir_owned, &ename)
-            .map_err(|_| FailReason::RetirementTreeAnomaly)?
-            .ok_or(FailReason::RetirementTreeAnomaly)?;
-        if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFREG {
-            return Err(FailReason::RetirementTreeAnomaly);
-        }
-        if stat.st_nlink != 1 {
-            return Err(FailReason::RetirementTreeAnomaly);
-        }
-    }
-    Ok(())
-}
-
-/// Immediately before deleting a `.stage-*` directory, re-stat it
-/// (nofollow, anchored) and confirm it is still exactly a validated
-/// stage directory. Mirrors [`revalidate_generation_before_delete`]
-/// for stage directories: a missing entry is tolerated (another pass,
-/// or this same pass on retry, already removed it); any other anomaly
-/// injected between enumeration and deletion -- an extra entry, a
-/// subdirectory, a hard-linked file -- fails closed rather than
-/// deleting a directory that no longer matches what was originally
-/// validated.
-fn revalidate_stage_before_delete(
-    generations_fd: BorrowedFd<'_>,
-    name: &str,
-) -> Result<(), FailReason> {
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    match path_safe::fstatat_nofollow(&generations_owned, name) {
-        Ok(Some(_)) => validate_stage_dir_contents(&generations_owned, name),
-        Ok(None) => Ok(()),
-        Err(_) => Err(FailReason::RetirementTreeAnomaly),
-    }
-}
-
-/// Discard a partially-staged `.stage-*` directory left behind by a
-/// crashed attempt that never reached a fully-staged, digest-matching
-/// state (so [`ensure_staged`] returned `Ok(false)` on recovery
-/// re-entry and there is no material to promote). No-ops if the stage
-/// directory is absent (the common, no-crash path, or a retry that
-/// already discarded it). If present, validates its contents are
-/// consistent with a partial/superseded staging attempt and deletes
-/// it -- propagating any validation or deletion failure so the caller
-/// never abandons the txlog record while leaving an orphaned,
-/// unvalidated stage directory on disk.
-fn discard_partial_stage_if_present(
-    generations_fd: BorrowedFd<'_>,
-    stage_name: &str,
-) -> Result<(), FailReason> {
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    match path_safe::fstatat_nofollow(&generations_owned, stage_name) {
-        Ok(Some(_)) => {
-            validate_stage_dir_contents(&generations_owned, stage_name)?;
-            remove_stage_dir(generations_fd, stage_name)
-        }
-        Ok(None) => Ok(()),
-        Err(_) => Err(FailReason::RetirementTreeAnomaly),
-    }
-}
-
-/// Fully delete one `.stage-*` directory: enumerate every child,
-/// delete each one (propagating any failure other than the child
-/// already being absent), prove the directory is observably empty,
-/// fsync it, then remove the directory itself and fsync its parent.
-/// Staged entries are real secret-tree contents — this is never a
-/// best-effort sweep, unlike the old `36d9dcf8`/`dab583f1` design's
-/// `sweep_stale_stage_dirs`: every failure here is propagated and
-/// blocks the caller from advancing.
-fn remove_stage_dir(generations_fd: BorrowedFd<'_>, name: &str) -> Result<(), FailReason> {
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    let dir_fd = match path_safe::open_at(
-        generations_fd,
-        Path::new(name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    ) {
-        Ok(fd) => fd,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            // Already gone. This may be a durable retry re-observing
-            // a completed deletion, or it may be a retry re-observing
-            // a deletion whose *own* trailing
-            // `fsync_fd(generations_fd)` failed before the caller
-            // could advance the phase. Retry that durability barrier
-            // now rather than assuming the earlier attempt's fsync
-            // (which we cannot distinguish from "never happened")
-            // actually completed.
-            fsync_fd(generations_fd)?;
-            return Ok(());
-        }
-        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
-    };
-    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
-    let entries = rustix::fs::Dir::read_from(dir_fd.as_fd())
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let mut names = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
-        let ename = entry
-            .file_name()
-            .to_str()
-            .map_err(|_| FailReason::RetirementTreeAnomaly)?
-            .to_owned();
-        if ename != "." && ename != ".." {
-            names.push(ename);
-        }
-    }
-    drop(dir_fd);
-    for ename in &names {
-        match path_safe::remove_path_safe(&dir_owned, ename) {
-            Ok(()) => {}
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-            Err(_) => return Err(FailReason::RetirementTreeAnomaly),
-        }
-    }
-    // Prove empty before removing: a deletion that silently left a
-    // child behind must never result in the parent being removed
-    // anyway.
-    let remaining = rustix::fs::Dir::read_from(dir_owned.as_fd())
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    for entry in remaining {
-        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
-        let ename = entry
-            .file_name()
-            .to_str()
-            .map_err(|_| FailReason::RetirementTreeAnomaly)?
-            .to_owned();
-        if ename != "." && ename != ".." {
-            return Err(FailReason::RetirementNotProvablyEmpty);
-        }
-    }
-    fsync_fd(dir_owned.as_fd())?;
-    match path_safe::remove_path_safe(&generations_owned, name) {
-        Ok(()) => {}
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
-    }
-    fsync_fd(generations_fd)?;
-    Ok(())
-}
-
-fn borrowed_to_owned_io(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
-    path_safe::open_at(fd, Path::new("."), OFlags::RDONLY | OFlags::DIRECTORY)
-}
-
-/// Stage `material` bytes into a fresh, collision-resistant directory
-/// beneath `generations/`, fsyncing the material file and the stage
-/// directory before returning. Idempotent with respect to
-/// `stage_name`: if a directory of that name already exists with a
-/// matching digest, this is a no-op (crash-recovery re-entry).
-fn ensure_staged(
-    generations_fd: BorrowedFd<'_>,
-    cfg: &SecretsLifecycleConfig,
-    stage_name: &str,
-    expected_digest_hex: &str,
-    material: Option<&SecretMaterial>,
-) -> Result<bool, FailReason> {
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    if let Ok(existing_digest) = digest_of_material_dir(&generations_owned, stage_name) {
-        if existing_digest == expected_digest_hex {
-            return Ok(true);
-        }
-        // Tampered/partial stage from a previous crash: nothing has
-        // been activated yet (we are still pre-EpochReady), so it is
-        // safe to discard and let the caller decide (abort/retry). The
-        // deletion itself must fully succeed and propagate any error;
-        // a stage directory is real secret material and is never
-        // swept on a best-effort basis.
-        remove_stage_dir(generations_owned.as_fd(), stage_name)?;
-        return Err(FailReason::RecoveryContentMismatch);
-    }
-
-    let Some(material) = material else {
-        return Ok(false);
-    };
-
-    path_safe::mkdir_at_exclusive(generations_fd, Path::new(stage_name), cfg.dir_mode)
-        .map_err(|_| FailReason::MaterialWriteFailed)?;
-    let stage_fd = path_safe::open_at(
-        generations_fd,
-        Path::new(stage_name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| FailReason::MaterialWriteFailed)?;
-    let stage_owned = borrowed_to_owned(stage_fd.as_fd())?;
-    path_safe::atomic_replace_fd_with_owner(
-        &stage_owned,
-        MATERIAL_FILE_NAME,
-        material.as_bytes(),
-        cfg.file_mode,
-        cfg.owner_uid,
-        cfg.owner_gid,
-    )
-    .map_err(|_| FailReason::MaterialWriteFailed)?;
-    fsync_fd(stage_fd.as_fd())?;
-    fsync_fd(generations_fd)?;
-    Ok(true)
-}
-
-fn digest_of_material_dir(generations_fd: &OwnedFd, dir_name: &str) -> io::Result<String> {
-    let dir_fd = path_safe::open_at(
-        generations_fd.as_fd(),
-        Path::new(dir_name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )?;
-    let dir_owned = borrowed_to_owned_io(dir_fd.as_fd())?;
-    let (_file_fd, _stat, bytes) = read_material_file_capped(&dir_owned)
-        .map_err(|reason| io::Error::other(format!("{reason:?}")))?;
-    let mut hasher = Sha256::new();
-    hasher.update(&*bytes);
-    Ok(hex_encode(&hasher.finalize()))
-}
-
-/// Rename the stage directory into its final numeric epoch name.
-/// Idempotent: if the final directory already exists with a matching
-/// digest (a previous crash-recovery pass already renamed it), this
-/// is a no-op.
-fn promote_stage_to_generation(
-    generations_fd: BorrowedFd<'_>,
-    stage_name: &str,
-    to_epoch: u64,
-    expected_digest_hex: &str,
-) -> Result<(), FailReason> {
-    let epoch_name = to_epoch.to_string();
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    if let Ok(existing_digest) = digest_of_material_dir(&generations_owned, &epoch_name) {
-        // A directory already occupies this epoch number (e.g. a
-        // recovery re-entry after the rename completed but the phase
-        // advance did not commit). It is only safe to treat this as
-        // "already promoted" if its content is exactly the content we
-        // intended to promote; any other content -- stale, foreign,
-        // or from an aborted/rolled-back attempt -- must never be
-        // silently accepted or overwritten.
-        if existing_digest == expected_digest_hex {
-            return Ok(());
-        }
-        return Err(FailReason::GenerationConflict);
-    }
-    rustix::fs::renameat(
-        generations_fd,
-        Path::new(stage_name),
-        generations_fd,
-        Path::new(&epoch_name),
-    )
-    .map_err(|_| FailReason::GenerationConflict)?;
-    fsync_fd(generations_fd)?;
-    Ok(())
-}
-
-fn capture_identity(
-    generations_fd: BorrowedFd<'_>,
-    epoch: u64,
-) -> Result<MaterialIdentity, FailReason> {
-    let epoch_name = epoch.to_string();
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    let dir_fd = path_safe::open_at(
-        generations_fd,
-        Path::new(&epoch_name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
-    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
-    let (material_fd, stat, bytes) = read_material_file_capped(&dir_owned)?;
-    let (has_acl, _) = path_safe::fd_extended_acl_present(material_fd.as_fd())
-        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
-    let mut hasher = Sha256::new();
-    hasher.update(&*bytes);
-    let digest_hex = hex_encode(&hasher.finalize());
-    let _ = generations_owned;
-    Ok(MaterialIdentity {
-        epoch,
-        dev: stat.st_dev,
-        ino: stat.st_ino,
-        uid: stat.st_uid,
-        gid: stat.st_gid,
-        mode: stat.st_mode & 0o7777,
-        nlink: stat.st_nlink,
-        has_acl,
-        digest_hex,
-    })
-}
-
-/// Tamper-verify a live generation against a recorded identity
-/// (used by rollback's Planned phase to confirm the retained
-/// generation has not drifted since it was recorded).
-fn verify_existing_generation_identity(
-    generations_fd: BorrowedFd<'_>,
-    expected: &MaterialIdentity,
-) -> Result<(), FailReason> {
-    let live = capture_identity(generations_fd, expected.epoch)?;
-    if live.uid != expected.uid || live.gid != expected.gid {
-        return Err(FailReason::IdentityOwnerMismatch);
-    }
-    if live.mode != expected.mode {
-        return Err(FailReason::IdentityModeMismatch);
-    }
-    if live.has_acl != expected.has_acl {
-        return Err(FailReason::IdentityAclMismatch);
-    }
-    if live.nlink != expected.nlink {
-        return Err(FailReason::IdentityLinkCountMismatch);
-    }
-    if live.digest_hex != expected.digest_hex {
-        return Err(FailReason::IdentityDigestMismatch);
-    }
-    if live.dev != expected.dev || live.ino != expected.ino {
-        return Err(FailReason::IdentityInodeMismatch);
-    }
-    Ok(())
-}
-
-/// The exact literal symlink target text `atomic_swap_current` writes
-/// for a given epoch: `generations/<epoch>`. This is a relative path
-/// anchored at the per-(vm,kind) secrets directory; any other literal
-/// text -- an absolute path, a path with extra segments, or a
-/// differently-rooted relative path -- must never be treated as
-/// resolving to that epoch, even if its final component happens to
-/// match the epoch number.
-fn expected_current_target(epoch: u64) -> String {
-    format!("{GENERATIONS_DIR_NAME}/{epoch}")
-}
-
-/// Read the exact literal text `current` resolves to, without any
-/// component-wise parsing. Returns `None` if the link is absent,
-/// unreadable, or not valid UTF-8.
-fn current_target_text(secrets_fd: BorrowedFd<'_>) -> Option<String> {
-    rustix::fs::readlinkat(secrets_fd, Path::new(CURRENT_LINK_NAME), Vec::new())
-        .ok()?
-        .into_string()
-        .ok()
-}
-
-/// Read the literal name `current` resolves to (its symlink target's
-/// exact literal text), parsed only if it is *exactly*
-/// `generations/<epoch>` and nothing else.
-fn read_current_target(secrets_fd: BorrowedFd<'_>) -> Option<u64> {
-    let target = current_target_text(secrets_fd)?;
-    let (dir, epoch_str) = target.split_once('/')?;
-    if dir != GENERATIONS_DIR_NAME {
-        return None;
-    }
-    parse_strict_epoch(epoch_str)
-}
-
-/// Verify that `current` resolves, by exact literal text, to
-/// `generations/<epoch>` -- not merely to a path whose final
-/// component happens to be that epoch number.
-fn current_resolves_exactly_to(secrets_fd: BorrowedFd<'_>, epoch: u64) -> bool {
-    match current_target_text(secrets_fd) {
-        Some(target) => target == expected_current_target(epoch),
-        None => false,
-    }
-}
-
-/// Confirm the `current` entry is exactly absent -- not merely a
-/// dangling/foreign symlink `current_target_text` happens to be
-/// unable to parse, and not some other filesystem object (regular
-/// file, directory, ...) squatting the reserved name. Used only where
-/// the invariant under test is "no active generation exists", so any
-/// entry at all (of any type, resolving to anything) must be treated
-/// as a live-state disagreement rather than silently ignored.
-fn current_is_genuinely_absent(secrets_fd: BorrowedFd<'_>) -> Result<bool, FailReason> {
-    let owned = borrowed_to_owned(secrets_fd)?;
-    match path_safe::fstatat_nofollow(&owned, CURRENT_LINK_NAME) {
-        Ok(Some(_)) => Ok(false),
-        Ok(None) => Ok(true),
-        Err(_) => Err(FailReason::MarkerTreeOpenFailed),
-    }
-}
-
-/// Atomically swap `current` to point at `generations/<epoch>` using a
-/// hidden-name-then-rename swap so there is never a moment `current`
-/// is absent. Idempotent: if `current` already resolves, by exact
-/// literal text, to `epoch`, this is a no-op.
-fn atomic_swap_current(secrets_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), FailReason> {
-    if current_resolves_exactly_to(secrets_fd, epoch) {
-        return Ok(());
-    }
-    let owned = borrowed_to_owned(secrets_fd)?;
-    let target = expected_current_target(epoch);
-    // Clean up a leftover swap-stage entry from a previous crash
-    // between symlink-creation and rename. `CURRENT_SWAP_STAGE_NAME`
-    // is only ever created via `symlinkat`, so
-    // `path_safe::remove_path_safe` (which refuses to operate on
-    // symlinks by design) can never actually remove it -- using it
-    // here would silently leave the stale symlink in place and the
-    // following `symlinkat` would then fail closed with `EEXIST`
-    // every retry. Instead: nofollow-stat the slot; if absent, there
-    // is nothing to clean up; if present and exactly a symlink,
-    // `unlinkat` it; if present but *not* a symlink (an anomaly no
-    // legitimate code path produces), fail closed rather than
-    // deleting an unexpected entry.
-    match path_safe::fstatat_nofollow(&owned, CURRENT_SWAP_STAGE_NAME)
-        .map_err(|_| FailReason::CurrentSwapFailed)?
-    {
-        None => {}
-        Some(stat) => {
-            if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFLNK {
-                return Err(FailReason::CurrentSwapFailed);
-            }
-            match rustix::fs::unlinkat(
-                secrets_fd,
-                Path::new(CURRENT_SWAP_STAGE_NAME),
-                rustix::fs::AtFlags::empty(),
-            ) {
-                Ok(()) | Err(rustix::io::Errno::NOENT) => {}
-                Err(_) => return Err(FailReason::CurrentSwapFailed),
-            }
-        }
-    }
-    rustix::fs::symlinkat(&target, secrets_fd, Path::new(CURRENT_SWAP_STAGE_NAME))
-        .map_err(|_| FailReason::CurrentSwapFailed)?;
-    rustix::fs::renameat(
-        secrets_fd,
-        Path::new(CURRENT_SWAP_STAGE_NAME),
-        secrets_fd,
-        Path::new(CURRENT_LINK_NAME),
-    )
-    .map_err(|_| FailReason::CurrentSwapFailed)?;
-    fsync_fd(secrets_fd)?;
-    Ok(())
-}
-
-/// `current` is always a symlink; [`path_safe::remove_path_safe`]
-/// refuses to operate on symlinks by design, so removal goes through
-/// a raw `unlinkat` instead. Tolerates absence (idempotent).
-fn remove_current_symlink(secrets_fd: BorrowedFd<'_>) -> Result<(), FailReason> {
-    match rustix::fs::unlinkat(
-        secrets_fd,
-        Path::new(CURRENT_LINK_NAME),
-        rustix::fs::AtFlags::empty(),
-    ) {
-        Ok(()) => {
-            fsync_fd(secrets_fd)?;
-            Ok(())
-        }
-        Err(rustix::io::Errno::NOENT) => Ok(()),
-        Err(_) => Err(FailReason::CurrentSwapFailed),
-    }
-}
-
-/// Remove one already-validated generation directory
-/// (`generations/<epoch>/material` then `generations/<epoch>/`).
-/// Tolerates the directory already being absent (idempotent
-/// crash-recovery replay). Any other failure is propagated: the
-/// caller must fail the whole retirement closed rather than continue
-/// past a partial deletion.
-fn remove_generation(generations_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), FailReason> {
-    let epoch_name = epoch.to_string();
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    let dir_fd = match path_safe::open_at(
-        generations_fd,
-        Path::new(&epoch_name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    ) {
-        Ok(fd) => fd,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            // Already gone -- but retry the trailing durability
-            // barrier in case a prior attempt deleted this entry and
-            // then failed its own `fsync_fd(generations_fd)` before
-            // the caller could advance the phase or commit a
-            // tombstone. Never assume that fsync happened just
-            // because the entry is absent.
-            fsync_fd(generations_fd)?;
-            return Ok(());
-        }
-        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
-    };
-    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
-    match path_safe::remove_path_safe(&dir_owned, MATERIAL_FILE_NAME) {
-        Ok(()) => {}
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
-    }
-    drop(dir_fd);
-    path_safe::remove_path_safe(&generations_owned, &epoch_name)
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    fsync_fd(generations_fd)?;
-    Ok(())
-}
-
-/// The fully-enumerated, validated contents of `generations/`: real
-/// generation epochs and real stage directories. Both halves are
-/// "real secret tree contents" for retirement purposes -- a stage
-/// directory is never swept separately or treated as ignorable.
-struct GenerationTreeContents {
-    epochs: Vec<u64>,
-    stage_names: Vec<String>,
-}
-
-/// Anchored enumeration of `generations/`, failing closed on any
-/// entry this cannot fully account for. Deletes nothing; a caller
-/// invokes this to *plan* retirement (or to detect drift before
-/// recovery/deletion), never as part of deleting.
-fn enumerate_and_validate_generation_tree(
-    generations_fd: BorrowedFd<'_>,
-) -> Result<GenerationTreeContents, FailReason> {
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    let dir = rustix::fs::Dir::read_from(generations_fd)
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let mut epochs = Vec::new();
-    let mut stage_names = Vec::new();
-    for entry in dir {
-        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
-        let name = entry
-            .file_name()
-            .to_str()
-            .map_err(|_| FailReason::RetirementTreeAnomaly)?
-            .to_owned();
-        if name == "." || name == ".." {
-            continue;
-        }
-        if name.starts_with(STAGE_PREFIX) {
-            // Stage directories are real secret-tree contents, not a
-            // separately-swept concern: validate their shape now and
-            // carry them in the plan so retirement/pruning enumerates,
-            // validates, and deletes them under the same accounting as
-            // generation epochs. Defense-in-depth: a live directory
-            // name matching the prefix but not the full closed
-            // `is_well_formed_stage_name` syntax (e.g. containing `/`
-            // or `..`, which the kernel would never actually produce
-            // as a single directory-entry name, or an unexpected
-            // length/charset) is treated as an anomaly rather than a
-            // stage directory this code will ever construct a path
-            // from.
-            if !is_well_formed_stage_name(&name) {
-                return Err(FailReason::RetirementTreeAnomaly);
-            }
-            validate_stage_dir_contents(&generations_owned, &name)?;
-            stage_names.push(name);
-            continue;
-        }
-        let Some(epoch) = parse_strict_epoch(&name) else {
-            return Err(FailReason::RetirementTreeAnomaly);
-        };
-        verify_generation_dir_is_exactly_material(&generations_owned, &name)?;
-        epochs.push(epoch);
-    }
-    epochs.sort_unstable();
-    stage_names.sort();
-    Ok(GenerationTreeContents {
-        epochs,
-        stage_names,
-    })
-}
-
-fn verify_generation_dir_is_exactly_material(
-    generations_fd: &OwnedFd,
-    name: &str,
-) -> Result<(), FailReason> {
-    let stat = path_safe::fstatat_nofollow(generations_fd, name)
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?
-        .ok_or(FailReason::RetirementTreeAnomaly)?;
-    if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFDIR {
-        return Err(FailReason::RetirementTreeAnomaly);
-    }
-    let dir_fd = path_safe::open_at(
-        generations_fd.as_fd(),
-        Path::new(name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
-    let inner = rustix::fs::Dir::read_from(dir_fd.as_fd())
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let mut saw_material = false;
-    for entry in inner {
-        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
-        let ename = entry
-            .file_name()
-            .to_str()
-            .map_err(|_| FailReason::RetirementTreeAnomaly)?
-            .to_owned();
-        if ename == "." || ename == ".." {
-            continue;
-        }
-        if ename != MATERIAL_FILE_NAME {
-            return Err(FailReason::RetirementTreeAnomaly);
-        }
-        saw_material = true;
-    }
-    if !saw_material {
-        return Err(FailReason::RetirementTreeAnomaly);
-    }
-    let material_stat = path_safe::fstatat_nofollow(&dir_owned, MATERIAL_FILE_NAME)
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?
-        .ok_or(FailReason::RetirementTreeAnomaly)?;
-    if (material_stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFREG {
-        return Err(FailReason::RetirementTreeAnomaly);
-    }
-    if material_stat.st_nlink != 1 {
-        return Err(FailReason::RetirementTreeAnomaly);
-    }
-    Ok(())
-}
-
-// ---------------------------------------------------------------------
-// Central pre-mutation validation
-// ---------------------------------------------------------------------
-
-/// Invoked by every public lifecycle action (provision/rotate/
-/// rollback/retire) immediately after loading the on-disk marker.
-/// Refuses to proceed if the marker's own semantics are internally
-/// inconsistent, if it does not match the caller's own `(vm_id,
-/// kind_slug)`, or if the live on-disk state has drifted from what
-/// the marker claims.
-///
-/// This validates **every** marker shape reachable on disk, not only
-/// an active one:
-/// - An *active* marker requires `current` to resolve, by *exact
-///   literal text*, to the marker's recorded active epoch. A symlink
-///   retargeted to any other path -- absolute, foreign-rooted, or
-///   merely ending in the right epoch number -- is never accepted as
-///   a match. This is the single reachable trigger for
-///   [`FailReason::IdentityCurrentTargetMismatch`] on the active path.
-/// - An *inactive* marker (`active == None`, whether a fresh never-
-///   provisioned state or a retirement tombstone) requires
-///   `previous == None`, coherent `retired`/`high_water_epoch`
-///   metadata, and -- critically -- that `current` is genuinely
-///   absent (not stale, not foreign, not dangling): a marker claiming
-///   "nothing active" is never accepted as consistent with a live
-///   `current` entry of any kind.
-fn verify_marker_against_live_state(
-    secrets_fd: BorrowedFd<'_>,
-    generations_fd: BorrowedFd<'_>,
-    vm_id: &str,
-    kind_slug: &str,
-    marker: &MarkerData,
-) -> Result<(), FailReason> {
-    if marker.vm != vm_id || marker.kind != kind_slug {
-        return Err(FailReason::MarkerTamperedOrMissingMaterial);
-    }
-    if marker.retired && marker.active.is_some() {
-        // A tombstoned marker must never also claim an active
-        // generation -- these two fields are mutually exclusive by
-        // construction in every write path this module performs.
-        return Err(FailReason::MarkerTamperedOrMissingMaterial);
-    }
-    let Some(active) = marker.active.as_ref() else {
-        // Inactive marker: either a fresh never-provisioned state
-        // (`retired == false`) or a retirement tombstone
-        // (`retired == true`). Validate complete tombstone / never-
-        // provisioned semantics rather than trivially accepting.
-        if marker.previous.is_some() {
-            // Retirement and (successful) provision both always
-            // clear `previous` together with `active`; a lingering
-            // `previous` over an inactive marker can only be tamper
-            // or corruption.
-            return Err(FailReason::MarkerTamperedOrMissingMaterial);
-        }
-        if marker.retired {
-            if marker.high_water_epoch == 0 {
-                // `retire()` always records the real epoch count
-                // that was retired; a tombstone claiming zero epochs
-                // were ever provisioned is incoherent.
-                return Err(FailReason::MarkerTamperedOrMissingMaterial);
-            }
-        } else if marker.high_water_epoch != 0 {
-            // A never-provisioned marker (no action has ever
-            // committed for this `(vm, kind)`) has no legitimate way
-            // to record a nonzero high-water epoch.
-            return Err(FailReason::MarkerTamperedOrMissingMaterial);
-        }
-        if !current_is_genuinely_absent(secrets_fd)? {
-            // Never treat an inactive marker as `verified_clean` (or
-            // otherwise consistent) over a stale, foreign, or
-            // otherwise still-present `current` entry.
-            return Err(FailReason::IdentityCurrentTargetMismatch);
-        }
-        return Ok(());
-    };
-    if active.epoch == 0 || active.epoch > marker.high_water_epoch {
-        return Err(FailReason::MarkerTamperedOrMissingMaterial);
-    }
-    if let Some(previous) = marker.previous.as_ref()
-        && (previous.epoch == 0
-            || previous.epoch == active.epoch
-            || previous.epoch > marker.high_water_epoch)
-    {
-        // `previous` need not be numerically less than `active`: a
-        // rollback swaps the pair, so `previous` can legitimately be
-        // the *larger* epoch that was just rolled back away from.
-        // What must always hold is that it is a distinct, real,
-        // never-exceeding-high-water epoch.
-        return Err(FailReason::MarkerTamperedOrMissingMaterial);
-    }
-    if !current_resolves_exactly_to(secrets_fd, active.epoch) {
-        return Err(FailReason::IdentityCurrentTargetMismatch);
-    }
-    verify_existing_generation_identity(generations_fd, active)?;
-    if let Some(previous) = marker.previous.as_ref() {
-        verify_existing_generation_identity(generations_fd, previous)?;
-    }
-    Ok(())
-}
-
-/// Immediately before deleting a generation directory as part of
-/// retirement, re-stat it (nofollow, anchored) and confirm it is
-/// still either a validated material directory, or the exact
-/// legitimate mid-deletion crash checkpoint `remove_generation` can
-/// leave behind: `material` already unlinked, but the (now-empty)
-/// epoch directory itself not yet removed. A missing entry is
-/// tolerated (another recovery pass, or this same pass on retry,
-/// already removed it entirely).
-///
-/// Recognizing the empty-directory checkpoint is reachable **only**
-/// from here -- i.e. only from `execute_retire`'s `CurrentRemoved`
-/// phase, always acting on a `RetireIntent` that has already passed
-/// `validate_retire_intent_semantics` (checked both when the intent is
-/// first written and every time a leftover txlog is re-read before
-/// recovery acts on it). Fresh, pre-retirement planning never goes
-/// through this function: `enumerate_and_validate_generation_tree`
-/// (used to build a brand-new retirement plan, and again to prove the
-/// tree fully empty once `EpochsRemoved` is reached) always calls the
-/// strict `verify_generation_dir_is_exactly_material` and remains
-/// exactly as strict as before -- an empty generation directory
-/// encountered there is still `FailReason::RetirementTreeAnomaly`, not
-/// a silently-accepted "nothing here yet" state.
-///
-/// To accept the directory as the empty checkpoint (rather than any
-/// other empty-directory shape an attacker could construct in its
-/// place) every one of these must hold:
-/// - the entry is still a directory (never a symlink, regular file, or
-///   any other type swapped into the same name -- that is a
-///   replacement, not a partially-deleted survivor, and fails closed);
-/// - it is still trusted-broker-owned at the expected `cfg.dir_mode`
-///   (a foreign owner, or any other mode, means the directory itself
-///   was replaced rather than left behind by this module's own
-///   deletion sequence, and fails closed);
-/// - it contains **zero** entries other than `.`/`..` -- any
-///   unrecognised leftover entry, or a `material` entry of the wrong
-///   type or link-count, fails closed rather than being swept away as
-///   part of "finishing" the deletion.
-///
-/// Any other anomaly -- wrong type, an unexpected extra entry, a
-/// hard-linked material file -- fails closed rather than deleting a
-/// directory that no longer matches what enumeration originally
-/// validated.
-fn revalidate_generation_before_delete(
-    generations_fd: BorrowedFd<'_>,
-    epoch: u64,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<(), FailReason> {
-    let epoch_name = epoch.to_string();
-    let generations_owned = borrowed_to_owned(generations_fd)?;
-    let stat = match path_safe::fstatat_nofollow(&generations_owned, &epoch_name) {
-        Ok(Some(stat)) => stat,
-        Ok(None) => return Ok(()),
-        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
-    };
-    if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFDIR {
-        return Err(FailReason::RetirementTreeAnomaly);
-    }
-    match verify_generation_dir_is_exactly_material(&generations_owned, &epoch_name) {
-        Ok(()) => return Ok(()),
-        Err(FailReason::RetirementTreeAnomaly) => {}
-        Err(other) => return Err(other),
-    }
-    // Not a fully-materialized generation: the only other shape this
-    // retire deletion loop may ever accept is the exact
-    // post-material-unlink, pre-directory-removal checkpoint, and only
-    // over a directory that is still verifiably this module's own
-    // trusted-broker-owned metadata directory.
-    verify_broker_owned(&stat, nix::libc::S_IFDIR, cfg.dir_mode)
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let dir_fd = path_safe::open_at(
-        generations_owned.as_fd(),
-        Path::new(&epoch_name),
-        OFlags::RDONLY | OFlags::DIRECTORY,
-    )
-    .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    let inner = rustix::fs::Dir::read_from(dir_fd.as_fd())
-        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    for entry in inner {
-        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
-        let ename = entry
-            .file_name()
-            .to_str()
-            .map_err(|_| FailReason::RetirementTreeAnomaly)?
-            .to_owned();
-        if ename != "." && ename != ".." {
-            // A genuinely empty checkpoint has zero entries; anything
-            // else here (an unrelated leftover, or a `material` entry
-            // that `verify_generation_dir_is_exactly_material` already
-            // rejected above as the wrong type/link-count) is an
-            // anomaly, never silently accepted.
-            return Err(FailReason::RetirementTreeAnomaly);
-        }
-    }
-    Ok(())
-}
-
-// ---------------------------------------------------------------------
-// Unified promote engine (fresh action + crash recovery)
-// ---------------------------------------------------------------------
-
-#[derive(Debug)]
-enum PromoteOutcome {
-    Completed(MarkerData),
-    /// Only reachable when recovering a crash that occurred before
-    /// any material was ever staged for a `create_epoch` intent —
-    /// i.e. nothing was ever activated. Discarding is safe.
-    AbortedNoMaterial,
-}
-
-fn execute_promote(
-    secrets_fd: BorrowedFd<'_>,
-    generations_fd: BorrowedFd<'_>,
-    cfg: &SecretsLifecycleConfig,
-    mut intent: PromoteIntent,
-    mut material: Option<&SecretMaterial>,
-) -> Result<PromoteOutcome, FailReason> {
-    loop {
-        match intent.phase {
-            PromotePhase::Planned => {
-                if intent.create_epoch {
-                    let epoch_name = intent.to_epoch.to_string();
-                    let generations_owned = borrowed_to_owned(generations_fd)?;
-                    let existing_digest =
-                        digest_of_material_dir(&generations_owned, &epoch_name).ok();
-                    match existing_digest {
-                        Some(digest) if digest == intent.expected_digest_hex => {
-                            // The rename to the final epoch name
-                            // already completed in a previous crashed
-                            // attempt. The epoch is fully materialized
-                            // with exactly the expected content: never
-                            // abandon or re-stage it, just continue
-                            // forward. The crashed attempt's own
-                            // trailing `fsync_fd(generations_fd)`
-                            // inside `promote_stage_to_generation` may
-                            // be exactly what failed and caused the
-                            // crash before the phase could advance --
-                            // retry that durability barrier now rather
-                            // than trusting it silently already
-                            // happened.
-                            fsync_fd(generations_fd)?;
-                        }
-                        Some(_) => {
-                            // Some directory already occupies this
-                            // epoch number, but its content does not
-                            // match what this transaction intended to
-                            // promote. This can only be a stale,
-                            // foreign, or previously-aborted
-                            // generation; never silently adopt or
-                            // overwrite it -- fail closed.
-                            return Err(FailReason::RecoveryContentMismatch);
-                        }
-                        None => {
-                            let staged = ensure_staged(
-                                generations_fd,
-                                cfg,
-                                &intent.stage_name,
-                                &intent.expected_digest_hex,
-                                material,
-                            )?;
-                            if !staged {
-                                // No fully-staged, digest-matching
-                                // material exists (this is either the
-                                // very first attempt with material
-                                // absent -- should not happen given
-                                // the public entry points always pass
-                                // material, but defensively handled --
-                                // or a recovery re-entry finding a
-                                // stage dir left in a partial state by
-                                // a crash between `mkdir_at_exclusive`
-                                // and the material write completing).
-                                // Never abandon a partial stage
-                                // directory silently: validate and
-                                // delete it (or fail closed) before
-                                // discarding the txlog record of it.
-                                discard_partial_stage_if_present(
-                                    generations_fd,
-                                    &intent.stage_name,
-                                )?;
-                                remove_txlog(secrets_fd)?;
-                                return Ok(PromoteOutcome::AbortedNoMaterial);
-                            }
-                            promote_stage_to_generation(
-                                generations_fd,
-                                &intent.stage_name,
-                                intent.to_epoch,
-                                &intent.expected_digest_hex,
-                            )?;
-                        }
-                    }
-                } else {
-                    let expected = intent
-                        .expected_identity
-                        .as_ref()
-                        .ok_or(FailReason::RecoveryAmbiguous)?;
-                    verify_existing_generation_identity(generations_fd, expected)?;
-                }
-                material = None;
-                intent.phase = PromotePhase::EpochReady;
-                write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
-            }
-            PromotePhase::EpochReady => {
-                // Recovery may resume directly at this phase from a
-                // persisted txlog written in a wholly separate process
-                // invocation -- `Planned`'s own verification above
-                // ran (if at all) only earlier in that other
-                // invocation's call stack, never here. Re-verify the
-                // complete intended target generation identity BEFORE
-                // swapping `current`: for a rollback (`expected_identity`
-                // present) this is the same full owner/mode/ACL/
-                // nlink/digest/inode comparison `Planned` uses; for a
-                // freshly-created epoch this is at least the digest
-                // check, so a tampered/replaced/missing target never
-                // gets activated.
-                if let Some(expected) = intent.expected_identity.as_ref() {
-                    verify_existing_generation_identity(generations_fd, expected)?;
-                } else {
-                    let identity = capture_identity(generations_fd, intent.to_epoch)?;
-                    if identity.digest_hex != intent.expected_digest_hex {
-                        return Err(FailReason::RecoveryContentMismatch);
-                    }
-                }
-                atomic_swap_current(secrets_fd, intent.to_epoch)?;
-                intent.phase = PromotePhase::CurrentPromoted;
-                write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
-            }
-            PromotePhase::CurrentPromoted => {
-                // Never write a marker claiming an active generation
-                // the live `current` symlink does not actually
-                // corroborate. A hand-edited/corrupted txlog claiming
-                // this phase over a `current` that does not resolve
-                // to `to_epoch` must fail closed here, before any
-                // marker mutation.
-                if !current_resolves_exactly_to(secrets_fd, intent.to_epoch) {
-                    return Err(FailReason::IdentityCurrentTargetMismatch);
-                }
-                let identity = capture_identity(generations_fd, intent.to_epoch)?;
-                if identity.digest_hex != intent.expected_digest_hex {
-                    // `current` already points at this epoch; we must
-                    // never revert it. This can only mean the intent
-                    // itself was corrupted (e.g. hand-edited txlog) —
-                    // fail closed without touching current/marker.
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                if intent.new_high_water_epoch < intent.to_epoch {
-                    return Err(FailReason::HighWaterRegressed);
-                }
-                // Re-verify `carry_previous`'s on-disk identity before
-                // writing it into the marker's `previous` field: the
-                // recorded identity in the txlog reflects a snapshot
-                // taken when the intent was first built, and this
-                // phase may run in a later, wholly separate recovery
-                // invocation. Never let a stale, tampered, or removed
-                // `previous` generation be asserted as still-valid
-                // marker state.
-                if let Some(previous) = intent.carry_previous.as_ref() {
-                    verify_existing_generation_identity(generations_fd, previous)?;
-                }
-                let marker = MarkerData {
-                    v: MARKER_SCHEMA_VERSION,
-                    vm: intent.vm.clone(),
-                    kind: intent.kind.clone(),
-                    retired: false,
-                    high_water_epoch: intent.new_high_water_epoch,
-                    active: Some(identity),
-                    previous: intent.carry_previous.clone(),
-                    first_provisioned_ms: intent.first_provisioned_ms,
-                    updated_ms: now_ms(),
-                };
-                write_marker(secrets_fd, &marker)?;
-                intent.phase = PromotePhase::MarkerCommitted;
-                write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
-            }
-            PromotePhase::MarkerCommitted => {
-                // Phase-specific validation must occur before any
-                // recovery mutation (pruning, stage cleanup) or txlog
-                // removal: re-read and verify the marker actually
-                // reflects this transaction's intended active
-                // generation, and that `current` still corroborates
-                // it, before proceeding. A hand-edited/corrupted
-                // txlog claiming `MarkerCommitted` over a marker/
-                // current that disagree must fail closed here rather
-                // than pruning or discarding state based on an
-                // unverified assumption.
-                if !current_resolves_exactly_to(secrets_fd, intent.to_epoch) {
-                    return Err(FailReason::IdentityCurrentTargetMismatch);
-                }
-                let marker = read_marker(secrets_fd)?.ok_or(FailReason::MarkerWriteFailed)?;
-                if marker.vm != intent.vm || marker.kind != intent.kind {
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                let active_matches = marker.active.as_ref().is_some_and(|a| {
-                    a.epoch == intent.to_epoch && a.digest_hex == intent.expected_digest_hex
-                });
-                if !active_matches {
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                if marker.previous != intent.carry_previous {
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                if let Some(prune) = intent.prune_epoch {
-                    // Defense in depth beyond `validate_promote_intent_
-                    // semantics`'s intrinsic `prune_epoch != to_epoch
-                    // && prune_epoch != carry_previous.epoch` check:
-                    // now that the marker's own `active`/`previous`
-                    // have been read and confirmed to equal
-                    // `intent.to_epoch`/`intent.carry_previous` above,
-                    // re-derive the same guarantee directly from the
-                    // marker actually on disk, never from the intent
-                    // alone -- pruning must never be able to target
-                    // the marker's live active or previous epoch.
-                    if marker.active.as_ref().is_some_and(|a| a.epoch == prune)
-                        || marker.previous.as_ref().is_some_and(|p| p.epoch == prune)
-                    {
-                        return Err(FailReason::RecoveryAmbiguous);
-                    }
-                    // Never discard a prune failure: pruning only
-                    // ever happens after the marker commit that no
-                    // longer references the pruned epoch has been
-                    // durably written above, so a `remove_generation`
-                    // failure here -- including a deletion that
-                    // succeeded but whose trailing `generations/`
-                    // directory fsync failed -- must propagate and
-                    // retain this durable `MarkerCommitted` txlog
-                    // entry (we return before reaching `remove_txlog`
-                    // below) rather than silently clearing it. A
-                    // future recovery pass resumes exactly here and
-                    // retries both the deletion and the durability
-                    // barrier; it never assumes an unsynced deletion
-                    // is final.
-                    remove_generation(generations_fd, prune)?;
-                }
-                // Any leftover `.stage-*` directory at this point is a
-                // real secret-tree entry from this or a prior crashed
-                // attempt (never the one this transaction just
-                // promoted -- that one was already renamed away).
-                // Enumerate, validate, and delete it, propagating any
-                // failure: a stage directory is never swept on a
-                // best-effort basis. Revalidate each immediately
-                // before deletion in case something changed between
-                // enumeration and delete.
-                let leftover = enumerate_and_validate_generation_tree(generations_fd)?;
-                for stage_name in leftover.stage_names {
-                    revalidate_stage_before_delete(generations_fd, &stage_name)?;
-                    remove_stage_dir(generations_fd, &stage_name)?;
-                }
-                remove_txlog(secrets_fd)?;
-                return Ok(PromoteOutcome::Completed(marker));
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------
-// Unified retire engine (fresh action + crash recovery)
-// ---------------------------------------------------------------------
-
-fn execute_retire(
-    secrets_fd: BorrowedFd<'_>,
-    generations_fd: BorrowedFd<'_>,
-    cfg: &SecretsLifecycleConfig,
-    mut intent: RetireIntent,
-) -> Result<(), FailReason> {
-    loop {
-        match intent.phase {
-            RetirePhase::Enumerated => {
-                let fresh = enumerate_and_validate_generation_tree(generations_fd)?;
-                if !fresh.epochs.iter().all(|e| intent.epochs.contains(e))
-                    || !fresh
-                        .stage_names
-                        .iter()
-                        .all(|s| intent.stage_names.contains(s))
-                {
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                // Recovery may resume directly at this phase from a
-                // persisted txlog written in a wholly separate process
-                // invocation, with `current` still live and never yet
-                // touched. Re-read and fully validate the marker
-                // against live state -- vm/kind identity, internal
-                // marker semantics, and (if it claims an active
-                // generation) `current`'s exact-target match and full
-                // material identity -- before performing this
-                // transaction's first mutation.
-                if let Some(marker) = read_marker(secrets_fd)? {
-                    verify_marker_against_live_state(
-                        secrets_fd,
-                        generations_fd,
-                        &intent.vm,
-                        &intent.kind,
-                        &marker,
-                    )?;
-                }
-                remove_current_symlink(secrets_fd)?;
-                intent.phase = RetirePhase::CurrentRemoved;
-                write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
-            }
-            RetirePhase::CurrentRemoved => {
-                // Phase-authority check: this phase's own precondition
-                // is that `Enumerated` already removed `current`. A
-                // persisted txlog resuming here in a separate
-                // recovery invocation must not proceed to delete any
-                // generation until that prior mutation is itself
-                // re-confirmed -- a `current` that reappeared (tamper,
-                // hand-edited txlog, or a foreign actor) must fail
-                // closed rather than let deletion continue underneath
-                // a live activation.
-                if !current_is_genuinely_absent(secrets_fd)? {
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                for &epoch in &intent.epochs {
-                    revalidate_generation_before_delete(generations_fd, epoch, cfg)?;
-                    remove_generation(generations_fd, epoch)?;
-                }
-                for stage_name in &intent.stage_names {
-                    // Staged entries are real secret-tree contents:
-                    // enumerate/validate/delete them exactly like
-                    // generation epochs, propagating every failure.
-                    // Revalidate immediately before deletion in case
-                    // something changed between enumeration and
-                    // delete.
-                    revalidate_stage_before_delete(generations_fd, stage_name)?;
-                    remove_stage_dir(generations_fd, stage_name)?;
-                }
-                intent.phase = RetirePhase::EpochsRemoved;
-                write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
-            }
-            RetirePhase::EpochsRemoved => {
-                // Phase-authority check: `current` must still be
-                // absent (this phase never re-creates it) before
-                // trusting a fresh re-enumeration to advance further.
-                if !current_is_genuinely_absent(secrets_fd)? {
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                let remaining = enumerate_and_validate_generation_tree(generations_fd)?;
-                if !remaining.epochs.is_empty() || !remaining.stage_names.is_empty() {
-                    return Err(FailReason::RetirementNotProvablyEmpty);
-                }
-                intent.phase = RetirePhase::ProvenEmpty;
-                write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
-            }
-            RetirePhase::ProvenEmpty => {
-                // Never write the tombstone marker on the strength of
-                // a *previous* invocation's emptiness proof alone: a
-                // persisted txlog resuming exactly here (in a wholly
-                // separate recovery pass) must re-prove both that
-                // `current` is absent and that the generations tree
-                // is still empty immediately before this phase's
-                // otherwise-unconditional mutation, rather than
-                // trusting `EpochsRemoved`'s prior check to still
-                // hold.
-                if !current_is_genuinely_absent(secrets_fd)? {
-                    return Err(FailReason::RecoveryAmbiguous);
-                }
-                let remaining = enumerate_and_validate_generation_tree(generations_fd)?;
-                if !remaining.epochs.is_empty() || !remaining.stage_names.is_empty() {
-                    return Err(FailReason::RetirementNotProvablyEmpty);
-                }
-                let marker = MarkerData {
-                    v: MARKER_SCHEMA_VERSION,
-                    vm: intent.vm.clone(),
-                    kind: intent.kind.clone(),
-                    retired: true,
-                    high_water_epoch: intent.high_water_epoch,
-                    active: None,
-                    previous: None,
-                    first_provisioned_ms: 0,
-                    updated_ms: now_ms(),
-                };
-                write_marker(secrets_fd, &marker)?;
-                remove_txlog(secrets_fd)?;
-                return Ok(());
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------
-// Recovery dispatch
-// ---------------------------------------------------------------------
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RecoveryError {
-    pub action: Option<LifecycleAction>,
-    pub reason: FailReason,
-}
-
-fn recover_if_needed(
-    secrets_fd: BorrowedFd<'_>,
-    generations_fd: BorrowedFd<'_>,
-    vm_id: &str,
-    kind: SecretKind,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<bool, RecoveryError> {
-    let txlog = read_txlog(secrets_fd, vm_id, kind).map_err(|reason| RecoveryError {
-        action: None,
-        reason,
-    })?;
-    let Some(txlog) = txlog else {
-        return Ok(false);
-    };
-    match txlog {
-        TxLog::Promote(intent) => {
-            let action = intent.action;
-            match execute_promote(secrets_fd, generations_fd, cfg, intent, None) {
-                Ok(_) => Ok(true),
-                Err(reason) => Err(RecoveryError {
-                    action: Some(action),
-                    reason,
-                }),
-            }
-        }
-        TxLog::Retire(intent) => match execute_retire(secrets_fd, generations_fd, cfg, intent) {
-            Ok(()) => Ok(true),
-            Err(reason) => Err(RecoveryError {
-                action: Some(LifecycleAction::Retire),
-                reason,
-            }),
-        },
-    }
-}
-
-/// Standalone entry point for draining a leftover crash-interrupted
-/// transaction independent of issuing a new lifecycle action (e.g. at
-/// realm controller/broker startup, per the module doc's wiring point
-/// §9). Returns `Ok(true)` if a leftover transaction was found and
-/// completed/discarded, `Ok(false)` if there was nothing to recover.
-pub fn recover_in_flight_transaction(
-    vm_id: &str,
-    kind: SecretKind,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<bool, SecretsLifecycleError> {
-    let paths = derive_paths(vm_id, kind, cfg).map_err(|reason| SecretsLifecycleError {
-        reason,
-        audit: SecretsLifecycleAuditFields::denied(
-            &SecretsLifecycleAuditContext {
-                vm_id: VmId::new(vm_id),
-                kind,
-                action: LifecycleAction::Provision,
-                base_dir_hash: String::new(),
-            },
-            false,
-            reason,
-        ),
-    })?;
-    let (secrets_fd, generations_fd) =
-        open_or_create_secrets_dir(&paths, cfg).map_err(|reason| {
-            let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
-            denied(&ctx, false, reason)
-        })?;
-    let _lock = acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| {
-        let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
-        denied(&ctx, false, reason)
-    })?;
-    match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), vm_id, kind, cfg) {
-        Ok(recovered) => Ok(recovered),
-        Err(err) => {
-            let ctx = context(
-                vm_id,
-                kind,
-                err.action.unwrap_or(LifecycleAction::Provision),
-                &paths,
-            );
-            Err(failed_closed(&ctx, false, err.reason))
-        }
-    }
-}
-
-// ---------------------------------------------------------------------
-// Public lifecycle actions
-// ---------------------------------------------------------------------
-
-/// `(paths, secrets_fd, generations_fd, lock, recovered_prior_transaction, marker)`.
-type OpenAndRecoverOk = (
-    SecretsLifecyclePaths,
-    OwnedFd,
-    OwnedFd,
-    LockGuard,
-    bool,
-    Option<MarkerData>,
-);
-
-fn open_and_recover(
-    vm_id: &str,
+fn context(
+    workload: &WorkloadId,
     kind: SecretKind,
     action: LifecycleAction,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<OpenAndRecoverOk, SecretsLifecycleError> {
-    let paths = derive_paths(vm_id, kind, cfg).map_err(|reason| {
-        let ctx = SecretsLifecycleAuditContext {
-            vm_id: VmId::new(vm_id),
-            kind,
-            action,
-            base_dir_hash: String::new(),
-        };
-        denied(&ctx, false, reason)
-    })?;
-    let ctx = context(vm_id, kind, action, &paths);
-    let (secrets_fd, generations_fd) =
-        open_or_create_secrets_dir(&paths, cfg).map_err(|reason| denied(&ctx, false, reason))?;
-    let lock =
-        acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| denied(&ctx, false, reason))?;
-    let recovered =
-        match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), vm_id, kind, cfg) {
-            Ok(recovered) => recovered,
-            Err(err) => {
-                let recovered_ctx = context(vm_id, kind, err.action.unwrap_or(action), &paths);
-                return Err(failed_closed(&recovered_ctx, false, err.reason));
-            }
-        };
-    let marker =
-        read_marker(secrets_fd.as_fd()).map_err(|reason| denied(&ctx, recovered, reason))?;
-    if let Some(marker) = &marker {
-        verify_marker_against_live_state(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            vm_id,
-            kind.as_slug(),
-            marker,
-        )
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
+) -> SecretsLifecycleAuditContext {
+    SecretsLifecycleAuditContext {
+        workload_id: workload.clone(),
+        kind,
+        action,
     }
-    Ok((paths, secrets_fd, generations_fd, lock, recovered, marker))
 }
 
+// ---------------------------------------------------------------------
+// Shared read + verify + debt-resolution
+// ---------------------------------------------------------------------
+
+/// Read the current [`DurableState`], validate its own internal
+/// consistency, independently re-verify the live digest of every
+/// generation it claims to reference, and fully drain any outstanding
+/// [`DurableState::pending_prune`] debt before returning.
+///
+/// **Invariant callers may rely on: a successful return always has an
+/// empty `pending_prune` list.** Every one of [`provision`], [`rotate`],
+/// [`rollback`], [`retire`] calls this first and therefore never needs
+/// to merge its own new debt with any pre-existing debt -- there is
+/// never any pre-existing debt left by the time this returns `Ok`.
+fn read_and_verify(
+    port: &dyn SecretsAuthorityPort,
+    workload: &WorkloadId,
+    kind: SecretKind,
+    ctx: &SecretsLifecycleAuditContext,
+) -> Result<(DurableState, OwnershipEpoch), SecretsLifecycleError> {
+    let (mut state, mut ownership) = port
+        .read_state(workload, kind)
+        .map_err(|e| failed_closed(ctx, map_port_error(e)))?;
+
+    state.validate_self_consistent().map_err(|reason| {
+        let _ = port.quarantine(workload, kind, QuarantineReason::StateSelfInconsistent);
+        failed_closed(ctx, reason)
+    })?;
+
+    if let Some(active) = state.active.clone() {
+        let live = port
+            .material_digest(workload, kind, active.epoch)
+            .map_err(|e| failed_closed(ctx, map_port_error(e)))?;
+        if live != active.digest_hex {
+            let _ = port.quarantine(workload, kind, QuarantineReason::ActiveChecksumMismatch);
+            return Err(failed_closed(ctx, FailReason::ChecksumMismatch));
+        }
+    }
+    if let Some(previous) = state.previous.clone() {
+        let live = port
+            .material_digest(workload, kind, previous.epoch)
+            .map_err(|e| failed_closed(ctx, map_port_error(e)))?;
+        if live != previous.digest_hex {
+            let _ = port.quarantine(workload, kind, QuarantineReason::PreviousChecksumMismatch);
+            return Err(failed_closed(ctx, FailReason::ChecksumMismatch));
+        }
+    }
+
+    if !state.pending_prune.is_empty() {
+        let still_pending: Vec<Epoch> = state
+            .pending_prune
+            .iter()
+            .copied()
+            .filter(|&epoch| port.prune_material(workload, kind, epoch).is_err())
+            .collect();
+        if still_pending != state.pending_prune {
+            let mut reduced = state.clone();
+            reduced.pending_prune = still_pending.clone();
+            ownership = port
+                .cas_commit(workload, kind, ownership, reduced.clone())
+                .map_err(|e| failed_closed(ctx, map_port_error(e)))?;
+            state = reduced;
+        }
+        if !still_pending.is_empty() {
+            return Err(denied(ctx, FailReason::PruneDebtUnresolved));
+        }
+    }
+
+    Ok((state, ownership))
+}
+
+/// Attempt to synchronously clear every entry `committed.pending_prune`
+/// still lists (the caller's own just-committed transition populated
+/// this list; `ownership` is the fencing token that commit returned),
+/// durably committing the (possibly smaller) result. Returns whether
+/// any entry remains pending. **Never itself returns an error**: the
+/// caller's own CAS transition already durably succeeded before this
+/// runs, so a prune shortfall here is recorded as debt for
+/// [`read_and_verify`] to resolve on a future call, never surfaced as
+/// this call's own failure (see the module doc's "forward recovery"
+/// section).
+fn attempt_prune_now(
+    port: &dyn SecretsAuthorityPort,
+    workload: &WorkloadId,
+    kind: SecretKind,
+    ownership: OwnershipEpoch,
+    committed: DurableState,
+) -> bool {
+    if committed.pending_prune.is_empty() {
+        return false;
+    }
+    let still_pending: Vec<Epoch> = committed
+        .pending_prune
+        .iter()
+        .copied()
+        .filter(|&epoch| port.prune_material(workload, kind, epoch).is_err())
+        .collect();
+    if still_pending.len() == committed.pending_prune.len() {
+        // Nothing cleared; the already-committed debt list is already
+        // exactly this, so there is nothing new to commit.
+        return true;
+    }
+    let mut reduced = committed;
+    reduced.pending_prune = still_pending.clone();
+    // Best-effort: if this follow-up commit itself loses a race, the
+    // debt is not lost -- whoever won that race read (at least) our
+    // full un-reduced `pending_prune` before their own commit (CAS is
+    // fully serialized), so their own `read_and_verify` call will
+    // itself attempt (idempotently) to prune the same epochs.
+    let _ = port.cas_commit(workload, kind, ownership, reduced);
+    !still_pending.is_empty()
+}
+
+// ---------------------------------------------------------------------
+// Public actions
+// ---------------------------------------------------------------------
+
 /// Provision fresh generation-1 material. Fails closed
-/// ([`FailReason::AlreadyProvisioned`], denied) if the marker already
-/// records an active (non-retired) generation, and
-/// ([`FailReason::GenerationConflict`], failed) if the physical tree
-/// is non-empty without a matching active marker (an anomaly this
-/// module refuses to silently adopt).
+/// ([`FailReason::AlreadyProvisioned`], denied) if the authority
+/// currently records an active generation for this `(workload, kind)`
+/// pair.
 pub fn provision(
-    vm_id: &str,
+    port: &dyn SecretsAuthorityPort,
+    workload: &WorkloadId,
     kind: SecretKind,
     material: SecretMaterial,
-    cfg: &SecretsLifecycleConfig,
 ) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
-        open_and_recover(vm_id, kind, LifecycleAction::Provision, cfg)?;
-    let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
+    let ctx = context(workload, kind, LifecycleAction::Provision);
+    let (state, ownership) = read_and_verify(port, workload, kind, &ctx)?;
 
-    if let Some(marker) = &marker
-        && marker.active.is_some()
-        && !marker.retired
-    {
-        return Err(denied(&ctx, recovered, FailReason::AlreadyProvisioned));
-    }
-    let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    if !existing.epochs.is_empty() || !existing.stage_names.is_empty() {
-        return Err(failed_closed(
-            &ctx,
-            recovered,
-            FailReason::GenerationConflict,
-        ));
+    if state.active.is_some() {
+        return Err(denied(&ctx, FailReason::AlreadyProvisioned));
     }
 
     let digest_hex = material.digest_hex();
-    let intent = PromoteIntent {
-        vm: vm_id.to_owned(),
-        kind: kind.as_slug().to_owned(),
-        action: LifecycleAction::Provision,
-        to_epoch: 1,
-        create_epoch: true,
-        stage_name: random_stage_name(),
-        expected_digest_hex: digest_hex.clone(),
-        expected_identity: None,
-        carry_previous: None,
-        prune_epoch: None,
-        new_high_water_epoch: 1,
-        first_provisioned_ms: now_ms(),
-        phase: PromotePhase::Planned,
-    };
-    validate_promote_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    match execute_promote(
-        secrets_fd.as_fd(),
-        generations_fd.as_fd(),
-        cfg,
-        intent,
-        Some(&material),
-    ) {
-        Ok(PromoteOutcome::Completed(new_marker)) => Ok(SecretsLifecycleAuditFields::provisioned(
-            &ctx,
-            new_marker.high_water_epoch,
-            digest_hex,
-            recovered,
-        )),
-        Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
-            &ctx,
-            recovered,
-            FailReason::MaterialWriteFailed,
-        )),
-        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
+    let epoch = Epoch::FIRST;
+    let stored_digest = port
+        .stage_material(workload, kind, epoch, &material)
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+    if stored_digest != digest_hex {
+        let _ = port.quarantine(workload, kind, QuarantineReason::ActiveChecksumMismatch);
+        return Err(failed_closed(&ctx, FailReason::ChecksumMismatch));
     }
-}
 
-/// Retained generations after a successful rotate/rollback: exactly
-/// `previous`'s epoch, when one exists.
-fn retained_from_previous(previous: &Option<MaterialIdentity>) -> Vec<u64> {
-    previous.as_ref().map(|p| vec![p.epoch]).unwrap_or_default()
+    let next = DurableState {
+        high_water_epoch: 1,
+        active: Some(GenerationRecord::new(epoch, digest_hex.clone())),
+        previous: None,
+        retired: false,
+        pending_prune: Vec::new(),
+    };
+    port.cas_commit(workload, kind, ownership, next)
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+
+    // Close the "last stage wins" race: refuse to certify success if
+    // the durably-committed epoch's live bytes don't match what this
+    // call itself just staged and committed.
+    let live = port
+        .material_digest(workload, kind, epoch)
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+    if live != digest_hex {
+        let _ = port.quarantine(workload, kind, QuarantineReason::ActiveChecksumMismatch);
+        return Err(failed_closed(&ctx, FailReason::ChecksumMismatch));
+    }
+
+    Ok(SecretsLifecycleAuditFields::provisioned(
+        &ctx, 1, digest_hex,
+    ))
 }
 
 /// Create and activate a new generation. Requires an active,
-/// non-retired marker (else [`FailReason::NotProvisioned`], denied).
-/// Allocates `to_epoch = high_water_epoch + 1` — never
-/// `current_epoch + 1` — so a rotate issued after a rollback can
-/// never collide with a still-materialised newer epoch the rollback
+/// non-retired generation (else [`FailReason::NotProvisioned`],
+/// denied). Allocates `to_epoch = high_water_epoch + 1` -- never
+/// `current_epoch + 1` -- so a rotate issued after a rollback can
+/// never collide with a still-materialized newer epoch the rollback
 /// moved away from.
 pub fn rotate(
-    vm_id: &str,
+    port: &dyn SecretsAuthorityPort,
+    workload: &WorkloadId,
     kind: SecretKind,
     material: SecretMaterial,
-    cfg: &SecretsLifecycleConfig,
 ) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
-        open_and_recover(vm_id, kind, LifecycleAction::Rotate, cfg)?;
-    let ctx = context(vm_id, kind, LifecycleAction::Rotate, &paths);
+    let ctx = context(workload, kind, LifecycleAction::Rotate);
+    let (state, ownership) = read_and_verify(port, workload, kind, &ctx)?;
 
-    let marker = match marker {
-        Some(marker) if marker.active.is_some() && !marker.retired => marker,
-        _ => return Err(denied(&ctx, recovered, FailReason::NotProvisioned)),
+    let Some(active) = state.active.clone() else {
+        return Err(denied(&ctx, FailReason::NotProvisioned));
     };
-    let active = marker.active.clone().expect("checked above");
-    let to_epoch = marker.high_water_epoch + 1;
+
+    let next_epoch_num = state.high_water_epoch.saturating_add(1);
+    let Some(next_epoch) = Epoch::from_raw(next_epoch_num) else {
+        // Only reachable if `high_water_epoch` were already
+        // `u64::MAX`, which `validate_self_consistent` cannot itself
+        // detect as corrupt but is not a realistic lineage length; a
+        // defensive backstop, never expected to trigger.
+        return Err(failed_closed(&ctx, FailReason::StateCorrupt));
+    };
     let digest_hex = material.digest_hex();
-    let intent = PromoteIntent {
-        vm: vm_id.to_owned(),
-        kind: kind.as_slug().to_owned(),
-        action: LifecycleAction::Rotate,
-        to_epoch,
-        create_epoch: true,
-        stage_name: random_stage_name(),
-        expected_digest_hex: digest_hex.clone(),
-        expected_identity: None,
-        carry_previous: Some(active),
-        prune_epoch: marker.previous.as_ref().map(|p| p.epoch),
-        new_high_water_epoch: to_epoch,
-        first_provisioned_ms: marker.first_provisioned_ms,
-        phase: PromotePhase::Planned,
-    };
-    validate_promote_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    match execute_promote(
-        secrets_fd.as_fd(),
-        generations_fd.as_fd(),
-        cfg,
-        intent,
-        Some(&material),
-    ) {
-        Ok(PromoteOutcome::Completed(new_marker)) => Ok(SecretsLifecycleAuditFields::rotated(
-            &ctx,
-            new_marker.active.as_ref().map(|i| i.epoch).unwrap_or(0),
-            new_marker.high_water_epoch,
-            retained_from_previous(&new_marker.previous),
-            digest_hex,
-            recovered,
-        )),
-        Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
-            &ctx,
-            recovered,
-            FailReason::MaterialWriteFailed,
-        )),
-        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
+
+    let stored_digest = port
+        .stage_material(workload, kind, next_epoch, &material)
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+    if stored_digest != digest_hex {
+        let _ = port.quarantine(workload, kind, QuarantineReason::ActiveChecksumMismatch);
+        return Err(failed_closed(&ctx, FailReason::ChecksumMismatch));
     }
-}
 
-/// Swap `current` back to the retained `previous` generation.
-/// Requires a `previous` entry (else [`FailReason::NoRollbackTarget`],
-/// denied). Tamper-verifies the retained generation's full recorded
-/// identity before promoting it. The generation being rolled back
-/// *from* becomes the new `previous` (so a rollback may itself be
-/// rolled back / "rolled forward"); `high_water_epoch` is unchanged
-/// (rollback never grows the monotonic mark) and nothing is pruned.
-pub fn rollback(
-    vm_id: &str,
-    kind: SecretKind,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
-        open_and_recover(vm_id, kind, LifecycleAction::Rollback, cfg)?;
-    let ctx = context(vm_id, kind, LifecycleAction::Rollback, &paths);
-
-    let marker = match marker {
-        Some(marker) if marker.active.is_some() && !marker.retired => marker,
-        _ => return Err(denied(&ctx, recovered, FailReason::NotProvisioned)),
-    };
-    let Some(previous) = marker.previous.clone() else {
-        return Err(denied(&ctx, recovered, FailReason::NoRollbackTarget));
-    };
-    let active = marker.active.clone().expect("checked above");
-    let intent = PromoteIntent {
-        vm: vm_id.to_owned(),
-        kind: kind.as_slug().to_owned(),
-        action: LifecycleAction::Rollback,
-        to_epoch: previous.epoch,
-        create_epoch: false,
-        stage_name: String::new(),
-        expected_digest_hex: previous.digest_hex.clone(),
-        expected_identity: Some(previous),
-        carry_previous: Some(active),
-        prune_epoch: None,
-        new_high_water_epoch: marker.high_water_epoch,
-        first_provisioned_ms: marker.first_provisioned_ms,
-        phase: PromotePhase::Planned,
-    };
-    validate_promote_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    match execute_promote(
-        secrets_fd.as_fd(),
-        generations_fd.as_fd(),
-        cfg,
-        intent,
-        None,
-    ) {
-        Ok(PromoteOutcome::Completed(new_marker)) => Ok(SecretsLifecycleAuditFields::rolled_back(
-            &ctx,
-            new_marker.active.as_ref().map(|i| i.epoch).unwrap_or(0),
-            new_marker.high_water_epoch,
-            retained_from_previous(&new_marker.previous),
-            recovered,
-        )),
-        Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
-            &ctx,
-            recovered,
-            FailReason::RecoveryAmbiguous,
-        )),
-        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
-    }
-}
-
-/// Remove every generation and tombstone the marker. Always
-/// anchored-enumerates and validates the *entire physical*
-/// `generations/` tree first, regardless of what the marker claims —
-/// an absent/tombstoned marker over non-empty storage is still fully
-/// retired (never treated as already-clean), and an active marker
-/// over empty storage fails closed
-/// ([`FailReason::PreviouslyProvisionedMaterialMissing`]) rather than
-/// silently accepting the discrepancy.
-pub fn retire(
-    vm_id: &str,
-    kind: SecretKind,
-    cfg: &SecretsLifecycleConfig,
-) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
-    let (paths, secrets_fd, generations_fd, _lock, recovered, marker) =
-        open_and_recover(vm_id, kind, LifecycleAction::Retire, cfg)?;
-    let ctx = context(vm_id, kind, LifecycleAction::Retire, &paths);
-
-    let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-
-    let recorded_high_water = marker.as_ref().map(|m| m.high_water_epoch).unwrap_or(0);
-    let marker_claims_active = marker
+    // The invariant documented on `read_and_verify` guarantees
+    // `state.pending_prune` is already empty here.
+    let pending_prune = state
+        .previous
         .as_ref()
-        .map(|m| m.active.is_some() && !m.retired)
-        .unwrap_or(false);
+        .map(|prior_previous| vec![prior_previous.epoch])
+        .unwrap_or_default();
 
-    if existing.epochs.is_empty() && existing.stage_names.is_empty() {
-        if marker_claims_active {
-            // Marker says material should exist; the physical tree
-            // disagrees. Fail closed rather than silently accepting
-            // "clean" over an unexplained discrepancy.
-            return Err(failed_closed(
-                &ctx,
-                recovered,
-                FailReason::PreviouslyProvisionedMaterialMissing,
-            ));
-        }
-        // Missing marker never implies clean storage, and the
-        // symmetric case matters just as much: never declare
-        // `verified_clean` over a stale, foreign, or otherwise
-        // still-present `current` entry -- regardless of whether a
-        // marker exists at all (an entirely absent marker skips
-        // `verify_marker_against_live_state`'s own current-absence
-        // check inside `open_and_recover`, so this call is the only
-        // place that invariant is enforced in that case).
-        if !current_is_genuinely_absent(secrets_fd.as_fd())
-            .map_err(|reason| failed_closed(&ctx, recovered, reason))?
-        {
-            return Err(failed_closed(
-                &ctx,
-                recovered,
-                FailReason::IdentityCurrentTargetMismatch,
-            ));
-        }
+    let next = DurableState {
+        high_water_epoch: next_epoch_num,
+        active: Some(GenerationRecord::new(next_epoch, digest_hex.clone())),
+        previous: Some(active),
+        retired: false,
+        pending_prune,
+    };
+    let new_ownership = port
+        .cas_commit(workload, kind, ownership, next.clone())
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+
+    let live = port
+        .material_digest(workload, kind, next_epoch)
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+    if live != digest_hex {
+        let _ = port.quarantine(workload, kind, QuarantineReason::ActiveChecksumMismatch);
+        return Err(failed_closed(&ctx, FailReason::ChecksumMismatch));
+    }
+
+    let retained = vec![next.previous.as_ref().expect("just set above").epoch.get()];
+    let prune_deferred = attempt_prune_now(port, workload, kind, new_ownership, next);
+
+    Ok(SecretsLifecycleAuditFields::rotated(
+        &ctx,
+        next_epoch.get(),
+        next_epoch_num,
+        retained,
+        digest_hex,
+        prune_deferred,
+    ))
+}
+
+/// Swap the active generation back to the retained `previous`
+/// generation. Requires a `previous` entry (else
+/// [`FailReason::NoRollbackTarget`], denied). The generation being
+/// rolled back *from* becomes the new `previous` (so a rollback may
+/// itself be rolled back / "rolled forward"); `high_water_epoch` is
+/// unchanged (rollback never grows the monotonic mark) and nothing is
+/// pruned.
+pub fn rollback(
+    port: &dyn SecretsAuthorityPort,
+    workload: &WorkloadId,
+    kind: SecretKind,
+) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
+    let ctx = context(workload, kind, LifecycleAction::Rollback);
+    let (state, ownership) = read_and_verify(port, workload, kind, &ctx)?;
+
+    let Some(active) = state.active.clone() else {
+        return Err(denied(&ctx, FailReason::NotProvisioned));
+    };
+    let Some(previous) = state.previous.clone() else {
+        return Err(denied(&ctx, FailReason::NoRollbackTarget));
+    };
+
+    // `previous`'s digest was already independently re-verified
+    // against live storage inside `read_and_verify` above (the
+    // "expected_digest_hex == expected_identity.digest_hex before
+    // mutation" invariant carried over from rounds 1-5); re-assert it
+    // here too so the check is visible at the exact call site that
+    // performs the mutation, not only inside the shared helper.
+    let live_previous_digest = port
+        .material_digest(workload, kind, previous.epoch)
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+    if live_previous_digest != previous.digest_hex {
+        let _ = port.quarantine(workload, kind, QuarantineReason::PreviousChecksumMismatch);
+        return Err(failed_closed(&ctx, FailReason::ChecksumMismatch));
+    }
+
+    let next = DurableState {
+        high_water_epoch: state.high_water_epoch,
+        active: Some(previous.clone()),
+        previous: Some(active.clone()),
+        retired: false,
+        // The invariant documented on `read_and_verify` guarantees
+        // this is already empty; rollback supersedes nothing new.
+        pending_prune: Vec::new(),
+    };
+    port.cas_commit(workload, kind, ownership, next)
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+
+    Ok(SecretsLifecycleAuditFields::rolled_back(
+        &ctx,
+        previous.epoch.get(),
+        state.high_water_epoch,
+        vec![active.epoch.get()],
+    ))
+}
+
+/// Retire this `(workload, kind)` pair: remove every generation and
+/// mark it retired. Always reachable, and always a no-op
+/// ([`FailReason`]-free `verified_clean`) when there is no active
+/// generation -- a missing/never-provisioned pair and an
+/// already-retired pair are indistinguishable to a caller of `retire`
+/// from this module's point of view, both correctly reported as
+/// already clean.
+pub fn retire(
+    port: &dyn SecretsAuthorityPort,
+    workload: &WorkloadId,
+    kind: SecretKind,
+) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
+    let ctx = context(workload, kind, LifecycleAction::Retire);
+    let (state, ownership) = read_and_verify(port, workload, kind, &ctx)?;
+
+    let Some(active) = state.active.clone() else {
         return Ok(SecretsLifecycleAuditFields::verified_clean(
             &ctx,
-            recovered,
-            recorded_high_water,
+            state.high_water_epoch,
         ));
-    }
-
-    let high_water_epoch =
-        recorded_high_water.max(existing.epochs.iter().copied().max().unwrap_or(0));
-    let intent = RetireIntent {
-        vm: vm_id.to_owned(),
-        kind: kind.as_slug().to_owned(),
-        epochs: existing.epochs,
-        stage_names: existing.stage_names,
-        high_water_epoch,
-        phase: RetirePhase::Enumerated,
     };
-    validate_retire_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
-    match execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), cfg, intent) {
-        Ok(()) => Ok(SecretsLifecycleAuditFields::retired(
-            &ctx,
-            high_water_epoch,
-            recovered,
-        )),
-        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
+
+    // The invariant documented on `read_and_verify` guarantees
+    // `state.pending_prune` is already empty, so this never exceeds
+    // `MAX_PENDING_PRUNE` (at most the former active + former
+    // previous, i.e. at most 2). `active.epoch` is not always
+    // numerically greater than `previous.epoch` -- a rollback can
+    // leave `active` at a *lower* epoch than `previous` -- so this
+    // must be explicitly sorted before it becomes part of a
+    // [`DurableState`], which requires `pending_prune` ascending (see
+    // [`DurableState::validate_self_consistent`]).
+    let mut pending_prune = vec![active.epoch];
+    if let Some(previous) = &state.previous {
+        pending_prune.push(previous.epoch);
     }
+    pending_prune.sort_unstable();
+    debug_assert!(pending_prune.len() <= MAX_PENDING_PRUNE);
+
+    let next = DurableState {
+        high_water_epoch: state.high_water_epoch,
+        active: None,
+        previous: None,
+        retired: true,
+        pending_prune,
+    };
+    let new_ownership = port
+        .cas_commit(workload, kind, ownership, next.clone())
+        .map_err(|e| failed_closed(&ctx, map_port_error(e)))?;
+
+    let prune_deferred = attempt_prune_now(port, workload, kind, new_ownership, next);
+
+    Ok(SecretsLifecycleAuditFields::retired(
+        &ctx,
+        state.high_water_epoch,
+        prune_deferred,
+    ))
 }
 
 // ---------------------------------------------------------------------
-// Tests
+// Test double: an in-memory `SecretsAuthorityPort` with fault injection
 // ---------------------------------------------------------------------
+
+/// An in-memory [`SecretsAuthorityPort`] used **only** by this module's
+/// own test suite below. It is not `pub`, has no relation to any real
+/// storage adapter, and exists purely so this file's crash/fault/
+/// concurrency/tamper tests never touch a filesystem, a lock, or any
+/// I/O primitive -- every test failure mode is expressed as an
+/// explicit, deterministic fault flag on this double.
+#[cfg(test)]
+mod fake_port {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Mutex;
+
+    use super::{
+        DurableState, Epoch, OwnershipEpoch, PortError, QuarantineReason, SecretKind,
+        SecretMaterial, SecretsAuthorityPort, WorkloadId,
+    };
+
+    fn digest_of(bytes: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        super::hex_encode(&hasher.finalize())
+    }
+
+    /// One `(workload, kind)` pair's key in every map below. `WorkloadId`
+    /// and `SecretKind` are both already `Hash + Eq`, so this is a plain
+    /// owned tuple -- no derived string/path key.
+    type Key = (WorkloadId, SecretKind);
+
+    /// Fault-injection knobs. The four `fail_*` flags are **one-shot**:
+    /// each is consumed (reset to `false`) the first time the matching
+    /// method is called after being set, via [`std::mem::take`], so a
+    /// test can inject exactly one failure at a precise step without
+    /// permanently wedging the double. [`Self::fail_prune_epochs`] is
+    /// deliberately **persistent** (not one-shot) so a test can model
+    /// "this epoch's prune keeps failing across several attempts" and
+    /// then explicitly clear it to observe eventual, self-healing
+    /// resolution via [`read_and_verify`](super::read_and_verify)'s debt
+    /// drain. [`Self::clobber_before_digest`] simulates the module doc's
+    /// "last stage wins" race by mutating the *actually stored* bytes
+    /// for a targeted epoch immediately before the next
+    /// [`SecretsAuthorityPort::material_digest`] call for that exact
+    /// epoch, then that call computes a real digest over the
+    /// now-corrupted bytes -- this is a realistic simulation of a
+    /// losing racer's late `stage_material` write, not a fabricated
+    /// wrong string.
+    #[derive(Default)]
+    pub struct Faults {
+        pub fail_read_state: bool,
+        pub fail_stage_material: bool,
+        pub fail_material_digest: bool,
+        pub fail_cas_commit: bool,
+        pub fail_prune_epochs: HashSet<u64>,
+        pub clobber_before_digest: Option<(u64, Vec<u8>)>,
+    }
+
+    #[derive(Default)]
+    struct Inner {
+        state: HashMap<Key, (DurableState, u64)>,
+        material: HashMap<(Key, u64), Vec<u8>>,
+        quarantined: HashMap<Key, QuarantineReason>,
+        faults: Faults,
+        cas_commit_attempts: u64,
+        prune_attempts: u64,
+    }
+
+    #[derive(Default)]
+    pub struct FakePort(Mutex<Inner>);
+
+    fn take_one_shot(flag: &mut bool) -> bool {
+        std::mem::take(flag)
+    }
+
+    impl FakePort {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        fn key(workload: &WorkloadId, kind: SecretKind) -> Key {
+            (workload.clone(), kind)
+        }
+
+        /// Replace the fault set wholesale (also used to clear every
+        /// flag between phases of a single multi-step test).
+        pub fn set_faults(&self, faults: Faults) {
+            self.0.lock().unwrap().faults = faults;
+        }
+
+        pub fn quarantined_for(
+            &self,
+            workload: &WorkloadId,
+            kind: SecretKind,
+        ) -> Option<QuarantineReason> {
+            self.0
+                .lock()
+                .unwrap()
+                .quarantined
+                .get(&Self::key(workload, kind))
+                .copied()
+        }
+
+        /// The exact durably committed [`DurableState`], bypassing this
+        /// module's own read path entirely -- used by tests to assert
+        /// on ground truth independent of `read_and_verify`.
+        pub fn raw_state(&self, workload: &WorkloadId, kind: SecretKind) -> Option<DurableState> {
+            self.0
+                .lock()
+                .unwrap()
+                .state
+                .get(&Self::key(workload, kind))
+                .map(|(state, _)| state.clone())
+        }
+
+        pub fn raw_material_epochs(&self, workload: &WorkloadId, kind: SecretKind) -> Vec<u64> {
+            let inner = self.0.lock().unwrap();
+            let k = Self::key(workload, kind);
+            let mut epochs: Vec<u64> = inner
+                .material
+                .keys()
+                .filter(|(key, _)| *key == k)
+                .map(|(_, epoch)| *epoch)
+                .collect();
+            epochs.sort_unstable();
+            epochs
+        }
+
+        pub fn cas_commit_attempts(&self) -> u64 {
+            self.0.lock().unwrap().cas_commit_attempts
+        }
+
+        pub fn prune_attempts(&self) -> u64 {
+            self.0.lock().unwrap().prune_attempts
+        }
+    }
+
+    impl SecretsAuthorityPort for FakePort {
+        fn read_state(
+            &self,
+            workload: &WorkloadId,
+            kind: SecretKind,
+        ) -> Result<(DurableState, OwnershipEpoch), PortError> {
+            let mut inner = self.0.lock().unwrap();
+            let k = Self::key(workload, kind);
+            if inner.quarantined.contains_key(&k) {
+                return Err(PortError::Quarantined);
+            }
+            if take_one_shot(&mut inner.faults.fail_read_state) {
+                return Err(PortError::Unavailable);
+            }
+            Ok(match inner.state.get(&k) {
+                Some((state, token)) => (state.clone(), OwnershipEpoch::from_raw(*token)),
+                None => (
+                    DurableState::never_provisioned(),
+                    OwnershipEpoch::NEVER_COMMITTED,
+                ),
+            })
+        }
+
+        fn stage_material(
+            &self,
+            workload: &WorkloadId,
+            kind: SecretKind,
+            epoch: Epoch,
+            material: &SecretMaterial,
+        ) -> Result<String, PortError> {
+            let mut inner = self.0.lock().unwrap();
+            let k = Self::key(workload, kind);
+            if inner.quarantined.contains_key(&k) {
+                return Err(PortError::Quarantined);
+            }
+            if take_one_shot(&mut inner.faults.fail_stage_material) {
+                return Err(PortError::Unavailable);
+            }
+            if let Some((state, _)) = inner.state.get(&k) {
+                let already_committed = state.active.as_ref().map(|g| g.epoch) == Some(epoch)
+                    || state.previous.as_ref().map(|g| g.epoch) == Some(epoch);
+                if already_committed {
+                    return Err(PortError::EpochAlreadyCommitted);
+                }
+            }
+            let bytes = material.as_bytes().to_vec();
+            let digest = digest_of(&bytes);
+            inner.material.insert((k, epoch.get()), bytes);
+            Ok(digest)
+        }
+
+        fn material_digest(
+            &self,
+            workload: &WorkloadId,
+            kind: SecretKind,
+            epoch: Epoch,
+        ) -> Result<String, PortError> {
+            let mut inner = self.0.lock().unwrap();
+            let k = Self::key(workload, kind);
+            if inner.quarantined.contains_key(&k) {
+                return Err(PortError::Quarantined);
+            }
+            if take_one_shot(&mut inner.faults.fail_material_digest) {
+                return Err(PortError::Unavailable);
+            }
+            // Check the target epoch WITHOUT consuming the fault first:
+            // an `if let Some(...) = opt.take() && guard` chain would
+            // unconditionally consume `opt` while evaluating the
+            // pattern, even when `guard` then fails for the wrong
+            // epoch -- silently discarding a fault meant for a later
+            // call. Only `.take()` once the epoch is confirmed to
+            // match.
+            if inner
+                .faults
+                .clobber_before_digest
+                .as_ref()
+                .map(|(epoch, _)| *epoch)
+                == Some(epoch.get())
+                && let Some((_, clobbered)) = inner.faults.clobber_before_digest.take()
+            {
+                inner.material.insert((k.clone(), epoch.get()), clobbered);
+            }
+            let bytes = inner
+                .material
+                .get(&(k, epoch.get()))
+                .cloned()
+                .ok_or(PortError::Unavailable)?;
+            Ok(digest_of(&bytes))
+        }
+
+        fn cas_commit(
+            &self,
+            workload: &WorkloadId,
+            kind: SecretKind,
+            expected: OwnershipEpoch,
+            next: DurableState,
+        ) -> Result<OwnershipEpoch, PortError> {
+            let mut inner = self.0.lock().unwrap();
+            let k = Self::key(workload, kind);
+            if inner.quarantined.contains_key(&k) {
+                return Err(PortError::Quarantined);
+            }
+            inner.cas_commit_attempts += 1;
+            if take_one_shot(&mut inner.faults.fail_cas_commit) {
+                return Err(PortError::Unavailable);
+            }
+            let current_token = inner
+                .state
+                .get(&k)
+                .map(|(_, token)| *token)
+                .unwrap_or(OwnershipEpoch::NEVER_COMMITTED.get());
+            if current_token != expected.get() {
+                return Err(PortError::OwnershipFenced);
+            }
+            let new_token = current_token + 1;
+            inner.state.insert(k, (next, new_token));
+            Ok(OwnershipEpoch::from_raw(new_token))
+        }
+
+        fn prune_material(
+            &self,
+            workload: &WorkloadId,
+            kind: SecretKind,
+            epoch: Epoch,
+        ) -> Result<(), PortError> {
+            let mut inner = self.0.lock().unwrap();
+            let k = Self::key(workload, kind);
+            if inner.quarantined.contains_key(&k) {
+                return Err(PortError::Quarantined);
+            }
+            inner.prune_attempts += 1;
+            if inner.faults.fail_prune_epochs.contains(&epoch.get()) {
+                return Err(PortError::Unavailable);
+            }
+            inner.material.remove(&(k, epoch.get()));
+            Ok(())
+        }
+
+        fn quarantine(
+            &self,
+            workload: &WorkloadId,
+            kind: SecretKind,
+            reason: QuarantineReason,
+        ) -> Result<(), PortError> {
+            let mut inner = self.0.lock().unwrap();
+            inner.quarantined.insert(Self::key(workload, kind), reason);
+            Ok(())
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::os::unix::fs::PermissionsExt;
-    use tempfile::tempdir;
+    use std::collections::HashSet;
 
-    fn cfg_at(root: &std::path::Path) -> SecretsLifecycleConfig {
-        SecretsLifecycleConfig {
-            state_root: root.to_path_buf(),
-            dir_mode: 0o700,
-            file_mode: 0o600,
-            owner_uid: None,
-            owner_gid: None,
-            lock_max_wait: Duration::from_millis(500),
-            lock_poll_interval: Duration::from_millis(5),
-        }
+    use super::fake_port::{FakePort, Faults};
+    use super::*;
+
+    fn wl_a() -> WorkloadId {
+        WorkloadId::parse("aaaaaaaaaaaaaaaaaaaa").expect("valid fixture workload id")
     }
+
+    fn wl_b() -> WorkloadId {
+        WorkloadId::parse("bbbbbbbbbbbbbbbbbbbq").expect("valid fixture workload id")
+    }
+
+    const KIND: SecretKind = SecretKind::GuestSigningKey;
 
     fn material(bytes: &[u8]) -> SecretMaterial {
-        SecretMaterial::new(bytes.to_vec()).expect("valid material")
+        SecretMaterial::new(bytes.to_vec()).expect("valid fixture material")
     }
 
-    fn assert_valid(fields: &SecretsLifecycleAuditFields) {
-        fields.validate().unwrap_or_else(|err| {
-            panic!("audit fields failed validation: {err}\nfields: {fields:?}")
-        });
+    fn digest_of(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        hex_encode(&hasher.finalize())
     }
 
-    /// RAII guard that makes every `fsync_fd` call in this thread fail
-    /// with [`FailReason::FsyncFailed`] for as long as it is held,
-    /// restoring normal behavior on drop (including via early
-    /// return/panic unwinding) so one test's fault injection can never
-    /// leak into another.
-    struct FsyncFaultGuard;
-    impl FsyncFaultGuard {
-        fn enable() -> Self {
-            FSYNC_SHOULD_FAIL.with(|c| c.set(true));
-            FsyncFaultGuard
-        }
-    }
-    impl Drop for FsyncFaultGuard {
-        fn drop(&mut self) {
-            FSYNC_SHOULD_FAIL.with(|c| c.set(false));
-        }
-    }
-
-    // -------------------------------------------------------------
-    // Happy path
-    // -------------------------------------------------------------
+    // -- Epoch / OwnershipEpoch -----------------------------------------
 
     #[test]
-    fn provision_rotate_rollback_retire_happy_path() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "alice";
-        let kind = SecretKind::GuestSigningKey;
+    fn epoch_from_raw_rejects_zero() {
+        assert_eq!(Epoch::from_raw(0), None);
+        assert_eq!(Epoch::from_raw(1), Some(Epoch::FIRST));
+        assert_eq!(Epoch::from_raw(7).unwrap().get(), 7);
+    }
 
-        let provisioned = provision(vm, kind, material(b"gen-1"), &cfg).unwrap();
-        assert_valid(&provisioned);
-        assert_eq!(provisioned.lineage_epoch, Some(1));
-        assert_eq!(provisioned.high_water_epoch, Some(1));
+    #[test]
+    fn epoch_display_is_plain_decimal() {
+        assert_eq!(Epoch::FIRST.to_string(), "1");
+        assert_eq!(Epoch::from_raw(42).unwrap().to_string(), "42");
+    }
 
-        // Duplicate provision on an active lineage is denied.
-        let err = provision(vm, kind, material(b"gen-1-again"), &cfg).unwrap_err();
+    #[test]
+    fn ownership_epoch_never_committed_is_zero() {
+        assert_eq!(OwnershipEpoch::NEVER_COMMITTED.get(), 0);
+    }
+
+    // -- DurableState self-consistency -----------------------------------
+
+    #[test]
+    fn durable_state_never_provisioned_is_self_consistent() {
+        DurableState::never_provisioned()
+            .validate_self_consistent()
+            .expect("never_provisioned must be self-consistent");
+    }
+
+    #[test]
+    fn durable_state_rejects_pending_prune_over_max() {
+        let state = DurableState {
+            high_water_epoch: 5,
+            active: Some(GenerationRecord::new(
+                Epoch::from_raw(5).unwrap(),
+                "a".repeat(64),
+            )),
+            previous: None,
+            retired: false,
+            pending_prune: vec![
+                Epoch::from_raw(1).unwrap(),
+                Epoch::from_raw(2).unwrap(),
+                Epoch::from_raw(3).unwrap(),
+            ],
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_unsorted_pending_prune() {
+        let state = DurableState {
+            high_water_epoch: 5,
+            active: Some(GenerationRecord::new(
+                Epoch::from_raw(5).unwrap(),
+                "a".repeat(64),
+            )),
+            previous: None,
+            retired: false,
+            pending_prune: vec![Epoch::from_raw(2).unwrap(), Epoch::from_raw(1).unwrap()],
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_duplicate_pending_prune() {
+        let state = DurableState {
+            high_water_epoch: 5,
+            active: Some(GenerationRecord::new(
+                Epoch::from_raw(5).unwrap(),
+                "a".repeat(64),
+            )),
+            previous: None,
+            retired: false,
+            pending_prune: vec![Epoch::from_raw(1).unwrap(), Epoch::from_raw(1).unwrap()],
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_retired_with_active() {
+        let state = DurableState {
+            high_water_epoch: 1,
+            active: Some(GenerationRecord::new(Epoch::FIRST, "a".repeat(64))),
+            previous: None,
+            retired: true,
+            pending_prune: Vec::new(),
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_retired_with_zero_high_water() {
+        let state = DurableState {
+            high_water_epoch: 0,
+            active: None,
+            previous: None,
+            retired: true,
+            pending_prune: Vec::new(),
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_never_provisioned_shape_with_previous_set() {
+        let state = DurableState {
+            high_water_epoch: 0,
+            active: None,
+            previous: Some(GenerationRecord::new(Epoch::FIRST, "a".repeat(64))),
+            retired: false,
+            pending_prune: Vec::new(),
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_active_with_invalid_digest() {
+        let state = DurableState {
+            high_water_epoch: 1,
+            active: Some(GenerationRecord::new(Epoch::FIRST, "not-hex".to_string())),
+            previous: None,
+            retired: false,
+            pending_prune: Vec::new(),
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_active_epoch_above_high_water() {
+        let state = DurableState {
+            high_water_epoch: 1,
+            active: Some(GenerationRecord::new(
+                Epoch::from_raw(2).unwrap(),
+                "a".repeat(64),
+            )),
+            previous: None,
+            retired: false,
+            pending_prune: Vec::new(),
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_previous_without_active() {
+        let state = DurableState {
+            high_water_epoch: 1,
+            active: None,
+            previous: Some(GenerationRecord::new(Epoch::FIRST, "a".repeat(64))),
+            retired: false,
+            pending_prune: Vec::new(),
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_previous_equal_to_active() {
+        let state = DurableState {
+            high_water_epoch: 1,
+            active: Some(GenerationRecord::new(Epoch::FIRST, "a".repeat(64))),
+            previous: Some(GenerationRecord::new(Epoch::FIRST, "b".repeat(64))),
+            retired: false,
+            pending_prune: Vec::new(),
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_pending_prune_overlapping_active() {
+        let state = DurableState {
+            high_water_epoch: 1,
+            active: Some(GenerationRecord::new(Epoch::FIRST, "a".repeat(64))),
+            previous: None,
+            retired: false,
+            pending_prune: vec![Epoch::FIRST],
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_pending_prune_overlapping_previous() {
+        let state = DurableState {
+            high_water_epoch: 2,
+            active: Some(GenerationRecord::new(
+                Epoch::from_raw(2).unwrap(),
+                "a".repeat(64),
+            )),
+            previous: Some(GenerationRecord::new(Epoch::FIRST, "b".repeat(64))),
+            retired: false,
+            pending_prune: vec![Epoch::FIRST],
+        };
+        assert_eq!(
+            state.validate_self_consistent(),
+            Err(FailReason::StateCorrupt)
+        );
+    }
+
+    // -- SecretMaterial ---------------------------------------------------
+
+    #[test]
+    fn secret_material_rejects_empty() {
+        assert_eq!(
+            SecretMaterial::new(Vec::new()).err(),
+            Some(FailReason::InvalidMaterial)
+        );
+    }
+
+    #[test]
+    fn secret_material_rejects_oversized() {
+        let oversized = vec![0_u8; SecretMaterial::MAX_LEN + 1];
+        assert_eq!(
+            SecretMaterial::new(oversized).err(),
+            Some(FailReason::InvalidMaterial)
+        );
+    }
+
+    #[test]
+    fn secret_material_accepts_max_len() {
+        let exact = vec![7_u8; SecretMaterial::MAX_LEN];
+        assert!(SecretMaterial::new(exact).is_ok());
+    }
+
+    #[test]
+    fn secret_material_debug_never_leaks_bytes() {
+        let mat = material(b"super-secret-tpm-blob");
+        let rendered = format!("{mat:?}");
+        assert!(!rendered.contains("super-secret-tpm-blob"));
+        assert!(rendered.contains("len"));
+    }
+
+    // -- provision --------------------------------------------------------
+
+    #[test]
+    fn provision_success_activates_epoch_one() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        let bytes = b"tpm-credential-v1".to_vec();
+        let expected_digest = digest_of(&bytes);
+
+        let audit = provision(&port, &wl, KIND, material(&bytes)).expect("provision must succeed");
+        assert_eq!(audit.result, LifecycleResult::Created);
+        assert_eq!(audit.lineage_epoch, Some(1));
+        assert_eq!(audit.material_digest_hex, Some(expected_digest.clone()));
+        audit.validate().expect("audit record must validate");
+
+        let state = port.raw_state(&wl, KIND).expect("state must be committed");
+        assert_eq!(state.high_water_epoch, 1);
+        assert_eq!(state.active.unwrap().digest_hex, expected_digest);
+        assert!(state.previous.is_none());
+        assert!(!state.retired);
+    }
+
+    #[test]
+    fn provision_denied_when_already_active() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"first")).expect("first provision must succeed");
+
+        let err = provision(&port, &wl, KIND, material(b"second")).expect_err("must be denied");
         assert_eq!(err.reason, FailReason::AlreadyProvisioned);
-
-        let rotated = rotate(vm, kind, material(b"gen-2"), &cfg).unwrap();
-        assert_valid(&rotated);
-        assert_eq!(rotated.lineage_epoch, Some(2));
-        assert_eq!(rotated.high_water_epoch, Some(2));
-        assert_eq!(rotated.retained_generations, vec![1]);
-
-        let rotated_again = rotate(vm, kind, material(b"gen-3"), &cfg).unwrap();
-        assert_valid(&rotated_again);
-        assert_eq!(rotated_again.lineage_epoch, Some(3));
-        assert_eq!(rotated_again.high_water_epoch, Some(3));
-        // Rotation prunes everything but the immediately-previous
-        // generation; epoch 1 is gone once epoch 3 supersedes epoch 2.
-        assert_eq!(rotated_again.retained_generations, vec![2]);
-
-        let rolled_back = rollback(vm, kind, &cfg).unwrap();
-        assert_valid(&rolled_back);
-        assert_eq!(rolled_back.lineage_epoch, Some(2));
-        // Rollback never grows the monotonic high-water mark.
-        assert_eq!(rolled_back.high_water_epoch, Some(3));
-        assert_eq!(rolled_back.retained_generations, vec![3]);
-
-        // Rolling back again ("redo") returns to epoch 3.
-        let redo = rollback(vm, kind, &cfg).unwrap();
-        assert_valid(&redo);
-        assert_eq!(redo.lineage_epoch, Some(3));
-        assert_eq!(redo.high_water_epoch, Some(3));
-        assert_eq!(redo.retained_generations, vec![2]);
-
-        let retired = retire(vm, kind, &cfg).unwrap();
-        assert_valid(&retired);
-        assert_eq!(retired.high_water_epoch, Some(3));
-
-        // Retiring an already-retired (never re-provisioned) lineage
-        // is a clean no-op, not an error.
-        let verified = retire(vm, kind, &cfg).unwrap();
-        assert_valid(&verified);
+        assert_eq!(err.audit.result, LifecycleResult::Denied);
+        err.audit.validate().expect("denied record must validate");
+        // Denial must not have mutated anything.
+        assert_eq!(port.raw_material_epochs(&wl, KIND), vec![1]);
     }
 
     #[test]
-    fn rotate_without_provision_is_denied() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let err = rotate("bob", SecretKind::TpmBoundCredential, material(b"x"), &cfg).unwrap_err();
+    fn provision_fails_closed_on_read_state_fault_with_zero_mutation() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        port.set_faults(Faults {
+            fail_read_state: true,
+            ..Default::default()
+        });
+
+        let err = provision(&port, &wl, KIND, material(b"x")).expect_err("must fail closed");
+        assert_eq!(err.reason, FailReason::PortUnavailable);
+        assert_eq!(err.audit.result, LifecycleResult::FailedClosed);
+        err.audit.validate().expect("failed record must validate");
+        assert!(port.raw_state(&wl, KIND).is_none(), "no partial commit");
+        assert!(port.raw_material_epochs(&wl, KIND).is_empty());
+    }
+
+    #[test]
+    fn provision_fails_closed_on_stage_material_fault_with_zero_mutation() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        port.set_faults(Faults {
+            fail_stage_material: true,
+            ..Default::default()
+        });
+
+        let err = provision(&port, &wl, KIND, material(b"x")).expect_err("must fail closed");
+        assert_eq!(err.reason, FailReason::PortUnavailable);
+        assert!(port.raw_state(&wl, KIND).is_none(), "no partial commit");
+        assert!(port.raw_material_epochs(&wl, KIND).is_empty());
+    }
+
+    #[test]
+    fn provision_fails_closed_on_cas_commit_fault_with_zero_activation() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        port.set_faults(Faults {
+            fail_cas_commit: true,
+            ..Default::default()
+        });
+
+        let err = provision(&port, &wl, KIND, material(b"x")).expect_err("must fail closed");
+        assert_eq!(err.reason, FailReason::PortUnavailable);
+        assert!(
+            port.raw_state(&wl, KIND).is_none(),
+            "a failed cas_commit must never leave a committed active generation"
+        );
+    }
+
+    #[test]
+    fn provision_detects_post_commit_clobber_and_quarantines() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        // Simulate a losing racer's `stage_material` call landing for
+        // epoch 1 immediately after this call's own `cas_commit`
+        // succeeds, corrupting the just-activated generation's bytes.
+        port.set_faults(Faults {
+            clobber_before_digest: Some((1, b"corrupted-by-loser".to_vec())),
+            ..Default::default()
+        });
+
+        let err =
+            provision(&port, &wl, KIND, material(b"legit")).expect_err("must detect the race");
+        assert_eq!(err.reason, FailReason::ChecksumMismatch);
+        assert_eq!(err.audit.result, LifecycleResult::FailedClosed);
+        assert_eq!(
+            port.quarantined_for(&wl, KIND),
+            Some(QuarantineReason::ActiveChecksumMismatch)
+        );
+        // The commit itself was NOT rolled back -- it durably happened
+        // and is now quarantined, not silently discarded.
+        assert!(port.raw_state(&wl, KIND).is_some());
+    }
+
+    #[test]
+    fn provision_after_quarantine_always_fails_closed() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        port.quarantine(&wl, KIND, QuarantineReason::StateSelfInconsistent)
+            .unwrap();
+
+        let err =
+            provision(&port, &wl, KIND, material(b"x")).expect_err("quarantine blocks everything");
+        assert_eq!(err.reason, FailReason::Quarantined);
+    }
+
+    // -- rotate -------------------------------------------------------------
+
+    #[test]
+    fn rotate_denied_when_never_provisioned() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        let err = rotate(&port, &wl, KIND, material(b"x")).expect_err("must be denied");
         assert_eq!(err.reason, FailReason::NotProvisioned);
     }
 
     #[test]
-    fn rollback_without_previous_generation_is_denied() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "carol";
-        let kind = SecretKind::SecurityKeyChannelState;
-        provision(vm, kind, material(b"only-gen"), &cfg).unwrap();
-        let err = rollback(vm, kind, &cfg).unwrap_err();
+    fn rotate_success_allocates_high_water_plus_one_and_prunes_immediately() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+
+        let audit = rotate(&port, &wl, KIND, material(b"gen2")).expect("rotate must succeed");
+        assert_eq!(audit.result, LifecycleResult::Rotated);
+        assert_eq!(audit.lineage_epoch, Some(2));
+        assert_eq!(audit.high_water_epoch, Some(2));
+        assert_eq!(audit.retained_generations, vec![1]);
+        assert!(
+            !audit.prune_deferred,
+            "gen1 has no rival pending prune, should prune immediately"
+        );
+        audit.validate().expect("audit record must validate");
+
+        let state = port.raw_state(&wl, KIND).unwrap();
+        assert_eq!(state.active.unwrap().epoch.get(), 2);
+        assert_eq!(state.previous.unwrap().epoch.get(), 1);
+        assert!(state.pending_prune.is_empty());
+    }
+
+    #[test]
+    fn rotate_twice_prunes_the_generation_two_steps_back() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
+        let audit =
+            rotate(&port, &wl, KIND, material(b"gen3")).expect("second rotate must succeed");
+        assert_eq!(audit.lineage_epoch, Some(3));
+        assert_eq!(audit.retained_generations, vec![2]);
+        assert!(!audit.prune_deferred);
+        assert_eq!(
+            port.raw_material_epochs(&wl, KIND),
+            vec![2, 3],
+            "gen1 must be pruned"
+        );
+    }
+
+    #[test]
+    fn rotate_after_rollback_allocates_from_high_water_not_active_epoch() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
+        // Roll back: active becomes epoch 1 again, previous becomes
+        // epoch 2. `high_water_epoch` stays 2 (rollback never grows it).
+        rollback(&port, &wl, KIND).unwrap();
+        assert_eq!(
+            port.raw_state(&wl, KIND)
+                .unwrap()
+                .active
+                .unwrap()
+                .epoch
+                .get(),
+            1
+        );
+
+        // A rotate now MUST allocate epoch 3 (high_water + 1), never
+        // epoch 2 (active + 1) -- epoch 2 is still materialized as
+        // `previous` and colliding with it would silently resurrect it.
+        let audit = rotate(&port, &wl, KIND, material(b"gen3")).expect("rotate must succeed");
+        assert_eq!(audit.lineage_epoch, Some(3));
+        assert_eq!(audit.high_water_epoch, Some(3));
+        assert_eq!(audit.retained_generations, vec![1]);
+    }
+
+    #[test]
+    fn rotate_defers_prune_when_faulted_and_surfaces_prune_deferred() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        // gen1 -> active=1. First rotate has nothing to prune yet
+        // (there is no pre-existing `previous` to supersede).
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
+        // Now active=2, previous=1 (retained). A *second* rotate
+        // supersedes that retained `previous` (epoch 1) -- the epoch a
+        // rotate schedules for pruning is always the generation being
+        // dropped from `previous`, never the epoch this call itself
+        // just activated.
+        let mut failing = HashSet::new();
+        failing.insert(1_u64);
+        port.set_faults(Faults {
+            fail_prune_epochs: failing,
+            ..Default::default()
+        });
+        let audit =
+            rotate(&port, &wl, KIND, material(b"gen3")).expect("rotate itself must still succeed");
+        assert!(
+            audit.prune_deferred,
+            "the epoch-1 prune failed, must be surfaced as deferred"
+        );
+        assert_eq!(
+            port.raw_state(&wl, KIND).unwrap().pending_prune,
+            vec![Epoch::FIRST]
+        );
+        // The deferred generation's bytes are not lost.
+        assert!(port.raw_material_epochs(&wl, KIND).contains(&1));
+
+        // Clear the fault and let the next action's `read_and_verify`
+        // drain the debt before doing its own work.
+        port.set_faults(Faults::default());
+        let audit2 = rotate(&port, &wl, KIND, material(b"gen4"))
+            .expect("rotate must succeed and drain debt");
+        assert!(
+            !audit2.prune_deferred,
+            "this rotate's own supersession (epoch 2) prunes cleanly"
+        );
+        assert!(port.raw_state(&wl, KIND).unwrap().pending_prune.is_empty());
+        assert_eq!(
+            port.raw_material_epochs(&wl, KIND),
+            vec![3, 4],
+            "epoch 1's debt must have been drained, and epoch 2 pruned by this rotate's own supersession"
+        );
+    }
+
+    #[test]
+    fn rotate_detects_post_commit_clobber_and_quarantines() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        port.set_faults(Faults {
+            clobber_before_digest: Some((2, b"corrupted".to_vec())),
+            ..Default::default()
+        });
+
+        let err = rotate(&port, &wl, KIND, material(b"gen2")).expect_err("must detect the race");
+        assert_eq!(err.reason, FailReason::ChecksumMismatch);
+        assert_eq!(
+            port.quarantined_for(&wl, KIND),
+            Some(QuarantineReason::ActiveChecksumMismatch)
+        );
+    }
+
+    #[test]
+    fn rotate_fails_closed_when_fenced_with_zero_mutation() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        // Fence exactly the next `cas_commit` call, simulating a
+        // concurrent writer that committed first.
+        port.set_faults(Faults {
+            fail_cas_commit: true,
+            ..Default::default()
+        });
+
+        let err = rotate(&port, &wl, KIND, material(b"gen2")).expect_err("must fail closed");
+        assert_eq!(err.reason, FailReason::PortUnavailable);
+        let state = port.raw_state(&wl, KIND).unwrap();
+        assert_eq!(state.active.unwrap().epoch.get(), 1, "must still be gen1");
+        assert!(state.previous.is_none());
+    }
+
+    // -- rollback -------------------------------------------------------------
+
+    #[test]
+    fn rollback_denied_never_provisioned() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        let err = rollback(&port, &wl, KIND).expect_err("must be denied");
+        assert_eq!(err.reason, FailReason::NotProvisioned);
+    }
+
+    #[test]
+    fn rollback_denied_no_rollback_target() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        let err = rollback(&port, &wl, KIND).expect_err("must be denied");
         assert_eq!(err.reason, FailReason::NoRollbackTarget);
     }
 
     #[test]
-    fn retire_never_provisioned_is_verified_clean() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let fields = retire("never-provisioned", SecretKind::GuestSigningKey, &cfg).unwrap();
-        assert_valid(&fields);
-        assert_eq!(fields.high_water_epoch, Some(0));
-    }
+    fn rollback_success_swaps_active_and_previous() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
 
-    #[test]
-    fn rotate_after_rollback_never_reuses_a_still_materialised_epoch() {
-        // Monotonic high-water allocation: rotate() must allocate
-        // strictly past every epoch the marker has ever recorded,
-        // even one a rollback moved *away* from and which therefore
-        // still physically exists on disk.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "dana";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-        // Now: active=2, previous=1, high_water=2.
-        let after_rollback = rollback(vm, kind, &cfg).unwrap();
-        assert_eq!(after_rollback.lineage_epoch, Some(1));
-        // active=1, previous=2 (still on disk, unpruned), high_water=2.
-        let after_rotate = rotate(vm, kind, material(b"e3"), &cfg).unwrap();
-        // Must allocate epoch 3, never epoch 2 (which is still the
-        // `previous` generation's live directory at this point).
-        assert_eq!(after_rotate.lineage_epoch, Some(3));
-        assert_eq!(after_rotate.high_water_epoch, Some(3));
-    }
-
-    // -------------------------------------------------------------
-    // Crash recovery
-    // -------------------------------------------------------------
-
-    #[test]
-    fn recovery_completes_a_promote_left_at_planned() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "erin";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name: random_stage_name(),
-            expected_digest_hex: material(b"e2").digest_hex(),
-            expected_identity: None,
-            carry_previous: read_marker(secrets_fd.as_fd())
-                .unwrap()
-                .and_then(|m| m.active),
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
-        drop(secrets_fd);
-        drop(generations_fd);
-
-        // No material handed to recovery: a `Planned` promote with no
-        // staged bytes yet must abort (discard) rather than fabricate
-        // material out of thin air.
-        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
-        assert!(recovered);
-        let fields = rotate(vm, kind, material(b"e2-redo"), &cfg).unwrap();
-        assert_valid(&fields);
-        assert_eq!(fields.lineage_epoch, Some(2));
-    }
-
-    #[test]
-    fn recovery_forward_completes_a_promote_left_at_current_promoted() {
-        // Once `current` has been swapped, recovery must always
-        // complete forward to a durable marker — never revert.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "frank";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e2");
-        let stage_name = random_stage_name();
-        assert!(
-            ensure_staged(
-                generations_fd.as_fd(),
-                &cfg,
-                &stage_name,
-                &mat.digest_hex(),
-                Some(&mat),
-            )
-            .unwrap()
-        );
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
-            .unwrap();
-        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
-        let prior_active = read_marker(secrets_fd.as_fd())
-            .unwrap()
-            .and_then(|m| m.active);
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: prior_active,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::CurrentPromoted,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
-        drop(secrets_fd);
-        drop(generations_fd);
-
-        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
-        assert!(recovered);
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert_eq!(marker.active.unwrap().epoch, 2);
-        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_none());
-    }
-
-    #[test]
-    fn recovery_completes_a_retire_left_at_current_removed() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "gina";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        remove_current_symlink(secrets_fd.as_fd()).unwrap();
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: Vec::new(),
-            high_water_epoch: 1,
-            phase: RetirePhase::CurrentRemoved,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent)).unwrap();
-        drop(secrets_fd);
-        drop(generations_fd);
-
-        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
-        assert!(recovered);
-        let fields = retire(vm, kind, &cfg).unwrap();
-        assert_valid(&fields);
-    }
-
-    #[test]
-    fn planned_promote_recovery_never_activates_partial_state_then_error() {
-        // Regression guard for "never return error after silently
-        // activating unrecoverable state": force recovery to fail
-        // *after* `current` has already moved (a corrupted intent at
-        // `CurrentPromoted`) and confirm the swap is never reverted —
-        // the on-disk `current` link must keep resolving to the
-        // (verifiably durable) epoch it was swapped to even though
-        // the recovery call itself returns an error.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "harold";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e2");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
-            .unwrap();
-        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
-        // Corrupt the recorded digest so `CurrentPromoted`'s identity
-        // check cannot match — this must fail closed, not silently
-        // re-swap `current` back to epoch 1.
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: "0".repeat(64),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::CurrentPromoted,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
-        let target_before = read_current_target(secrets_fd.as_fd());
-        drop(secrets_fd);
-        drop(generations_fd);
-
-        let err = recover_in_flight_transaction(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::RecoveryAmbiguous);
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // `current` must still point at epoch 2 — the activation that
-        // already happened is never rolled back by a failed recovery.
-        assert_eq!(read_current_target(secrets_fd.as_fd()), target_before);
-        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(2));
-    }
-
-    // -------------------------------------------------------------
-    // Tamper detection
-    // -------------------------------------------------------------
-
-    #[test]
-    fn rollback_detects_owner_mode_and_digest_tampering() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "iris";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let material_path = paths
-            .kind_root
-            .join(GENERATIONS_DIR_NAME)
-            .join("1")
-            .join(MATERIAL_FILE_NAME);
-
-        // Digest tamper: overwrite the retained generation's bytes.
-        std::fs::write(&material_path, b"tampered-bytes").unwrap();
-        let err = rollback(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IdentityDigestMismatch);
-
-        // Restore then tamper the mode instead.
-        std::fs::write(&material_path, b"e1").unwrap();
-        let mut perms = std::fs::metadata(&material_path).unwrap().permissions();
-        perms.set_mode(0o666);
-        std::fs::set_permissions(&material_path, perms).unwrap();
-        let err = rollback(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IdentityModeMismatch);
-    }
-
-    #[test]
-    fn rollback_detects_hardlinked_material() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "jack";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        let material_path = gen_dir.join(MATERIAL_FILE_NAME);
-        let extra_link = gen_dir.join("extra-hardlink");
-        std::fs::hard_link(&material_path, &extra_link).unwrap();
-
-        let err = rollback(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IdentityLinkCountMismatch);
-    }
-
-    // -------------------------------------------------------------
-    // Retirement tree anomaly / fail-closed enumeration
-    // -------------------------------------------------------------
-
-    #[test]
-    fn retire_fails_closed_on_unexpected_entry_and_deletes_nothing() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "karen";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        std::fs::write(generations_dir.join("not-an-epoch"), b"bogus").unwrap();
-
-        let err = retire(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::RetirementTreeAnomaly);
-        // Nothing was deleted: the legitimate generation is intact.
-        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
-        assert!(generations_dir.join("not-an-epoch").is_file());
-    }
-
-    #[test]
-    fn retire_fails_closed_on_hardlinked_material_in_tree() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "leo";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::hard_link(
-            gen_dir.join(MATERIAL_FILE_NAME),
-            gen_dir.join("extra-hardlink"),
-        )
-        .unwrap();
-
-        // The hard-linked generation is still the marker's recorded
-        // *active* generation, so the central pre-mutation identity
-        // check (`verify_marker_against_live_state`, run before
-        // retire's own tree enumeration) catches the link-count drift
-        // first, with a more specific reason than the generic
-        // tree-anomaly enumeration would have produced.
-        let err = retire(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IdentityLinkCountMismatch);
-    }
-
-    #[test]
-    fn retire_fails_closed_when_marker_active_but_tree_already_empty() {
-        // "Missing marker never implies clean storage" — and
-        // symmetrically, an active marker over physically-empty
-        // storage must never be silently accepted as clean either.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "mabel";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
-        std::fs::remove_dir(&gen_dir).unwrap();
-
-        let err = retire(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::PreviouslyProvisionedMaterialMissing);
-    }
-
-    #[test]
-    fn retire_on_nonempty_tree_with_missing_marker_still_retires() {
-        // A missing marker file must never be interpreted as "already
-        // clean" when the physical generation tree is non-empty.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "nate";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        std::fs::remove_file(paths.kind_root.join(MARKER_FILE_NAME)).unwrap();
-
-        let fields = retire(vm, kind, &cfg).unwrap();
-        assert_valid(&fields);
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        assert_eq!(std::fs::read_dir(&generations_dir).unwrap().count(), 0);
-    }
-
-    // -------------------------------------------------------------
-    // Locking / concurrency
-    // -------------------------------------------------------------
-
-    #[test]
-    fn concurrent_holder_blocks_a_second_lock_attempt() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "olive";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Hold the exclusive lock open across the whole scope below.
-        let _held = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap();
-
-        let short_wait_cfg = SecretsLifecycleConfig {
-            lock_max_wait: Duration::from_millis(60),
-            lock_poll_interval: Duration::from_millis(5),
-            ..cfg.clone()
-        };
-        let err = rotate(vm, kind, material(b"e2"), &short_wait_cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::LockUnavailable);
-    }
-
-    // -------------------------------------------------------------
-    // Zeroization / material hygiene
-    // -------------------------------------------------------------
-
-    #[test]
-    fn secret_material_rejects_empty_and_oversized_input() {
+        let audit = rollback(&port, &wl, KIND).expect("rollback must succeed");
+        assert_eq!(audit.result, LifecycleResult::RolledBack);
+        assert_eq!(audit.lineage_epoch, Some(1));
         assert_eq!(
-            SecretMaterial::new(Vec::new()).unwrap_err(),
-            FailReason::InvalidMaterial
+            audit.high_water_epoch,
+            Some(2),
+            "rollback never grows high_water"
         );
+        assert_eq!(audit.retained_generations, vec![2]);
+
+        let state = port.raw_state(&wl, KIND).unwrap();
+        assert_eq!(state.active.unwrap().epoch.get(), 1);
+        assert_eq!(state.previous.unwrap().epoch.get(), 2);
+    }
+
+    #[test]
+    fn rollback_can_itself_be_rolled_forward() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
+        rollback(&port, &wl, KIND).unwrap();
+
+        let audit = rollback(&port, &wl, KIND).expect("rolling forward must succeed");
+        assert_eq!(audit.lineage_epoch, Some(2));
+        let state = port.raw_state(&wl, KIND).unwrap();
+        assert_eq!(state.active.unwrap().epoch.get(), 2);
+        assert_eq!(state.previous.unwrap().epoch.get(), 1);
+    }
+
+    #[test]
+    fn rollback_detects_previous_tamper_and_quarantines() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
+        // Tamper with the retained `previous` (epoch 1) generation's
+        // live bytes directly, bypassing the protocol entirely.
+        port.set_faults(Faults {
+            clobber_before_digest: Some((1, b"tampered".to_vec())),
+            ..Default::default()
+        });
+
+        let err = rollback(&port, &wl, KIND).expect_err("must detect the tamper");
+        assert_eq!(err.reason, FailReason::ChecksumMismatch);
         assert_eq!(
-            SecretMaterial::new(vec![0u8; SecretMaterial::MAX_LEN + 1]).unwrap_err(),
-            FailReason::InvalidMaterial
+            port.quarantined_for(&wl, KIND),
+            Some(QuarantineReason::PreviousChecksumMismatch)
         );
     }
 
-    #[test]
-    fn secret_material_debug_never_prints_bytes() {
-        let mat = material(b"super-secret-bytes");
-        let rendered = format!("{mat:?}");
-        assert!(!rendered.contains("super-secret-bytes"));
-        assert!(rendered.contains("len"));
-    }
-
-    // -------------------------------------------------------------
-    // Path / vm-id validation
-    // -------------------------------------------------------------
+    // -- retire -------------------------------------------------------------
 
     #[test]
-    fn invalid_vm_id_is_rejected_before_any_filesystem_access() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let err = provision(
-            "Not-Valid!",
-            SecretKind::GuestSigningKey,
-            material(b"x"),
-            &cfg,
-        )
-        .unwrap_err();
-        assert_eq!(err.reason, FailReason::InvalidVmId);
-        // Nothing was created under the state root.
-        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
-    }
-
-    // -------------------------------------------------------------
-    // Finding-round-3 adversarial coverage: fsync-failure injection
-    // -------------------------------------------------------------
-
-    #[test]
-    fn fsync_failure_in_ensure_staged_blocks_and_is_retryable() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("mia", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"fresh");
-        let stage_name = random_stage_name();
-
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = ensure_staged(
-                generations_fd.as_fd(),
-                &cfg,
-                &stage_name,
-                &mat.digest_hex(),
-                Some(&mat),
-            )
-            .unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // The material bytes were durably written to disk by the time
-        // `fsync_fd` was reached (only the sync itself failed), so a
-        // retry with fsync working again must observe the same digest
-        // and complete idempotently rather than double-writing or
-        // erroring.
+    fn retire_verified_clean_when_never_provisioned() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        let audit = retire(&port, &wl, KIND).expect("retire on never-provisioned must be clean");
+        assert_eq!(audit.result, LifecycleResult::VerifiedClean);
+        audit.validate().expect("must validate");
         assert!(
-            ensure_staged(
-                generations_fd.as_fd(),
-                &cfg,
-                &stage_name,
-                &mat.digest_hex(),
-                Some(&mat),
-            )
-            .unwrap()
+            port.raw_state(&wl, KIND).is_none(),
+            "must not fabricate a committed state"
         );
     }
 
     #[test]
-    fn fsync_failure_in_promote_stage_to_generation_blocks_and_is_retryable() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("nadia", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"fresh");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
+    fn retire_verified_clean_when_already_retired() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        retire(&port, &wl, KIND).unwrap();
 
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = promote_stage_to_generation(
-                generations_fd.as_fd(),
-                &stage_name,
-                7,
-                &mat.digest_hex(),
-            )
-            .unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // The rename already landed on disk before the failed fsync;
-        // retrying must see the matching digest at the final name and
-        // treat it as already-promoted (never re-rename, never error).
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 7, &mat.digest_hex())
-            .unwrap();
+        let audit = retire(&port, &wl, KIND).expect("second retire must be clean, not an error");
+        assert_eq!(audit.result, LifecycleResult::VerifiedClean);
+        assert_eq!(audit.high_water_epoch, Some(1));
     }
 
     #[test]
-    fn fsync_failure_in_atomic_swap_current_blocks_and_is_retryable() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "oscar";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Materialise a second generation directly (bypassing the
-        // marker/txlog machinery) so swapping `current` to it is a
-        // genuine change of target, not a same-epoch no-op that would
-        // short-circuit before ever reaching `fsync_fd`.
-        let mat2 = material(b"e2");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat2.digest_hex(),
-            Some(&mat2),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat2.digest_hex())
-            .unwrap();
+    fn retire_prunes_active_and_previous() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
 
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = atomic_swap_current(secrets_fd.as_fd(), 2).unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // `current` still resolves correctly afterward: either the
-        // rename never completed (still epoch 1, unchanged) or it did
-        // and only the sync failed -- both are safe, and a retry with
-        // fsync restored must succeed.
-        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
-        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 2));
+        let audit = retire(&port, &wl, KIND).expect("retire must succeed");
+        assert_eq!(audit.result, LifecycleResult::Retired);
+        assert!(!audit.prune_deferred);
+        audit.validate().expect("must validate");
+
+        let state = port.raw_state(&wl, KIND).unwrap();
+        assert!(state.retired);
+        assert!(state.active.is_none());
+        assert!(state.previous.is_none());
+        assert!(port.raw_material_epochs(&wl, KIND).is_empty());
     }
 
     #[test]
-    fn fsync_failure_in_write_marker_blocks_marker_commit_phase() {
-        // Drive `execute_promote` up to `CurrentPromoted` normally
-        // (fsync working), then inject a failure exactly at the
-        // `write_marker` call inside the `CurrentPromoted` phase and
-        // confirm: (a) the call fails with `FsyncFailed`; (b) the
-        // txlog still records `CurrentPromoted` (the phase advance to
-        // `MarkerCommitted` never durably landed, so a crash here is
-        // still recoverable rather than mistaken for "finished"); and
-        // (c) a subsequent recovery pass with fsync restored
-        // completes the promotion and removes the txlog.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "priya";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+    fn retire_sorts_pending_prune_when_active_epoch_is_lower_than_previous() {
+        // Regression test: a rollback can leave `active` at a
+        // *numerically lower* epoch than `previous` (e.g. active=1,
+        // previous=2 after one rotate + one rollback). `retire` must
+        // still produce an ascending-sorted `pending_prune`, or the
+        // committed `DurableState` would fail its own
+        // `validate_self_consistent` sortedness check.
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
+        rollback(&port, &wl, KIND).unwrap();
+        let state_before = port.raw_state(&wl, KIND).unwrap();
+        assert_eq!(state_before.active.unwrap().epoch.get(), 1);
+        assert_eq!(state_before.previous.unwrap().epoch.get(), 2);
 
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e2");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
-            .unwrap();
-        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::CurrentPromoted,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone())).unwrap();
+        // Fault every prune so the committed `pending_prune` list is
+        // directly observable (not immediately drained).
+        let mut failing = HashSet::new();
+        failing.insert(1_u64);
+        failing.insert(2_u64);
+        port.set_faults(Faults {
+            fail_prune_epochs: failing,
+            ..Default::default()
+        });
 
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = execute_promote(
-                secrets_fd.as_fd(),
-                generations_fd.as_fd(),
-                &cfg,
-                intent,
-                None,
-            )
-            .unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // The marker rename+write already landed (fsync only
-        // failed to make it durable, it did not block visibility),
-        // so this process's own next read already observes epoch 2;
-        // what fsync failing must guarantee is that the phase was
-        // never advanced past `CurrentPromoted` -- the txlog still
-        // records that phase, so a crash here is safely recoverable
-        // rather than being treated as already-finished.
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert_eq!(marker.active.as_ref().unwrap().epoch, 2);
-        let txlog = read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().unwrap();
-        match txlog {
-            TxLog::Promote(intent) => assert_eq!(intent.phase, PromotePhase::CurrentPromoted),
-            TxLog::Retire(_) => panic!("expected a leftover Promote txlog"),
-        }
-
-        // With fsync restored, recovery completes forward: the
-        // txlog is durably removed and the marker remains at epoch 2.
-        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
-        assert!(recovered);
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert_eq!(marker.active.as_ref().unwrap().epoch, 2);
-        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_none());
-    }
-
-    #[test]
-    fn fsync_failure_in_remove_generation_blocks_and_is_retryable() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("quinn", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = remove_generation(generations_fd.as_fd(), 1).unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // Idempotent retry (whether or not the delete itself already
-        // landed) must succeed once fsync works again.
-        remove_generation(generations_fd.as_fd(), 1).unwrap();
-    }
-
-    #[test]
-    fn fsync_failure_in_remove_stage_dir_blocks_and_is_retryable() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("rex", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"stray");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap();
-    }
-
-    // -------------------------------------------------------------
-    // Finding 2: orphan-epoch / pre-existing-digest scenarios
-    // -------------------------------------------------------------
-
-    #[test]
-    fn promote_stage_to_generation_rejects_foreign_content_at_target_epoch() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("sasha", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-
-        // A foreign directory already occupies the target epoch
-        // number with content that does not match what we intend to
-        // promote.
-        let foreign = material(b"foreign-content");
-        let foreign_stage = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &foreign_stage,
-            &foreign.digest_hex(),
-            Some(&foreign),
-        )
-        .unwrap();
-        promote_stage_to_generation(
-            generations_fd.as_fd(),
-            &foreign_stage,
-            5,
-            &foreign.digest_hex(),
-        )
-        .unwrap();
-
-        let intended = material(b"intended-content");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &intended.digest_hex(),
-            Some(&intended),
-        )
-        .unwrap();
-        let err = promote_stage_to_generation(
-            generations_fd.as_fd(),
-            &stage_name,
-            5,
-            &intended.digest_hex(),
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::GenerationConflict);
-        // The foreign directory must be untouched -- never silently
-        // overwritten or adopted.
+        let audit = retire(&port, &wl, KIND).expect("retire itself must still succeed");
+        assert!(audit.prune_deferred);
+        let state = port.raw_state(&wl, KIND).unwrap();
         assert_eq!(
-            digest_of_material_dir(&borrowed_to_owned(generations_fd.as_fd()).unwrap(), "5")
-                .unwrap(),
-            foreign.digest_hex()
+            state.pending_prune,
+            vec![Epoch::FIRST, Epoch::from_raw(2).unwrap()]
         );
     }
 
     #[test]
-    fn planned_phase_recovery_detects_already_renamed_orphan_epoch_and_continues() {
-        // Regression guard for "never abandon/reuse an orphan epoch":
-        // simulate a crash where the stage-to-epoch rename already
-        // completed but the phase-advance write from `Planned` to
-        // `EpochReady` never committed. Recovery must detect the
-        // already-renamed epoch by exact digest match and continue
-        // forward, never abandon the transaction nor silently adopt a
-        // mismatched directory.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "tariq";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+    fn retire_defers_prune_when_faulted_then_next_action_drains_debt() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        rotate(&port, &wl, KIND, material(b"gen2")).unwrap();
 
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e2");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        // Simulate the rename having already happened, but the txlog
-        // still recording `Planned` (as if the crash landed between
-        // the rename and the phase-advance write).
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
-            .unwrap();
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
-        drop(secrets_fd);
-        drop(generations_fd);
+        let mut failing = HashSet::new();
+        failing.insert(1_u64);
+        failing.insert(2_u64);
+        port.set_faults(Faults {
+            fail_prune_epochs: failing,
+            ..Default::default()
+        });
+        let audit = retire(&port, &wl, KIND).expect("retire must still succeed");
+        assert!(audit.prune_deferred);
+        assert_eq!(port.raw_material_epochs(&wl, KIND), vec![1, 2]);
 
-        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
-        assert!(recovered);
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert_eq!(marker.active.unwrap().epoch, 2);
-    }
-
-    #[test]
-    fn planned_phase_recovery_rejects_mismatched_content_at_orphan_epoch() {
-        // The inverse of the above: the pre-existing directory at the
-        // target epoch number has content that does NOT match the
-        // recorded transaction's expected digest. This must never be
-        // silently adopted -- fail closed instead.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "umberto";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let foreign = material(b"unexpected-content");
-        let foreign_stage = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &foreign_stage,
-            &foreign.digest_hex(),
-            Some(&foreign),
-        )
-        .unwrap();
-        promote_stage_to_generation(
-            generations_fd.as_fd(),
-            &foreign_stage,
-            2,
-            &foreign.digest_hex(),
-        )
-        .unwrap();
-
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name: random_stage_name(),
-            expected_digest_hex: material(b"e2").digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
-        drop(secrets_fd);
-        drop(generations_fd);
-
-        let err = recover_in_flight_transaction(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::RecoveryContentMismatch);
-        // Epoch 1 (the real active generation) must be entirely
-        // untouched.
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(1));
-    }
-
-    // -------------------------------------------------------------
-    // Finding 1: literal-`current`-target tamper
-    // -------------------------------------------------------------
-
-    #[test]
-    fn current_resolves_exactly_to_rejects_foreign_path_with_matching_final_component() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("vera", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-
-        // A symlink whose target merely *ends* in the right epoch
-        // number, but is not the exact literal `generations/<epoch>`
-        // text, must never be treated as resolving to that epoch.
-        let _ = rustix::fs::unlinkat(
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-            rustix::fs::AtFlags::empty(),
+        port.set_faults(Faults::default());
+        // A fresh provision must fully drain the retired lineage's
+        // debt before it may reuse epoch 1's key.
+        provision(&port, &wl, KIND, material(b"fresh-gen1"))
+            .expect("provision must drain debt and succeed");
+        assert_eq!(port.raw_material_epochs(&wl, KIND), vec![1]);
+        let state = port.raw_state(&wl, KIND).unwrap();
+        assert_eq!(
+            state.high_water_epoch, 1,
+            "provision resets high_water for a fresh lineage"
         );
-        rustix::fs::symlinkat(
-            "/some/foreign/absolute/path/7",
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-        )
-        .unwrap();
-        assert!(!current_resolves_exactly_to(secrets_fd.as_fd(), 7));
-        assert_eq!(read_current_target(secrets_fd.as_fd()), None);
-
-        let _ = rustix::fs::unlinkat(
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-            rustix::fs::AtFlags::empty(),
-        );
-        rustix::fs::symlinkat(
-            "../../foreign/7",
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-        )
-        .unwrap();
-        assert!(!current_resolves_exactly_to(secrets_fd.as_fd(), 7));
-        assert_eq!(read_current_target(secrets_fd.as_fd()), None);
-
-        let _ = rustix::fs::unlinkat(
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-            rustix::fs::AtFlags::empty(),
-        );
-        rustix::fs::symlinkat(
-            expected_current_target(7),
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-        )
-        .unwrap();
-        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 7));
-        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(7));
+        assert!(state.pending_prune.is_empty());
     }
 
-    #[test]
-    fn tampered_current_symlink_is_reachable_and_fails_closed_on_rotate() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "wendy";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let _ = rustix::fs::unlinkat(
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-            rustix::fs::AtFlags::empty(),
-        );
-        // Retarget `current` to an absolute path whose final
-        // component happens to be "1" (the real active epoch's
-        // number) but which is not the literal `generations/1` text
-        // this module ever writes.
-        rustix::fs::symlinkat(
-            "/etc/passwd/../1",
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_LINK_NAME),
-        )
-        .unwrap();
-        drop(secrets_fd);
-
-        let err = rotate(vm, kind, material(b"e2"), &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IdentityCurrentTargetMismatch);
-    }
-
-    // -------------------------------------------------------------
-    // Finding 3: staged entries are real, propagated deletions
-    // -------------------------------------------------------------
+    // -- Cross-cutting: concurrency, quarantine permanence ------------------
 
     #[test]
-    fn validate_stage_dir_contents_rejects_extra_entries_and_subdirectories() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("xander", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-
-        let owned = borrowed_to_owned(generations_fd.as_fd()).unwrap();
-        let stage_dir_fd = path_safe::open_at(
-            owned.as_fd(),
-            Path::new(&stage_name),
-            OFlags::RDONLY | OFlags::DIRECTORY,
-        )
-        .unwrap();
-        let stage_dir_owned = borrowed_to_owned(stage_dir_fd.as_fd()).unwrap();
-        path_safe::mkdir_at(stage_dir_owned.as_fd(), Path::new("extra-subdir"), 0o700).unwrap();
-
-        let err = validate_stage_dir_contents(&owned, &stage_name).unwrap_err();
-        assert_eq!(err, FailReason::RetirementTreeAnomaly);
-    }
-
-    #[test]
-    fn stage_dir_deletion_failure_propagates_and_blocks_retire() {
-        // A stage directory that cannot be fully enumerated/deleted
-        // (here: it contains an anomalous subdirectory rather than at
-        // most one regular-file entry) must block retirement entirely
-        // -- never a best-effort, ignored sweep.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "yara";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let stray = random_stage_name();
-        path_safe::mkdir_at_exclusive(generations_fd.as_fd(), Path::new(&stray), 0o700).unwrap();
-        let stray_owned = borrowed_to_owned(generations_fd.as_fd()).unwrap();
-        let stray_fd = path_safe::open_at(
-            stray_owned.as_fd(),
-            Path::new(&stray),
-            OFlags::RDONLY | OFlags::DIRECTORY,
-        )
-        .unwrap();
-        let stray_dir_owned = borrowed_to_owned(stray_fd.as_fd()).unwrap();
-        path_safe::mkdir_at(stray_dir_owned.as_fd(), Path::new("nested"), 0o700).unwrap();
-
-        let err = retire(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::RetirementTreeAnomaly);
-        // Nothing was deleted: the legitimate generation and the
-        // anomalous stray directory are both still present.
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
-        assert!(generations_dir.join(&stray).is_dir());
-    }
-
-    #[test]
-    fn retire_deletes_stray_stage_directories_as_real_content() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "zane";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let stray_mat = material(b"stray-stage-content");
-        let stray_stage = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stray_stage,
-            &stray_mat.digest_hex(),
-            Some(&stray_mat),
-        )
-        .unwrap();
-
-        let fields = retire(vm, kind, &cfg).unwrap();
-        assert_valid(&fields);
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        assert_eq!(std::fs::read_dir(&generations_dir).unwrap().count(), 0);
-    }
-
-    // -------------------------------------------------------------
-    // Finding 5: txlog semantic validation / pre-delete revalidation
-    // -------------------------------------------------------------
-
-    #[test]
-    fn txlog_with_wrong_vm_is_rejected_before_recovery_acts() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "amara";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let intent = RetireIntent {
-            vm: "someone-else".to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: Vec::new(),
-            high_water_epoch: 1,
-            phase: RetirePhase::CurrentRemoved,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent)).unwrap();
-        drop(secrets_fd);
-
-        let err = recover_in_flight_transaction(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IntentCorrupt);
-        // Nothing was touched: the active generation is intact.
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(1));
-    }
-
-    #[test]
-    fn txlog_with_non_monotonic_epochs_is_rejected() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("boaz", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let intent = RetireIntent {
-            vm: "boaz".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            epochs: vec![3, 1],
-            stage_names: Vec::new(),
-            high_water_epoch: 3,
-            phase: RetirePhase::Enumerated,
-        };
-        let err = validate_retire_intent_semantics(&intent, "boaz", SecretKind::GuestSigningKey)
-            .unwrap_err();
-        assert_eq!(err, FailReason::IntentCorrupt);
-        drop(secrets_fd);
-    }
-
-    #[test]
-    fn revalidate_generation_before_delete_catches_a_tamper_immediately_before_delete() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("carys", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-
-        // Absent generation is tolerated (idempotent replay).
-        revalidate_generation_before_delete(generations_fd.as_fd(), 2, &cfg).unwrap();
-
-        // Tamper: hard-link a second name into the generation just
-        // before deletion would occur.
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::hard_link(gen_dir.join(MATERIAL_FILE_NAME), gen_dir.join("planted")).unwrap();
-        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1, &cfg).unwrap_err();
-        assert_eq!(err, FailReason::RetirementTreeAnomaly);
-    }
-
-    // -------------------------------------------------------------
-    // Finding 6: broker-owned metadata / lock-file verification
-    // -------------------------------------------------------------
-
-    #[test]
-    fn acquire_lock_rejects_a_wrong_mode_lock_file() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("dov", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        drop(_generations_fd);
-        drop(secrets_fd);
-
-        let lock_path = paths.kind_root.join(LOCK_FILE_NAME);
-        std::fs::write(&lock_path, b"").unwrap();
-        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o666)).unwrap();
-
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let err = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap_err();
-        assert_eq!(err, FailReason::BrokerOwnershipViolation);
-    }
-
-    #[test]
-    fn acquire_lock_rejects_a_hardlinked_lock_file() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("elan", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        drop(generations_fd);
-        drop(secrets_fd);
-
-        let lock_path = paths.kind_root.join(LOCK_FILE_NAME);
-        std::fs::write(&lock_path, b"").unwrap();
-        std::fs::set_permissions(
-            &lock_path,
-            std::fs::Permissions::from_mode(FILE_MODE_DEFAULT),
-        )
-        .unwrap();
-        std::fs::hard_link(&lock_path, paths.kind_root.join("lock-plant")).unwrap();
-
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let err = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap_err();
-        assert_eq!(err, FailReason::BrokerOwnershipViolation);
-    }
-
-    #[test]
-    fn acquire_lock_rejects_a_wrong_mode_parent_directory() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("farid", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-
-        // Tamper the mode on the already-open `kind_root` directory
-        // (the lock file's anchored parent) via its live inode --
-        // re-opening through `open_or_create_secrets_dir` would
-        // silently reassert the correct mode via `ensure_dir` before
-        // `acquire_lock` ever ran, masking the drift this test must
-        // prove is caught. Using the still-open fd's `fstat` view
-        // instead observes the tamper exactly like a concurrent
-        // actor's `chmod` on the live directory would.
-        std::fs::set_permissions(&paths.kind_root, std::fs::Permissions::from_mode(0o777)).unwrap();
-
-        let err = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap_err();
-        assert_eq!(err, FailReason::BrokerOwnershipViolation);
-    }
-
-    #[test]
-    fn open_or_create_secrets_dir_reasserts_mode_drift_on_metadata_dirs() {
-        // `ensure_dir` only reasserts *mode*, not owner, when passed
-        // `None, None`; confirm the mode side of that contract is
-        // actually exercised end to end (a drifted mode on the
-        // metadata directories is corrected on the next open) rather
-        // than merely assumed from construction.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("gilad", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        drop(generations_fd);
-        drop(secrets_fd);
-
-        std::fs::set_permissions(&paths.kind_root, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let stat = path_safe::fstat_fd(secrets_fd.as_fd()).unwrap();
-        assert_eq!((stat.st_mode as u32) & 0o7777, cfg.dir_mode);
-    }
-
-    // -------------------------------------------------------------
-    // Finding 1: central validation catches marker/live drift on
-    // every action, not only the one that caused it
-    // -------------------------------------------------------------
-
-    #[test]
-    fn central_validation_runs_identically_for_every_public_action() {
-        // A single tamper (retargeting `current` away from the
-        // marker's recorded active epoch) must be caught by
-        // `provision`, `rotate`, `rollback`, and `retire` alike, since
-        // all four route through the same `open_and_recover` choke
-        // point rather than four separately-maintained checks.
-        for action in ["rotate", "rollback", "retire"] {
-            let dir = tempdir().unwrap();
-            let cfg = cfg_at(dir.path());
-            let vm = "hana";
-            let kind = SecretKind::GuestSigningKey;
-            provision(vm, kind, material(b"e1"), &cfg).unwrap();
-            rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-
-            let paths = derive_paths(vm, kind, &cfg).unwrap();
-            let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-            let _ = rustix::fs::unlinkat(
-                secrets_fd.as_fd(),
-                Path::new(CURRENT_LINK_NAME),
-                rustix::fs::AtFlags::empty(),
-            );
-            rustix::fs::symlinkat(
-                "/nonexistent/tamper/2",
-                secrets_fd.as_fd(),
-                Path::new(CURRENT_LINK_NAME),
-            )
-            .unwrap();
-            drop(secrets_fd);
-
-            let err = match action {
-                "rotate" => rotate(vm, kind, material(b"e3"), &cfg).unwrap_err(),
-                "rollback" => rollback(vm, kind, &cfg).unwrap_err(),
-                "retire" => retire(vm, kind, &cfg).unwrap_err(),
-                _ => unreachable!(),
-            };
-            assert_eq!(
-                err.reason,
-                FailReason::IdentityCurrentTargetMismatch,
-                "action {action} did not reach the central validation choke point"
-            );
-        }
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 1: Planned-phase partial-stage discard on abort
-    // -------------------------------------------------------------
-
-    #[test]
-    fn planned_recovery_discards_a_partial_stage_before_aborting_no_material() {
-        // Simulate a crash between `mkdir_at_exclusive` succeeding and
-        // the material write ever completing: an empty `.stage-*`
-        // directory exists on disk, but `ensure_staged` (given no
-        // in-memory `material`, as on a real recovery re-entry) can
-        // neither find a fully-staged digest-matching directory nor
-        // write fresh material. The stage directory must be validated
-        // and deleted -- never abandoned -- before the txlog record is
-        // discarded.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("orphan-stage", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let stage_name = random_stage_name();
-        // An empty stage directory: `mkdir_at_exclusive` succeeded,
-        // nothing was ever written into it.
-        path_safe::mkdir_at_exclusive(generations_fd.as_fd(), Path::new(&stage_name), cfg.dir_mode)
-            .unwrap();
-
-        let intent = PromoteIntent {
-            vm: "orphan-stage".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name: stage_name.clone(),
-            expected_digest_hex: material(b"never-written").digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        let outcome = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap();
-        assert!(matches!(outcome, PromoteOutcome::AbortedNoMaterial));
-        // The partial stage directory must be gone, not orphaned.
-        assert!(
-            path_safe::fstatat_nofollow(
-                &borrowed_to_owned(generations_fd.as_fd()).unwrap(),
-                &stage_name
-            )
-            .unwrap()
-            .is_none()
-        );
-        // The txlog must also be gone (the abort was fully committed,
-        // not left wedged).
-        assert!(
-            read_txlog(
-                secrets_fd.as_fd(),
-                "orphan-stage",
-                SecretKind::GuestSigningKey
-            )
-            .unwrap()
-            .is_none()
-        );
-    }
-
-    #[test]
-    fn planned_recovery_fails_closed_on_an_unvalidatable_partial_stage_and_retains_txlog() {
-        // The inverse: the leftover stage directory is not a
-        // recognizable partial-write shape (e.g. a stray subdirectory
-        // was injected into it) -- `discard_partial_stage_if_present`
-        // must propagate that anomaly rather than silently discarding
-        // it, and the txlog record must survive so a future recovery
-        // attempt can still reason about it. No orphan wedge: the
-        // transaction fails closed instead of being silently dropped
-        // over unrecognized on-disk state.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("bad-stage", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let stage_name = random_stage_name();
-        path_safe::mkdir_at_exclusive(generations_fd.as_fd(), Path::new(&stage_name), cfg.dir_mode)
-            .unwrap();
-        let stage_dir_fd = path_safe::open_at(
-            generations_fd.as_fd(),
-            Path::new(&stage_name),
-            OFlags::RDONLY | OFlags::DIRECTORY,
-        )
-        .unwrap();
-        let stage_dir_owned = borrowed_to_owned(stage_dir_fd.as_fd()).unwrap();
-        // A subdirectory is never a valid stage-dir entry shape.
-        path_safe::mkdir_at(stage_dir_owned.as_fd(), Path::new("anomaly"), 0o700).unwrap();
-
-        let intent = PromoteIntent {
-            vm: "bad-stage".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name: stage_name.clone(),
-            expected_digest_hex: material(b"never-written").digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone())).unwrap();
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::RetirementTreeAnomaly);
-        // Never silently activated: the stage dir is untouched and the
-        // txlog record still exists for a future recovery attempt to
-        // reason about.
-        assert!(
-            path_safe::fstatat_nofollow(
-                &borrowed_to_owned(generations_fd.as_fd()).unwrap(),
-                &stage_name
-            )
-            .unwrap()
-            .is_some()
-        );
-        assert!(
-            read_txlog(secrets_fd.as_fd(), "bad-stage", SecretKind::GuestSigningKey)
-                .unwrap()
-                .is_some()
-        );
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 2: `current`-swap leftover stage-symlink cleanup
-    // -------------------------------------------------------------
-
-    #[test]
-    fn atomic_swap_current_removes_a_leftover_swap_stage_symlink_from_a_prior_crash() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("swap-retry", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        // Leave a leftover swap-stage symlink behind, as if a prior
-        // crash landed between `symlinkat` and `renameat`.
-        rustix::fs::symlinkat(
-            expected_current_target(1),
-            secrets_fd.as_fd(),
-            Path::new(CURRENT_SWAP_STAGE_NAME),
-        )
-        .unwrap();
-        // Must not fail with EEXIST on retry: the leftover symlink is
-        // actually removed (not left in place by a no-op
-        // `remove_path_safe` call), so the fresh `symlinkat` below it
-        // succeeds.
-        atomic_swap_current(secrets_fd.as_fd(), 1).unwrap();
-        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 1));
-        assert!(
-            path_safe::fstatat_nofollow(
-                &borrowed_to_owned(secrets_fd.as_fd()).unwrap(),
-                CURRENT_SWAP_STAGE_NAME
-            )
-            .unwrap()
-            .is_none()
-        );
-    }
-
-    #[test]
-    fn atomic_swap_current_fails_closed_on_a_non_symlink_swap_stage_entry() {
-        // An anomaly no legitimate code path produces: something
-        // other than a symlink occupies the swap-stage slot. Must
-        // fail closed rather than deleting an unexpected entry.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("swap-anomaly", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        let secrets_owned = borrowed_to_owned(secrets_fd.as_fd()).unwrap();
-        path_safe::create_file_at_safe(
-            &secrets_owned,
-            CURRENT_SWAP_STAGE_NAME,
-            nix::libc::O_RDWR | nix::libc::O_CREAT,
-            FILE_MODE_DEFAULT,
-        )
-        .unwrap();
-
-        let err = atomic_swap_current(secrets_fd.as_fd(), 1).unwrap_err();
-        assert_eq!(err, FailReason::CurrentSwapFailed);
-        // The anomalous entry must be left untouched, not deleted.
-        let stat = path_safe::fstatat_nofollow(&secrets_owned, CURRENT_SWAP_STAGE_NAME)
-            .unwrap()
-            .unwrap();
-        assert_eq!(stat.st_mode & nix::libc::S_IFMT, nix::libc::S_IFREG);
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 3: existing-digest-match `Planned` branch retries
-    // its own durability barrier
-    // -------------------------------------------------------------
-
-    #[test]
-    fn planned_recovery_existing_digest_match_retries_generations_fsync() {
-        // The rename to the final epoch name already completed (a
-        // prior crashed attempt got as far as
-        // `promote_stage_to_generation`, whose own trailing
-        // `fsync_fd(generations_fd)` may be exactly what failed and
-        // crashed the attempt before the phase could advance). Recovery
-        // re-entry finding a digest match must retry that durability
-        // barrier, not silently assume it already happened.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("digest-match-fsync", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        let intent = PromoteIntent {
-            vm: "digest-match-fsync".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = execute_promote(
-                secrets_fd.as_fd(),
-                generations_fd.as_fd(),
-                &cfg,
-                intent.clone(),
-                None,
-            )
-            .unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // Retry without the fault must succeed and complete the whole
-        // transaction.
-        let outcome = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap();
-        assert!(matches!(outcome, PromoteOutcome::Completed(_)));
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 4: `NotFound` fast paths still retry the
-    // generations-dir fsync durability barrier
-    // -------------------------------------------------------------
-
-    #[test]
-    fn remove_generation_notfound_fast_path_still_retries_fsync() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("gen-notfound-fsync", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Epoch 7 was never created: the `NotFound` fast path is hit
-        // immediately.
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = remove_generation(generations_fd.as_fd(), 7).unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        remove_generation(generations_fd.as_fd(), 7).unwrap();
-    }
-
-    #[test]
-    fn remove_stage_dir_notfound_fast_path_still_retries_fsync() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths =
-            derive_paths("stage-notfound-fsync", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let stage_name = random_stage_name();
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap();
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 5: phase-specific current/marker identity
-    // validation before recovery mutation or txlog removal
-    // -------------------------------------------------------------
-
-    #[test]
-    fn current_promoted_recovery_rejects_current_not_pointing_at_to_epoch() {
-        // A hand-edited/corrupted txlog claims `CurrentPromoted` over
-        // a `current` that does not actually resolve to `to_epoch`.
-        // Must fail closed before any marker mutation, never write a
-        // marker claiming an active generation `current` does not
-        // corroborate.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("cp-mismatch", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        // `current` is left absent/unset -- never swapped to epoch 1 --
-        // yet the txlog claims `CurrentPromoted`.
-        let intent = PromoteIntent {
-            vm: "cp-mismatch".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::CurrentPromoted,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::IdentityCurrentTargetMismatch);
-        // No marker must have been written.
-        assert!(read_marker(secrets_fd.as_fd()).unwrap().is_none());
-    }
-
-    #[test]
-    fn marker_committed_recovery_rejects_current_not_pointing_at_to_epoch() {
-        // `MarkerCommitted` recovery must independently re-verify
-        // `current` before pruning/cleanup/txlog-removal, not just
-        // trust the phase label.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("mc-current-mismatch", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        // Note: `current` is never swapped here.
-        let intent = PromoteIntent {
-            vm: "mc-current-mismatch".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::MarkerCommitted,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::IdentityCurrentTargetMismatch);
-    }
-
-    #[test]
-    fn marker_committed_recovery_rejects_a_marker_disagreeing_with_the_intent() {
-        // `current` correctly resolves to `to_epoch`, but the marker
-        // on disk does not reflect this transaction's intended active
-        // epoch/digest (e.g. a stale marker from before this
-        // transaction, or one hand-edited independently of the
-        // txlog). `MarkerCommitted` recovery must reject this rather
-        // than proceeding with pruning/cleanup based on an unverified
-        // assumption.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("mc-marker-mismatch", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        atomic_swap_current(secrets_fd.as_fd(), 1).unwrap();
-        // Write a marker that does not correspond to this transaction
-        // (wrong high-water/active state -- e.g. still reflecting
-        // "nothing provisioned yet").
-        let stale_marker = MarkerData {
-            v: MARKER_SCHEMA_VERSION,
-            vm: "mc-marker-mismatch".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            retired: false,
-            high_water_epoch: 0,
-            active: None,
-            previous: None,
-            first_provisioned_ms: 0,
-            updated_ms: now_ms(),
-        };
-        write_marker(secrets_fd.as_fd(), &stale_marker).unwrap();
-
-        let intent = PromoteIntent {
-            vm: "mc-marker-mismatch".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::MarkerCommitted,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::RecoveryAmbiguous);
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 6: closed stage-name syntax + immediate
-    // pre-delete revalidation
-    // -------------------------------------------------------------
-
-    #[test]
-    fn is_well_formed_stage_name_accepts_only_the_exact_random_stage_name_syntax() {
-        assert!(is_well_formed_stage_name(&random_stage_name()));
-        assert!(is_well_formed_stage_name(&random_stage_name()));
-        for bad in [
-            "",
-            ".stage-",
-            ".stage-too-short",
-            &format!("{STAGE_PREFIX}{}", "a".repeat(31)),
-            &format!("{STAGE_PREFIX}{}", "a".repeat(33)),
-            &format!("{STAGE_PREFIX}{}", "A".repeat(32)),
-            &format!("{STAGE_PREFIX}{}", "g".repeat(32)),
-            &format!("{STAGE_PREFIX}../{}", "a".repeat(29)),
-            &format!("{STAGE_PREFIX}{}/etc", "a".repeat(28)),
-            "not-a-stage-name",
-        ] {
-            assert!(
-                !is_well_formed_stage_name(bad),
-                "expected {bad:?} to be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn validate_promote_intent_semantics_rejects_a_path_traversal_stage_name() {
-        // A corrupted/hand-edited txlog must never reach an anchored
-        // path-safe call with an attacker-controlled path component.
-        let intent = PromoteIntent {
-            vm: "traversal".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name: format!("{STAGE_PREFIX}../../etc/passwd"),
-            expected_digest_hex: material(b"x").digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        let err =
-            validate_promote_intent_semantics(&intent, "traversal", SecretKind::GuestSigningKey)
-                .unwrap_err();
-        assert_eq!(err, FailReason::IntentCorrupt);
-    }
-
-    #[test]
-    fn validate_retire_intent_semantics_rejects_a_path_traversal_stage_name() {
-        let intent = RetireIntent {
-            vm: "traversal2".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            epochs: vec![],
-            stage_names: vec![format!("{STAGE_PREFIX}/etc/passwd")],
-            high_water_epoch: 1,
-            phase: RetirePhase::Enumerated,
-        };
-        let err =
-            validate_retire_intent_semantics(&intent, "traversal2", SecretKind::GuestSigningKey)
-                .unwrap_err();
-        assert_eq!(err, FailReason::IntentCorrupt);
-    }
-
-    #[test]
-    fn revalidate_stage_before_delete_catches_a_tamper_injected_just_before_delete() {
-        // Mirrors `revalidate_generation_before_delete_catches_a_tamper_
-        // immediately_before_delete` for stage directories: a stage
-        // dir enumerated and validated earlier is tampered with (an
-        // extra entry injected) between enumeration and the delete
-        // call. The immediate pre-delete revalidation must catch it.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("stage-tamper", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"pending");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        // Originally validates cleanly.
-        revalidate_stage_before_delete(generations_fd.as_fd(), &stage_name).unwrap();
-
-        // Tamper: inject a second entry into the stage dir.
-        let generations_owned = borrowed_to_owned(generations_fd.as_fd()).unwrap();
-        let stage_dir_fd = path_safe::open_at(
-            generations_owned.as_fd(),
-            Path::new(&stage_name),
-            OFlags::RDONLY | OFlags::DIRECTORY,
-        )
-        .unwrap();
-        let stage_dir_owned = borrowed_to_owned(stage_dir_fd.as_fd()).unwrap();
-        path_safe::mkdir_at(stage_dir_owned.as_fd(), Path::new("tamper"), 0o700).unwrap();
-
-        let err = revalidate_stage_before_delete(generations_fd.as_fd(), &stage_name).unwrap_err();
-        assert_eq!(err, FailReason::RetirementTreeAnomaly);
-    }
-
-    #[test]
-    fn revalidate_stage_before_delete_tolerates_absence() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths = derive_paths("stage-absent", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        revalidate_stage_before_delete(generations_fd.as_fd(), &random_stage_name()).unwrap();
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 7: rollback intent digest/identity consistency
-    // -------------------------------------------------------------
-
-    #[test]
-    fn validate_promote_intent_semantics_rejects_rollback_digest_identity_mismatch() {
-        let identity = MaterialIdentity {
-            epoch: 1,
-            dev: 1,
-            ino: 1,
-            uid: 0,
-            gid: 0,
-            mode: 0o600,
-            nlink: 1,
-            has_acl: false,
-            digest_hex: material(b"actual").digest_hex(),
-        };
-        let intent = PromoteIntent {
-            vm: "rollback-mismatch".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Rollback,
-            to_epoch: 1,
-            create_epoch: false,
-            stage_name: String::new(),
-            // Deliberately inconsistent with `identity.digest_hex`.
-            expected_digest_hex: material(b"different").digest_hex(),
-            expected_identity: Some(identity),
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        let err = validate_promote_intent_semantics(
-            &intent,
-            "rollback-mismatch",
-            SecretKind::GuestSigningKey,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::IntentCorrupt);
-    }
-
-    #[test]
-    fn validate_promote_intent_semantics_accepts_consistent_rollback_digest_identity() {
-        let identity = MaterialIdentity {
-            epoch: 1,
-            dev: 1,
-            ino: 1,
-            uid: 0,
-            gid: 0,
-            mode: 0o600,
-            nlink: 1,
-            has_acl: false,
-            digest_hex: material(b"actual").digest_hex(),
-        };
-        let intent = PromoteIntent {
-            vm: "rollback-consistent".to_owned(),
-            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
-            action: LifecycleAction::Rollback,
-            to_epoch: 1,
-            create_epoch: false,
-            stage_name: String::new(),
-            expected_digest_hex: identity.digest_hex.clone(),
-            expected_identity: Some(identity),
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::Planned,
-        };
-        validate_promote_intent_semantics(
-            &intent,
-            "rollback-consistent",
-            SecretKind::GuestSigningKey,
-        )
-        .unwrap();
-    }
-
-    // -------------------------------------------------------------
-    // Round-4 finding 8: `recovered_prior_transaction` threading
-    // -------------------------------------------------------------
-
-    #[test]
-    fn recovered_prior_transaction_is_true_on_a_denial_reached_after_successful_recovery() {
-        // `provision` first drains a leftover crashed `rotate`
-        // transaction (recoverable: the rename to epoch 2 already
-        // completed with a matching digest, so recovery can run it
-        // all the way to completion), then hits `AlreadyProvisioned`
-        // because the marker is now active. The denial must carry
-        // `recovered_prior_transaction: true`.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "recovered-denied";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat2 = material(b"e2");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat2.digest_hex(),
-            Some(&mat2),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat2.digest_hex())
-            .unwrap();
-        let marker_before = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat2.digest_hex(),
-            expected_identity: None,
-            carry_previous: marker_before.active.clone(),
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: marker_before.first_provisioned_ms,
-            phase: PromotePhase::Planned,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
-        drop(secrets_fd);
-        drop(generations_fd);
-
-        let err = provision(vm, kind, material(b"e3"), &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::AlreadyProvisioned);
-        assert!(
-            err.audit.recovered_prior_transaction,
-            "denial reached after a successful mid-call recovery must record it"
-        );
-
-        // Sanity: recovery genuinely ran (the crashed rotate is fully
-        // completed, epoch 2 is now active).
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert_eq!(marker.active.unwrap().epoch, 2);
-    }
-
-    #[test]
-    fn recovered_prior_transaction_is_false_on_the_common_no_crash_denial_path() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let err = rotate(
-            "never-provisioned",
-            SecretKind::GuestSigningKey,
-            material(b"e1"),
-            &cfg,
-        )
-        .unwrap_err();
-        assert_eq!(err.reason, FailReason::NotProvisioned);
-        assert!(!err.audit.recovered_prior_transaction);
-    }
-
-    // -------------------------------------------------------------
-    // Round-5 finding: txlog-backed retirement recovery must accept
-    // the legitimate "material already unlinked, epoch directory not
-    // yet removed" crash checkpoint -- but only from the retire
-    // txlog-recovery deletion loop, and only over a directory that
-    // still proves out as this module's own trusted-broker-owned,
-    // fully empty metadata directory. Fresh pre-retirement planning
-    // (`retire()`'s initial enumeration) must remain exactly as
-    // strict as before.
-    // -------------------------------------------------------------
-
-    #[test]
-    fn execute_retire_finishes_a_generation_crashed_immediately_after_material_unlink() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "crash-after-material-unlink";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        // Simulate the crash: `remove_generation` already unlinked
-        // `material` but the process died before it removed the
-        // now-empty epoch directory entry itself.
-        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
-        assert_eq!(std::fs::read_dir(&gen_dir).unwrap().count(), 0);
-
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        remove_current_symlink(secrets_fd.as_fd()).unwrap();
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: vec![],
-            high_water_epoch: 1,
-            phase: RetirePhase::CurrentRemoved,
-        };
-        execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap();
-
-        assert!(!gen_dir.exists());
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert!(marker.retired);
-        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_none());
-    }
-
-    #[test]
-    fn execute_retire_cleans_up_mixed_crashed_and_still_materialized_generations() {
-        // A multi-generation retry: one epoch was left in the empty
-        // post-material-unlink checkpoint by a prior crashed attempt,
-        // another is still fully materialized and was never touched.
-        // Both must be correctly removed in one pass.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "mixed-crash-retry";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        let gen1_dir = generations_dir.join("1");
-        let gen2_dir = generations_dir.join("2");
-        // Epoch 1: crashed mid-deletion (material unlinked, directory
-        // left behind). Epoch 2: untouched, still fully materialized.
-        std::fs::remove_file(gen1_dir.join(MATERIAL_FILE_NAME)).unwrap();
-        assert_eq!(std::fs::read_dir(&gen1_dir).unwrap().count(), 0);
-        assert!(gen2_dir.join(MATERIAL_FILE_NAME).exists());
-
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        remove_current_symlink(secrets_fd.as_fd()).unwrap();
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1, 2],
-            stage_names: vec![],
+    fn concurrent_cas_commit_race_one_wins_one_fenced_with_zero_mutation() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+
+        // Two callers both read the same pre-rotate state...
+        let (state_a, ownership_a) = port.read_state(&wl, KIND).unwrap();
+        let (state_b, ownership_b) = port.read_state(&wl, KIND).unwrap();
+        assert_eq!(ownership_a, ownership_b);
+
+        // ...and both compute a next state for epoch 2.
+        let next_a = DurableState {
             high_water_epoch: 2,
-            phase: RetirePhase::CurrentRemoved,
-        };
-        execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap();
-
-        assert!(!gen1_dir.exists());
-        assert!(!gen2_dir.exists());
-        assert_eq!(std::fs::read_dir(&generations_dir).unwrap().count(), 0);
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert!(marker.retired);
-    }
-
-    #[test]
-    fn resumed_generation_deletion_retries_a_failed_directory_fsync() {
-        // Fault-inject the trailing `fsync_fd(generations_fd)` barrier
-        // specifically while finishing a crash-left empty checkpoint:
-        // the failure must block phase advancement rather than being
-        // silently swallowed, and a bare retry (no other mutation)
-        // must complete the whole retirement.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "resumed-deletion-fsync-fault";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
-
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        remove_current_symlink(secrets_fd.as_fd()).unwrap();
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: vec![],
-            high_water_epoch: 1,
-            phase: RetirePhase::CurrentRemoved,
-        };
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = execute_retire(
-                secrets_fd.as_fd(),
-                generations_fd.as_fd(),
-                &cfg,
-                intent.clone(),
-            )
-            .unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // The directory entry itself was already removed by
-        // `remove_generation` before the fsync it retried failed; the
-        // retry below must not require the entry to still be present.
-        assert!(!gen_dir.exists());
-        execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap();
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert!(marker.retired);
-    }
-
-    #[test]
-    fn revalidate_generation_before_delete_rejects_a_fake_empty_directory_with_wrong_mode() {
-        // An empty directory alone is not sufficient: it must also
-        // still be trusted-broker-owned at the expected mode. A
-        // foreign/incorrectly-moded replacement fails closed rather
-        // than being swept away as "finishing" a legitimate deletion.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths =
-            derive_paths("fake-empty-wrong-mode", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
-        assert_eq!(std::fs::read_dir(&gen_dir).unwrap().count(), 0);
-        let mut perms = std::fs::metadata(&gen_dir).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&gen_dir, perms).unwrap();
-
-        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1, &cfg).unwrap_err();
-        assert_eq!(err, FailReason::RetirementTreeAnomaly);
-        // Nothing was deleted: the anomaly is detected, not swept.
-        assert!(gen_dir.exists());
-    }
-
-    #[test]
-    fn revalidate_generation_before_delete_rejects_an_empty_looking_directory_with_a_stray_entry() {
-        // Zero *recognized* entries is required, not merely "no
-        // `material`". An unrelated leftover entry alongside a
-        // missing `material` must still fail closed.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let paths =
-            derive_paths("fake-empty-stray-entry", SecretKind::GuestSigningKey, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
-        std::fs::write(gen_dir.join("rogue"), b"unexpected").unwrap();
-
-        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1, &cfg).unwrap_err();
-        assert_eq!(err, FailReason::RetirementTreeAnomaly);
-        assert!(gen_dir.exists());
-    }
-
-    #[test]
-    fn fresh_retire_over_a_crashed_generation_checkpoint_still_fails_closed() {
-        // The empty-checkpoint acceptance is reachable *only* from the
-        // retire txlog-recovery deletion loop. A brand-new, fresh call
-        // to `retire()` (no leftover txlog) must still go through the
-        // strict initial enumeration and fail closed over the exact
-        // same on-disk state the crash-recovery tests above complete
-        // successfully.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "fresh-retire-over-crash-state";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
-
-        let err = retire(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::PreviouslyProvisionedMaterialMissing);
-        // Fails closed without deleting anything.
-        assert!(gen_dir.exists());
-    }
-
-    // -------------------------------------------------------------
-    // Round-6 finding 1: promotion recovery phase-ordering
-    // -------------------------------------------------------------
-
-    #[test]
-    fn epoch_ready_recovery_rejects_a_tampered_freshly_created_target_before_swapping_current() {
-        // `EpochReady` recovery resuming in a separate invocation must
-        // re-verify the intended target's digest BEFORE swapping
-        // `current` -- a target tampered between `Planned` (in one
-        // process) and `EpochReady` recovery (in another) must never
-        // be activated.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "epoch-ready-tamper-fresh";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        // Tamper the target epoch's material after it was promoted,
-        // simulating drift between the crashed attempt and this
-        // recovery pass.
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::write(gen_dir.join(MATERIAL_FILE_NAME), b"tampered").unwrap();
-
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::EpochReady,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::RecoveryContentMismatch);
-        // `current` was never swapped.
-        assert!(!current_resolves_exactly_to(secrets_fd.as_fd(), 1));
-        assert!(read_marker(secrets_fd.as_fd()).unwrap().is_none());
-    }
-
-    #[test]
-    fn epoch_ready_recovery_rejects_a_tampered_rollback_target_before_swapping_current() {
-        // Rollback's `EpochReady` recovery must re-run the full
-        // owner/mode/ACL/nlink/digest/inode comparison against
-        // `expected_identity` before swapping `current`, not merely
-        // trust that `Planned` already checked it in an earlier
-        // invocation.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "epoch-ready-tamper-rollback";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Capture the *correct* identity of epoch 1 (the rollback
-        // target) before tampering.
-        let expected = capture_identity(generations_fd.as_fd(), 1).unwrap();
-        // Tamper the rollback target's mode after the identity was
-        // captured/recorded into the intent.
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::set_permissions(
-            gen_dir.join(MATERIAL_FILE_NAME),
-            std::fs::Permissions::from_mode(0o777),
-        )
-        .unwrap();
-
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rollback,
-            to_epoch: 1,
-            create_epoch: false,
-            stage_name: random_stage_name(),
-            expected_digest_hex: expected.digest_hex.clone(),
-            expected_identity: Some(expected),
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::EpochReady,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::IdentityModeMismatch);
-        // `current` must still resolve to the pre-rollback active
-        // epoch (2), never having been swapped toward the tampered
-        // target.
-        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 2));
-    }
-
-    #[test]
-    fn current_promoted_recovery_rejects_a_tampered_carry_previous_before_marker_write() {
-        // `CurrentPromoted` recovery must re-verify `carry_previous`'s
-        // on-disk identity before writing it into the marker's
-        // `previous` field -- a `previous` generation tampered between
-        // intent-build time and this recovery pass must never be
-        // asserted as still-valid marker state.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "current-promoted-tamper-previous";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let carry_previous = capture_identity(generations_fd.as_fd(), 1).unwrap();
-        // Tamper epoch 1 (the carried-forward `previous`) after its
-        // identity was captured -- change its content (and therefore
-        // digest) so the tamper is unambiguous regardless of the
-        // material file's original mode.
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::write(gen_dir.join(MATERIAL_FILE_NAME), b"tampered-previous").unwrap();
-
-        let mat = material(b"e2");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
-            .unwrap();
-        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
-
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: Some(carry_previous),
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::CurrentPromoted,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::IdentityDigestMismatch);
-        // The pre-existing (provision-time) marker must be untouched:
-        // no marker claiming epoch 2 active was ever written.
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        assert_eq!(marker.active.unwrap().epoch, 1);
-    }
-
-    #[test]
-    fn marker_committed_recovery_rejects_a_marker_vm_kind_mismatch() {
-        // A marker whose `active`/`previous` line up with the intent
-        // but whose `vm`/`kind` do not must still be rejected --
-        // proves the vm/kind check is independent of the
-        // active/previous comparison.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "mc-vm-kind-mismatch";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let mat = material(b"e1");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
-            .unwrap();
-        atomic_swap_current(secrets_fd.as_fd(), 1).unwrap();
-        let identity = capture_identity(generations_fd.as_fd(), 1).unwrap();
-        let wrong_kind_marker = MarkerData {
-            v: MARKER_SCHEMA_VERSION,
-            vm: vm.to_owned(),
-            // Wrong kind slug, everything else matches.
-            kind: SecretKind::SecurityKeyChannelState.as_slug().to_owned(),
+            active: Some(GenerationRecord::new(
+                Epoch::from_raw(2).unwrap(),
+                "a".repeat(64),
+            )),
+            previous: state_a.active.clone(),
             retired: false,
-            high_water_epoch: 1,
-            active: Some(identity),
-            previous: None,
-            first_provisioned_ms: now_ms(),
-            updated_ms: now_ms(),
+            pending_prune: Vec::new(),
         };
-        write_marker(secrets_fd.as_fd(), &wrong_kind_marker).unwrap();
+        let next_b = DurableState {
+            high_water_epoch: 2,
+            active: Some(GenerationRecord::new(
+                Epoch::from_raw(2).unwrap(),
+                "b".repeat(64),
+            )),
+            previous: state_b.active.clone(),
+            retired: false,
+            pending_prune: Vec::new(),
+        };
 
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name,
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: None,
-            prune_epoch: None,
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::MarkerCommitted,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::RecoveryAmbiguous);
+        let winner = port.cas_commit(&wl, KIND, ownership_a, next_a.clone());
+        assert!(winner.is_ok(), "the first committer must win");
+        let loser = port.cas_commit(&wl, KIND, ownership_b, next_b);
+        assert_eq!(loser, Err(PortError::OwnershipFenced));
+
+        // The loser's attempt must not have mutated anything: the
+        // winner's own state is exactly what is committed.
+        assert_eq!(port.raw_state(&wl, KIND).unwrap(), next_a);
     }
 
     #[test]
-    fn marker_committed_recovery_rejects_a_previous_mismatch() {
-        // Active epoch/digest agree, but the marker's `previous` does
-        // not match `intent.carry_previous` -- must still be rejected
-        // as its own, independent check.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "mc-previous-mismatch";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Marker on disk (from the real rotate) correctly carries
-        // previous = epoch 1. Build an intent claiming a *different*
-        // (nonexistent) previous epoch.
-        let bogus_previous = MaterialIdentity {
-            epoch: 1,
-            dev: 0,
-            ino: 0,
-            uid: 0,
-            gid: 0,
-            mode: 0o600,
-            nlink: 1,
-            has_acl: false,
-            digest_hex: "0".repeat(64),
-        };
-        let mat = material(b"e2");
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: 2,
-            create_epoch: true,
-            stage_name: random_stage_name(),
-            expected_digest_hex: mat.digest_hex(),
-            expected_identity: None,
-            carry_previous: Some(bogus_previous),
-            prune_epoch: None,
-            new_high_water_epoch: 2,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::MarkerCommitted,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::RecoveryAmbiguous);
-    }
-
-    #[test]
-    fn marker_committed_recovery_rejects_pruning_the_markers_own_active_epoch() {
-        // Defense in depth: even though `validate_promote_intent_
-        // semantics` already rejects `prune_epoch == to_epoch`/
-        // `carry_previous.epoch` as an intrinsic intent-shape check,
-        // `MarkerCommitted` recovery must independently re-derive the
-        // same guarantee from the marker actually read from disk.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "mc-prune-collision";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        let active = marker.active.clone().unwrap();
-
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Provision,
-            to_epoch: 1,
-            create_epoch: true,
-            stage_name: random_stage_name(),
-            expected_digest_hex: active.digest_hex.clone(),
-            expected_identity: None,
-            carry_previous: None,
-            // Hand-edited/corrupted txlog: prune targets the marker's
-            // own active epoch.
-            prune_epoch: Some(1),
-            new_high_water_epoch: 1,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::MarkerCommitted,
-        };
-        let err = execute_promote(
-            secrets_fd.as_fd(),
-            generations_fd.as_fd(),
-            &cfg,
-            intent,
-            None,
-        )
-        .unwrap_err();
-        assert_eq!(err, FailReason::RecoveryAmbiguous);
-        // Nothing was pruned.
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
-    }
-
-    #[test]
-    fn marker_committed_prune_fsync_failure_retains_txlog_for_retry() {
-        // Pruning durability: if `remove_generation` succeeds in
-        // deleting content but its trailing `generations/` directory
-        // fsync fails, the already-durable `MarkerCommitted` txlog
-        // must be retained (never cleared) so a later recovery pass
-        // resumes exactly here and retries the barrier.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "mc-prune-fsync-retry";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        let active = marker.active.clone().unwrap();
-        let previous = marker.previous.clone();
-
-        // Stage an extra leftover generation the prune step is free
-        // to target so the fsync-failure path is genuinely exercised
-        // through `remove_generation`, not skipped for lack of a
-        // prune target.
-        let stray_mat = material(b"stray");
-        let stray_stage = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stray_stage,
-            &stray_mat.digest_hex(),
-            Some(&stray_mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(
-            generations_fd.as_fd(),
-            &stray_stage,
-            99,
-            &stray_mat.digest_hex(),
-        )
-        .unwrap();
-
-        let intent = PromoteIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            action: LifecycleAction::Rotate,
-            to_epoch: active.epoch,
-            create_epoch: true,
-            stage_name: random_stage_name(),
-            expected_digest_hex: active.digest_hex.clone(),
-            expected_identity: None,
-            carry_previous: previous,
-            prune_epoch: Some(99),
-            new_high_water_epoch: active.epoch,
-            first_provisioned_ms: now_ms(),
-            phase: PromotePhase::MarkerCommitted,
-        };
-        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone())).unwrap();
-
-        {
-            let _fault = FsyncFaultGuard::enable();
-            let err = execute_promote(
-                secrets_fd.as_fd(),
-                generations_fd.as_fd(),
-                &cfg,
-                intent,
-                None,
-            )
-            .unwrap_err();
-            assert_eq!(err, FailReason::FsyncFailed);
-        }
-        // The txlog must still be present: the prune failure must not
-        // have caused `remove_txlog` to run.
-        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_some());
-    }
-
-    // -------------------------------------------------------------
-    // Round-6 finding 2: retire recovery phase-ordering /
-    // phase-authority checks
-    // -------------------------------------------------------------
-
-    #[test]
-    fn enumerated_phase_rejects_a_marker_disagreeing_with_live_state_before_removing_current() {
-        // `execute_retire`'s own `Enumerated` handler (exercised
-        // directly here the way a separate recovery-invocation would
-        // resume it) must re-read and fully validate the marker
-        // against live state before its first mutation
-        // (`remove_current_symlink`) -- not merely trust a validation
-        // that may have run in an earlier, different process
-        // invocation.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "enumerated-marker-mismatch";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Corrupt the marker's recorded digest without touching the
-        // real on-disk generation content.
-        let mut marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
-        marker.active.as_mut().unwrap().digest_hex = "0".repeat(64);
-        write_marker(secrets_fd.as_fd(), &marker).unwrap();
-
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: Vec::new(),
-            high_water_epoch: 1,
-            phase: RetirePhase::Enumerated,
-        };
-        let err =
-            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
-        assert_eq!(err, FailReason::IdentityDigestMismatch);
-        // Nothing was deleted: `current` and the generation are both
-        // still intact.
-        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 1));
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
-    }
-
-    #[test]
-    fn current_removed_phase_rejects_resumption_when_current_still_present() {
-        // Phase-authority check: a txlog resuming at `CurrentRemoved`
-        // asserts, by construction, that `Enumerated` already removed
-        // `current`. A hand-edited/corrupted txlog claiming this
-        // phase over a still-present `current` must fail closed
-        // before deleting any generation.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "current-removed-still-present";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // `current` is deliberately left in place, unlike the
-        // legitimate `CurrentRemoved` precondition.
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: Vec::new(),
-            high_water_epoch: 1,
-            phase: RetirePhase::CurrentRemoved,
-        };
-        let err =
-            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
-        assert_eq!(err, FailReason::RecoveryAmbiguous);
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
-    }
-
-    #[test]
-    fn epochs_removed_phase_rejects_resumption_when_current_still_present() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "epochs-removed-still-present";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: Vec::new(),
-            high_water_epoch: 1,
-            phase: RetirePhase::EpochsRemoved,
-        };
-        let err =
-            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
-        assert_eq!(err, FailReason::RecoveryAmbiguous);
-        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
-        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
-    }
-
-    #[test]
-    fn proven_empty_phase_rejects_resumption_when_tree_is_no_longer_empty() {
-        // Never write the tombstone marker on the strength of a
-        // *previous* invocation's emptiness proof alone: a persisted
-        // txlog resuming at `ProvenEmpty` must re-prove the tree is
-        // still empty immediately before this phase's otherwise-
-        // unconditional mutation.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "proven-empty-reappeared";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Simulate a generation reappearing between `EpochsRemoved`
-        // and this resumed `ProvenEmpty` pass (e.g. a foreign actor,
-        // or a bug elsewhere) by planting one directly.
-        let mat = material(b"reappeared");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 5, &mat.digest_hex())
+    fn quarantine_is_permanent_and_blocks_every_port_method() {
+        let port = FakePort::new();
+        let wl = wl_a();
+        provision(&port, &wl, KIND, material(b"gen1")).unwrap();
+        port.quarantine(&wl, KIND, QuarantineReason::StateSelfInconsistent)
             .unwrap();
 
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: Vec::new(),
-            high_water_epoch: 1,
-            phase: RetirePhase::ProvenEmpty,
-        };
-        let err =
-            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
-        assert_eq!(err, FailReason::RetirementNotProvablyEmpty);
-        // No tombstone marker was written.
-        assert!(read_marker(secrets_fd.as_fd()).unwrap().is_none());
-    }
-
-    #[test]
-    fn proven_empty_phase_rejects_resumption_when_current_still_present() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "proven-empty-current-present";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // `current` still resolves to epoch 1 even though the txlog
-        // claims the tree has already been proven empty.
-        let intent = RetireIntent {
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            epochs: vec![1],
-            stage_names: Vec::new(),
-            high_water_epoch: 1,
-            phase: RetirePhase::ProvenEmpty,
-        };
-        let err =
-            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
-        assert_eq!(err, FailReason::RecoveryAmbiguous);
-        assert!(
-            read_marker(secrets_fd.as_fd())
-                .unwrap()
-                .unwrap()
-                .active
-                .is_some()
+        assert_eq!(
+            port.read_state(&wl, KIND).unwrap_err(),
+            PortError::Quarantined
         );
-    }
+        assert_eq!(
+            port.stage_material(&wl, KIND, Epoch::from_raw(2).unwrap(), &material(b"x"))
+                .unwrap_err(),
+            PortError::Quarantined
+        );
+        assert_eq!(
+            port.material_digest(&wl, KIND, Epoch::FIRST).unwrap_err(),
+            PortError::Quarantined
+        );
+        assert_eq!(
+            port.cas_commit(
+                &wl,
+                KIND,
+                OwnershipEpoch::NEVER_COMMITTED,
+                DurableState::never_provisioned()
+            )
+            .unwrap_err(),
+            PortError::Quarantined
+        );
+        assert_eq!(
+            port.prune_material(&wl, KIND, Epoch::FIRST).unwrap_err(),
+            PortError::Quarantined
+        );
 
-    // -------------------------------------------------------------
-    // Round-6 finding 5: inactive/tombstone marker validation
-    // -------------------------------------------------------------
-
-    #[test]
-    fn open_and_recover_rejects_an_inactive_marker_with_lingering_previous() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "inactive-lingering-previous";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let bogus_previous = MaterialIdentity {
-            epoch: 1,
-            dev: 0,
-            ino: 0,
-            uid: 0,
-            gid: 0,
-            mode: 0o600,
-            nlink: 1,
-            has_acl: false,
-            digest_hex: "0".repeat(64),
-        };
-        let marker = MarkerData {
-            v: MARKER_SCHEMA_VERSION,
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            retired: false,
-            high_water_epoch: 0,
-            active: None,
-            // Inactive marker with a lingering `previous` -- always
-            // tamper/corruption, never a legitimate write-path shape.
-            previous: Some(bogus_previous),
-            first_provisioned_ms: 0,
-            updated_ms: now_ms(),
-        };
-        write_marker(secrets_fd.as_fd(), &marker).unwrap();
-        drop(secrets_fd);
-
-        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::MarkerTamperedOrMissingMaterial);
+        for outcome in [
+            provision(&port, &wl, KIND, material(b"x"))
+                .map(|_| ())
+                .unwrap_err()
+                .reason,
+            rotate(&port, &wl, KIND, material(b"x"))
+                .map(|_| ())
+                .unwrap_err()
+                .reason,
+            rollback(&port, &wl, KIND).map(|_| ()).unwrap_err().reason,
+            retire(&port, &wl, KIND).map(|_| ()).unwrap_err().reason,
+        ] {
+            assert_eq!(outcome, FailReason::Quarantined);
+        }
     }
 
     #[test]
-    fn open_and_recover_rejects_a_tombstone_with_zero_high_water() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "tombstone-zero-high-water";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let marker = MarkerData {
-            v: MARKER_SCHEMA_VERSION,
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            // A tombstone claiming `retired == true` must always
-            // carry the real epoch count that was retired.
-            retired: true,
-            high_water_epoch: 0,
-            active: None,
-            previous: None,
-            first_provisioned_ms: 0,
-            updated_ms: now_ms(),
-        };
-        write_marker(secrets_fd.as_fd(), &marker).unwrap();
-        drop(secrets_fd);
+    fn two_distinct_workloads_never_interfere() {
+        let port = FakePort::new();
+        let wl_x = wl_a();
+        let wl_y = wl_b();
+        provision(&port, &wl_x, KIND, material(b"x-gen1")).unwrap();
+        provision(&port, &wl_y, KIND, material(b"y-gen1")).unwrap();
+        retire(&port, &wl_x, KIND).unwrap();
 
-        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::MarkerTamperedOrMissingMaterial);
-    }
-
-    #[test]
-    fn open_and_recover_rejects_a_never_provisioned_marker_with_nonzero_high_water() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "never-provisioned-nonzero-high-water";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let marker = MarkerData {
-            v: MARKER_SCHEMA_VERSION,
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            retired: false,
-            // Never-provisioned but claims a nonzero high-water --
-            // has no legitimate write path.
-            high_water_epoch: 3,
-            active: None,
-            previous: None,
-            first_provisioned_ms: 0,
-            updated_ms: now_ms(),
-        };
-        write_marker(secrets_fd.as_fd(), &marker).unwrap();
-        drop(secrets_fd);
-
-        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::MarkerTamperedOrMissingMaterial);
-    }
-
-    #[test]
-    fn open_and_recover_rejects_an_inactive_marker_over_a_stale_foreign_current() {
-        // Never treat an inactive marker as consistent (let alone
-        // `verified_clean`) over a stale, foreign, or otherwise
-        // still-present `current` entry.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "inactive-stale-current";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        // Plant a foreign `current` pointing at a real-looking, but
-        // never-recorded, generation.
-        let mat = material(b"foreign");
-        let stage_name = random_stage_name();
-        ensure_staged(
-            generations_fd.as_fd(),
-            &cfg,
-            &stage_name,
-            &mat.digest_hex(),
-            Some(&mat),
-        )
-        .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 7, &mat.digest_hex())
-            .unwrap();
-        atomic_swap_current(secrets_fd.as_fd(), 7).unwrap();
-        // Marker claims a clean, never-provisioned state -- disagrees
-        // with the live `current`.
-        let marker = MarkerData {
-            v: MARKER_SCHEMA_VERSION,
-            vm: vm.to_owned(),
-            kind: kind.as_slug().to_owned(),
-            retired: false,
-            high_water_epoch: 0,
-            active: None,
-            previous: None,
-            first_provisioned_ms: 0,
-            updated_ms: now_ms(),
-        };
-        write_marker(secrets_fd.as_fd(), &marker).unwrap();
-        drop(secrets_fd);
-        drop(generations_fd);
-
-        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IdentityCurrentTargetMismatch);
-    }
-
-    #[test]
-    fn retire_verified_clean_rejects_when_current_present_despite_missing_marker() {
-        // Symmetric to "missing marker never implies clean storage":
-        // when the marker file is entirely absent (so
-        // `verify_marker_against_live_state` never runs at all) and
-        // the physical generation tree is empty, `retire()`'s own
-        // `verified_clean` path must still independently check
-        // `current` itself, rather than declare clean storage over a
-        // stale/foreign `current` entry.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "verified-clean-stale-current";
-        let kind = SecretKind::GuestSigningKey;
-        provision(vm, kind, material(b"e1"), &cfg).unwrap();
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        // Remove the generation content and the marker, but leave
-        // `current` behind pointing at the now-vanished epoch --
-        // exactly the pathological "empty tree, no marker, but
-        // current still present" state.
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
-        std::fs::remove_dir(&gen_dir).unwrap();
-        std::fs::remove_file(paths.kind_root.join(MARKER_FILE_NAME)).unwrap();
-
-        let err = retire(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::IdentityCurrentTargetMismatch);
-    }
-
-    // -------------------------------------------------------------
-    // Round-6 finding 6: material read type/size hardening
-    // -------------------------------------------------------------
-
-    #[test]
-    fn capture_identity_rejects_an_oversized_material_file_without_reading_it_whole() {
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "oversized-material-read";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::create_dir(&gen_dir).unwrap();
-        // Plant a file larger than the closed read cap directly
-        // (bypassing `SecretMaterial`'s own constructor-time size
-        // check) to prove the *read layer* itself also refuses to
-        // read an oversized on-disk entry.
-        let oversized = vec![0u8; SecretMaterial::MAX_LEN + 2];
-        std::fs::write(gen_dir.join(MATERIAL_FILE_NAME), &oversized).unwrap();
-
-        let err = capture_identity(generations_fd.as_fd(), 1).unwrap_err();
-        assert_eq!(err, FailReason::PreviouslyProvisionedMaterialMissing);
-    }
-
-    #[test]
-    fn capture_identity_rejects_a_fifo_planted_at_the_material_path() {
-        // A FIFO planted at the material path must be rejected before
-        // any read is attempted -- opened non-blocking specifically
-        // so this can never hang indefinitely.
-        let dir = tempdir().unwrap();
-        let cfg = cfg_at(dir.path());
-        let vm = "fifo-material-read";
-        let kind = SecretKind::GuestSigningKey;
-        let paths = derive_paths(vm, kind, &cfg).unwrap();
-        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
-        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
-        std::fs::create_dir(&gen_dir).unwrap();
-        let material_path = gen_dir.join(MATERIAL_FILE_NAME);
-        nix::unistd::mkfifo(
-            &material_path,
-            nix::sys::stat::Mode::from_bits_truncate(0o600),
-        )
-        .unwrap();
-
-        let err = capture_identity(generations_fd.as_fd(), 1).unwrap_err();
-        assert_eq!(err, FailReason::PreviouslyProvisionedMaterialMissing);
+        assert!(port.raw_state(&wl_x, KIND).unwrap().retired);
+        assert!(!port.raw_state(&wl_y, KIND).unwrap().retired);
+        assert_eq!(port.raw_material_epochs(&wl_y, KIND), vec![1]);
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
@@ -493,21 +493,33 @@ impl std::fmt::Display for SecretsLifecycleError {
 
 impl std::error::Error for SecretsLifecycleError {}
 
-fn denied(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> SecretsLifecycleError {
+/// `recovered` must reflect whether this call already successfully
+/// drained a leftover crashed transaction (via [`open_and_recover`])
+/// before reaching this denial — see
+/// [`SecretsLifecycleAuditFields::denied`].
+fn denied(
+    ctx: &SecretsLifecycleAuditContext,
+    recovered: bool,
+    reason: FailReason,
+) -> SecretsLifecycleError {
     SecretsLifecycleError {
         reason,
-        audit: SecretsLifecycleAuditFields::denied(ctx, reason),
+        audit: SecretsLifecycleAuditFields::denied(ctx, recovered, reason),
     }
 }
 
+/// `recovered` must reflect whether this call already successfully
+/// drained a leftover crashed transaction before this failure — see
+/// [`SecretsLifecycleAuditFields::failed`].
 fn failed_closed(
     ctx: &SecretsLifecycleAuditContext,
+    recovered: bool,
     marker_result: MarkerResult,
     reason: FailReason,
 ) -> SecretsLifecycleError {
     SecretsLifecycleError {
         reason,
-        audit: SecretsLifecycleAuditFields::failed(ctx, marker_result, reason),
+        audit: SecretsLifecycleAuditFields::failed(ctx, recovered, marker_result, reason),
     }
 }
 
@@ -663,7 +675,7 @@ fn validate_promote_intent_semantics(
         return Err(FailReason::IntentCorrupt);
     }
     if intent.create_epoch {
-        if intent.stage_name.is_empty() || !intent.stage_name.starts_with(STAGE_PREFIX) {
+        if intent.stage_name.is_empty() || !is_well_formed_stage_name(&intent.stage_name) {
             return Err(FailReason::IntentCorrupt);
         }
         if intent.expected_identity.is_some() {
@@ -674,7 +686,9 @@ fn validate_promote_intent_semantics(
             return Err(FailReason::IntentCorrupt);
         }
         match &intent.expected_identity {
-            Some(identity) if identity.epoch == intent.to_epoch => {}
+            Some(identity)
+                if identity.epoch == intent.to_epoch
+                    && identity.digest_hex == intent.expected_digest_hex => {}
             _ => return Err(FailReason::IntentCorrupt),
         }
     }
@@ -726,7 +740,7 @@ fn validate_retire_intent_semantics(
         || intent
             .stage_names
             .iter()
-            .any(|s| !s.starts_with(STAGE_PREFIX))
+            .any(|s| !is_well_formed_stage_name(s))
     {
         return Err(FailReason::IntentCorrupt);
     }
@@ -977,6 +991,27 @@ fn random_stage_name() -> String {
     format!("{STAGE_PREFIX}{}", hex_encode(&digest[..16]))
 }
 
+/// The exact closed syntax [`random_stage_name`] always produces:
+/// `STAGE_PREFIX` followed by exactly 32 lowercase-hex characters, as
+/// one single path component with no separator or parent-reference
+/// syntax. Used to validate every stage name that originates from a
+/// txlog (fresh construction *and* recovery reload) before it is ever
+/// used as an anchored path component -- a corrupted or hand-edited
+/// txlog containing `/`, `..`, or any other value must never reach an
+/// `openat`-family call.
+fn is_well_formed_stage_name(name: &str) -> bool {
+    if name.contains('/') || name.contains("..") {
+        return false;
+    }
+    let Some(suffix) = name.strip_prefix(STAGE_PREFIX) else {
+        return false;
+    };
+    suffix.len() == 32
+        && suffix
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b.is_ascii_lowercase() && b.is_ascii_hexdigit()))
+}
+
 fn parse_strict_epoch(name: &str) -> Option<u64> {
     if name.is_empty() || !name.bytes().all(|b| b.is_ascii_digit()) {
         return None;
@@ -1035,6 +1070,52 @@ fn validate_stage_dir_contents(generations_fd: &OwnedFd, name: &str) -> Result<(
     Ok(())
 }
 
+/// Immediately before deleting a `.stage-*` directory, re-stat it
+/// (nofollow, anchored) and confirm it is still exactly a validated
+/// stage directory. Mirrors [`revalidate_generation_before_delete`]
+/// for stage directories: a missing entry is tolerated (another pass,
+/// or this same pass on retry, already removed it); any other anomaly
+/// injected between enumeration and deletion -- an extra entry, a
+/// subdirectory, a hard-linked file -- fails closed rather than
+/// deleting a directory that no longer matches what was originally
+/// validated.
+fn revalidate_stage_before_delete(
+    generations_fd: BorrowedFd<'_>,
+    name: &str,
+) -> Result<(), FailReason> {
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    match path_safe::fstatat_nofollow(&generations_owned, name) {
+        Ok(Some(_)) => validate_stage_dir_contents(&generations_owned, name),
+        Ok(None) => Ok(()),
+        Err(_) => Err(FailReason::RetirementTreeAnomaly),
+    }
+}
+
+/// Discard a partially-staged `.stage-*` directory left behind by a
+/// crashed attempt that never reached a fully-staged, digest-matching
+/// state (so [`ensure_staged`] returned `Ok(false)` on recovery
+/// re-entry and there is no material to promote). No-ops if the stage
+/// directory is absent (the common, no-crash path, or a retry that
+/// already discarded it). If present, validates its contents are
+/// consistent with a partial/superseded staging attempt and deletes
+/// it -- propagating any validation or deletion failure so the caller
+/// never abandons the txlog record while leaving an orphaned,
+/// unvalidated stage directory on disk.
+fn discard_partial_stage_if_present(
+    generations_fd: BorrowedFd<'_>,
+    stage_name: &str,
+) -> Result<(), FailReason> {
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    match path_safe::fstatat_nofollow(&generations_owned, stage_name) {
+        Ok(Some(_)) => {
+            validate_stage_dir_contents(&generations_owned, stage_name)?;
+            remove_stage_dir(generations_fd, stage_name)
+        }
+        Ok(None) => Ok(()),
+        Err(_) => Err(FailReason::RetirementTreeAnomaly),
+    }
+}
+
 /// Fully delete one `.stage-*` directory: enumerate every child,
 /// delete each one (propagating any failure other than the child
 /// already being absent), prove the directory is observably empty,
@@ -1051,7 +1132,18 @@ fn remove_stage_dir(generations_fd: BorrowedFd<'_>, name: &str) -> Result<(), Fa
         OFlags::RDONLY | OFlags::DIRECTORY,
     ) {
         Ok(fd) => fd,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            // Already gone. This may be a durable retry re-observing
+            // a completed deletion, or it may be a retry re-observing
+            // a deletion whose *own* trailing
+            // `fsync_fd(generations_fd)` failed before the caller
+            // could advance the phase. Retry that durability barrier
+            // now rather than assuming the earlier attempt's fsync
+            // (which we cannot distinguish from "never happened")
+            // actually completed.
+            fsync_fd(generations_fd)?;
+            return Ok(());
+        }
         Err(_) => return Err(FailReason::RetirementTreeAnomaly),
     };
     let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
@@ -1337,9 +1429,36 @@ fn atomic_swap_current(secrets_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), Fai
     }
     let owned = borrowed_to_owned(secrets_fd)?;
     let target = expected_current_target(epoch);
-    // Best-effort cleanup of a leftover stage symlink from a previous
-    // crash between symlink-creation and rename.
-    let _ = path_safe::remove_path_safe(&owned, CURRENT_SWAP_STAGE_NAME);
+    // Clean up a leftover swap-stage entry from a previous crash
+    // between symlink-creation and rename. `CURRENT_SWAP_STAGE_NAME`
+    // is only ever created via `symlinkat`, so
+    // `path_safe::remove_path_safe` (which refuses to operate on
+    // symlinks by design) can never actually remove it -- using it
+    // here would silently leave the stale symlink in place and the
+    // following `symlinkat` would then fail closed with `EEXIST`
+    // every retry. Instead: nofollow-stat the slot; if absent, there
+    // is nothing to clean up; if present and exactly a symlink,
+    // `unlinkat` it; if present but *not* a symlink (an anomaly no
+    // legitimate code path produces), fail closed rather than
+    // deleting an unexpected entry.
+    match path_safe::fstatat_nofollow(&owned, CURRENT_SWAP_STAGE_NAME)
+        .map_err(|_| FailReason::CurrentSwapFailed)?
+    {
+        None => {}
+        Some(stat) => {
+            if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFLNK {
+                return Err(FailReason::CurrentSwapFailed);
+            }
+            match rustix::fs::unlinkat(
+                secrets_fd,
+                Path::new(CURRENT_SWAP_STAGE_NAME),
+                rustix::fs::AtFlags::empty(),
+            ) {
+                Ok(()) | Err(rustix::io::Errno::NOENT) => {}
+                Err(_) => return Err(FailReason::CurrentSwapFailed),
+            }
+        }
+    }
     rustix::fs::symlinkat(&target, secrets_fd, Path::new(CURRENT_SWAP_STAGE_NAME))
         .map_err(|_| FailReason::CurrentSwapFailed)?;
     rustix::fs::renameat(
@@ -1386,7 +1505,16 @@ fn remove_generation(generations_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), F
         OFlags::RDONLY | OFlags::DIRECTORY,
     ) {
         Ok(fd) => fd,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            // Already gone -- but retry the trailing durability
+            // barrier in case a prior attempt deleted this entry and
+            // then failed its own `fsync_fd(generations_fd)` before
+            // the caller could advance the phase or commit a
+            // tombstone. Never assume that fsync happened just
+            // because the entry is absent.
+            fsync_fd(generations_fd)?;
+            return Ok(());
+        }
         Err(_) => return Err(FailReason::RetirementTreeAnomaly),
     };
     let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
@@ -1438,7 +1566,17 @@ fn enumerate_and_validate_generation_tree(
             // separately-swept concern: validate their shape now and
             // carry them in the plan so retirement/pruning enumerates,
             // validates, and deletes them under the same accounting as
-            // generation epochs.
+            // generation epochs. Defense-in-depth: a live directory
+            // name matching the prefix but not the full closed
+            // `is_well_formed_stage_name` syntax (e.g. containing `/`
+            // or `..`, which the kernel would never actually produce
+            // as a single directory-entry name, or an unexpected
+            // length/charset) is treated as an anomaly rather than a
+            // stage directory this code will ever construct a path
+            // from.
+            if !is_well_formed_stage_name(&name) {
+                return Err(FailReason::RetirementTreeAnomaly);
+            }
             validate_stage_dir_contents(&generations_owned, &name)?;
             stage_names.push(name);
             continue;
@@ -1620,11 +1758,18 @@ fn execute_promote(
                         Some(digest) if digest == intent.expected_digest_hex => {
                             // The rename to the final epoch name
                             // already completed in a previous crashed
-                            // attempt (the phase-advance write itself
-                            // did not commit before the crash). The
-                            // epoch is fully materialized with exactly
-                            // the expected content: never abandon or
-                            // re-stage it, just continue forward.
+                            // attempt. The epoch is fully materialized
+                            // with exactly the expected content: never
+                            // abandon or re-stage it, just continue
+                            // forward. The crashed attempt's own
+                            // trailing `fsync_fd(generations_fd)`
+                            // inside `promote_stage_to_generation` may
+                            // be exactly what failed and caused the
+                            // crash before the phase could advance --
+                            // retry that durability barrier now rather
+                            // than trusting it silently already
+                            // happened.
+                            fsync_fd(generations_fd)?;
                         }
                         Some(_) => {
                             // Some directory already occupies this
@@ -1645,6 +1790,24 @@ fn execute_promote(
                                 material,
                             )?;
                             if !staged {
+                                // No fully-staged, digest-matching
+                                // material exists (this is either the
+                                // very first attempt with material
+                                // absent -- should not happen given
+                                // the public entry points always pass
+                                // material, but defensively handled --
+                                // or a recovery re-entry finding a
+                                // stage dir left in a partial state by
+                                // a crash between `mkdir_at_exclusive`
+                                // and the material write completing).
+                                // Never abandon a partial stage
+                                // directory silently: validate and
+                                // delete it (or fail closed) before
+                                // discarding the txlog record of it.
+                                discard_partial_stage_if_present(
+                                    generations_fd,
+                                    &intent.stage_name,
+                                )?;
                                 remove_txlog(secrets_fd)?;
                                 return Ok(PromoteOutcome::AbortedNoMaterial);
                             }
@@ -1673,6 +1836,15 @@ fn execute_promote(
                 write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
             }
             PromotePhase::CurrentPromoted => {
+                // Never write a marker claiming an active generation
+                // the live `current` symlink does not actually
+                // corroborate. A hand-edited/corrupted txlog claiming
+                // this phase over a `current` that does not resolve
+                // to `to_epoch` must fail closed here, before any
+                // marker mutation.
+                if !current_resolves_exactly_to(secrets_fd, intent.to_epoch) {
+                    return Err(FailReason::IdentityCurrentTargetMismatch);
+                }
                 let identity = capture_identity(generations_fd, intent.to_epoch)?;
                 if identity.digest_hex != intent.expected_digest_hex {
                     // `current` already points at this epoch; we must
@@ -1700,13 +1872,35 @@ fn execute_promote(
                 write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
             }
             PromotePhase::MarkerCommitted => {
+                // Phase-specific validation must occur before any
+                // recovery mutation (pruning, stage cleanup) or txlog
+                // removal: re-read and verify the marker actually
+                // reflects this transaction's intended active
+                // generation, and that `current` still corroborates
+                // it, before proceeding. A hand-edited/corrupted
+                // txlog claiming `MarkerCommitted` over a marker/
+                // current that disagree must fail closed here rather
+                // than pruning or discarding state based on an
+                // unverified assumption.
+                if !current_resolves_exactly_to(secrets_fd, intent.to_epoch) {
+                    return Err(FailReason::IdentityCurrentTargetMismatch);
+                }
+                let marker = read_marker(secrets_fd)?.ok_or(FailReason::MarkerWriteFailed)?;
+                let active_matches = marker.active.as_ref().is_some_and(|a| {
+                    a.epoch == intent.to_epoch && a.digest_hex == intent.expected_digest_hex
+                });
+                if !active_matches {
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
                 if let Some(prune) = intent.prune_epoch {
                     // Best-effort: pruning failure does not fail the
                     // action (the marker already durably reflects the
                     // correct active/previous state); it only leaves
                     // an orphaned generation directory for a future
                     // retire() to clean up via its full-tree
-                    // enumeration.
+                    // enumeration. Pruning only ever happens after the
+                    // marker commit that no longer references the
+                    // pruned epoch has been durably written above.
                     let _ = remove_generation(generations_fd, prune);
                 }
                 // Any leftover `.stage-*` directory at this point is a
@@ -1715,13 +1909,15 @@ fn execute_promote(
                 // promoted -- that one was already renamed away).
                 // Enumerate, validate, and delete it, propagating any
                 // failure: a stage directory is never swept on a
-                // best-effort basis.
+                // best-effort basis. Revalidate each immediately
+                // before deletion in case something changed between
+                // enumeration and delete.
                 let leftover = enumerate_and_validate_generation_tree(generations_fd)?;
                 for stage_name in leftover.stage_names {
+                    revalidate_stage_before_delete(generations_fd, &stage_name)?;
                     remove_stage_dir(generations_fd, &stage_name)?;
                 }
                 remove_txlog(secrets_fd)?;
-                let marker = read_marker(secrets_fd)?.ok_or(FailReason::MarkerWriteFailed)?;
                 return Ok(PromoteOutcome::Completed(marker));
             }
         }
@@ -1762,6 +1958,10 @@ fn execute_retire(
                     // Staged entries are real secret-tree contents:
                     // enumerate/validate/delete them exactly like
                     // generation epochs, propagating every failure.
+                    // Revalidate immediately before deletion in case
+                    // something changed between enumeration and
+                    // delete.
+                    revalidate_stage_before_delete(generations_fd, stage_name)?;
                     remove_stage_dir(generations_fd, stage_name)?;
                 }
                 intent.phase = RetirePhase::EpochsRemoved;
@@ -1859,17 +2059,18 @@ pub fn recover_in_flight_transaction(
                 action: LifecycleAction::Provision,
                 base_dir_hash: String::new(),
             },
+            false,
             reason,
         ),
     })?;
     let (secrets_fd, generations_fd) =
         open_or_create_secrets_dir(&paths, cfg).map_err(|reason| {
             let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
-            denied(&ctx, reason)
+            denied(&ctx, false, reason)
         })?;
     let _lock = acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| {
         let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
-        denied(&ctx, reason)
+        denied(&ctx, false, reason)
     })?;
     match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), vm_id, kind, cfg) {
         Ok(recovered) => Ok(recovered),
@@ -1880,7 +2081,12 @@ pub fn recover_in_flight_transaction(
                 err.action.unwrap_or(LifecycleAction::Provision),
                 &paths,
             );
-            Err(failed_closed(&ctx, MarkerResult::FailedClosed, err.reason))
+            Err(failed_closed(
+                &ctx,
+                false,
+                MarkerResult::FailedClosed,
+                err.reason,
+            ))
         }
     }
 }
@@ -1912,12 +2118,13 @@ fn open_and_recover(
             action,
             base_dir_hash: String::new(),
         };
-        denied(&ctx, reason)
+        denied(&ctx, false, reason)
     })?;
     let ctx = context(vm_id, kind, action, &paths);
     let (secrets_fd, generations_fd) =
-        open_or_create_secrets_dir(&paths, cfg).map_err(|reason| denied(&ctx, reason))?;
-    let lock = acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| denied(&ctx, reason))?;
+        open_or_create_secrets_dir(&paths, cfg).map_err(|reason| denied(&ctx, false, reason))?;
+    let lock =
+        acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| denied(&ctx, false, reason))?;
     let recovered =
         match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), vm_id, kind, cfg) {
             Ok(recovered) => recovered,
@@ -1925,12 +2132,14 @@ fn open_and_recover(
                 let recovered_ctx = context(vm_id, kind, err.action.unwrap_or(action), &paths);
                 return Err(failed_closed(
                     &recovered_ctx,
+                    false,
                     MarkerResult::FailedClosed,
                     err.reason,
                 ));
             }
         };
-    let marker = read_marker(secrets_fd.as_fd()).map_err(|reason| denied(&ctx, reason))?;
+    let marker =
+        read_marker(secrets_fd.as_fd()).map_err(|reason| denied(&ctx, recovered, reason))?;
     if let Some(marker) = &marker {
         verify_marker_against_live_state(
             secrets_fd.as_fd(),
@@ -1939,7 +2148,7 @@ fn open_and_recover(
             kind,
             marker,
         )
-        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     }
     Ok((paths, secrets_fd, generations_fd, lock, recovered, marker))
 }
@@ -1964,13 +2173,14 @@ pub fn provision(
         && marker.active.is_some()
         && !marker.retired
     {
-        return Err(denied(&ctx, FailReason::AlreadyProvisioned));
+        return Err(denied(&ctx, recovered, FailReason::AlreadyProvisioned));
     }
     let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
-        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     if !existing.epochs.is_empty() || !existing.stage_names.is_empty() {
         return Err(failed_closed(
             &ctx,
+            recovered,
             MarkerResult::FailedClosed,
             FailReason::GenerationConflict,
         ));
@@ -1992,8 +2202,10 @@ pub fn provision(
         first_provisioned_ms: now_ms(),
         phase: PromotePhase::Planned,
     };
+    validate_promote_intent_semantics(&intent, vm_id, kind)
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     match execute_promote(
         secrets_fd.as_fd(),
         generations_fd.as_fd(),
@@ -2009,10 +2221,16 @@ pub fn provision(
         )),
         Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
+            recovered,
             MarkerResult::FailedClosed,
             FailReason::MaterialWriteFailed,
         )),
-        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
+        Err(reason) => Err(failed_closed(
+            &ctx,
+            recovered,
+            MarkerResult::FailedClosed,
+            reason,
+        )),
     }
 }
 
@@ -2040,7 +2258,7 @@ pub fn rotate(
 
     let marker = match marker {
         Some(marker) if marker.active.is_some() && !marker.retired => marker,
-        _ => return Err(denied(&ctx, FailReason::NotProvisioned)),
+        _ => return Err(denied(&ctx, recovered, FailReason::NotProvisioned)),
     };
     let active = marker.active.clone().expect("checked above");
     let to_epoch = marker.high_water_epoch + 1;
@@ -2060,8 +2278,10 @@ pub fn rotate(
         first_provisioned_ms: marker.first_provisioned_ms,
         phase: PromotePhase::Planned,
     };
+    validate_promote_intent_semantics(&intent, vm_id, kind)
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     match execute_promote(
         secrets_fd.as_fd(),
         generations_fd.as_fd(),
@@ -2079,10 +2299,16 @@ pub fn rotate(
         )),
         Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
+            recovered,
             MarkerResult::FailedClosed,
             FailReason::MaterialWriteFailed,
         )),
-        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
+        Err(reason) => Err(failed_closed(
+            &ctx,
+            recovered,
+            MarkerResult::FailedClosed,
+            reason,
+        )),
     }
 }
 
@@ -2104,10 +2330,10 @@ pub fn rollback(
 
     let marker = match marker {
         Some(marker) if marker.active.is_some() && !marker.retired => marker,
-        _ => return Err(denied(&ctx, FailReason::NotProvisioned)),
+        _ => return Err(denied(&ctx, recovered, FailReason::NotProvisioned)),
     };
     let Some(previous) = marker.previous.clone() else {
-        return Err(denied(&ctx, FailReason::NoRollbackTarget));
+        return Err(denied(&ctx, recovered, FailReason::NoRollbackTarget));
     };
     let active = marker.active.clone().expect("checked above");
     let intent = PromoteIntent {
@@ -2125,8 +2351,10 @@ pub fn rollback(
         first_provisioned_ms: marker.first_provisioned_ms,
         phase: PromotePhase::Planned,
     };
+    validate_promote_intent_semantics(&intent, vm_id, kind)
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     match execute_promote(
         secrets_fd.as_fd(),
         generations_fd.as_fd(),
@@ -2143,10 +2371,16 @@ pub fn rollback(
         )),
         Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
+            recovered,
             MarkerResult::FailedClosed,
             FailReason::RecoveryAmbiguous,
         )),
-        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
+        Err(reason) => Err(failed_closed(
+            &ctx,
+            recovered,
+            MarkerResult::FailedClosed,
+            reason,
+        )),
     }
 }
 
@@ -2168,7 +2402,7 @@ pub fn retire(
     let ctx = context(vm_id, kind, LifecycleAction::Retire, &paths);
 
     let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
-        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
 
     let recorded_high_water = marker.as_ref().map(|m| m.high_water_epoch).unwrap_or(0);
     let marker_claims_active = marker
@@ -2183,12 +2417,14 @@ pub fn retire(
             // "clean" over an unexplained discrepancy.
             return Err(failed_closed(
                 &ctx,
+                recovered,
                 MarkerResult::FailedClosed,
                 FailReason::PreviouslyProvisionedMaterialMissing,
             ));
         }
         return Ok(SecretsLifecycleAuditFields::verified_clean(
             &ctx,
+            recovered,
             recorded_high_water,
         ));
     }
@@ -2203,15 +2439,22 @@ pub fn retire(
         high_water_epoch,
         phase: RetirePhase::Enumerated,
     };
+    validate_retire_intent_semantics(&intent, vm_id, kind)
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
     match execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), intent) {
         Ok(()) => Ok(SecretsLifecycleAuditFields::retired(
             &ctx,
             high_water_epoch,
             recovered,
         )),
-        Err(reason) => Err(failed_closed(&ctx, MarkerResult::FailedClosed, reason)),
+        Err(reason) => Err(failed_closed(
+            &ctx,
+            recovered,
+            MarkerResult::FailedClosed,
+            reason,
+        )),
     }
 }
 
@@ -3616,5 +3859,788 @@ mod tests {
                 "action {action} did not reach the central validation choke point"
             );
         }
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 1: Planned-phase partial-stage discard on abort
+    // -------------------------------------------------------------
+
+    #[test]
+    fn planned_recovery_discards_a_partial_stage_before_aborting_no_material() {
+        // Simulate a crash between `mkdir_at_exclusive` succeeding and
+        // the material write ever completing: an empty `.stage-*`
+        // directory exists on disk, but `ensure_staged` (given no
+        // in-memory `material`, as on a real recovery re-entry) can
+        // neither find a fully-staged digest-matching directory nor
+        // write fresh material. The stage directory must be validated
+        // and deleted -- never abandoned -- before the txlog record is
+        // discarded.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("orphan-stage", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let stage_name = random_stage_name();
+        // An empty stage directory: `mkdir_at_exclusive` succeeded,
+        // nothing was ever written into it.
+        path_safe::mkdir_at_exclusive(generations_fd.as_fd(), Path::new(&stage_name), cfg.dir_mode)
+            .unwrap();
+
+        let intent = PromoteIntent {
+            vm: "orphan-stage".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name: stage_name.clone(),
+            expected_digest_hex: material(b"never-written").digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        let outcome = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(outcome, PromoteOutcome::AbortedNoMaterial));
+        // The partial stage directory must be gone, not orphaned.
+        assert!(
+            path_safe::fstatat_nofollow(
+                &borrowed_to_owned(generations_fd.as_fd()).unwrap(),
+                &stage_name
+            )
+            .unwrap()
+            .is_none()
+        );
+        // The txlog must also be gone (the abort was fully committed,
+        // not left wedged).
+        assert!(
+            read_txlog(
+                secrets_fd.as_fd(),
+                "orphan-stage",
+                SecretKind::GuestSigningKey
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn planned_recovery_fails_closed_on_an_unvalidatable_partial_stage_and_retains_txlog() {
+        // The inverse: the leftover stage directory is not a
+        // recognizable partial-write shape (e.g. a stray subdirectory
+        // was injected into it) -- `discard_partial_stage_if_present`
+        // must propagate that anomaly rather than silently discarding
+        // it, and the txlog record must survive so a future recovery
+        // attempt can still reason about it. No orphan wedge: the
+        // transaction fails closed instead of being silently dropped
+        // over unrecognized on-disk state.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("bad-stage", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let stage_name = random_stage_name();
+        path_safe::mkdir_at_exclusive(generations_fd.as_fd(), Path::new(&stage_name), cfg.dir_mode)
+            .unwrap();
+        let stage_dir_fd = path_safe::open_at(
+            generations_fd.as_fd(),
+            Path::new(&stage_name),
+            OFlags::RDONLY | OFlags::DIRECTORY,
+        )
+        .unwrap();
+        let stage_dir_owned = borrowed_to_owned(stage_dir_fd.as_fd()).unwrap();
+        // A subdirectory is never a valid stage-dir entry shape.
+        path_safe::mkdir_at(stage_dir_owned.as_fd(), Path::new("anomaly"), 0o700).unwrap();
+
+        let intent = PromoteIntent {
+            vm: "bad-stage".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name: stage_name.clone(),
+            expected_digest_hex: material(b"never-written").digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone())).unwrap();
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::RetirementTreeAnomaly);
+        // Never silently activated: the stage dir is untouched and the
+        // txlog record still exists for a future recovery attempt to
+        // reason about.
+        assert!(
+            path_safe::fstatat_nofollow(
+                &borrowed_to_owned(generations_fd.as_fd()).unwrap(),
+                &stage_name
+            )
+            .unwrap()
+            .is_some()
+        );
+        assert!(
+            read_txlog(secrets_fd.as_fd(), "bad-stage", SecretKind::GuestSigningKey)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 2: `current`-swap leftover stage-symlink cleanup
+    // -------------------------------------------------------------
+
+    #[test]
+    fn atomic_swap_current_removes_a_leftover_swap_stage_symlink_from_a_prior_crash() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("swap-retry", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        // Leave a leftover swap-stage symlink behind, as if a prior
+        // crash landed between `symlinkat` and `renameat`.
+        rustix::fs::symlinkat(
+            expected_current_target(1),
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_SWAP_STAGE_NAME),
+        )
+        .unwrap();
+        // Must not fail with EEXIST on retry: the leftover symlink is
+        // actually removed (not left in place by a no-op
+        // `remove_path_safe` call), so the fresh `symlinkat` below it
+        // succeeds.
+        atomic_swap_current(secrets_fd.as_fd(), 1).unwrap();
+        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 1));
+        assert!(
+            path_safe::fstatat_nofollow(
+                &borrowed_to_owned(secrets_fd.as_fd()).unwrap(),
+                CURRENT_SWAP_STAGE_NAME
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn atomic_swap_current_fails_closed_on_a_non_symlink_swap_stage_entry() {
+        // An anomaly no legitimate code path produces: something
+        // other than a symlink occupies the swap-stage slot. Must
+        // fail closed rather than deleting an unexpected entry.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("swap-anomaly", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        let secrets_owned = borrowed_to_owned(secrets_fd.as_fd()).unwrap();
+        path_safe::create_file_at_safe(
+            &secrets_owned,
+            CURRENT_SWAP_STAGE_NAME,
+            nix::libc::O_RDWR | nix::libc::O_CREAT,
+            FILE_MODE_DEFAULT,
+        )
+        .unwrap();
+
+        let err = atomic_swap_current(secrets_fd.as_fd(), 1).unwrap_err();
+        assert_eq!(err, FailReason::CurrentSwapFailed);
+        // The anomalous entry must be left untouched, not deleted.
+        let stat = path_safe::fstatat_nofollow(&secrets_owned, CURRENT_SWAP_STAGE_NAME)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stat.st_mode & nix::libc::S_IFMT, nix::libc::S_IFREG);
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 3: existing-digest-match `Planned` branch retries
+    // its own durability barrier
+    // -------------------------------------------------------------
+
+    #[test]
+    fn planned_recovery_existing_digest_match_retries_generations_fsync() {
+        // The rename to the final epoch name already completed (a
+        // prior crashed attempt got as far as
+        // `promote_stage_to_generation`, whose own trailing
+        // `fsync_fd(generations_fd)` may be exactly what failed and
+        // crashed the attempt before the phase could advance). Recovery
+        // re-entry finding a digest match must retry that durability
+        // barrier, not silently assume it already happened.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("digest-match-fsync", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        let intent = PromoteIntent {
+            vm: "digest-match-fsync".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = execute_promote(
+                secrets_fd.as_fd(),
+                generations_fd.as_fd(),
+                &cfg,
+                intent.clone(),
+                None,
+            )
+            .unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // Retry without the fault must succeed and complete the whole
+        // transaction.
+        let outcome = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(outcome, PromoteOutcome::Completed(_)));
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 4: `NotFound` fast paths still retry the
+    // generations-dir fsync durability barrier
+    // -------------------------------------------------------------
+
+    #[test]
+    fn remove_generation_notfound_fast_path_still_retries_fsync() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("gen-notfound-fsync", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Epoch 7 was never created: the `NotFound` fast path is hit
+        // immediately.
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = remove_generation(generations_fd.as_fd(), 7).unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        remove_generation(generations_fd.as_fd(), 7).unwrap();
+    }
+
+    #[test]
+    fn remove_stage_dir_notfound_fast_path_still_retries_fsync() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths =
+            derive_paths("stage-notfound-fsync", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let stage_name = random_stage_name();
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap();
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 5: phase-specific current/marker identity
+    // validation before recovery mutation or txlog removal
+    // -------------------------------------------------------------
+
+    #[test]
+    fn current_promoted_recovery_rejects_current_not_pointing_at_to_epoch() {
+        // A hand-edited/corrupted txlog claims `CurrentPromoted` over
+        // a `current` that does not actually resolve to `to_epoch`.
+        // Must fail closed before any marker mutation, never write a
+        // marker claiming an active generation `current` does not
+        // corroborate.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("cp-mismatch", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        // `current` is left absent/unset -- never swapped to epoch 1 --
+        // yet the txlog claims `CurrentPromoted`.
+        let intent = PromoteIntent {
+            vm: "cp-mismatch".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::CurrentPromoted,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::IdentityCurrentTargetMismatch);
+        // No marker must have been written.
+        assert!(read_marker(secrets_fd.as_fd()).unwrap().is_none());
+    }
+
+    #[test]
+    fn marker_committed_recovery_rejects_current_not_pointing_at_to_epoch() {
+        // `MarkerCommitted` recovery must independently re-verify
+        // `current` before pruning/cleanup/txlog-removal, not just
+        // trust the phase label.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("mc-current-mismatch", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        // Note: `current` is never swapped here.
+        let intent = PromoteIntent {
+            vm: "mc-current-mismatch".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::MarkerCommitted,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::IdentityCurrentTargetMismatch);
+    }
+
+    #[test]
+    fn marker_committed_recovery_rejects_a_marker_disagreeing_with_the_intent() {
+        // `current` correctly resolves to `to_epoch`, but the marker
+        // on disk does not reflect this transaction's intended active
+        // epoch/digest (e.g. a stale marker from before this
+        // transaction, or one hand-edited independently of the
+        // txlog). `MarkerCommitted` recovery must reject this rather
+        // than proceeding with pruning/cleanup based on an unverified
+        // assumption.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("mc-marker-mismatch", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        atomic_swap_current(secrets_fd.as_fd(), 1).unwrap();
+        // Write a marker that does not correspond to this transaction
+        // (wrong high-water/active state -- e.g. still reflecting
+        // "nothing provisioned yet").
+        let stale_marker = MarkerData {
+            v: MARKER_SCHEMA_VERSION,
+            vm: "mc-marker-mismatch".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            retired: false,
+            high_water_epoch: 0,
+            active: None,
+            previous: None,
+            first_provisioned_ms: 0,
+            updated_ms: now_ms(),
+        };
+        write_marker(secrets_fd.as_fd(), &stale_marker).unwrap();
+
+        let intent = PromoteIntent {
+            vm: "mc-marker-mismatch".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::MarkerCommitted,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::RecoveryAmbiguous);
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 6: closed stage-name syntax + immediate
+    // pre-delete revalidation
+    // -------------------------------------------------------------
+
+    #[test]
+    fn is_well_formed_stage_name_accepts_only_the_exact_random_stage_name_syntax() {
+        assert!(is_well_formed_stage_name(&random_stage_name()));
+        assert!(is_well_formed_stage_name(&random_stage_name()));
+        for bad in [
+            "",
+            ".stage-",
+            ".stage-too-short",
+            &format!("{STAGE_PREFIX}{}", "a".repeat(31)),
+            &format!("{STAGE_PREFIX}{}", "a".repeat(33)),
+            &format!("{STAGE_PREFIX}{}", "A".repeat(32)),
+            &format!("{STAGE_PREFIX}{}", "g".repeat(32)),
+            &format!("{STAGE_PREFIX}../{}", "a".repeat(29)),
+            &format!("{STAGE_PREFIX}{}/etc", "a".repeat(28)),
+            "not-a-stage-name",
+        ] {
+            assert!(
+                !is_well_formed_stage_name(bad),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_promote_intent_semantics_rejects_a_path_traversal_stage_name() {
+        // A corrupted/hand-edited txlog must never reach an anchored
+        // path-safe call with an attacker-controlled path component.
+        let intent = PromoteIntent {
+            vm: "traversal".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name: format!("{STAGE_PREFIX}../../etc/passwd"),
+            expected_digest_hex: material(b"x").digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        let err =
+            validate_promote_intent_semantics(&intent, "traversal", SecretKind::GuestSigningKey)
+                .unwrap_err();
+        assert_eq!(err, FailReason::IntentCorrupt);
+    }
+
+    #[test]
+    fn validate_retire_intent_semantics_rejects_a_path_traversal_stage_name() {
+        let intent = RetireIntent {
+            vm: "traversal2".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            epochs: vec![],
+            stage_names: vec![format!("{STAGE_PREFIX}/etc/passwd")],
+            high_water_epoch: 1,
+            phase: RetirePhase::Enumerated,
+        };
+        let err =
+            validate_retire_intent_semantics(&intent, "traversal2", SecretKind::GuestSigningKey)
+                .unwrap_err();
+        assert_eq!(err, FailReason::IntentCorrupt);
+    }
+
+    #[test]
+    fn revalidate_stage_before_delete_catches_a_tamper_injected_just_before_delete() {
+        // Mirrors `revalidate_generation_before_delete_catches_a_tamper_
+        // immediately_before_delete` for stage directories: a stage
+        // dir enumerated and validated earlier is tampered with (an
+        // extra entry injected) between enumeration and the delete
+        // call. The immediate pre-delete revalidation must catch it.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("stage-tamper", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"pending");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        // Originally validates cleanly.
+        revalidate_stage_before_delete(generations_fd.as_fd(), &stage_name).unwrap();
+
+        // Tamper: inject a second entry into the stage dir.
+        let generations_owned = borrowed_to_owned(generations_fd.as_fd()).unwrap();
+        let stage_dir_fd = path_safe::open_at(
+            generations_owned.as_fd(),
+            Path::new(&stage_name),
+            OFlags::RDONLY | OFlags::DIRECTORY,
+        )
+        .unwrap();
+        let stage_dir_owned = borrowed_to_owned(stage_dir_fd.as_fd()).unwrap();
+        path_safe::mkdir_at(stage_dir_owned.as_fd(), Path::new("tamper"), 0o700).unwrap();
+
+        let err = revalidate_stage_before_delete(generations_fd.as_fd(), &stage_name).unwrap_err();
+        assert_eq!(err, FailReason::RetirementTreeAnomaly);
+    }
+
+    #[test]
+    fn revalidate_stage_before_delete_tolerates_absence() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("stage-absent", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        revalidate_stage_before_delete(generations_fd.as_fd(), &random_stage_name()).unwrap();
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 7: rollback intent digest/identity consistency
+    // -------------------------------------------------------------
+
+    #[test]
+    fn validate_promote_intent_semantics_rejects_rollback_digest_identity_mismatch() {
+        let identity = MaterialIdentity {
+            epoch: 1,
+            dev: 1,
+            ino: 1,
+            uid: 0,
+            gid: 0,
+            mode: 0o600,
+            nlink: 1,
+            has_acl: false,
+            digest_hex: material(b"actual").digest_hex(),
+        };
+        let intent = PromoteIntent {
+            vm: "rollback-mismatch".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Rollback,
+            to_epoch: 1,
+            create_epoch: false,
+            stage_name: String::new(),
+            // Deliberately inconsistent with `identity.digest_hex`.
+            expected_digest_hex: material(b"different").digest_hex(),
+            expected_identity: Some(identity),
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        let err = validate_promote_intent_semantics(
+            &intent,
+            "rollback-mismatch",
+            SecretKind::GuestSigningKey,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::IntentCorrupt);
+    }
+
+    #[test]
+    fn validate_promote_intent_semantics_accepts_consistent_rollback_digest_identity() {
+        let identity = MaterialIdentity {
+            epoch: 1,
+            dev: 1,
+            ino: 1,
+            uid: 0,
+            gid: 0,
+            mode: 0o600,
+            nlink: 1,
+            has_acl: false,
+            digest_hex: material(b"actual").digest_hex(),
+        };
+        let intent = PromoteIntent {
+            vm: "rollback-consistent".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            action: LifecycleAction::Rollback,
+            to_epoch: 1,
+            create_epoch: false,
+            stage_name: String::new(),
+            expected_digest_hex: identity.digest_hex.clone(),
+            expected_identity: Some(identity),
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        validate_promote_intent_semantics(
+            &intent,
+            "rollback-consistent",
+            SecretKind::GuestSigningKey,
+        )
+        .unwrap();
+    }
+
+    // -------------------------------------------------------------
+    // Round-4 finding 8: `recovered_prior_transaction` threading
+    // -------------------------------------------------------------
+
+    #[test]
+    fn recovered_prior_transaction_is_true_on_a_denial_reached_after_successful_recovery() {
+        // `provision` first drains a leftover crashed `rotate`
+        // transaction (recoverable: the rename to epoch 2 already
+        // completed with a matching digest, so recovery can run it
+        // all the way to completion), then hits `AlreadyProvisioned`
+        // because the marker is now active. The denial must carry
+        // `recovered_prior_transaction: true`.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "recovered-denied";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat2 = material(b"e2");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat2.digest_hex(),
+            Some(&mat2),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat2.digest_hex())
+            .unwrap();
+        let marker_before = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat2.digest_hex(),
+            expected_identity: None,
+            carry_previous: marker_before.active.clone(),
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: marker_before.first_provisioned_ms,
+            phase: PromotePhase::Planned,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
+        drop(secrets_fd);
+        drop(generations_fd);
+
+        let err = provision(vm, kind, material(b"e3"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::AlreadyProvisioned);
+        assert!(
+            err.audit.recovered_prior_transaction,
+            "denial reached after a successful mid-call recovery must record it"
+        );
+
+        // Sanity: recovery genuinely ran (the crashed rotate is fully
+        // completed, epoch 2 is now active).
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert_eq!(marker.active.unwrap().epoch, 2);
+    }
+
+    #[test]
+    fn recovered_prior_transaction_is_false_on_the_common_no_crash_denial_path() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let err = rotate(
+            "never-provisioned",
+            SecretKind::GuestSigningKey,
+            material(b"e1"),
+            &cfg,
+        )
+        .unwrap_err();
+        assert_eq!(err.reason, FailReason::NotProvisioned);
+        assert!(!err.audit.recovered_prior_transaction);
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
@@ -1,0 +1,1220 @@
+//! Provision / rotate / rollback / retire engine for per-realm secrets
+//! material (TPM-bound credentials, guest signing keys, and
+//! security-key channel state — see [`SecretKind`]).
+//!
+//! This module is the storage/atomicity/rotation-state layer only. It
+//! never generates raw secret material itself (that stays a caller
+//! concern — e.g. calling `ssh-keygen` for a [`SecretKind::GuestSigningKey`],
+//! or deriving a TPM attestation blob for a [`SecretKind::TpmBoundCredential`]),
+//! and it never touches `swtpm_dir.rs`'s physical NVRAM state or
+//! `security_key.rs`'s CTAPHID transport directly. It provides one
+//! generic, fd-relative, fail-closed engine that every secret kind
+//! shares for:
+//!
+//!   - laying out `<per_vm_state_root>/secrets/<kind-slug>/generations/<n>/material`
+//!     plus a `current` symlink, atomically swapped with a
+//!     rename-based two-step (mirrors the broker's other atomic-swap
+//!     idioms, e.g. `d2b_host::hardlink_farm::swap_current_symlink`,
+//!     but implemented directly against an fd-anchored `secrets_dir`
+//!     rather than reusing that store-view-specific helper);
+//!   - an identity-bound tamper-guard marker (dev/ino of the active
+//!     generation directory) under a dedicated marker tree, kept
+//!     independent of `swtpm_dir.rs`'s own per-VM marker so this
+//!     component never touches that file;
+//!   - fail-closed behaviour for every drift/tamper condition,
+//!     mirroring the `swtpm_dir.rs` philosophy: a previously-active
+//!     marker whose material vanished, or on-disk material with no
+//!     matching active marker, both abort rather than silently adopt
+//!     or silently reprovision.
+//!
+//! # Integration wiring points (deliberately NOT performed here)
+//!
+//! Per the W8 `secrets-lifecycle` component scope, this module is not
+//! wired into any shared sink. The integrator still needs to:
+//!
+//!   1. Add `pub mod secrets_lifecycle;` and
+//!      `pub mod secrets_rotation_audit;` to
+//!      `packages/d2b-priv-broker/src/ops/mod.rs`.
+//!   2. Add an `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
+//!      variant (and a matching `from_operation_value` arm) to
+//!      `packages/d2b-priv-broker/src/ops/audit_op.rs`.
+//!   3. Add new wire request/response DTOs (in `d2b-contracts`) and a
+//!      dispatch path in `packages/d2b-priv-broker/src/runtime.rs` that
+//!      calls [`provision`]/[`rotate`]/[`rollback`]/[`retire`] and
+//!      emits the returned [`SecretsLifecycleAuditFields`] through
+//!      `crate::audit::AuditLog`. The plan text explicitly forbids
+//!      adding a new broker op enum family from within this component,
+//!      so this wiring is out of scope here.
+//!   4. Decide, at the integration site, what bundle-resolved field
+//!      supplies `per_vm_state_root` for [`derive_paths`] (mirrors how
+//!      `swtpm_dir::derive_paths` takes a `&SpawnRunnerPlan`).
+//!   5. Decide whether `SecretKind::GuestSigningKey` material comes
+//!      from `exec_reconcile::run_ssh_keygen` output fed into
+//!      [`rotate`]'s `material` parameter, or stays separate.
+//!   6. Decide the exact coupling between `SecretKind::TpmBoundCredential`
+//!      rotation and `swtpm_dir.rs`'s physical NVRAM (e.g. whether a
+//!      rotate here should also trigger a swtpm reseal) — this is a
+//!      product/security decision beyond this component's scope.
+//!   7. Wire `packages/d2b-sk-frontend/src/secrets_channel.rs`'s
+//!      `ChannelState` into `services/security_key/mod.rs`'s
+//!      `SessionConfig` so a `SecretKind::SecurityKeyChannelState`
+//!      rotation on the broker side can propagate a fresh
+//!      `channel_binding`/`reconnect_generation` to the guest session
+//!      (neither file is owned by this component).
+//!   8. Run `gen-nix-unit-pins.sh` after this component lands so
+//!      `tests/unit/nix/pinned/*.txt` picks up the new
+//!      `w8-secrets-lifecycle-eval.nix` case names (not run here since
+//!      the pinned files are not owned by this component).
+
+use std::fmt;
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::path::{Path, PathBuf};
+
+use nix::libc;
+use rustix::fs::OFlags;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use crate::ops::hosts::stable_hash_str;
+use crate::ops::secrets_rotation_audit::{
+    LifecycleAction, MarkerResult, SecretKind, SecretsLifecycleAuditContext,
+    SecretsLifecycleAuditFields,
+};
+use crate::sys::path_safe;
+
+/// Root of the dedicated per-kind tamper-guard marker tree. Kept
+/// distinct from `swtpm_dir.rs`'s own per-VM marker tree
+/// (`/var/lib/d2b/swtpm-markers/<vm>`) so this component never reads
+/// or writes that file.
+pub const MARKER_TREE_ROOT: &str = "/var/lib/d2b/secrets-lifecycle-markers";
+
+/// On-disk schema version for the marker JSON body.
+const MARKER_SCHEMA_VERSION: u32 = 1;
+
+const SECRETS_ROOT_DIR_MODE: u32 = 0o750;
+const SECRETS_KIND_DIR_MODE: u32 = 0o700;
+const GENERATION_DIR_MODE: u32 = 0o700;
+const MATERIAL_FILE_MODE: u32 = 0o600;
+const MARKER_DIR_MODE: u32 = 0o700;
+const MARKER_FILE_MODE: u32 = 0o600;
+
+/// Closed set of path-free, redaction-safe failure reason slugs. Every
+/// public function in this module only ever surfaces one of these —
+/// never a raw `io::Error` message, which could embed a path.
+pub mod reasons {
+    pub const INVALID_VM_ID: &str = "invalid-vm-id";
+    pub const DERIVATION_FAILED: &str = "path-derivation-failed";
+    pub const PARENT_OPEN_FAILED: &str = "secrets-dir-open-failed";
+    pub const MARKER_TREE_FAILED: &str = "marker-tree-open-failed";
+    pub const MARKER_WRITE_FAILED: &str = "marker-write-failed";
+    pub const MARKER_TAMPERED: &str = "marker-tampered-or-missing-material";
+    pub const ALREADY_PROVISIONED: &str = "already-provisioned";
+    pub const ALREADY_RETIRED: &str = "already-retired";
+    pub const NOT_PROVISIONED: &str = "not-provisioned";
+    pub const NO_ROLLBACK_TARGET: &str = "no-rollback-target";
+    pub const PREVIOUSLY_PROVISIONED_MATERIAL_MISSING: &str =
+        "previously-provisioned-material-missing";
+    pub const GENERATION_CONFLICT: &str = "generation-conflict";
+    pub const MATERIAL_WRITE_FAILED: &str = "material-write-failed";
+    pub const CURRENT_SWAP_FAILED: &str = "current-swap-failed";
+    pub const INVALID_MATERIAL: &str = "invalid-material";
+}
+
+/// Runtime configuration for a single lifecycle call. Kept separate
+/// from [`SecretsLifecyclePaths`] so tests can point ownership/enforcement
+/// at scratch-safe values without touching the derived path shape.
+#[derive(Debug, Clone, Copy)]
+pub struct SecretsLifecycleConfig {
+    /// Expected owner of the secrets-state tree (typically the
+    /// broker's own uid/gid; per-kind consumers never get direct
+    /// filesystem access).
+    pub expected_uid: u32,
+    pub expected_gid: u32,
+    /// Owner of the tamper-guard marker file/dir. Usually identical to
+    /// `expected_uid`/`expected_gid`, but kept distinct in case a
+    /// future policy roots the marker tree under a narrower principal.
+    pub marker_owner_uid: u32,
+    pub marker_owner_gid: u32,
+    /// Monotonic wall-clock milliseconds used to stamp the marker.
+    /// Caller-supplied (not read from the system clock in this
+    /// module) so tests are deterministic.
+    pub now_ms: u64,
+    /// When `true`, refuse a world-writable parent directory on
+    /// production-looking paths (`/var/lib/d2b/...`). Tests targeting
+    /// a scratch tempdir set this to `false`.
+    pub enforce_root_parents: bool,
+}
+
+/// Derived, path-bearing (but never logged) locations for one
+/// `(vm, kind)` pair.
+#[derive(Debug, Clone)]
+pub struct SecretsLifecyclePaths {
+    pub vm_id: String,
+    pub kind: SecretKind,
+    /// `<per_vm_state_root>/secrets/<kind-slug>`
+    pub secrets_dir: PathBuf,
+    /// `<MARKER_TREE_ROOT>/<vm_id>`
+    pub marker_dir: PathBuf,
+}
+
+fn valid_vm_id(vm_id: &str) -> bool {
+    let mut chars = vm_id.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Derive the paths this component owns for `(vm_id, kind)` beneath
+/// `per_vm_state_root`. `per_vm_state_root` is expected to already
+/// exist (established by the caller's own per-VM state-dir prepare
+/// step); this function does not create it.
+pub fn derive_paths(
+    per_vm_state_root: &Path,
+    vm_id: &str,
+    kind: SecretKind,
+) -> Result<SecretsLifecyclePaths, &'static str> {
+    if !valid_vm_id(vm_id) {
+        return Err(reasons::INVALID_VM_ID);
+    }
+    if !per_vm_state_root.is_absolute() {
+        return Err(reasons::DERIVATION_FAILED);
+    }
+    Ok(SecretsLifecyclePaths {
+        vm_id: vm_id.to_owned(),
+        kind,
+        secrets_dir: per_vm_state_root.join("secrets").join(kind.as_slug()),
+        marker_dir: PathBuf::from(MARKER_TREE_ROOT).join(vm_id),
+    })
+}
+
+/// Zeroizing, digest-only-Debug wrapper around raw secret material
+/// bytes. Never implements a byte-exposing `Display`, and `Debug`
+/// never prints the bytes or their length-derived shape beyond a
+/// fixed placeholder.
+pub struct SecretMaterial(Zeroizing<Vec<u8>>);
+
+impl SecretMaterial {
+    /// Generous but bounded ceiling so a single material blob can
+    /// never grow unbounded (a 1 MiB budget comfortably covers a TPM
+    /// attestation blob, an SSH host key bundle, or channel-binding
+    /// wire material with headroom).
+    pub const MAX_LEN: usize = 1 << 20;
+
+    pub fn new(bytes: Vec<u8>) -> Result<Self, &'static str> {
+        if bytes.is_empty() || bytes.len() > Self::MAX_LEN {
+            return Err(reasons::INVALID_MATERIAL);
+        }
+        Ok(Self(Zeroizing::new(bytes)))
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// SHA-256 hex digest of the material. Safe to audit/log — the
+    /// raw bytes never are.
+    pub fn digest_hex(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.as_bytes());
+        let digest = hasher.finalize();
+        let mut out = String::with_capacity(64);
+        for byte in digest {
+            out.push_str(&format!("{byte:02x}"));
+        }
+        out
+    }
+}
+
+impl fmt::Debug for SecretMaterial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SecretMaterial")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
+
+/// Path-free, material-free error returned by every public function
+/// in this module. Carries the fully-formed audit record so a caller
+/// need not reconstruct it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretsLifecycleError {
+    pub reason: &'static str,
+    pub audit: SecretsLifecycleAuditFields,
+}
+
+impl fmt::Display for SecretsLifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "secrets-lifecycle {:?} failed: {}",
+            self.audit.action, self.reason
+        )
+    }
+}
+
+impl std::error::Error for SecretsLifecycleError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct MarkerData {
+    v: u32,
+    vm: String,
+    kind: String,
+    retired: bool,
+    generation: Option<u32>,
+    previous_generation: Option<u32>,
+    active_dev: Option<u64>,
+    active_ino: Option<u64>,
+    first_provisioned_ms: u64,
+    updated_ms: u64,
+}
+
+fn io_from_rustix(err: rustix::io::Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(err.raw_os_error())
+}
+
+fn production_path(path: &Path) -> bool {
+    path.starts_with("/var/lib/d2b")
+}
+
+fn context(paths: &SecretsLifecyclePaths, action: LifecycleAction) -> SecretsLifecycleAuditContext {
+    SecretsLifecycleAuditContext {
+        vm_id: paths.vm_id.clone(),
+        kind: paths.kind,
+        action,
+        base_dir_hash: stable_hash_str(&paths.secrets_dir.display().to_string()),
+    }
+}
+
+fn ensure_marker_tree(
+    paths: &SecretsLifecyclePaths,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<OwnedFd, &'static str> {
+    if cfg.enforce_root_parents && production_path(&paths.marker_dir) {
+        path_safe::refuse_world_writable_parent(&paths.marker_dir)
+            .map_err(|_| reasons::MARKER_TREE_FAILED)?;
+    }
+    // `paths.marker_dir` is `<marker_tree_root>/<vm_id>`. Unlike the
+    // per-VM secrets root (established by an earlier, out-of-scope
+    // state-dir prepare step), the marker tree root itself is a
+    // fresh top-level directory this module owns end-to-end, so it
+    // is not safe to assume it already exists. Create it first (a
+    // no-op once any VM has provisioned once) before creating the
+    // per-VM leaf beneath it.
+    let marker_root = paths
+        .marker_dir
+        .parent()
+        .ok_or(reasons::MARKER_TREE_FAILED)?;
+    path_safe::ensure_dir(
+        marker_root,
+        MARKER_DIR_MODE,
+        Some(cfg.marker_owner_uid),
+        Some(cfg.marker_owner_gid),
+    )
+    .map_err(|_| reasons::MARKER_TREE_FAILED)?;
+    path_safe::ensure_dir(
+        &paths.marker_dir,
+        MARKER_DIR_MODE,
+        Some(cfg.marker_owner_uid),
+        Some(cfg.marker_owner_gid),
+    )
+    .map_err(|_| reasons::MARKER_TREE_FAILED)?;
+    path_safe::open_dir_path_safe(&paths.marker_dir).map_err(|_| reasons::MARKER_TREE_FAILED)
+}
+
+fn read_marker(
+    marker_dir_fd: &OwnedFd,
+    paths: &SecretsLifecyclePaths,
+) -> Result<Option<MarkerData>, &'static str> {
+    let name = paths.kind.as_slug();
+    let stat = match path_safe::fstatat_nofollow(marker_dir_fd, name) {
+        Ok(Some(stat)) => stat,
+        Ok(None) => return Ok(None),
+        Err(_) => return Err(reasons::MARKER_TAMPERED),
+    };
+    if (stat.st_mode & libc::S_IFMT) != libc::S_IFREG {
+        return Err(reasons::MARKER_TAMPERED);
+    }
+    let fd = path_safe::open_file_at_safe(marker_dir_fd, name, libc::O_RDONLY)
+        .map_err(|_| reasons::MARKER_TAMPERED)?;
+    let mut file = std::fs::File::from(fd);
+    let mut buf = String::new();
+    {
+        use std::io::Read;
+        file.read_to_string(&mut buf)
+            .map_err(|_| reasons::MARKER_TAMPERED)?;
+    }
+    let data: MarkerData = serde_json::from_str(&buf).map_err(|_| reasons::MARKER_TAMPERED)?;
+    if data.v != MARKER_SCHEMA_VERSION || data.vm != paths.vm_id || data.kind != name {
+        return Err(reasons::MARKER_TAMPERED);
+    }
+    Ok(Some(data))
+}
+
+fn write_marker(
+    marker_dir_fd: &OwnedFd,
+    paths: &SecretsLifecyclePaths,
+    cfg: &SecretsLifecycleConfig,
+    data: &MarkerData,
+) -> Result<(), &'static str> {
+    let body = serde_json::to_vec(data).map_err(|_| reasons::MARKER_WRITE_FAILED)?;
+    path_safe::atomic_replace_fd_with_owner(
+        marker_dir_fd,
+        paths.kind.as_slug(),
+        &body,
+        MARKER_FILE_MODE,
+        Some(cfg.marker_owner_uid),
+        Some(cfg.marker_owner_gid),
+    )
+    .map_err(|_| reasons::MARKER_WRITE_FAILED)
+}
+
+fn open_or_create_secrets_dir(
+    paths: &SecretsLifecyclePaths,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<OwnedFd, &'static str> {
+    let secrets_root = paths
+        .secrets_dir
+        .parent()
+        .ok_or(reasons::DERIVATION_FAILED)?;
+    path_safe::ensure_dir(
+        secrets_root,
+        SECRETS_ROOT_DIR_MODE,
+        Some(cfg.expected_uid),
+        Some(cfg.expected_gid),
+    )
+    .map_err(|_| reasons::PARENT_OPEN_FAILED)?;
+    path_safe::ensure_dir(
+        &paths.secrets_dir,
+        SECRETS_KIND_DIR_MODE,
+        Some(cfg.expected_uid),
+        Some(cfg.expected_gid),
+    )
+    .map_err(|_| reasons::PARENT_OPEN_FAILED)?;
+    path_safe::ensure_dir(
+        &paths.secrets_dir.join("generations"),
+        SECRETS_KIND_DIR_MODE,
+        Some(cfg.expected_uid),
+        Some(cfg.expected_gid),
+    )
+    .map_err(|_| reasons::PARENT_OPEN_FAILED)?;
+    path_safe::open_dir_path_safe(&paths.secrets_dir).map_err(|_| reasons::PARENT_OPEN_FAILED)
+}
+
+fn open_generations_dir(secrets_dir_fd: &OwnedFd) -> Result<OwnedFd, &'static str> {
+    path_safe::open_at(
+        secrets_dir_fd.as_fd(),
+        Path::new("generations"),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )
+    .map_err(|_| reasons::PARENT_OPEN_FAILED)
+}
+
+fn write_generation(
+    secrets_dir_fd: &OwnedFd,
+    generation: u32,
+    material: &SecretMaterial,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<libc::stat, &'static str> {
+    let generations_fd = open_generations_dir(secrets_dir_fd)?;
+    let name = generation.to_string();
+    path_safe::mkdir_at_exclusive(
+        generations_fd.as_fd(),
+        Path::new(&name),
+        GENERATION_DIR_MODE,
+    )
+    .map_err(|err| {
+        if err.kind() == std::io::ErrorKind::AlreadyExists {
+            reasons::GENERATION_CONFLICT
+        } else {
+            reasons::MATERIAL_WRITE_FAILED
+        }
+    })?;
+    let generation_fd = path_safe::open_at(
+        generations_fd.as_fd(),
+        Path::new(&name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )
+    .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
+    path_safe::fchmod(generation_fd.as_fd(), GENERATION_DIR_MODE)
+        .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
+    path_safe::fchown(
+        generation_fd.as_fd(),
+        Some(cfg.expected_uid),
+        Some(cfg.expected_gid),
+    )
+    .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
+
+    let file_fd = path_safe::create_file_at_safe(
+        &generation_fd,
+        "material",
+        libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL,
+        MATERIAL_FILE_MODE,
+    )
+    .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
+    {
+        use std::io::Write;
+        let mut file = std::fs::File::from(file_fd);
+        file.write_all(material.as_bytes())
+            .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
+        file.sync_all()
+            .map_err(|_| reasons::MATERIAL_WRITE_FAILED)?;
+    }
+    path_safe::fstat_fd(generation_fd.as_fd()).map_err(|_| reasons::MATERIAL_WRITE_FAILED)
+}
+
+fn stat_generation(secrets_dir_fd: &OwnedFd, generation: u32) -> Result<libc::stat, &'static str> {
+    let generations_fd = open_generations_dir(secrets_dir_fd)?;
+    let name = generation.to_string();
+    let fd = path_safe::open_at(
+        generations_fd.as_fd(),
+        Path::new(&name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    )
+    .map_err(|_| reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING)?;
+    path_safe::fstat_fd(fd.as_fd()).map_err(|_| reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING)
+}
+
+/// Best-effort removal of one generation directory's `material` file
+/// and the directory itself. Never fails the caller: a stale
+/// generation left behind after a crash is picked up by the next
+/// rotate/retire's own retention bookkeeping, never silently trusted
+/// as current.
+fn remove_generation(secrets_dir_fd: &OwnedFd, generation: u32) {
+    let Ok(generations_fd) = open_generations_dir(secrets_dir_fd) else {
+        return;
+    };
+    let name = generation.to_string();
+    if let Ok(generation_fd) = path_safe::open_at(
+        generations_fd.as_fd(),
+        Path::new(&name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    ) {
+        let _ = path_safe::remove_path_safe(&generation_fd, "material");
+    }
+    let _ = path_safe::remove_path_safe(&generations_fd, &name);
+}
+
+/// Best-effort removal of the `current` symlink itself. `current` is
+/// always a symlink by construction (see [`atomic_swap_current`]), so
+/// unlike [`path_safe::remove_path_safe`] (which deliberately refuses
+/// to operate on a symlink as a generic anti-planting guard for
+/// contexts where a symlink would be unexpected) this removes the
+/// link entry directly without following it. Never fails the caller.
+fn remove_current_symlink(secrets_dir_fd: &OwnedFd) {
+    let _ = rustix::fs::unlinkat(
+        secrets_dir_fd.as_fd(),
+        "current",
+        rustix::fs::AtFlags::empty(),
+    );
+}
+
+/// Atomically point the `current` symlink at `generations/<generation>`
+/// using a hidden-name symlink-then-rename swap against the already
+/// fd-anchored `secrets_dir`, so no window ever exposes a half-written
+/// or dangling `current`.
+fn atomic_swap_current(
+    secrets_dir_fd: BorrowedFd<'_>,
+    generation: u32,
+) -> Result<(), &'static str> {
+    let target = format!("generations/{generation}");
+    let tmp_name = format!(".current.tmp.{}", std::process::id());
+    let _ = rustix::fs::unlinkat(
+        secrets_dir_fd,
+        tmp_name.as_str(),
+        rustix::fs::AtFlags::empty(),
+    );
+    rustix::fs::symlinkat(target.as_str(), secrets_dir_fd, tmp_name.as_str())
+        .map_err(io_from_rustix)
+        .map_err(|_| reasons::CURRENT_SWAP_FAILED)?;
+    match rustix::fs::renameat(secrets_dir_fd, tmp_name.as_str(), secrets_dir_fd, "current") {
+        Ok(()) => {
+            let _ = rustix::fs::fsync(secrets_dir_fd);
+            Ok(())
+        }
+        Err(_) => {
+            let _ = rustix::fs::unlinkat(
+                secrets_dir_fd,
+                tmp_name.as_str(),
+                rustix::fs::AtFlags::empty(),
+            );
+            Err(reasons::CURRENT_SWAP_FAILED)
+        }
+    }
+}
+
+fn current_present(secrets_dir_fd: &OwnedFd) -> Result<bool, &'static str> {
+    path_safe::fstatat_nofollow(secrets_dir_fd, "current")
+        .map(|stat| stat.is_some())
+        .map_err(|_| reasons::MARKER_TAMPERED)
+}
+
+fn verify_active_identity(
+    secrets_dir_fd: &OwnedFd,
+    marker: &MarkerData,
+) -> Result<(), &'static str> {
+    let generation = marker.generation.ok_or(reasons::MARKER_TAMPERED)?;
+    let (expected_dev, expected_ino) = match (marker.active_dev, marker.active_ino) {
+        (Some(dev), Some(ino)) => (dev, ino),
+        _ => return Err(reasons::MARKER_TAMPERED),
+    };
+    let stat = stat_generation(secrets_dir_fd, generation)?;
+    if stat.st_dev != expected_dev || stat.st_ino != expected_ino {
+        return Err(reasons::MARKER_TAMPERED);
+    }
+    Ok(())
+}
+
+/// Provision fresh (generation 1) material for `(vm, kind)`.
+///
+/// Fails closed with [`reasons::ALREADY_PROVISIONED`] if active
+/// material already exists (callers should use [`rotate`] instead).
+/// Fails closed with [`reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING`]
+/// if the marker records active material but the generation vanished.
+/// Fails closed with [`reasons::MARKER_TAMPERED`] if material exists on
+/// disk with no matching active marker (never silently adopted).
+/// Succeeds (fresh generation 1) when never provisioned, or when the
+/// prior provisioning was cleanly retired.
+pub fn provision(
+    paths: &SecretsLifecyclePaths,
+    cfg: &SecretsLifecycleConfig,
+    material: &SecretMaterial,
+) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
+    let ctx = context(paths, LifecycleAction::Provision);
+    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+    let existing = read_marker(&marker_dir_fd, paths).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+    let secrets_dir_fd =
+        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        })?;
+    let has_current = current_present(&secrets_dir_fd).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+    let marker_active = existing.as_ref().map(|m| !m.retired).unwrap_or(false);
+
+    match (marker_active, has_current) {
+        (true, true) => {
+            return Err(SecretsLifecycleError {
+                reason: reasons::ALREADY_PROVISIONED,
+                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::ALREADY_PROVISIONED),
+            });
+        }
+        (true, false) => {
+            return Err(SecretsLifecycleError {
+                reason: reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING,
+                ),
+            });
+        }
+        (false, true) => {
+            // Material present with no active marker backing it: a
+            // planted or drifted directory. Never silently adopted.
+            return Err(SecretsLifecycleError {
+                reason: reasons::MARKER_TAMPERED,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reasons::MARKER_TAMPERED,
+                ),
+            });
+        }
+        (false, false) => {}
+    }
+
+    let stat = write_generation(&secrets_dir_fd, 1, material, cfg).map_err(|reason| {
+        SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        }
+    })?;
+    atomic_swap_current(secrets_dir_fd.as_fd(), 1).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+
+    let marker = MarkerData {
+        v: MARKER_SCHEMA_VERSION,
+        vm: paths.vm_id.clone(),
+        kind: paths.kind.as_slug().to_owned(),
+        retired: false,
+        generation: Some(1),
+        previous_generation: None,
+        active_dev: Some(stat.st_dev),
+        active_ino: Some(stat.st_ino),
+        first_provisioned_ms: cfg.now_ms,
+        updated_ms: cfg.now_ms,
+    };
+    write_marker(&marker_dir_fd, paths, cfg, &marker).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+
+    Ok(SecretsLifecycleAuditFields::provisioned(
+        &ctx,
+        material.digest_hex(),
+    ))
+}
+
+/// Rotate `(vm, kind)` to a new generation, retaining exactly the
+/// immediately-prior generation for [`rollback`].
+///
+/// Requires an active (non-retired) marker; verifies the marker's
+/// recorded active generation identity against the live directory
+/// before mutating, so a TOCTOU swap of the active generation's
+/// content is caught rather than silently rotated forward from an
+/// attacker-controlled base.
+pub fn rotate(
+    paths: &SecretsLifecyclePaths,
+    cfg: &SecretsLifecycleConfig,
+    material: &SecretMaterial,
+) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
+    let ctx = context(paths, LifecycleAction::Rotate);
+    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+    let marker = match read_marker(&marker_dir_fd, paths) {
+        Ok(Some(marker)) if !marker.retired => marker,
+        Ok(Some(_)) => {
+            return Err(SecretsLifecycleError {
+                reason: reasons::ALREADY_RETIRED,
+                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::ALREADY_RETIRED),
+            });
+        }
+        Ok(None) => {
+            return Err(SecretsLifecycleError {
+                reason: reasons::NOT_PROVISIONED,
+                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::NOT_PROVISIONED),
+            });
+        }
+        Err(reason) => {
+            return Err(SecretsLifecycleError {
+                reason,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reason,
+                ),
+            });
+        }
+    };
+
+    let secrets_dir_fd =
+        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        })?;
+    verify_active_identity(&secrets_dir_fd, &marker).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+
+    let current_generation = marker.generation.ok_or_else(|| SecretsLifecycleError {
+        reason: reasons::MARKER_TAMPERED,
+        audit: SecretsLifecycleAuditFields::failed(
+            &ctx,
+            MarkerResult::FailedClosed,
+            reasons::MARKER_TAMPERED,
+        ),
+    })?;
+    let new_generation =
+        current_generation
+            .checked_add(1)
+            .ok_or_else(|| SecretsLifecycleError {
+                reason: reasons::GENERATION_CONFLICT,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reasons::GENERATION_CONFLICT,
+                ),
+            })?;
+
+    let stat =
+        write_generation(&secrets_dir_fd, new_generation, material, cfg).map_err(|reason| {
+            SecretsLifecycleError {
+                reason,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reason,
+                ),
+            }
+        })?;
+    atomic_swap_current(secrets_dir_fd.as_fd(), new_generation).map_err(|reason| {
+        SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        }
+    })?;
+
+    // Retention policy: keep exactly the generation we just rotated
+    // away from; prune anything older. Best-effort — a prune failure
+    // never rolls back the already-committed rotate.
+    if let Some(stale) = marker.previous_generation {
+        remove_generation(&secrets_dir_fd, stale);
+    }
+
+    let updated_marker = MarkerData {
+        v: MARKER_SCHEMA_VERSION,
+        vm: paths.vm_id.clone(),
+        kind: paths.kind.as_slug().to_owned(),
+        retired: false,
+        generation: Some(new_generation),
+        previous_generation: Some(current_generation),
+        active_dev: Some(stat.st_dev),
+        active_ino: Some(stat.st_ino),
+        first_provisioned_ms: marker.first_provisioned_ms,
+        updated_ms: cfg.now_ms,
+    };
+    write_marker(&marker_dir_fd, paths, cfg, &updated_marker).map_err(|reason| {
+        SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        }
+    })?;
+
+    Ok(SecretsLifecycleAuditFields::rotated(
+        &ctx,
+        new_generation,
+        vec![current_generation],
+        material.digest_hex(),
+    ))
+}
+
+/// Swap `current` back to the immediately-prior generation recorded
+/// by the marker. Fails closed with [`reasons::NO_ROLLBACK_TARGET`] if
+/// no previous generation is tracked (either never rotated, or the
+/// retained generation was already pruned by a later action).
+pub fn rollback(
+    paths: &SecretsLifecyclePaths,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
+    let ctx = context(paths, LifecycleAction::Rollback);
+    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+    let marker = match read_marker(&marker_dir_fd, paths) {
+        Ok(Some(marker)) if !marker.retired => marker,
+        Ok(Some(_)) => {
+            return Err(SecretsLifecycleError {
+                reason: reasons::ALREADY_RETIRED,
+                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::ALREADY_RETIRED),
+            });
+        }
+        Ok(None) => {
+            return Err(SecretsLifecycleError {
+                reason: reasons::NOT_PROVISIONED,
+                audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::NOT_PROVISIONED),
+            });
+        }
+        Err(reason) => {
+            return Err(SecretsLifecycleError {
+                reason,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reason,
+                ),
+            });
+        }
+    };
+    let Some(previous_generation) = marker.previous_generation else {
+        return Err(SecretsLifecycleError {
+            reason: reasons::NO_ROLLBACK_TARGET,
+            audit: SecretsLifecycleAuditFields::denied(&ctx, reasons::NO_ROLLBACK_TARGET),
+        });
+    };
+
+    let secrets_dir_fd =
+        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        })?;
+    verify_active_identity(&secrets_dir_fd, &marker).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+    let previous_stat =
+        stat_generation(&secrets_dir_fd, previous_generation).map_err(|reason| {
+            SecretsLifecycleError {
+                reason,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reason,
+                ),
+            }
+        })?;
+
+    let current_generation = marker.generation.ok_or_else(|| SecretsLifecycleError {
+        reason: reasons::MARKER_TAMPERED,
+        audit: SecretsLifecycleAuditFields::failed(
+            &ctx,
+            MarkerResult::FailedClosed,
+            reasons::MARKER_TAMPERED,
+        ),
+    })?;
+
+    atomic_swap_current(secrets_dir_fd.as_fd(), previous_generation).map_err(|reason| {
+        SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        }
+    })?;
+
+    let updated_marker = MarkerData {
+        v: MARKER_SCHEMA_VERSION,
+        vm: paths.vm_id.clone(),
+        kind: paths.kind.as_slug().to_owned(),
+        retired: false,
+        generation: Some(previous_generation),
+        previous_generation: Some(current_generation),
+        active_dev: Some(previous_stat.st_dev),
+        active_ino: Some(previous_stat.st_ino),
+        first_provisioned_ms: marker.first_provisioned_ms,
+        updated_ms: cfg.now_ms,
+    };
+    write_marker(&marker_dir_fd, paths, cfg, &updated_marker).map_err(|reason| {
+        SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        }
+    })?;
+
+    Ok(SecretsLifecycleAuditFields::rolled_back(
+        &ctx,
+        previous_generation,
+        vec![current_generation],
+    ))
+}
+
+/// Retire `(vm, kind)`: remove all tracked generations, the `current`
+/// symlink, and tombstone the marker. Idempotent — retiring an
+/// already-retired or never-provisioned kind returns
+/// [`crate::ops::secrets_rotation_audit::LifecycleResult::VerifiedClean`]
+/// rather than an error.
+///
+/// Fails closed (rather than proceeding to tombstone) if the marker
+/// records active material that has already vanished from disk — an
+/// operator must investigate the drift before this component treats
+/// the kind as cleanly retired.
+pub fn retire(
+    paths: &SecretsLifecyclePaths,
+    cfg: &SecretsLifecycleConfig,
+) -> Result<SecretsLifecycleAuditFields, SecretsLifecycleError> {
+    let ctx = context(paths, LifecycleAction::Retire);
+    let marker_dir_fd = ensure_marker_tree(paths, cfg).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+    let marker = match read_marker(&marker_dir_fd, paths) {
+        Ok(None) => return Ok(SecretsLifecycleAuditFields::verified_clean(&ctx, None)),
+        Ok(Some(marker)) if marker.retired => {
+            return Ok(SecretsLifecycleAuditFields::verified_clean(&ctx, None));
+        }
+        Ok(Some(marker)) => marker,
+        Err(reason) => {
+            return Err(SecretsLifecycleError {
+                reason,
+                audit: SecretsLifecycleAuditFields::failed(
+                    &ctx,
+                    MarkerResult::FailedClosed,
+                    reason,
+                ),
+            });
+        }
+    };
+
+    let secrets_dir_fd =
+        open_or_create_secrets_dir(paths, cfg).map_err(|reason| SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        })?;
+    verify_active_identity(&secrets_dir_fd, &marker).map_err(|reason| SecretsLifecycleError {
+        reason,
+        audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+    })?;
+
+    remove_current_symlink(&secrets_dir_fd);
+    if let Some(generation) = marker.generation {
+        remove_generation(&secrets_dir_fd, generation);
+    }
+    if let Some(previous) = marker.previous_generation {
+        remove_generation(&secrets_dir_fd, previous);
+    }
+
+    let tombstoned_marker = MarkerData {
+        v: MARKER_SCHEMA_VERSION,
+        vm: paths.vm_id.clone(),
+        kind: paths.kind.as_slug().to_owned(),
+        retired: true,
+        generation: None,
+        previous_generation: None,
+        active_dev: None,
+        active_ino: None,
+        first_provisioned_ms: marker.first_provisioned_ms,
+        updated_ms: cfg.now_ms,
+    };
+    write_marker(&marker_dir_fd, paths, cfg, &tombstoned_marker).map_err(|reason| {
+        SecretsLifecycleError {
+            reason,
+            audit: SecretsLifecycleAuditFields::failed(&ctx, MarkerResult::FailedClosed, reason),
+        }
+    })?;
+
+    Ok(SecretsLifecycleAuditFields::retired(&ctx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::secrets_rotation_audit::LifecycleResult;
+
+    fn test_cfg(now_ms: u64) -> SecretsLifecycleConfig {
+        let uid = nix::unistd::getuid().as_raw();
+        let gid = nix::unistd::getgid().as_raw();
+        SecretsLifecycleConfig {
+            expected_uid: uid,
+            expected_gid: gid,
+            marker_owner_uid: uid,
+            marker_owner_gid: gid,
+            now_ms,
+            enforce_root_parents: false,
+        }
+    }
+
+    /// Build test paths that mirror `derive_paths`'s real contract:
+    /// `secrets_dir` sits beneath a `per_vm_state_root` that the
+    /// (out-of-scope) state-dir prepare step is assumed to have
+    /// already created, so this helper creates that stand-in root
+    /// itself. `marker_dir`'s parent (the marker tree root) is
+    /// deliberately left uncreated so tests exercise this module's
+    /// own first-use creation of it.
+    fn test_paths(root: &Path, vm: &str, kind: SecretKind) -> SecretsLifecyclePaths {
+        let per_vm_state_root = root.join("state").join(vm);
+        std::fs::create_dir_all(&per_vm_state_root).expect("stand-in per-vm root");
+        SecretsLifecyclePaths {
+            vm_id: vm.to_owned(),
+            kind,
+            secrets_dir: per_vm_state_root.join("secrets").join(kind.as_slug()),
+            marker_dir: root.join("markers").join(vm),
+        }
+    }
+
+    fn material(byte: u8) -> SecretMaterial {
+        SecretMaterial::new(vec![byte; 32]).expect("valid material")
+    }
+
+    #[test]
+    fn valid_vm_id_accepts_and_rejects_expected_shapes() {
+        assert!(valid_vm_id("work"));
+        assert!(valid_vm_id("corp-vm-1"));
+        assert!(!valid_vm_id(""));
+        assert!(!valid_vm_id("Work"));
+        assert!(!valid_vm_id("1work"));
+        assert!(!valid_vm_id("work/etc"));
+    }
+
+    #[test]
+    fn derive_paths_rejects_invalid_vm_id_and_relative_root() {
+        assert!(
+            derive_paths(
+                Path::new("/var/lib/d2b/vms/work"),
+                "Bad",
+                SecretKind::GuestSigningKey
+            )
+            .is_err()
+        );
+        assert!(derive_paths(Path::new("relative"), "work", SecretKind::GuestSigningKey).is_err());
+        let paths = derive_paths(
+            Path::new("/var/lib/d2b/vms/work"),
+            "work",
+            SecretKind::GuestSigningKey,
+        )
+        .expect("valid derivation");
+        assert_eq!(
+            paths.secrets_dir,
+            Path::new("/var/lib/d2b/vms/work/secrets/guest-signing-key")
+        );
+        assert_eq!(paths.marker_dir, Path::new(MARKER_TREE_ROOT).join("work"));
+    }
+
+    #[test]
+    fn secret_material_rejects_empty_and_oversized() {
+        assert!(SecretMaterial::new(Vec::new()).is_err());
+        assert!(SecretMaterial::new(vec![0u8; SecretMaterial::MAX_LEN + 1]).is_err());
+        assert!(SecretMaterial::new(vec![1u8; 4]).is_ok());
+    }
+
+    #[test]
+    fn secret_material_debug_never_prints_bytes() {
+        let m = material(0xAB);
+        let debug = format!("{m:?}");
+        assert!(!debug.contains("171"));
+        assert!(debug.contains("redacted"));
+    }
+
+    #[test]
+    fn provision_then_rotate_then_rollback_then_retire_round_trip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
+        let cfg = test_cfg(1_000);
+
+        let provisioned = provision(&paths, &cfg, &material(1)).expect("provision succeeds");
+        assert_eq!(provisioned.result, LifecycleResult::Created);
+        assert_eq!(provisioned.generation, Some(1));
+
+        let rotated = rotate(&paths, &test_cfg(2_000), &material(2)).expect("rotate succeeds");
+        assert_eq!(rotated.result, LifecycleResult::Rotated);
+        assert_eq!(rotated.generation, Some(2));
+        assert_eq!(rotated.retained_generations, vec![1]);
+
+        let rolled_back = rollback(&paths, &test_cfg(3_000)).expect("rollback succeeds");
+        assert_eq!(rolled_back.result, LifecycleResult::RolledBack);
+        assert_eq!(rolled_back.generation, Some(1));
+        assert_eq!(rolled_back.retained_generations, vec![2]);
+
+        let retired = retire(&paths, &test_cfg(4_000)).expect("retire succeeds");
+        assert_eq!(retired.result, LifecycleResult::Retired);
+
+        // Idempotent retire.
+        let retired_again = retire(&paths, &test_cfg(5_000)).expect("retire is idempotent");
+        assert_eq!(retired_again.result, LifecycleResult::VerifiedClean);
+    }
+
+    #[test]
+    fn provision_twice_without_retire_is_denied() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::TpmBoundCredential);
+        let cfg = test_cfg(1_000);
+        provision(&paths, &cfg, &material(1)).expect("first provision succeeds");
+        let err = provision(&paths, &cfg, &material(2)).expect_err("second provision denied");
+        assert_eq!(err.reason, reasons::ALREADY_PROVISIONED);
+        assert_eq!(err.audit.result, LifecycleResult::Denied);
+    }
+
+    #[test]
+    fn rotate_without_provision_is_denied() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::SecurityKeyChannelState);
+        let cfg = test_cfg(1_000);
+        let err = rotate(&paths, &cfg, &material(1)).expect_err("rotate without provision denied");
+        assert_eq!(err.reason, reasons::NOT_PROVISIONED);
+    }
+
+    #[test]
+    fn rollback_without_prior_rotate_has_no_target() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
+        let cfg = test_cfg(1_000);
+        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
+        let err = rollback(&paths, &test_cfg(2_000)).expect_err("no rollback target");
+        assert_eq!(err.reason, reasons::NO_ROLLBACK_TARGET);
+    }
+
+    #[test]
+    fn provision_after_clean_retire_succeeds_at_generation_one() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
+        let cfg = test_cfg(1_000);
+        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
+        retire(&paths, &test_cfg(2_000)).expect("retire succeeds");
+        let reprovisioned =
+            provision(&paths, &test_cfg(3_000), &material(3)).expect("re-provision succeeds");
+        assert_eq!(reprovisioned.generation, Some(1));
+    }
+
+    #[test]
+    fn provision_fails_closed_when_marker_missing_but_current_exists() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
+        let cfg = test_cfg(1_000);
+        // Simulate drift: the secrets tree exists (with a `current`
+        // symlink and a generation) but the marker was never written
+        // (or was removed out of band).
+        let secrets_dir_fd = open_or_create_secrets_dir(&paths, &cfg).expect("dir created");
+        write_generation(&secrets_dir_fd, 1, &material(9), &cfg).expect("material written");
+        atomic_swap_current(secrets_dir_fd.as_fd(), 1).expect("swap succeeds");
+
+        let err = provision(&paths, &cfg, &material(1)).expect_err("must fail closed");
+        assert_eq!(err.reason, reasons::MARKER_TAMPERED);
+    }
+
+    #[test]
+    fn provision_fails_closed_when_marker_active_but_material_vanished() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
+        let cfg = test_cfg(1_000);
+        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
+
+        // Simulate an out-of-band deletion of the material tree while
+        // the marker still claims it is active. `current` is a
+        // symlink by construction, so simulate a manual/out-of-band
+        // unlink directly rather than through the safe wrapper (which
+        // deliberately refuses to touch symlinks elsewhere).
+        let secrets_dir_fd = open_or_create_secrets_dir(&paths, &cfg).expect("dir reopened");
+        remove_current_symlink(&secrets_dir_fd);
+        remove_generation(&secrets_dir_fd, 1);
+
+        let err = provision(&paths, &cfg, &material(2)).expect_err("must fail closed");
+        assert_eq!(err.reason, reasons::PREVIOUSLY_PROVISIONED_MATERIAL_MISSING);
+    }
+
+    #[test]
+    fn rotate_fails_closed_when_active_generation_content_swapped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
+        let cfg = test_cfg(1_000);
+        provision(&paths, &cfg, &material(1)).expect("provision succeeds");
+
+        // Simulate a TOCTOU swap by directly corrupting the marker's
+        // recorded identity rather than deleting/recreating the
+        // generation directory: on some filesystems a freed inode
+        // number can be reused immediately, which would make a
+        // delete-then-recreate swap non-deterministic to detect here
+        // even though the same dev/ino check still fails closed in
+        // practice against a genuinely different backing inode.
+        let marker_dir_fd = ensure_marker_tree(&paths, &cfg).expect("marker tree");
+        let mut marker = read_marker(&marker_dir_fd, &paths)
+            .expect("marker read")
+            .expect("marker present");
+        marker.active_ino = Some(
+            marker
+                .active_ino
+                .expect("active ino recorded")
+                .wrapping_add(1),
+        );
+        write_marker(&marker_dir_fd, &paths, &cfg, &marker).expect("marker corrupted");
+
+        let err = rotate(&paths, &test_cfg(2_000), &material(2)).expect_err("must fail closed");
+        assert_eq!(err.reason, reasons::MARKER_TAMPERED);
+    }
+
+    #[test]
+    fn multiple_kinds_for_same_vm_are_independent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tpm_paths = test_paths(tmp.path(), "work", SecretKind::TpmBoundCredential);
+        let signing_paths = test_paths(tmp.path(), "work", SecretKind::GuestSigningKey);
+        let cfg = test_cfg(1_000);
+
+        provision(&tpm_paths, &cfg, &material(1)).expect("tpm provision succeeds");
+        // The other kind for the same VM must still report not-provisioned.
+        let err =
+            rotate(&signing_paths, &cfg, &material(2)).expect_err("independent kind is untouched");
+        assert_eq!(err.reason, reasons::NOT_PROVISIONED);
+    }
+}

--- a/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
@@ -457,6 +457,13 @@ pub struct RetireIntent {
     /// this transaction. Recovery re-enumerates fresh and requires the
     /// fresh result to be a subset of this plan.
     pub epochs: Vec<u64>,
+    /// Every `.stage-*` staging directory found in the same
+    /// enumeration. Staged entries are real secret-tree contents (a
+    /// stage dir contains, or is about to contain, a copy of
+    /// caller-supplied material bytes): they are deleted exactly like
+    /// `epochs`, with every failure propagated, never as a
+    /// best-effort sweep.
+    pub stage_names: Vec<String>,
     pub high_water_epoch: u64,
     pub phase: RetirePhase,
 }
@@ -536,12 +543,30 @@ fn open_or_create_secrets_dir(
         .parent()
         .ok_or(FailReason::SecretsDirOpenFailed)?;
     path_safe::open_dir_path_safe(&cfg.state_root).map_err(|_| FailReason::SecretsDirOpenFailed)?;
-    path_safe::ensure_dir(vm_dir, cfg.dir_mode, cfg.owner_uid, cfg.owner_gid)
+    // Metadata directories (the per-VM directory, the per-kind
+    // secrets root, and `generations/`) are trusted-broker-owned
+    // bookkeeping, never a consumer-owned material leaf: `cfg.
+    // owner_uid`/`owner_gid` apply only to the `material` file
+    // written by `ensure_staged`. `ensure_dir` only reasserts mode on
+    // every call (it does not re-`chown` when passed `None, None`),
+    // so ownership drift is independently verified here rather than
+    // trusted from construction alone.
+    path_safe::ensure_dir(vm_dir, cfg.dir_mode, None, None)
         .map_err(|_| FailReason::SecretsDirOpenFailed)?;
-    path_safe::ensure_dir(&paths.kind_root, cfg.dir_mode, cfg.owner_uid, cfg.owner_gid)
+    let vm_dir_fd =
+        path_safe::open_dir_path_safe(vm_dir).map_err(|_| FailReason::SecretsDirOpenFailed)?;
+    let vm_dir_stat =
+        path_safe::fstat_fd(vm_dir_fd.as_fd()).map_err(|_| FailReason::BrokerOwnershipViolation)?;
+    verify_broker_owned(&vm_dir_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
+    drop(vm_dir_fd);
+
+    path_safe::ensure_dir(&paths.kind_root, cfg.dir_mode, None, None)
         .map_err(|_| FailReason::SecretsDirOpenFailed)?;
     let secrets_fd = path_safe::open_dir_path_safe(&paths.kind_root)
         .map_err(|_| FailReason::SecretsDirOpenFailed)?;
+    let secrets_stat = path_safe::fstat_fd(secrets_fd.as_fd())
+        .map_err(|_| FailReason::BrokerOwnershipViolation)?;
+    verify_broker_owned(&secrets_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
     path_safe::mkdir_at(
         secrets_fd.as_fd(),
         Path::new(GENERATIONS_DIR_NAME),
@@ -554,6 +579,9 @@ fn open_or_create_secrets_dir(
         OFlags::RDONLY | OFlags::DIRECTORY,
     )
     .map_err(|_| FailReason::MarkerTreeOpenFailed)?;
+    let generations_stat = path_safe::fstat_fd(generations_fd.as_fd())
+        .map_err(|_| FailReason::BrokerOwnershipViolation)?;
+    verify_broker_owned(&generations_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
     Ok((secrets_fd, generations_fd))
 }
 
@@ -597,11 +625,119 @@ fn write_marker(secrets_fd: BorrowedFd<'_>, marker: &MarkerData) -> Result<(), F
         None,
     )
     .map_err(|_| FailReason::MarkerWriteFailed)?;
-    fsync_fd(secrets_fd);
+    fsync_fd(secrets_fd)?;
     Ok(())
 }
 
-fn read_txlog(secrets_fd: BorrowedFd<'_>) -> Result<Option<TxLog>, FailReason> {
+/// Cross-field semantic validation of a leftover `txlog`, bound to the
+/// exact `(vm, kind)` directory it was found in. Run immediately on
+/// read, *before* any recovery attempt: a txlog naming a different
+/// `(vm, kind)`, an internally inconsistent phase/epoch/stage/
+/// high-water combination, or an action a `PromoteIntent` cannot
+/// legally carry is [`FailReason::IntentCorrupt`] rather than
+/// something recovery tries to interpret.
+fn validate_txlog_semantics(log: &TxLog, vm_id: &str, kind: SecretKind) -> Result<(), FailReason> {
+    match log {
+        TxLog::Promote(intent) => validate_promote_intent_semantics(intent, vm_id, kind),
+        TxLog::Retire(intent) => validate_retire_intent_semantics(intent, vm_id, kind),
+    }
+}
+
+fn validate_promote_intent_semantics(
+    intent: &PromoteIntent,
+    vm_id: &str,
+    kind: SecretKind,
+) -> Result<(), FailReason> {
+    if intent.vm != vm_id || intent.kind != kind.as_slug() {
+        return Err(FailReason::IntentCorrupt);
+    }
+    if intent.to_epoch == 0 {
+        return Err(FailReason::IntentCorrupt);
+    }
+    let action_wants_create = match intent.action {
+        LifecycleAction::Provision | LifecycleAction::Rotate => true,
+        LifecycleAction::Rollback => false,
+        LifecycleAction::Retire => return Err(FailReason::IntentCorrupt),
+    };
+    if intent.create_epoch != action_wants_create {
+        return Err(FailReason::IntentCorrupt);
+    }
+    if intent.create_epoch {
+        if intent.stage_name.is_empty() || !intent.stage_name.starts_with(STAGE_PREFIX) {
+            return Err(FailReason::IntentCorrupt);
+        }
+        if intent.expected_identity.is_some() {
+            return Err(FailReason::IntentCorrupt);
+        }
+    } else {
+        if !intent.stage_name.is_empty() {
+            return Err(FailReason::IntentCorrupt);
+        }
+        match &intent.expected_identity {
+            Some(identity) if identity.epoch == intent.to_epoch => {}
+            _ => return Err(FailReason::IntentCorrupt),
+        }
+    }
+    if intent.new_high_water_epoch < intent.to_epoch {
+        return Err(FailReason::IntentCorrupt);
+    }
+    if let Some(previous) = &intent.carry_previous
+        && previous.epoch == intent.to_epoch
+    {
+        return Err(FailReason::IntentCorrupt);
+    }
+    if let Some(prune) = intent.prune_epoch
+        && (prune == intent.to_epoch
+            || intent
+                .carry_previous
+                .as_ref()
+                .is_some_and(|p| p.epoch == prune))
+    {
+        return Err(FailReason::IntentCorrupt);
+    }
+    Ok(())
+}
+
+fn validate_retire_intent_semantics(
+    intent: &RetireIntent,
+    vm_id: &str,
+    kind: SecretKind,
+) -> Result<(), FailReason> {
+    if intent.vm != vm_id || intent.kind != kind.as_slug() {
+        return Err(FailReason::IntentCorrupt);
+    }
+    let mut sorted_epochs = intent.epochs.clone();
+    sorted_epochs.sort_unstable();
+    sorted_epochs.dedup();
+    if sorted_epochs != intent.epochs {
+        return Err(FailReason::IntentCorrupt);
+    }
+    if intent
+        .epochs
+        .iter()
+        .any(|&e| e == 0 || e > intent.high_water_epoch)
+    {
+        return Err(FailReason::IntentCorrupt);
+    }
+    let mut sorted_stage_names = intent.stage_names.clone();
+    sorted_stage_names.sort();
+    sorted_stage_names.dedup();
+    if sorted_stage_names != intent.stage_names
+        || intent
+            .stage_names
+            .iter()
+            .any(|s| !s.starts_with(STAGE_PREFIX))
+    {
+        return Err(FailReason::IntentCorrupt);
+    }
+    Ok(())
+}
+
+fn read_txlog(
+    secrets_fd: BorrowedFd<'_>,
+    vm_id: &str,
+    kind: SecretKind,
+) -> Result<Option<TxLog>, FailReason> {
     let owned = borrowed_to_owned(secrets_fd)?;
     let fd = match path_safe::open_file_at_safe(&owned, TXLOG_FILE_NAME, nix::libc::O_RDONLY) {
         Ok(fd) => fd,
@@ -610,6 +746,7 @@ fn read_txlog(secrets_fd: BorrowedFd<'_>) -> Result<Option<TxLog>, FailReason> {
     };
     let bytes = read_fd_to_end(fd.as_fd()).map_err(|_| FailReason::IntentCorrupt)?;
     let log: TxLog = serde_json::from_slice(&bytes).map_err(|_| FailReason::IntentCorrupt)?;
+    validate_txlog_semantics(&log, vm_id, kind)?;
     Ok(Some(log))
 }
 
@@ -625,7 +762,7 @@ fn write_txlog(secrets_fd: BorrowedFd<'_>, log: &TxLog) -> Result<(), FailReason
         None,
     )
     .map_err(|_| FailReason::IntentWriteFailed)?;
-    fsync_fd(secrets_fd);
+    fsync_fd(secrets_fd)?;
     Ok(())
 }
 
@@ -636,7 +773,7 @@ fn remove_txlog(secrets_fd: BorrowedFd<'_>) -> Result<(), FailReason> {
         Err(err) if err.kind() == io::ErrorKind::NotFound => {}
         Err(_) => return Err(FailReason::IntentWriteFailed),
     }
-    fsync_fd(secrets_fd);
+    fsync_fd(secrets_fd)?;
     Ok(())
 }
 
@@ -666,8 +803,23 @@ fn read_fd_to_end(fd: BorrowedFd<'_>) -> io::Result<Vec<u8>> {
     Ok(buf)
 }
 
-fn fsync_fd(fd: BorrowedFd<'_>) {
-    let _ = rustix::fs::fsync(fd);
+// Test-only fault injection seam: when enabled (see
+// `tests::FsyncFaultGuard`), every `fsync_fd` call fails with
+// `FailReason::FsyncFailed` instead of touching the filesystem, so
+// tests can prove each phase-advancement point genuinely blocks on a
+// durable sync rather than merely calling `fsync` and ignoring the
+// result.
+#[cfg(test)]
+thread_local! {
+    static FSYNC_SHOULD_FAIL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn fsync_fd(fd: BorrowedFd<'_>) -> Result<(), FailReason> {
+    #[cfg(test)]
+    if FSYNC_SHOULD_FAIL.with(|c| c.get()) {
+        return Err(FailReason::FsyncFailed);
+    }
+    rustix::fs::fsync(fd).map_err(|_| FailReason::FsyncFailed)
 }
 
 fn io_from_rustix(err: rustix::io::Errno) -> io::Error {
@@ -675,18 +827,86 @@ fn io_from_rustix(err: rustix::io::Errno) -> io::Error {
 }
 
 // ---------------------------------------------------------------------
+// Broker-trusted ownership (metadata dirs, lock file)
+// ---------------------------------------------------------------------
+
+/// The trusted "broker owner" identity for every path this module
+/// manages *except* a `material` file leaf: metadata directories
+/// (`kind_root`, `generations/`), the marker, the txlog, and the lock
+/// file. Since this module only ever runs inside the broker process,
+/// "owned by the broker" and "owned by this process's effective
+/// uid/gid" are the same statement — a path this module is about to
+/// trust for locking or transaction bookkeeping that reports some
+/// *other* owner was not created by this code path and must never be
+/// trusted, regardless of what `cfg.owner_uid`/`cfg.owner_gid` (the
+/// separate, *consumer*-facing identity applied only to material file
+/// leaves — see [`ensure_staged`]) say.
+fn broker_identity() -> (u32, u32) {
+    (
+        rustix::process::geteuid().as_raw(),
+        rustix::process::getegid().as_raw(),
+    )
+}
+
+/// Verify `stat` is exactly `expected_type` (`S_IFDIR`/`S_IFREG`),
+/// owned by the trusted broker identity, has exactly `expected_mode`
+/// permission bits, and (for a regular file) exactly one hard link.
+/// Any mismatch is [`FailReason::BrokerOwnershipViolation`] — this is
+/// the check that makes broker-owned metadata/lock paths
+/// "non-replaceable": a foreign-owned or hard-linked stand-in is
+/// refused rather than silently trusted.
+fn verify_broker_owned(
+    stat: &nix::libc::stat,
+    expected_type: nix::libc::mode_t,
+    expected_mode: u32,
+) -> Result<(), FailReason> {
+    let (uid, gid) = broker_identity();
+    if (stat.st_mode & nix::libc::S_IFMT) != expected_type {
+        return Err(FailReason::BrokerOwnershipViolation);
+    }
+    if stat.st_uid != uid || stat.st_gid != gid {
+        return Err(FailReason::BrokerOwnershipViolation);
+    }
+    if (stat.st_mode & 0o7777) != expected_mode {
+        return Err(FailReason::BrokerOwnershipViolation);
+    }
+    if expected_type == nix::libc::S_IFREG && stat.st_nlink != 1 {
+        return Err(FailReason::BrokerOwnershipViolation);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
 // Cross-process lock
 // ---------------------------------------------------------------------
 
+#[derive(Debug)]
 pub struct LockGuard {
     _file: std::fs::File,
 }
 
+/// Acquire the cross-process exclusive lock for one `(vm, kind)`
+/// directory. Before trusting the `flock`, this verifies: the
+/// anchored parent (`secrets_fd`, i.e. `kind_root`) is a trusted-
+/// broker-owned directory with the expected mode; the lock file
+/// itself is a trusted-broker-owned regular file with the expected
+/// mode and exactly one hard link (never a hard-link plant); and,
+/// immediately after the `flock` succeeds, that the directory entry
+/// named `lock` still resolves (by `(dev, ino)`) to the exact file
+/// this call opened and locked — guarding against the classic
+/// flock-via-path race where another actor unlinks-and-recreates the
+/// lock file between this call's `open` and its `flock`, which would
+/// let two callers each hold an uncontended lock on two different,
+/// now-unlinked-vs-live inodes of the same name.
 fn acquire_lock(
     secrets_fd: BorrowedFd<'_>,
     cfg: &SecretsLifecycleConfig,
 ) -> Result<LockGuard, FailReason> {
     let owned = borrowed_to_owned(secrets_fd)?;
+    let parent_stat =
+        path_safe::fstat_fd(secrets_fd).map_err(|_| FailReason::BrokerOwnershipViolation)?;
+    verify_broker_owned(&parent_stat, nix::libc::S_IFDIR, cfg.dir_mode)?;
+
     let fd = path_safe::create_file_at_safe(
         &owned,
         LOCK_FILE_NAME,
@@ -694,11 +914,31 @@ fn acquire_lock(
         FILE_MODE_DEFAULT,
     )
     .map_err(|_| FailReason::LockUnavailable)?;
+    let lock_stat =
+        path_safe::fstat_fd(fd.as_fd()).map_err(|_| FailReason::BrokerOwnershipViolation)?;
+    verify_broker_owned(&lock_stat, nix::libc::S_IFREG, FILE_MODE_DEFAULT)?;
+
     let file: std::fs::File = fd.into();
     let deadline = Instant::now() + cfg.lock_max_wait;
     loop {
         match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
-            Ok(()) => return Ok(LockGuard { _file: file }),
+            Ok(()) => {
+                // Re-stat by name (anchored beneath the already-
+                // verified `secrets_fd` parent) and compare `(dev,
+                // ino)` against the fd we just locked: if another
+                // actor swapped the `lock` entry between our open and
+                // our successful flock, the identity will differ and
+                // we must not trust this lock.
+                let by_name = path_safe::fstatat_nofollow(&owned, LOCK_FILE_NAME)
+                    .map_err(|_| FailReason::BrokerOwnershipViolation)?
+                    .ok_or(FailReason::BrokerOwnershipViolation)?;
+                let by_fd = path_safe::fstat_fd(file.as_fd())
+                    .map_err(|_| FailReason::BrokerOwnershipViolation)?;
+                if by_name.st_dev != by_fd.st_dev || by_name.st_ino != by_fd.st_ino {
+                    return Err(FailReason::BrokerOwnershipViolation);
+                }
+                return Ok(LockGuard { _file: file });
+            }
             Err(nix::errno::Errno::EWOULDBLOCK) => {
                 if Instant::now() >= deadline {
                     return Err(FailReason::LockUnavailable);
@@ -747,57 +987,120 @@ fn parse_strict_epoch(name: &str) -> Option<u64> {
     name.parse::<u64>().ok()
 }
 
-/// Sweep any leftover `.stage-*` directories (from a crash before a
-/// stage was ever recorded in a txlog, or one already superseded).
-/// Best-effort: failures are ignored, since a stray stage dir has no
-/// bearing on correctness (it is never referenced by `current` or the
-/// marker).
-fn sweep_stale_stage_dirs(generations_fd: BorrowedFd<'_>, keep: Option<&str>) {
-    let owned = match borrowed_to_owned(generations_fd) {
-        Ok(fd) => fd,
-        Err(_) => return,
-    };
-    let Ok(dir) = rustix::fs::Dir::read_from(generations_fd) else {
-        return;
-    };
-    for entry in dir.flatten() {
-        let Ok(name) = entry.file_name().to_str() else {
-            continue;
-        };
-        if name == "." || name == ".." {
-            continue;
-        }
-        if !name.starts_with(STAGE_PREFIX) {
-            continue;
-        }
-        if keep == Some(name) {
-            continue;
-        }
-        let _ = remove_dir_tree_one_level(&owned, name);
-    }
-}
-
-/// Remove a one-level directory (a stage dir contains at most one
-/// `material` file) via `remove_path_safe` on each child then the
-/// directory itself.
-fn remove_dir_tree_one_level(parent_fd: &OwnedFd, name: &str) -> io::Result<()> {
-    if let Ok(child_fd) = path_safe::open_at(
-        parent_fd.as_fd(),
+/// Validate a `.stage-*` directory's contents are consistent with an
+/// in-progress or superseded staging attempt: at most one entry,
+/// which (if present) must be a regular file with exactly one hard
+/// link (either the final `material` name, or a stray hidden
+/// temp-file name a crash left behind mid-write via
+/// `path_safe::atomic_replace_fd_with_owner`'s named-stage fallback).
+/// Anything else (a subdirectory, a symlink, more than one entry, or
+/// a hard-linked file) is an anomaly this refuses to silently delete.
+fn validate_stage_dir_contents(generations_fd: &OwnedFd, name: &str) -> Result<(), FailReason> {
+    let dir_fd = path_safe::open_at(
+        generations_fd.as_fd(),
         Path::new(name),
         OFlags::RDONLY | OFlags::DIRECTORY,
-    ) && let Ok(dir) = rustix::fs::Dir::read_from(child_fd.as_fd())
-    {
-        let child_owned = borrowed_to_owned_io(child_fd.as_fd())?;
-        for entry in dir.flatten() {
-            if let Ok(cname) = entry.file_name().to_str()
-                && cname != "."
-                && cname != ".."
-            {
-                let _ = path_safe::remove_path_safe(&child_owned, cname);
-            }
+    )
+    .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
+    let inner = rustix::fs::Dir::read_from(dir_fd.as_fd())
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let mut seen: Option<String> = None;
+    for entry in inner {
+        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
+        let ename = entry
+            .file_name()
+            .to_str()
+            .map_err(|_| FailReason::RetirementTreeAnomaly)?
+            .to_owned();
+        if ename == "." || ename == ".." {
+            continue;
+        }
+        if seen.is_some() {
+            return Err(FailReason::RetirementTreeAnomaly);
+        }
+        seen = Some(ename);
+    }
+    if let Some(ename) = seen {
+        let stat = path_safe::fstatat_nofollow(&dir_owned, &ename)
+            .map_err(|_| FailReason::RetirementTreeAnomaly)?
+            .ok_or(FailReason::RetirementTreeAnomaly)?;
+        if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFREG {
+            return Err(FailReason::RetirementTreeAnomaly);
+        }
+        if stat.st_nlink != 1 {
+            return Err(FailReason::RetirementTreeAnomaly);
         }
     }
-    path_safe::remove_path_safe(parent_fd, name)
+    Ok(())
+}
+
+/// Fully delete one `.stage-*` directory: enumerate every child,
+/// delete each one (propagating any failure other than the child
+/// already being absent), prove the directory is observably empty,
+/// fsync it, then remove the directory itself and fsync its parent.
+/// Staged entries are real secret-tree contents — this is never a
+/// best-effort sweep, unlike the old `36d9dcf8`/`dab583f1` design's
+/// `sweep_stale_stage_dirs`: every failure here is propagated and
+/// blocks the caller from advancing.
+fn remove_stage_dir(generations_fd: BorrowedFd<'_>, name: &str) -> Result<(), FailReason> {
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    let dir_fd = match path_safe::open_at(
+        generations_fd,
+        Path::new(name),
+        OFlags::RDONLY | OFlags::DIRECTORY,
+    ) {
+        Ok(fd) => fd,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
+    };
+    let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
+    let entries = rustix::fs::Dir::read_from(dir_fd.as_fd())
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    let mut names = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
+        let ename = entry
+            .file_name()
+            .to_str()
+            .map_err(|_| FailReason::RetirementTreeAnomaly)?
+            .to_owned();
+        if ename != "." && ename != ".." {
+            names.push(ename);
+        }
+    }
+    drop(dir_fd);
+    for ename in &names {
+        match path_safe::remove_path_safe(&dir_owned, ename) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(_) => return Err(FailReason::RetirementTreeAnomaly),
+        }
+    }
+    // Prove empty before removing: a deletion that silently left a
+    // child behind must never result in the parent being removed
+    // anyway.
+    let remaining = rustix::fs::Dir::read_from(dir_owned.as_fd())
+        .map_err(|_| FailReason::RetirementTreeAnomaly)?;
+    for entry in remaining {
+        let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
+        let ename = entry
+            .file_name()
+            .to_str()
+            .map_err(|_| FailReason::RetirementTreeAnomaly)?
+            .to_owned();
+        if ename != "." && ename != ".." {
+            return Err(FailReason::RetirementNotProvablyEmpty);
+        }
+    }
+    fsync_fd(dir_owned.as_fd())?;
+    match path_safe::remove_path_safe(&generations_owned, name) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(_) => return Err(FailReason::RetirementTreeAnomaly),
+    }
+    fsync_fd(generations_fd)?;
+    Ok(())
 }
 
 fn borrowed_to_owned_io(fd: BorrowedFd<'_>) -> io::Result<OwnedFd> {
@@ -823,8 +1126,11 @@ fn ensure_staged(
         }
         // Tampered/partial stage from a previous crash: nothing has
         // been activated yet (we are still pre-EpochReady), so it is
-        // safe to discard and let the caller decide (abort/retry).
-        let _ = remove_dir_tree_one_level(&generations_owned, stage_name);
+        // safe to discard and let the caller decide (abort/retry). The
+        // deletion itself must fully succeed and propagate any error;
+        // a stage directory is real secret material and is never
+        // swept on a best-effort basis.
+        remove_stage_dir(generations_owned.as_fd(), stage_name)?;
         return Err(FailReason::RecoveryContentMismatch);
     }
 
@@ -850,8 +1156,8 @@ fn ensure_staged(
         cfg.owner_gid,
     )
     .map_err(|_| FailReason::MaterialWriteFailed)?;
-    fsync_fd(stage_fd.as_fd());
-    fsync_fd(generations_fd);
+    fsync_fd(stage_fd.as_fd())?;
+    fsync_fd(generations_fd)?;
     Ok(true)
 }
 
@@ -880,11 +1186,22 @@ fn promote_stage_to_generation(
     generations_fd: BorrowedFd<'_>,
     stage_name: &str,
     to_epoch: u64,
+    expected_digest_hex: &str,
 ) -> Result<(), FailReason> {
     let epoch_name = to_epoch.to_string();
     let generations_owned = borrowed_to_owned(generations_fd)?;
-    if digest_of_material_dir(&generations_owned, &epoch_name).is_ok() {
-        return Ok(());
+    if let Ok(existing_digest) = digest_of_material_dir(&generations_owned, &epoch_name) {
+        // A directory already occupies this epoch number (e.g. a
+        // recovery re-entry after the rename completed but the phase
+        // advance did not commit). It is only safe to treat this as
+        // "already promoted" if its content is exactly the content we
+        // intended to promote; any other content -- stale, foreign,
+        // or from an aborted/rolled-back attempt -- must never be
+        // silently accepted or overwritten.
+        if existing_digest == expected_digest_hex {
+            return Ok(());
+        }
+        return Err(FailReason::GenerationConflict);
     }
     rustix::fs::renameat(
         generations_fd,
@@ -893,7 +1210,7 @@ fn promote_stage_to_generation(
         Path::new(&epoch_name),
     )
     .map_err(|_| FailReason::GenerationConflict)?;
-    fsync_fd(generations_fd);
+    fsync_fd(generations_fd)?;
     Ok(())
 }
 
@@ -967,27 +1284,59 @@ fn verify_existing_generation_identity(
     Ok(())
 }
 
-/// Read the literal name `current` resolves to (its symlink target's
-/// final component), without following the link past that.
-fn read_current_target(secrets_fd: BorrowedFd<'_>) -> Option<u64> {
-    let target = rustix::fs::readlinkat(secrets_fd, Path::new(CURRENT_LINK_NAME), Vec::new())
+/// The exact literal symlink target text `atomic_swap_current` writes
+/// for a given epoch: `generations/<epoch>`. This is a relative path
+/// anchored at the per-(vm,kind) secrets directory; any other literal
+/// text -- an absolute path, a path with extra segments, or a
+/// differently-rooted relative path -- must never be treated as
+/// resolving to that epoch, even if its final component happens to
+/// match the epoch number.
+fn expected_current_target(epoch: u64) -> String {
+    format!("{GENERATIONS_DIR_NAME}/{epoch}")
+}
+
+/// Read the exact literal text `current` resolves to, without any
+/// component-wise parsing. Returns `None` if the link is absent,
+/// unreadable, or not valid UTF-8.
+fn current_target_text(secrets_fd: BorrowedFd<'_>) -> Option<String> {
+    rustix::fs::readlinkat(secrets_fd, Path::new(CURRENT_LINK_NAME), Vec::new())
         .ok()?
         .into_string()
-        .ok()?;
-    let name = Path::new(&target).file_name()?.to_str()?;
-    parse_strict_epoch(name)
+        .ok()
+}
+
+/// Read the literal name `current` resolves to (its symlink target's
+/// exact literal text), parsed only if it is *exactly*
+/// `generations/<epoch>` and nothing else.
+fn read_current_target(secrets_fd: BorrowedFd<'_>) -> Option<u64> {
+    let target = current_target_text(secrets_fd)?;
+    let (dir, epoch_str) = target.split_once('/')?;
+    if dir != GENERATIONS_DIR_NAME {
+        return None;
+    }
+    parse_strict_epoch(epoch_str)
+}
+
+/// Verify that `current` resolves, by exact literal text, to
+/// `generations/<epoch>` -- not merely to a path whose final
+/// component happens to be that epoch number.
+fn current_resolves_exactly_to(secrets_fd: BorrowedFd<'_>, epoch: u64) -> bool {
+    match current_target_text(secrets_fd) {
+        Some(target) => target == expected_current_target(epoch),
+        None => false,
+    }
 }
 
 /// Atomically swap `current` to point at `generations/<epoch>` using a
 /// hidden-name-then-rename swap so there is never a moment `current`
-/// is absent. Idempotent: if `current` already resolves to `epoch`,
-/// this is a no-op.
+/// is absent. Idempotent: if `current` already resolves, by exact
+/// literal text, to `epoch`, this is a no-op.
 fn atomic_swap_current(secrets_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), FailReason> {
-    if read_current_target(secrets_fd) == Some(epoch) {
+    if current_resolves_exactly_to(secrets_fd, epoch) {
         return Ok(());
     }
     let owned = borrowed_to_owned(secrets_fd)?;
-    let target = PathBuf::from(GENERATIONS_DIR_NAME).join(epoch.to_string());
+    let target = expected_current_target(epoch);
     // Best-effort cleanup of a leftover stage symlink from a previous
     // crash between symlink-creation and rename.
     let _ = path_safe::remove_path_safe(&owned, CURRENT_SWAP_STAGE_NAME);
@@ -1000,7 +1349,7 @@ fn atomic_swap_current(secrets_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), Fai
         Path::new(CURRENT_LINK_NAME),
     )
     .map_err(|_| FailReason::CurrentSwapFailed)?;
-    fsync_fd(secrets_fd);
+    fsync_fd(secrets_fd)?;
     Ok(())
 }
 
@@ -1014,7 +1363,7 @@ fn remove_current_symlink(secrets_fd: BorrowedFd<'_>) -> Result<(), FailReason> 
         rustix::fs::AtFlags::empty(),
     ) {
         Ok(()) => {
-            fsync_fd(secrets_fd);
+            fsync_fd(secrets_fd)?;
             Ok(())
         }
         Err(rustix::io::Errno::NOENT) => Ok(()),
@@ -1049,20 +1398,31 @@ fn remove_generation(generations_fd: BorrowedFd<'_>, epoch: u64) -> Result<(), F
     drop(dir_fd);
     path_safe::remove_path_safe(&generations_owned, &epoch_name)
         .map_err(|_| FailReason::RetirementTreeAnomaly)?;
-    fsync_fd(generations_fd);
+    fsync_fd(generations_fd)?;
     Ok(())
+}
+
+/// The fully-enumerated, validated contents of `generations/`: real
+/// generation epochs and real stage directories. Both halves are
+/// "real secret tree contents" for retirement purposes -- a stage
+/// directory is never swept separately or treated as ignorable.
+struct GenerationTreeContents {
+    epochs: Vec<u64>,
+    stage_names: Vec<String>,
 }
 
 /// Anchored enumeration of `generations/`, failing closed on any
 /// entry this cannot fully account for. Deletes nothing; a caller
-/// invokes this to *plan* retirement, never as part of deleting.
+/// invokes this to *plan* retirement (or to detect drift before
+/// recovery/deletion), never as part of deleting.
 fn enumerate_and_validate_generation_tree(
     generations_fd: BorrowedFd<'_>,
-) -> Result<Vec<u64>, FailReason> {
+) -> Result<GenerationTreeContents, FailReason> {
     let generations_owned = borrowed_to_owned(generations_fd)?;
     let dir = rustix::fs::Dir::read_from(generations_fd)
         .map_err(|_| FailReason::RetirementTreeAnomaly)?;
     let mut epochs = Vec::new();
+    let mut stage_names = Vec::new();
     for entry in dir {
         let entry = entry.map_err(|_| FailReason::RetirementTreeAnomaly)?;
         let name = entry
@@ -1074,10 +1434,13 @@ fn enumerate_and_validate_generation_tree(
             continue;
         }
         if name.starts_with(STAGE_PREFIX) {
-            // Stage dirs are swept separately, never part of the
-            // retirement plan; their presence does not block
-            // retirement, but they must not be miscounted as a
-            // generation either.
+            // Stage directories are real secret-tree contents, not a
+            // separately-swept concern: validate their shape now and
+            // carry them in the plan so retirement/pruning enumerates,
+            // validates, and deletes them under the same accounting as
+            // generation epochs.
+            validate_stage_dir_contents(&generations_owned, &name)?;
+            stage_names.push(name);
             continue;
         }
         let Some(epoch) = parse_strict_epoch(&name) else {
@@ -1087,7 +1450,11 @@ fn enumerate_and_validate_generation_tree(
         epochs.push(epoch);
     }
     epochs.sort_unstable();
-    Ok(epochs)
+    stage_names.sort();
+    Ok(GenerationTreeContents {
+        epochs,
+        stage_names,
+    })
 }
 
 fn verify_generation_dir_is_exactly_material(
@@ -1141,9 +1508,91 @@ fn verify_generation_dir_is_exactly_material(
 }
 
 // ---------------------------------------------------------------------
+// Central pre-mutation validation
+// ---------------------------------------------------------------------
+
+/// Invoked by every public lifecycle action (provision/rotate/
+/// rollback/retire) immediately after loading the on-disk marker,
+/// whenever that marker records an active generation. Refuses to
+/// proceed if the marker's own semantics are internally inconsistent,
+/// or if it does not match the caller's own `(vm_id, kind)`, or if the
+/// live on-disk state has drifted from what the marker claims -- most
+/// importantly, whether `current` resolves, by *exact literal text*,
+/// to the marker's recorded active epoch. A symlink retargeted to any
+/// other path -- absolute, foreign-rooted, or merely ending in the
+/// right epoch number -- is never accepted as a match. This is the
+/// single reachable trigger for
+/// [`FailReason::IdentityCurrentTargetMismatch`].
+fn verify_marker_against_live_state(
+    secrets_fd: BorrowedFd<'_>,
+    generations_fd: BorrowedFd<'_>,
+    vm_id: &str,
+    kind: SecretKind,
+    marker: &MarkerData,
+) -> Result<(), FailReason> {
+    if marker.vm != vm_id || marker.kind != kind.as_slug() {
+        return Err(FailReason::MarkerTamperedOrMissingMaterial);
+    }
+    if marker.retired && marker.active.is_some() {
+        // A tombstoned marker must never also claim an active
+        // generation -- these two fields are mutually exclusive by
+        // construction in every write path this module performs.
+        return Err(FailReason::MarkerTamperedOrMissingMaterial);
+    }
+    let Some(active) = marker.active.as_ref() else {
+        return Ok(());
+    };
+    if active.epoch == 0 || active.epoch > marker.high_water_epoch {
+        return Err(FailReason::MarkerTamperedOrMissingMaterial);
+    }
+    if let Some(previous) = marker.previous.as_ref()
+        && (previous.epoch == 0
+            || previous.epoch == active.epoch
+            || previous.epoch > marker.high_water_epoch)
+    {
+        // `previous` need not be numerically less than `active`: a
+        // rollback swaps the pair, so `previous` can legitimately be
+        // the *larger* epoch that was just rolled back away from.
+        // What must always hold is that it is a distinct, real,
+        // never-exceeding-high-water epoch.
+        return Err(FailReason::MarkerTamperedOrMissingMaterial);
+    }
+    if !current_resolves_exactly_to(secrets_fd, active.epoch) {
+        return Err(FailReason::IdentityCurrentTargetMismatch);
+    }
+    verify_existing_generation_identity(generations_fd, active)?;
+    if let Some(previous) = marker.previous.as_ref() {
+        verify_existing_generation_identity(generations_fd, previous)?;
+    }
+    Ok(())
+}
+
+/// Immediately before deleting a generation directory as part of
+/// retirement, re-stat it (nofollow, anchored) and confirm it is
+/// still exactly a validated material directory. A missing entry is
+/// tolerated (another recovery pass, or this same pass on retry,
+/// already removed it); any other anomaly -- wrong type, extra
+/// entries, a hard-linked material file -- fails closed rather than
+/// deleting a directory that no longer matches what enumeration
+/// originally validated.
+fn revalidate_generation_before_delete(
+    generations_fd: BorrowedFd<'_>,
+    epoch: u64,
+) -> Result<(), FailReason> {
+    let epoch_name = epoch.to_string();
+    let generations_owned = borrowed_to_owned(generations_fd)?;
+    match path_safe::fstatat_nofollow(&generations_owned, &epoch_name) {
+        Ok(Some(_)) => verify_generation_dir_is_exactly_material(&generations_owned, &epoch_name),
+        Ok(None) => Ok(()),
+        Err(_) => Err(FailReason::RetirementTreeAnomaly),
+    }
+}
+
+// ---------------------------------------------------------------------
 // Unified promote engine (fresh action + crash recovery)
 // ---------------------------------------------------------------------
 
+#[derive(Debug)]
 enum PromoteOutcome {
     Completed(MarkerData),
     /// Only reachable when recovering a crash that occurred before
@@ -1163,22 +1612,50 @@ fn execute_promote(
         match intent.phase {
             PromotePhase::Planned => {
                 if intent.create_epoch {
-                    let staged = ensure_staged(
-                        generations_fd,
-                        cfg,
-                        &intent.stage_name,
-                        &intent.expected_digest_hex,
-                        material,
-                    )?;
-                    if !staged {
-                        remove_txlog(secrets_fd)?;
-                        return Ok(PromoteOutcome::AbortedNoMaterial);
+                    let epoch_name = intent.to_epoch.to_string();
+                    let generations_owned = borrowed_to_owned(generations_fd)?;
+                    let existing_digest =
+                        digest_of_material_dir(&generations_owned, &epoch_name).ok();
+                    match existing_digest {
+                        Some(digest) if digest == intent.expected_digest_hex => {
+                            // The rename to the final epoch name
+                            // already completed in a previous crashed
+                            // attempt (the phase-advance write itself
+                            // did not commit before the crash). The
+                            // epoch is fully materialized with exactly
+                            // the expected content: never abandon or
+                            // re-stage it, just continue forward.
+                        }
+                        Some(_) => {
+                            // Some directory already occupies this
+                            // epoch number, but its content does not
+                            // match what this transaction intended to
+                            // promote. This can only be a stale,
+                            // foreign, or previously-aborted
+                            // generation; never silently adopt or
+                            // overwrite it -- fail closed.
+                            return Err(FailReason::RecoveryContentMismatch);
+                        }
+                        None => {
+                            let staged = ensure_staged(
+                                generations_fd,
+                                cfg,
+                                &intent.stage_name,
+                                &intent.expected_digest_hex,
+                                material,
+                            )?;
+                            if !staged {
+                                remove_txlog(secrets_fd)?;
+                                return Ok(PromoteOutcome::AbortedNoMaterial);
+                            }
+                            promote_stage_to_generation(
+                                generations_fd,
+                                &intent.stage_name,
+                                intent.to_epoch,
+                                &intent.expected_digest_hex,
+                            )?;
+                        }
                     }
-                    promote_stage_to_generation(
-                        generations_fd,
-                        &intent.stage_name,
-                        intent.to_epoch,
-                    )?;
                 } else {
                     let expected = intent
                         .expected_identity
@@ -1232,7 +1709,17 @@ fn execute_promote(
                     // enumeration.
                     let _ = remove_generation(generations_fd, prune);
                 }
-                sweep_stale_stage_dirs(generations_fd, None);
+                // Any leftover `.stage-*` directory at this point is a
+                // real secret-tree entry from this or a prior crashed
+                // attempt (never the one this transaction just
+                // promoted -- that one was already renamed away).
+                // Enumerate, validate, and delete it, propagating any
+                // failure: a stage directory is never swept on a
+                // best-effort basis.
+                let leftover = enumerate_and_validate_generation_tree(generations_fd)?;
+                for stage_name in leftover.stage_names {
+                    remove_stage_dir(generations_fd, &stage_name)?;
+                }
                 remove_txlog(secrets_fd)?;
                 let marker = read_marker(secrets_fd)?.ok_or(FailReason::MarkerWriteFailed)?;
                 return Ok(PromoteOutcome::Completed(marker));
@@ -1254,7 +1741,12 @@ fn execute_retire(
         match intent.phase {
             RetirePhase::Enumerated => {
                 let fresh = enumerate_and_validate_generation_tree(generations_fd)?;
-                if !fresh.iter().all(|e| intent.epochs.contains(e)) {
+                if !fresh.epochs.iter().all(|e| intent.epochs.contains(e))
+                    || !fresh
+                        .stage_names
+                        .iter()
+                        .all(|s| intent.stage_names.contains(s))
+                {
                     return Err(FailReason::RecoveryAmbiguous);
                 }
                 remove_current_symlink(secrets_fd)?;
@@ -1263,21 +1755,27 @@ fn execute_retire(
             }
             RetirePhase::CurrentRemoved => {
                 for &epoch in &intent.epochs {
+                    revalidate_generation_before_delete(generations_fd, epoch)?;
                     remove_generation(generations_fd, epoch)?;
+                }
+                for stage_name in &intent.stage_names {
+                    // Staged entries are real secret-tree contents:
+                    // enumerate/validate/delete them exactly like
+                    // generation epochs, propagating every failure.
+                    remove_stage_dir(generations_fd, stage_name)?;
                 }
                 intent.phase = RetirePhase::EpochsRemoved;
                 write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
             }
             RetirePhase::EpochsRemoved => {
                 let remaining = enumerate_and_validate_generation_tree(generations_fd)?;
-                if !remaining.is_empty() {
+                if !remaining.epochs.is_empty() || !remaining.stage_names.is_empty() {
                     return Err(FailReason::RetirementNotProvablyEmpty);
                 }
                 intent.phase = RetirePhase::ProvenEmpty;
                 write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
             }
             RetirePhase::ProvenEmpty => {
-                sweep_stale_stage_dirs(generations_fd, None);
                 let marker = MarkerData {
                     v: MARKER_SCHEMA_VERSION,
                     vm: intent.vm.clone(),
@@ -1310,9 +1808,11 @@ pub struct RecoveryError {
 fn recover_if_needed(
     secrets_fd: BorrowedFd<'_>,
     generations_fd: BorrowedFd<'_>,
+    vm_id: &str,
+    kind: SecretKind,
     cfg: &SecretsLifecycleConfig,
 ) -> Result<bool, RecoveryError> {
-    let txlog = read_txlog(secrets_fd).map_err(|reason| RecoveryError {
+    let txlog = read_txlog(secrets_fd, vm_id, kind).map_err(|reason| RecoveryError {
         action: None,
         reason,
     })?;
@@ -1371,7 +1871,7 @@ pub fn recover_in_flight_transaction(
         let ctx = context(vm_id, kind, LifecycleAction::Provision, &paths);
         denied(&ctx, reason)
     })?;
-    match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), cfg) {
+    match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), vm_id, kind, cfg) {
         Ok(recovered) => Ok(recovered),
         Err(err) => {
             let ctx = context(
@@ -1418,18 +1918,29 @@ fn open_and_recover(
     let (secrets_fd, generations_fd) =
         open_or_create_secrets_dir(&paths, cfg).map_err(|reason| denied(&ctx, reason))?;
     let lock = acquire_lock(secrets_fd.as_fd(), cfg).map_err(|reason| denied(&ctx, reason))?;
-    let recovered = match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), cfg) {
-        Ok(recovered) => recovered,
-        Err(err) => {
-            let recovered_ctx = context(vm_id, kind, err.action.unwrap_or(action), &paths);
-            return Err(failed_closed(
-                &recovered_ctx,
-                MarkerResult::FailedClosed,
-                err.reason,
-            ));
-        }
-    };
+    let recovered =
+        match recover_if_needed(secrets_fd.as_fd(), generations_fd.as_fd(), vm_id, kind, cfg) {
+            Ok(recovered) => recovered,
+            Err(err) => {
+                let recovered_ctx = context(vm_id, kind, err.action.unwrap_or(action), &paths);
+                return Err(failed_closed(
+                    &recovered_ctx,
+                    MarkerResult::FailedClosed,
+                    err.reason,
+                ));
+            }
+        };
     let marker = read_marker(secrets_fd.as_fd()).map_err(|reason| denied(&ctx, reason))?;
+    if let Some(marker) = &marker {
+        verify_marker_against_live_state(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            vm_id,
+            kind,
+            marker,
+        )
+        .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
+    }
     Ok((paths, secrets_fd, generations_fd, lock, recovered, marker))
 }
 
@@ -1457,7 +1968,7 @@ pub fn provision(
     }
     let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
         .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
-    if !existing.is_empty() {
+    if !existing.epochs.is_empty() || !existing.stage_names.is_empty() {
         return Err(failed_closed(
             &ctx,
             MarkerResult::FailedClosed,
@@ -1656,7 +2167,6 @@ pub fn retire(
         open_and_recover(vm_id, kind, LifecycleAction::Retire, cfg)?;
     let ctx = context(vm_id, kind, LifecycleAction::Retire, &paths);
 
-    sweep_stale_stage_dirs(generations_fd.as_fd(), None);
     let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
         .map_err(|reason| failed_closed(&ctx, MarkerResult::FailedClosed, reason))?;
 
@@ -1666,7 +2176,7 @@ pub fn retire(
         .map(|m| m.active.is_some() && !m.retired)
         .unwrap_or(false);
 
-    if existing.is_empty() {
+    if existing.epochs.is_empty() && existing.stage_names.is_empty() {
         if marker_claims_active {
             // Marker says material should exist; the physical tree
             // disagrees. Fail closed rather than silently accepting
@@ -1683,11 +2193,13 @@ pub fn retire(
         ));
     }
 
-    let high_water_epoch = recorded_high_water.max(existing.iter().copied().max().unwrap_or(0));
+    let high_water_epoch =
+        recorded_high_water.max(existing.epochs.iter().copied().max().unwrap_or(0));
     let intent = RetireIntent {
         vm: vm_id.to_owned(),
         kind: kind.as_slug().to_owned(),
-        epochs: existing,
+        epochs: existing.epochs,
+        stage_names: existing.stage_names,
         high_water_epoch,
         phase: RetirePhase::Enumerated,
     };
@@ -1733,6 +2245,24 @@ mod tests {
         fields.validate().unwrap_or_else(|err| {
             panic!("audit fields failed validation: {err}\nfields: {fields:?}")
         });
+    }
+
+    /// RAII guard that makes every `fsync_fd` call in this thread fail
+    /// with [`FailReason::FsyncFailed`] for as long as it is held,
+    /// restoring normal behavior on drop (including via early
+    /// return/panic unwinding) so one test's fault injection can never
+    /// leak into another.
+    struct FsyncFaultGuard;
+    impl FsyncFaultGuard {
+        fn enable() -> Self {
+            FSYNC_SHOULD_FAIL.with(|c| c.set(true));
+            FsyncFaultGuard
+        }
+    }
+    impl Drop for FsyncFaultGuard {
+        fn drop(&mut self) {
+            FSYNC_SHOULD_FAIL.with(|c| c.set(false));
+        }
     }
 
     // -------------------------------------------------------------
@@ -1913,7 +2443,8 @@ mod tests {
             )
             .unwrap()
         );
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2).unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
+            .unwrap();
         atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
         let prior_active = read_marker(secrets_fd.as_fd())
             .unwrap()
@@ -1944,7 +2475,7 @@ mod tests {
         let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
         let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
         assert_eq!(marker.active.unwrap().epoch, 2);
-        assert!(read_txlog(secrets_fd.as_fd()).unwrap().is_none());
+        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_none());
     }
 
     #[test]
@@ -1962,6 +2493,7 @@ mod tests {
             vm: vm.to_owned(),
             kind: kind.as_slug().to_owned(),
             epochs: vec![1],
+            stage_names: Vec::new(),
             high_water_epoch: 1,
             phase: RetirePhase::CurrentRemoved,
         };
@@ -2002,7 +2534,8 @@ mod tests {
             Some(&mat),
         )
         .unwrap();
-        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2).unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
+            .unwrap();
         atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
         // Corrupt the recorded digest so `CurrentPromoted`'s identity
         // check cannot match — this must fail closed, not silently
@@ -2130,8 +2663,14 @@ mod tests {
         )
         .unwrap();
 
+        // The hard-linked generation is still the marker's recorded
+        // *active* generation, so the central pre-mutation identity
+        // check (`verify_marker_against_live_state`, run before
+        // retire's own tree enumeration) catches the link-count drift
+        // first, with a more specific reason than the generic
+        // tree-anomaly enumeration would have produced.
         let err = retire(vm, kind, &cfg).unwrap_err();
-        assert_eq!(err.reason, FailReason::RetirementTreeAnomaly);
+        assert_eq!(err.reason, FailReason::IdentityLinkCountMismatch);
     }
 
     #[test]
@@ -2241,5 +2780,841 @@ mod tests {
         assert_eq!(err.reason, FailReason::InvalidVmId);
         // Nothing was created under the state root.
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    // -------------------------------------------------------------
+    // Finding-round-3 adversarial coverage: fsync-failure injection
+    // -------------------------------------------------------------
+
+    #[test]
+    fn fsync_failure_in_ensure_staged_blocks_and_is_retryable() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("mia", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"fresh");
+        let stage_name = random_stage_name();
+
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = ensure_staged(
+                generations_fd.as_fd(),
+                &cfg,
+                &stage_name,
+                &mat.digest_hex(),
+                Some(&mat),
+            )
+            .unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // The material bytes were durably written to disk by the time
+        // `fsync_fd` was reached (only the sync itself failed), so a
+        // retry with fsync working again must observe the same digest
+        // and complete idempotently rather than double-writing or
+        // erroring.
+        assert!(
+            ensure_staged(
+                generations_fd.as_fd(),
+                &cfg,
+                &stage_name,
+                &mat.digest_hex(),
+                Some(&mat),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn fsync_failure_in_promote_stage_to_generation_blocks_and_is_retryable() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("nadia", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"fresh");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = promote_stage_to_generation(
+                generations_fd.as_fd(),
+                &stage_name,
+                7,
+                &mat.digest_hex(),
+            )
+            .unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // The rename already landed on disk before the failed fsync;
+        // retrying must see the matching digest at the final name and
+        // treat it as already-promoted (never re-rename, never error).
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 7, &mat.digest_hex())
+            .unwrap();
+    }
+
+    #[test]
+    fn fsync_failure_in_atomic_swap_current_blocks_and_is_retryable() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "oscar";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Materialise a second generation directly (bypassing the
+        // marker/txlog machinery) so swapping `current` to it is a
+        // genuine change of target, not a same-epoch no-op that would
+        // short-circuit before ever reaching `fsync_fd`.
+        let mat2 = material(b"e2");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat2.digest_hex(),
+            Some(&mat2),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat2.digest_hex())
+            .unwrap();
+
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = atomic_swap_current(secrets_fd.as_fd(), 2).unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // `current` still resolves correctly afterward: either the
+        // rename never completed (still epoch 1, unchanged) or it did
+        // and only the sync failed -- both are safe, and a retry with
+        // fsync restored must succeed.
+        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
+        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 2));
+    }
+
+    #[test]
+    fn fsync_failure_in_write_marker_blocks_marker_commit_phase() {
+        // Drive `execute_promote` up to `CurrentPromoted` normally
+        // (fsync working), then inject a failure exactly at the
+        // `write_marker` call inside the `CurrentPromoted` phase and
+        // confirm: (a) the call fails with `FsyncFailed`; (b) the
+        // txlog still records `CurrentPromoted` (the phase advance to
+        // `MarkerCommitted` never durably landed, so a crash here is
+        // still recoverable rather than mistaken for "finished"); and
+        // (c) a subsequent recovery pass with fsync restored
+        // completes the promotion and removes the txlog.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "priya";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e2");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
+            .unwrap();
+        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::CurrentPromoted,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone())).unwrap();
+
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = execute_promote(
+                secrets_fd.as_fd(),
+                generations_fd.as_fd(),
+                &cfg,
+                intent,
+                None,
+            )
+            .unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // The marker rename+write already landed (fsync only
+        // failed to make it durable, it did not block visibility),
+        // so this process's own next read already observes epoch 2;
+        // what fsync failing must guarantee is that the phase was
+        // never advanced past `CurrentPromoted` -- the txlog still
+        // records that phase, so a crash here is safely recoverable
+        // rather than being treated as already-finished.
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert_eq!(marker.active.as_ref().unwrap().epoch, 2);
+        let txlog = read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().unwrap();
+        match txlog {
+            TxLog::Promote(intent) => assert_eq!(intent.phase, PromotePhase::CurrentPromoted),
+            TxLog::Retire(_) => panic!("expected a leftover Promote txlog"),
+        }
+
+        // With fsync restored, recovery completes forward: the
+        // txlog is durably removed and the marker remains at epoch 2.
+        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
+        assert!(recovered);
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert_eq!(marker.active.as_ref().unwrap().epoch, 2);
+        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_none());
+    }
+
+    #[test]
+    fn fsync_failure_in_remove_generation_blocks_and_is_retryable() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("quinn", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = remove_generation(generations_fd.as_fd(), 1).unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // Idempotent retry (whether or not the delete itself already
+        // landed) must succeed once fsync works again.
+        remove_generation(generations_fd.as_fd(), 1).unwrap();
+    }
+
+    #[test]
+    fn fsync_failure_in_remove_stage_dir_blocks_and_is_retryable() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("rex", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"stray");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        remove_stage_dir(generations_fd.as_fd(), &stage_name).unwrap();
+    }
+
+    // -------------------------------------------------------------
+    // Finding 2: orphan-epoch / pre-existing-digest scenarios
+    // -------------------------------------------------------------
+
+    #[test]
+    fn promote_stage_to_generation_rejects_foreign_content_at_target_epoch() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("sasha", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+
+        // A foreign directory already occupies the target epoch
+        // number with content that does not match what we intend to
+        // promote.
+        let foreign = material(b"foreign-content");
+        let foreign_stage = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &foreign_stage,
+            &foreign.digest_hex(),
+            Some(&foreign),
+        )
+        .unwrap();
+        promote_stage_to_generation(
+            generations_fd.as_fd(),
+            &foreign_stage,
+            5,
+            &foreign.digest_hex(),
+        )
+        .unwrap();
+
+        let intended = material(b"intended-content");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &intended.digest_hex(),
+            Some(&intended),
+        )
+        .unwrap();
+        let err = promote_stage_to_generation(
+            generations_fd.as_fd(),
+            &stage_name,
+            5,
+            &intended.digest_hex(),
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::GenerationConflict);
+        // The foreign directory must be untouched -- never silently
+        // overwritten or adopted.
+        assert_eq!(
+            digest_of_material_dir(&borrowed_to_owned(generations_fd.as_fd()).unwrap(), "5")
+                .unwrap(),
+            foreign.digest_hex()
+        );
+    }
+
+    #[test]
+    fn planned_phase_recovery_detects_already_renamed_orphan_epoch_and_continues() {
+        // Regression guard for "never abandon/reuse an orphan epoch":
+        // simulate a crash where the stage-to-epoch rename already
+        // completed but the phase-advance write from `Planned` to
+        // `EpochReady` never committed. Recovery must detect the
+        // already-renamed epoch by exact digest match and continue
+        // forward, never abandon the transaction nor silently adopt a
+        // mismatched directory.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "tariq";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e2");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        // Simulate the rename having already happened, but the txlog
+        // still recording `Planned` (as if the crash landed between
+        // the rename and the phase-advance write).
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
+            .unwrap();
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
+        drop(secrets_fd);
+        drop(generations_fd);
+
+        let recovered = recover_in_flight_transaction(vm, kind, &cfg).unwrap();
+        assert!(recovered);
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert_eq!(marker.active.unwrap().epoch, 2);
+    }
+
+    #[test]
+    fn planned_phase_recovery_rejects_mismatched_content_at_orphan_epoch() {
+        // The inverse of the above: the pre-existing directory at the
+        // target epoch number has content that does NOT match the
+        // recorded transaction's expected digest. This must never be
+        // silently adopted -- fail closed instead.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "umberto";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let foreign = material(b"unexpected-content");
+        let foreign_stage = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &foreign_stage,
+            &foreign.digest_hex(),
+            Some(&foreign),
+        )
+        .unwrap();
+        promote_stage_to_generation(
+            generations_fd.as_fd(),
+            &foreign_stage,
+            2,
+            &foreign.digest_hex(),
+        )
+        .unwrap();
+
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name: random_stage_name(),
+            expected_digest_hex: material(b"e2").digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::Planned,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent)).unwrap();
+        drop(secrets_fd);
+        drop(generations_fd);
+
+        let err = recover_in_flight_transaction(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::RecoveryContentMismatch);
+        // Epoch 1 (the real active generation) must be entirely
+        // untouched.
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(1));
+    }
+
+    // -------------------------------------------------------------
+    // Finding 1: literal-`current`-target tamper
+    // -------------------------------------------------------------
+
+    #[test]
+    fn current_resolves_exactly_to_rejects_foreign_path_with_matching_final_component() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("vera", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+
+        // A symlink whose target merely *ends* in the right epoch
+        // number, but is not the exact literal `generations/<epoch>`
+        // text, must never be treated as resolving to that epoch.
+        let _ = rustix::fs::unlinkat(
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+            rustix::fs::AtFlags::empty(),
+        );
+        rustix::fs::symlinkat(
+            "/some/foreign/absolute/path/7",
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+        )
+        .unwrap();
+        assert!(!current_resolves_exactly_to(secrets_fd.as_fd(), 7));
+        assert_eq!(read_current_target(secrets_fd.as_fd()), None);
+
+        let _ = rustix::fs::unlinkat(
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+            rustix::fs::AtFlags::empty(),
+        );
+        rustix::fs::symlinkat(
+            "../../foreign/7",
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+        )
+        .unwrap();
+        assert!(!current_resolves_exactly_to(secrets_fd.as_fd(), 7));
+        assert_eq!(read_current_target(secrets_fd.as_fd()), None);
+
+        let _ = rustix::fs::unlinkat(
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+            rustix::fs::AtFlags::empty(),
+        );
+        rustix::fs::symlinkat(
+            expected_current_target(7),
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+        )
+        .unwrap();
+        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 7));
+        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(7));
+    }
+
+    #[test]
+    fn tampered_current_symlink_is_reachable_and_fails_closed_on_rotate() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "wendy";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let _ = rustix::fs::unlinkat(
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+            rustix::fs::AtFlags::empty(),
+        );
+        // Retarget `current` to an absolute path whose final
+        // component happens to be "1" (the real active epoch's
+        // number) but which is not the literal `generations/1` text
+        // this module ever writes.
+        rustix::fs::symlinkat(
+            "/etc/passwd/../1",
+            secrets_fd.as_fd(),
+            Path::new(CURRENT_LINK_NAME),
+        )
+        .unwrap();
+        drop(secrets_fd);
+
+        let err = rotate(vm, kind, material(b"e2"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::IdentityCurrentTargetMismatch);
+    }
+
+    // -------------------------------------------------------------
+    // Finding 3: staged entries are real, propagated deletions
+    // -------------------------------------------------------------
+
+    #[test]
+    fn validate_stage_dir_contents_rejects_extra_entries_and_subdirectories() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("xander", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+
+        let owned = borrowed_to_owned(generations_fd.as_fd()).unwrap();
+        let stage_dir_fd = path_safe::open_at(
+            owned.as_fd(),
+            Path::new(&stage_name),
+            OFlags::RDONLY | OFlags::DIRECTORY,
+        )
+        .unwrap();
+        let stage_dir_owned = borrowed_to_owned(stage_dir_fd.as_fd()).unwrap();
+        path_safe::mkdir_at(stage_dir_owned.as_fd(), Path::new("extra-subdir"), 0o700).unwrap();
+
+        let err = validate_stage_dir_contents(&owned, &stage_name).unwrap_err();
+        assert_eq!(err, FailReason::RetirementTreeAnomaly);
+    }
+
+    #[test]
+    fn stage_dir_deletion_failure_propagates_and_blocks_retire() {
+        // A stage directory that cannot be fully enumerated/deleted
+        // (here: it contains an anomalous subdirectory rather than at
+        // most one regular-file entry) must block retirement entirely
+        // -- never a best-effort, ignored sweep.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "yara";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let stray = random_stage_name();
+        path_safe::mkdir_at_exclusive(generations_fd.as_fd(), Path::new(&stray), 0o700).unwrap();
+        let stray_owned = borrowed_to_owned(generations_fd.as_fd()).unwrap();
+        let stray_fd = path_safe::open_at(
+            stray_owned.as_fd(),
+            Path::new(&stray),
+            OFlags::RDONLY | OFlags::DIRECTORY,
+        )
+        .unwrap();
+        let stray_dir_owned = borrowed_to_owned(stray_fd.as_fd()).unwrap();
+        path_safe::mkdir_at(stray_dir_owned.as_fd(), Path::new("nested"), 0o700).unwrap();
+
+        let err = retire(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::RetirementTreeAnomaly);
+        // Nothing was deleted: the legitimate generation and the
+        // anomalous stray directory are both still present.
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
+        assert!(generations_dir.join(&stray).is_dir());
+    }
+
+    #[test]
+    fn retire_deletes_stray_stage_directories_as_real_content() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "zane";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let stray_mat = material(b"stray-stage-content");
+        let stray_stage = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stray_stage,
+            &stray_mat.digest_hex(),
+            Some(&stray_mat),
+        )
+        .unwrap();
+
+        let fields = retire(vm, kind, &cfg).unwrap();
+        assert_valid(&fields);
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        assert_eq!(std::fs::read_dir(&generations_dir).unwrap().count(), 0);
+    }
+
+    // -------------------------------------------------------------
+    // Finding 5: txlog semantic validation / pre-delete revalidation
+    // -------------------------------------------------------------
+
+    #[test]
+    fn txlog_with_wrong_vm_is_rejected_before_recovery_acts() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "amara";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let intent = RetireIntent {
+            vm: "someone-else".to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: Vec::new(),
+            high_water_epoch: 1,
+            phase: RetirePhase::CurrentRemoved,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent)).unwrap();
+        drop(secrets_fd);
+
+        let err = recover_in_flight_transaction(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::IntentCorrupt);
+        // Nothing was touched: the active generation is intact.
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        assert_eq!(read_current_target(secrets_fd.as_fd()), Some(1));
+    }
+
+    #[test]
+    fn txlog_with_non_monotonic_epochs_is_rejected() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("boaz", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let intent = RetireIntent {
+            vm: "boaz".to_owned(),
+            kind: SecretKind::GuestSigningKey.as_slug().to_owned(),
+            epochs: vec![3, 1],
+            stage_names: Vec::new(),
+            high_water_epoch: 3,
+            phase: RetirePhase::Enumerated,
+        };
+        let err = validate_retire_intent_semantics(&intent, "boaz", SecretKind::GuestSigningKey)
+            .unwrap_err();
+        assert_eq!(err, FailReason::IntentCorrupt);
+        drop(secrets_fd);
+    }
+
+    #[test]
+    fn revalidate_generation_before_delete_catches_a_tamper_immediately_before_delete() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("carys", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+
+        // Absent generation is tolerated (idempotent replay).
+        revalidate_generation_before_delete(generations_fd.as_fd(), 2).unwrap();
+
+        // Tamper: hard-link a second name into the generation just
+        // before deletion would occur.
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::hard_link(gen_dir.join(MATERIAL_FILE_NAME), gen_dir.join("planted")).unwrap();
+        let err = revalidate_generation_before_delete(generations_fd.as_fd(), 1).unwrap_err();
+        assert_eq!(err, FailReason::RetirementTreeAnomaly);
+    }
+
+    // -------------------------------------------------------------
+    // Finding 6: broker-owned metadata / lock-file verification
+    // -------------------------------------------------------------
+
+    #[test]
+    fn acquire_lock_rejects_a_wrong_mode_lock_file() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("dov", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        drop(_generations_fd);
+        drop(secrets_fd);
+
+        let lock_path = paths.kind_root.join(LOCK_FILE_NAME);
+        std::fs::write(&lock_path, b"").unwrap();
+        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let err = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap_err();
+        assert_eq!(err, FailReason::BrokerOwnershipViolation);
+    }
+
+    #[test]
+    fn acquire_lock_rejects_a_hardlinked_lock_file() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("elan", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        drop(generations_fd);
+        drop(secrets_fd);
+
+        let lock_path = paths.kind_root.join(LOCK_FILE_NAME);
+        std::fs::write(&lock_path, b"").unwrap();
+        std::fs::set_permissions(
+            &lock_path,
+            std::fs::Permissions::from_mode(FILE_MODE_DEFAULT),
+        )
+        .unwrap();
+        std::fs::hard_link(&lock_path, paths.kind_root.join("lock-plant")).unwrap();
+
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let err = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap_err();
+        assert_eq!(err, FailReason::BrokerOwnershipViolation);
+    }
+
+    #[test]
+    fn acquire_lock_rejects_a_wrong_mode_parent_directory() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("farid", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+
+        // Tamper the mode on the already-open `kind_root` directory
+        // (the lock file's anchored parent) via its live inode --
+        // re-opening through `open_or_create_secrets_dir` would
+        // silently reassert the correct mode via `ensure_dir` before
+        // `acquire_lock` ever ran, masking the drift this test must
+        // prove is caught. Using the still-open fd's `fstat` view
+        // instead observes the tamper exactly like a concurrent
+        // actor's `chmod` on the live directory would.
+        std::fs::set_permissions(&paths.kind_root, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let err = acquire_lock(secrets_fd.as_fd(), &cfg).unwrap_err();
+        assert_eq!(err, FailReason::BrokerOwnershipViolation);
+    }
+
+    #[test]
+    fn open_or_create_secrets_dir_reasserts_mode_drift_on_metadata_dirs() {
+        // `ensure_dir` only reasserts *mode*, not owner, when passed
+        // `None, None`; confirm the mode side of that contract is
+        // actually exercised end to end (a drifted mode on the
+        // metadata directories is corrected on the next open) rather
+        // than merely assumed from construction.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let paths = derive_paths("gilad", SecretKind::GuestSigningKey, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        drop(generations_fd);
+        drop(secrets_fd);
+
+        std::fs::set_permissions(&paths.kind_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let stat = path_safe::fstat_fd(secrets_fd.as_fd()).unwrap();
+        assert_eq!((stat.st_mode as u32) & 0o7777, cfg.dir_mode);
+    }
+
+    // -------------------------------------------------------------
+    // Finding 1: central validation catches marker/live drift on
+    // every action, not only the one that caused it
+    // -------------------------------------------------------------
+
+    #[test]
+    fn central_validation_runs_identically_for_every_public_action() {
+        // A single tamper (retargeting `current` away from the
+        // marker's recorded active epoch) must be caught by
+        // `provision`, `rotate`, `rollback`, and `retire` alike, since
+        // all four route through the same `open_and_recover` choke
+        // point rather than four separately-maintained checks.
+        for action in ["rotate", "rollback", "retire"] {
+            let dir = tempdir().unwrap();
+            let cfg = cfg_at(dir.path());
+            let vm = "hana";
+            let kind = SecretKind::GuestSigningKey;
+            provision(vm, kind, material(b"e1"), &cfg).unwrap();
+            rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+
+            let paths = derive_paths(vm, kind, &cfg).unwrap();
+            let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+            let _ = rustix::fs::unlinkat(
+                secrets_fd.as_fd(),
+                Path::new(CURRENT_LINK_NAME),
+                rustix::fs::AtFlags::empty(),
+            );
+            rustix::fs::symlinkat(
+                "/nonexistent/tamper/2",
+                secrets_fd.as_fd(),
+                Path::new(CURRENT_LINK_NAME),
+            )
+            .unwrap();
+            drop(secrets_fd);
+
+            let err = match action {
+                "rotate" => rotate(vm, kind, material(b"e3"), &cfg).unwrap_err(),
+                "rollback" => rollback(vm, kind, &cfg).unwrap_err(),
+                "retire" => retire(vm, kind, &cfg).unwrap_err(),
+                _ => unreachable!(),
+            };
+            assert_eq!(
+                err.reason,
+                FailReason::IdentityCurrentTargetMismatch,
+                "action {action} did not reach the central validation choke point"
+            );
+        }
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs
@@ -145,7 +145,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use nix::fcntl::{FlockArg, flock};
 use rustix::fs::OFlags;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -153,10 +152,11 @@ use zeroize::Zeroizing;
 
 use crate::ops::hosts::stable_hash_str;
 use crate::ops::secrets_rotation_audit::{
-    FailReason, LifecycleAction, MarkerResult, SecretKind, SecretsLifecycleAuditContext,
+    FailReason, LifecycleAction, SecretKind, SecretsLifecycleAuditContext,
     SecretsLifecycleAuditFields,
 };
 use crate::sys::path_safe;
+use d2b_contracts::types::VmId;
 
 // ---------------------------------------------------------------------
 // Constants
@@ -270,7 +270,7 @@ fn context(
     paths: &SecretsLifecyclePaths,
 ) -> SecretsLifecycleAuditContext {
     SecretsLifecycleAuditContext {
-        vm_id: vm_id.to_owned(),
+        vm_id: VmId::new(vm_id),
         kind,
         action,
         base_dir_hash: paths.base_dir_hash.clone(),
@@ -510,16 +510,17 @@ fn denied(
 
 /// `recovered` must reflect whether this call already successfully
 /// drained a leftover crashed transaction before this failure — see
-/// [`SecretsLifecycleAuditFields::failed`].
+/// [`SecretsLifecycleAuditFields::failed`]. There is no
+/// caller-supplied `MarkerResult` here: `failed` itself always
+/// records `MarkerResult::FailedClosed`.
 fn failed_closed(
     ctx: &SecretsLifecycleAuditContext,
     recovered: bool,
-    marker_result: MarkerResult,
     reason: FailReason,
 ) -> SecretsLifecycleError {
     SecretsLifecycleError {
         reason,
-        audit: SecretsLifecycleAuditFields::failed(ctx, recovered, marker_result, reason),
+        audit: SecretsLifecycleAuditFields::failed(ctx, recovered, reason),
     }
 }
 
@@ -817,6 +818,90 @@ fn read_fd_to_end(fd: BorrowedFd<'_>) -> io::Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// One byte more than [`SecretMaterial::MAX_LEN`]: large enough to
+/// distinguish "at the maximum permitted size" from "oversized",
+/// small enough that a read against this cap can never be unbounded.
+const MATERIAL_READ_CAP: u64 = SecretMaterial::MAX_LEN as u64 + 1;
+
+/// Read up to `cap` bytes from `fd` directly into a
+/// `Zeroizing<Vec<u8>>` -- never through an intermediate plain
+/// `Vec<u8>` -- so a partial-read-then-error buffer is zeroized on
+/// drop rather than silently dropped as ordinary heap memory. Returns
+/// an error (without ever exceeding `cap` bytes of allocation) if the
+/// stream still has unread data past `cap`, so a file that grows
+/// between `fstat` and `read` can never be read past the cap either.
+fn read_fd_to_end_capped(fd: BorrowedFd<'_>, cap: u64) -> io::Result<Zeroizing<Vec<u8>>> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd as _;
+    let dup = rustix::fs::fcntl_dupfd_cloexec(fd, 0).map_err(io_from_rustix)?;
+    let file: std::fs::File = dup.into();
+    // Cap the reader at `cap + 1`: reading exactly `cap + 1` bytes
+    // successfully proves the underlying stream is oversized, which
+    // we reject below, while never allocating more than `cap + 1`
+    // bytes regardless of how large the real stream actually is.
+    let mut limited = file.take(cap + 1);
+    let mut buf = Zeroizing::new(Vec::new());
+    limited.read_to_end(&mut buf)?;
+    let _ = fd.as_raw_fd();
+    if buf.len() as u64 > cap {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "material file exceeds the closed read cap",
+        ));
+    }
+    Ok(buf)
+}
+
+/// Safely open, type/size-verify, and read an on-disk material file
+/// beneath `dir_fd`, returning the opened fd (for any further
+/// fd-based checks the caller needs, e.g. an ACL probe), its `fstat`
+/// result, and its full contents in a buffer that is *never*
+/// observable as a plain, unwrapped `Vec<u8>`.
+///
+/// - Opens with `O_RDONLY | O_NONBLOCK`: nofollow / no-magiclink /
+///   beneath-only resolution is already enforced unconditionally by
+///   [`path_safe::open_file_at_safe`]; `O_NONBLOCK` additionally
+///   guarantees this call can never block indefinitely if a FIFO has
+///   been planted at the material path instead of a regular file.
+/// - Rejects, before reading a single byte, anything that is not a
+///   regular file or whose reported size exceeds
+///   [`MATERIAL_READ_CAP`] -- a device, FIFO, or corrupt/oversized
+///   on-disk entry is never read.
+/// - Reads directly into a `Zeroizing<Vec<u8>>` via
+///   [`read_fd_to_end_capped`] (never through an intermediate plain
+///   `Vec<u8>`).
+///
+/// Callers that need to compare *owner/mode/nlink* identity against
+/// an expected value (e.g. tamper detection across a rollback) do so
+/// on the returned `stat` themselves, using the existing per-field
+/// `FailReason` variants (`IdentityOwnerMismatch`,
+/// `IdentityModeMismatch`, `IdentityLinkCountMismatch`, ...) -- this
+/// function only enforces the type/size invariants that must hold
+/// before *any* read is safe to attempt; it deliberately does not
+/// reject on nlink so that identity capture can still surface the
+/// precise mismatch reason downstream.
+fn read_material_file_capped(
+    dir_fd: &OwnedFd,
+) -> Result<(OwnedFd, nix::libc::stat, Zeroizing<Vec<u8>>), FailReason> {
+    let file_fd = path_safe::open_file_at_safe(
+        dir_fd,
+        MATERIAL_FILE_NAME,
+        nix::libc::O_RDONLY | nix::libc::O_NONBLOCK,
+    )
+    .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    let stat = path_safe::fstat_fd(file_fd.as_fd())
+        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    if (stat.st_mode & nix::libc::S_IFMT) != nix::libc::S_IFREG {
+        return Err(FailReason::PreviouslyProvisionedMaterialMissing);
+    }
+    if stat.st_size < 0 || stat.st_size as u64 > MATERIAL_READ_CAP {
+        return Err(FailReason::PreviouslyProvisionedMaterialMissing);
+    }
+    let bytes = read_fd_to_end_capped(file_fd.as_fd(), MATERIAL_READ_CAP)
+        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    Ok((file_fd, stat, bytes))
+}
+
 // Test-only fault injection seam: when enabled (see
 // `tests::FsyncFaultGuard`), every `fsync_fd` call fails with
 // `FailReason::FsyncFailed` instead of touching the filesystem, so
@@ -890,6 +975,48 @@ fn verify_broker_owned(
     Ok(())
 }
 
+/// Build a whole-file (`l_len == 0`, `l_start == 0`, `l_whence ==
+/// SEEK_SET`) `libc::flock` descriptor for an OFD lock/unlock
+/// operation. `l_pid` is left `0`: the kernel ignores it for
+/// `F_OFD_*` commands (it is only meaningful for the classic
+/// process-associated `F_SETLK`/`F_GETLK`).
+fn whole_file_flock(l_type: nix::libc::c_short) -> nix::libc::flock {
+    nix::libc::flock {
+        l_type,
+        l_whence: nix::libc::SEEK_SET as nix::libc::c_short,
+        l_start: 0,
+        l_len: 0,
+        l_pid: 0,
+    }
+}
+
+/// Attempt to acquire a non-blocking, whole-file, exclusive **open
+/// file description** (OFD) lock on `fd` via `F_OFD_SETLK`
+/// (`F_OFD_SETLKW`'s non-blocking sibling). This is the repository's
+/// established cross-process advisory-lock primitive (mirroring
+/// `d2bd::audio_dispatch::ofd_lock`/`ofd_unlock`'s `F_OFD_SETLK{,W}`
+/// pattern) rather than BSD `flock(2)`: an OFD lock is associated
+/// with the *open file description*, not the owning process, so it
+/// composes correctly with `fork`/exec and with a single process
+/// holding multiple independent fds on the same lock file — unlike
+/// BSD `flock`, whose whole-process association would let two
+/// unrelated fds opened by the same process silently share one lock.
+///
+/// Returns `Ok(true)` if the lock was acquired, `Ok(false)` if it is
+/// currently held by another open file description (the caller should
+/// retry), and `Err` for any other failure. Both `EAGAIN` and `EACCES`
+/// are treated as "held elsewhere" per the Linux `fcntl(2)` manual
+/// page, which documents either errno as possible for a conflicting
+/// `F_SETLK`-family lock request depending on lock type.
+fn try_ofd_lock_exclusive(fd: BorrowedFd<'_>) -> Result<bool, FailReason> {
+    let fl = whole_file_flock(nix::libc::F_WRLCK as nix::libc::c_short);
+    match nix::fcntl::fcntl(fd.as_raw_fd(), nix::fcntl::FcntlArg::F_OFD_SETLK(&fl)) {
+        Ok(_) => Ok(true),
+        Err(nix::errno::Errno::EAGAIN) | Err(nix::errno::Errno::EACCES) => Ok(false),
+        Err(_) => Err(FailReason::LockUnavailable),
+    }
+}
+
 // ---------------------------------------------------------------------
 // Cross-process lock
 // ---------------------------------------------------------------------
@@ -900,18 +1027,29 @@ pub struct LockGuard {
 }
 
 /// Acquire the cross-process exclusive lock for one `(vm, kind)`
-/// directory. Before trusting the `flock`, this verifies: the
+/// directory. Before trusting the OFD lock, this verifies: the
 /// anchored parent (`secrets_fd`, i.e. `kind_root`) is a trusted-
 /// broker-owned directory with the expected mode; the lock file
 /// itself is a trusted-broker-owned regular file with the expected
 /// mode and exactly one hard link (never a hard-link plant); and,
-/// immediately after the `flock` succeeds, that the directory entry
+/// immediately after the lock succeeds, that the directory entry
 /// named `lock` still resolves (by `(dev, ino)`) to the exact file
 /// this call opened and locked — guarding against the classic
-/// flock-via-path race where another actor unlinks-and-recreates the
-/// lock file between this call's `open` and its `flock`, which would
-/// let two callers each hold an uncontended lock on two different,
-/// now-unlinked-vs-live inodes of the same name.
+/// lock-via-path race where another actor unlinks-and-recreates the
+/// lock file between this call's `open` and its lock attempt, which
+/// would let two callers each hold an uncontended lock on two
+/// different, now-unlinked-vs-live inodes of the same name. The
+/// underlying primitive is the repository's `F_OFD_SETLK` convention
+/// (see [`try_ofd_lock_exclusive`]), not BSD `flock`; releasing the
+/// lock is simply closing `LockGuard`'s owned fd (the kernel drops an
+/// OFD lock exactly when every fd referencing its open file
+/// description is closed — no separate unlock call is needed, and
+/// [`LockGuard`] deliberately exposes no public/forgeable "is locked"
+/// proof, only an opaque RAII token).
+///
+/// A full generated-sync-row `d2b-state::LockSet`/`AuthorityRef`
+/// integration remains an explicit integrator-owned wiring point: see
+/// the module doc's "Integration wiring points" §5.
 fn acquire_lock(
     secrets_fd: BorrowedFd<'_>,
     cfg: &SecretsLifecycleConfig,
@@ -935,13 +1073,13 @@ fn acquire_lock(
     let file: std::fs::File = fd.into();
     let deadline = Instant::now() + cfg.lock_max_wait;
     loop {
-        match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
-            Ok(()) => {
+        match try_ofd_lock_exclusive(file.as_fd())? {
+            true => {
                 // Re-stat by name (anchored beneath the already-
                 // verified `secrets_fd` parent) and compare `(dev,
                 // ino)` against the fd we just locked: if another
                 // actor swapped the `lock` entry between our open and
-                // our successful flock, the identity will differ and
+                // our successful lock, the identity will differ and
                 // we must not trust this lock.
                 let by_name = path_safe::fstatat_nofollow(&owned, LOCK_FILE_NAME)
                     .map_err(|_| FailReason::BrokerOwnershipViolation)?
@@ -953,13 +1091,12 @@ fn acquire_lock(
                 }
                 return Ok(LockGuard { _file: file });
             }
-            Err(nix::errno::Errno::EWOULDBLOCK) => {
+            false => {
                 if Instant::now() >= deadline {
                     return Err(FailReason::LockUnavailable);
                 }
                 std::thread::sleep(cfg.lock_poll_interval);
             }
-            Err(_) => return Err(FailReason::LockUnavailable),
         }
     }
 }
@@ -1259,12 +1396,9 @@ fn digest_of_material_dir(generations_fd: &OwnedFd, dir_name: &str) -> io::Resul
         Path::new(dir_name),
         OFlags::RDONLY | OFlags::DIRECTORY,
     )?;
-    let material_fd = path_safe::open_file_at_safe(
-        &borrowed_to_owned_io(dir_fd.as_fd())?,
-        MATERIAL_FILE_NAME,
-        nix::libc::O_RDONLY,
-    )?;
-    let bytes = Zeroizing::new(read_fd_to_end(material_fd.as_fd())?);
+    let dir_owned = borrowed_to_owned_io(dir_fd.as_fd())?;
+    let (_file_fd, _stat, bytes) = read_material_file_capped(&dir_owned)
+        .map_err(|reason| io::Error::other(format!("{reason:?}")))?;
     let mut hasher = Sha256::new();
     hasher.update(&*bytes);
     Ok(hex_encode(&hasher.finalize()))
@@ -1319,29 +1453,21 @@ fn capture_identity(
     )
     .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
     let dir_owned = borrowed_to_owned(dir_fd.as_fd())?;
-    let material_fd =
-        path_safe::open_file_at_safe(&dir_owned, MATERIAL_FILE_NAME, nix::libc::O_RDONLY)
-            .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
-    let stat = path_safe::fstat_fd(material_fd.as_fd())
-        .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
+    let (material_fd, stat, bytes) = read_material_file_capped(&dir_owned)?;
     let (has_acl, _) = path_safe::fd_extended_acl_present(material_fd.as_fd())
         .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?;
-    let bytes = Zeroizing::new(
-        read_fd_to_end(material_fd.as_fd())
-            .map_err(|_| FailReason::PreviouslyProvisionedMaterialMissing)?,
-    );
     let mut hasher = Sha256::new();
     hasher.update(&*bytes);
     let digest_hex = hex_encode(&hasher.finalize());
     let _ = generations_owned;
     Ok(MaterialIdentity {
         epoch,
-        dev: stat.st_dev as u64,
-        ino: stat.st_ino as u64,
+        dev: stat.st_dev,
+        ino: stat.st_ino,
         uid: stat.st_uid,
         gid: stat.st_gid,
-        mode: (stat.st_mode as u32) & 0o7777,
-        nlink: stat.st_nlink as u64,
+        mode: stat.st_mode & 0o7777,
+        nlink: stat.st_nlink,
         has_acl,
         digest_hex,
     })
@@ -1416,6 +1542,22 @@ fn current_resolves_exactly_to(secrets_fd: BorrowedFd<'_>, epoch: u64) -> bool {
     match current_target_text(secrets_fd) {
         Some(target) => target == expected_current_target(epoch),
         None => false,
+    }
+}
+
+/// Confirm the `current` entry is exactly absent -- not merely a
+/// dangling/foreign symlink `current_target_text` happens to be
+/// unable to parse, and not some other filesystem object (regular
+/// file, directory, ...) squatting the reserved name. Used only where
+/// the invariant under test is "no active generation exists", so any
+/// entry at all (of any type, resolving to anything) must be treated
+/// as a live-state disagreement rather than silently ignored.
+fn current_is_genuinely_absent(secrets_fd: BorrowedFd<'_>) -> Result<bool, FailReason> {
+    let owned = borrowed_to_owned(secrets_fd)?;
+    match path_safe::fstatat_nofollow(&owned, CURRENT_LINK_NAME) {
+        Ok(Some(_)) => Ok(false),
+        Ok(None) => Ok(true),
+        Err(_) => Err(FailReason::MarkerTreeOpenFailed),
     }
 }
 
@@ -1650,25 +1792,35 @@ fn verify_generation_dir_is_exactly_material(
 // ---------------------------------------------------------------------
 
 /// Invoked by every public lifecycle action (provision/rotate/
-/// rollback/retire) immediately after loading the on-disk marker,
-/// whenever that marker records an active generation. Refuses to
-/// proceed if the marker's own semantics are internally inconsistent,
-/// or if it does not match the caller's own `(vm_id, kind)`, or if the
-/// live on-disk state has drifted from what the marker claims -- most
-/// importantly, whether `current` resolves, by *exact literal text*,
-/// to the marker's recorded active epoch. A symlink retargeted to any
-/// other path -- absolute, foreign-rooted, or merely ending in the
-/// right epoch number -- is never accepted as a match. This is the
-/// single reachable trigger for
-/// [`FailReason::IdentityCurrentTargetMismatch`].
+/// rollback/retire) immediately after loading the on-disk marker.
+/// Refuses to proceed if the marker's own semantics are internally
+/// inconsistent, if it does not match the caller's own `(vm_id,
+/// kind_slug)`, or if the live on-disk state has drifted from what
+/// the marker claims.
+///
+/// This validates **every** marker shape reachable on disk, not only
+/// an active one:
+/// - An *active* marker requires `current` to resolve, by *exact
+///   literal text*, to the marker's recorded active epoch. A symlink
+///   retargeted to any other path -- absolute, foreign-rooted, or
+///   merely ending in the right epoch number -- is never accepted as
+///   a match. This is the single reachable trigger for
+///   [`FailReason::IdentityCurrentTargetMismatch`] on the active path.
+/// - An *inactive* marker (`active == None`, whether a fresh never-
+///   provisioned state or a retirement tombstone) requires
+///   `previous == None`, coherent `retired`/`high_water_epoch`
+///   metadata, and -- critically -- that `current` is genuinely
+///   absent (not stale, not foreign, not dangling): a marker claiming
+///   "nothing active" is never accepted as consistent with a live
+///   `current` entry of any kind.
 fn verify_marker_against_live_state(
     secrets_fd: BorrowedFd<'_>,
     generations_fd: BorrowedFd<'_>,
     vm_id: &str,
-    kind: SecretKind,
+    kind_slug: &str,
     marker: &MarkerData,
 ) -> Result<(), FailReason> {
-    if marker.vm != vm_id || marker.kind != kind.as_slug() {
+    if marker.vm != vm_id || marker.kind != kind_slug {
         return Err(FailReason::MarkerTamperedOrMissingMaterial);
     }
     if marker.retired && marker.active.is_some() {
@@ -1678,6 +1830,36 @@ fn verify_marker_against_live_state(
         return Err(FailReason::MarkerTamperedOrMissingMaterial);
     }
     let Some(active) = marker.active.as_ref() else {
+        // Inactive marker: either a fresh never-provisioned state
+        // (`retired == false`) or a retirement tombstone
+        // (`retired == true`). Validate complete tombstone / never-
+        // provisioned semantics rather than trivially accepting.
+        if marker.previous.is_some() {
+            // Retirement and (successful) provision both always
+            // clear `previous` together with `active`; a lingering
+            // `previous` over an inactive marker can only be tamper
+            // or corruption.
+            return Err(FailReason::MarkerTamperedOrMissingMaterial);
+        }
+        if marker.retired {
+            if marker.high_water_epoch == 0 {
+                // `retire()` always records the real epoch count
+                // that was retired; a tombstone claiming zero epochs
+                // were ever provisioned is incoherent.
+                return Err(FailReason::MarkerTamperedOrMissingMaterial);
+            }
+        } else if marker.high_water_epoch != 0 {
+            // A never-provisioned marker (no action has ever
+            // committed for this `(vm, kind)`) has no legitimate way
+            // to record a nonzero high-water epoch.
+            return Err(FailReason::MarkerTamperedOrMissingMaterial);
+        }
+        if !current_is_genuinely_absent(secrets_fd)? {
+            // Never treat an inactive marker as `verified_clean` (or
+            // otherwise consistent) over a stale, foreign, or
+            // otherwise still-present `current` entry.
+            return Err(FailReason::IdentityCurrentTargetMismatch);
+        }
         return Ok(());
     };
     if active.epoch == 0 || active.epoch > marker.high_water_epoch {
@@ -1906,6 +2088,26 @@ fn execute_promote(
                 write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
             }
             PromotePhase::EpochReady => {
+                // Recovery may resume directly at this phase from a
+                // persisted txlog written in a wholly separate process
+                // invocation -- `Planned`'s own verification above
+                // ran (if at all) only earlier in that other
+                // invocation's call stack, never here. Re-verify the
+                // complete intended target generation identity BEFORE
+                // swapping `current`: for a rollback (`expected_identity`
+                // present) this is the same full owner/mode/ACL/
+                // nlink/digest/inode comparison `Planned` uses; for a
+                // freshly-created epoch this is at least the digest
+                // check, so a tampered/replaced/missing target never
+                // gets activated.
+                if let Some(expected) = intent.expected_identity.as_ref() {
+                    verify_existing_generation_identity(generations_fd, expected)?;
+                } else {
+                    let identity = capture_identity(generations_fd, intent.to_epoch)?;
+                    if identity.digest_hex != intent.expected_digest_hex {
+                        return Err(FailReason::RecoveryContentMismatch);
+                    }
+                }
                 atomic_swap_current(secrets_fd, intent.to_epoch)?;
                 intent.phase = PromotePhase::CurrentPromoted;
                 write_txlog(secrets_fd, &TxLog::Promote(intent.clone()))?;
@@ -1930,6 +2132,17 @@ fn execute_promote(
                 }
                 if intent.new_high_water_epoch < intent.to_epoch {
                     return Err(FailReason::HighWaterRegressed);
+                }
+                // Re-verify `carry_previous`'s on-disk identity before
+                // writing it into the marker's `previous` field: the
+                // recorded identity in the txlog reflects a snapshot
+                // taken when the intent was first built, and this
+                // phase may run in a later, wholly separate recovery
+                // invocation. Never let a stale, tampered, or removed
+                // `previous` generation be asserted as still-valid
+                // marker state.
+                if let Some(previous) = intent.carry_previous.as_ref() {
+                    verify_existing_generation_identity(generations_fd, previous)?;
                 }
                 let marker = MarkerData {
                     v: MARKER_SCHEMA_VERSION,
@@ -1961,22 +2174,49 @@ fn execute_promote(
                     return Err(FailReason::IdentityCurrentTargetMismatch);
                 }
                 let marker = read_marker(secrets_fd)?.ok_or(FailReason::MarkerWriteFailed)?;
+                if marker.vm != intent.vm || marker.kind != intent.kind {
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
                 let active_matches = marker.active.as_ref().is_some_and(|a| {
                     a.epoch == intent.to_epoch && a.digest_hex == intent.expected_digest_hex
                 });
                 if !active_matches {
                     return Err(FailReason::RecoveryAmbiguous);
                 }
+                if marker.previous != intent.carry_previous {
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
                 if let Some(prune) = intent.prune_epoch {
-                    // Best-effort: pruning failure does not fail the
-                    // action (the marker already durably reflects the
-                    // correct active/previous state); it only leaves
-                    // an orphaned generation directory for a future
-                    // retire() to clean up via its full-tree
-                    // enumeration. Pruning only ever happens after the
-                    // marker commit that no longer references the
-                    // pruned epoch has been durably written above.
-                    let _ = remove_generation(generations_fd, prune);
+                    // Defense in depth beyond `validate_promote_intent_
+                    // semantics`'s intrinsic `prune_epoch != to_epoch
+                    // && prune_epoch != carry_previous.epoch` check:
+                    // now that the marker's own `active`/`previous`
+                    // have been read and confirmed to equal
+                    // `intent.to_epoch`/`intent.carry_previous` above,
+                    // re-derive the same guarantee directly from the
+                    // marker actually on disk, never from the intent
+                    // alone -- pruning must never be able to target
+                    // the marker's live active or previous epoch.
+                    if marker.active.as_ref().is_some_and(|a| a.epoch == prune)
+                        || marker.previous.as_ref().is_some_and(|p| p.epoch == prune)
+                    {
+                        return Err(FailReason::RecoveryAmbiguous);
+                    }
+                    // Never discard a prune failure: pruning only
+                    // ever happens after the marker commit that no
+                    // longer references the pruned epoch has been
+                    // durably written above, so a `remove_generation`
+                    // failure here -- including a deletion that
+                    // succeeded but whose trailing `generations/`
+                    // directory fsync failed -- must propagate and
+                    // retain this durable `MarkerCommitted` txlog
+                    // entry (we return before reaching `remove_txlog`
+                    // below) rather than silently clearing it. A
+                    // future recovery pass resumes exactly here and
+                    // retries both the deletion and the durability
+                    // barrier; it never assumes an unsynced deletion
+                    // is final.
+                    remove_generation(generations_fd, prune)?;
                 }
                 // Any leftover `.stage-*` directory at this point is a
                 // real secret-tree entry from this or a prior crashed
@@ -2021,11 +2261,41 @@ fn execute_retire(
                 {
                     return Err(FailReason::RecoveryAmbiguous);
                 }
+                // Recovery may resume directly at this phase from a
+                // persisted txlog written in a wholly separate process
+                // invocation, with `current` still live and never yet
+                // touched. Re-read and fully validate the marker
+                // against live state -- vm/kind identity, internal
+                // marker semantics, and (if it claims an active
+                // generation) `current`'s exact-target match and full
+                // material identity -- before performing this
+                // transaction's first mutation.
+                if let Some(marker) = read_marker(secrets_fd)? {
+                    verify_marker_against_live_state(
+                        secrets_fd,
+                        generations_fd,
+                        &intent.vm,
+                        &intent.kind,
+                        &marker,
+                    )?;
+                }
                 remove_current_symlink(secrets_fd)?;
                 intent.phase = RetirePhase::CurrentRemoved;
                 write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
             }
             RetirePhase::CurrentRemoved => {
+                // Phase-authority check: this phase's own precondition
+                // is that `Enumerated` already removed `current`. A
+                // persisted txlog resuming here in a separate
+                // recovery invocation must not proceed to delete any
+                // generation until that prior mutation is itself
+                // re-confirmed -- a `current` that reappeared (tamper,
+                // hand-edited txlog, or a foreign actor) must fail
+                // closed rather than let deletion continue underneath
+                // a live activation.
+                if !current_is_genuinely_absent(secrets_fd)? {
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
                 for &epoch in &intent.epochs {
                     revalidate_generation_before_delete(generations_fd, epoch, cfg)?;
                     remove_generation(generations_fd, epoch)?;
@@ -2044,6 +2314,12 @@ fn execute_retire(
                 write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
             }
             RetirePhase::EpochsRemoved => {
+                // Phase-authority check: `current` must still be
+                // absent (this phase never re-creates it) before
+                // trusting a fresh re-enumeration to advance further.
+                if !current_is_genuinely_absent(secrets_fd)? {
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
                 let remaining = enumerate_and_validate_generation_tree(generations_fd)?;
                 if !remaining.epochs.is_empty() || !remaining.stage_names.is_empty() {
                     return Err(FailReason::RetirementNotProvablyEmpty);
@@ -2052,6 +2328,22 @@ fn execute_retire(
                 write_txlog(secrets_fd, &TxLog::Retire(intent.clone()))?;
             }
             RetirePhase::ProvenEmpty => {
+                // Never write the tombstone marker on the strength of
+                // a *previous* invocation's emptiness proof alone: a
+                // persisted txlog resuming exactly here (in a wholly
+                // separate recovery pass) must re-prove both that
+                // `current` is absent and that the generations tree
+                // is still empty immediately before this phase's
+                // otherwise-unconditional mutation, rather than
+                // trusting `EpochsRemoved`'s prior check to still
+                // hold.
+                if !current_is_genuinely_absent(secrets_fd)? {
+                    return Err(FailReason::RecoveryAmbiguous);
+                }
+                let remaining = enumerate_and_validate_generation_tree(generations_fd)?;
+                if !remaining.epochs.is_empty() || !remaining.stage_names.is_empty() {
+                    return Err(FailReason::RetirementNotProvablyEmpty);
+                }
                 let marker = MarkerData {
                     v: MARKER_SCHEMA_VERSION,
                     vm: intent.vm.clone(),
@@ -2130,7 +2422,7 @@ pub fn recover_in_flight_transaction(
         reason,
         audit: SecretsLifecycleAuditFields::denied(
             &SecretsLifecycleAuditContext {
-                vm_id: vm_id.to_owned(),
+                vm_id: VmId::new(vm_id),
                 kind,
                 action: LifecycleAction::Provision,
                 base_dir_hash: String::new(),
@@ -2157,12 +2449,7 @@ pub fn recover_in_flight_transaction(
                 err.action.unwrap_or(LifecycleAction::Provision),
                 &paths,
             );
-            Err(failed_closed(
-                &ctx,
-                false,
-                MarkerResult::FailedClosed,
-                err.reason,
-            ))
+            Err(failed_closed(&ctx, false, err.reason))
         }
     }
 }
@@ -2189,7 +2476,7 @@ fn open_and_recover(
 ) -> Result<OpenAndRecoverOk, SecretsLifecycleError> {
     let paths = derive_paths(vm_id, kind, cfg).map_err(|reason| {
         let ctx = SecretsLifecycleAuditContext {
-            vm_id: vm_id.to_owned(),
+            vm_id: VmId::new(vm_id),
             kind,
             action,
             base_dir_hash: String::new(),
@@ -2206,12 +2493,7 @@ fn open_and_recover(
             Ok(recovered) => recovered,
             Err(err) => {
                 let recovered_ctx = context(vm_id, kind, err.action.unwrap_or(action), &paths);
-                return Err(failed_closed(
-                    &recovered_ctx,
-                    false,
-                    MarkerResult::FailedClosed,
-                    err.reason,
-                ));
+                return Err(failed_closed(&recovered_ctx, false, err.reason));
             }
         };
     let marker =
@@ -2221,10 +2503,10 @@ fn open_and_recover(
             secrets_fd.as_fd(),
             generations_fd.as_fd(),
             vm_id,
-            kind,
+            kind.as_slug(),
             marker,
         )
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     }
     Ok((paths, secrets_fd, generations_fd, lock, recovered, marker))
 }
@@ -2252,12 +2534,11 @@ pub fn provision(
         return Err(denied(&ctx, recovered, FailReason::AlreadyProvisioned));
     }
     let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     if !existing.epochs.is_empty() || !existing.stage_names.is_empty() {
         return Err(failed_closed(
             &ctx,
             recovered,
-            MarkerResult::FailedClosed,
             FailReason::GenerationConflict,
         ));
     }
@@ -2279,9 +2560,9 @@ pub fn provision(
         phase: PromotePhase::Planned,
     };
     validate_promote_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     match execute_promote(
         secrets_fd.as_fd(),
         generations_fd.as_fd(),
@@ -2298,15 +2579,9 @@ pub fn provision(
         Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
             recovered,
-            MarkerResult::FailedClosed,
             FailReason::MaterialWriteFailed,
         )),
-        Err(reason) => Err(failed_closed(
-            &ctx,
-            recovered,
-            MarkerResult::FailedClosed,
-            reason,
-        )),
+        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
     }
 }
 
@@ -2355,9 +2630,9 @@ pub fn rotate(
         phase: PromotePhase::Planned,
     };
     validate_promote_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     match execute_promote(
         secrets_fd.as_fd(),
         generations_fd.as_fd(),
@@ -2376,15 +2651,9 @@ pub fn rotate(
         Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
             recovered,
-            MarkerResult::FailedClosed,
             FailReason::MaterialWriteFailed,
         )),
-        Err(reason) => Err(failed_closed(
-            &ctx,
-            recovered,
-            MarkerResult::FailedClosed,
-            reason,
-        )),
+        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
     }
 }
 
@@ -2428,9 +2697,9 @@ pub fn rollback(
         phase: PromotePhase::Planned,
     };
     validate_promote_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     match execute_promote(
         secrets_fd.as_fd(),
         generations_fd.as_fd(),
@@ -2448,15 +2717,9 @@ pub fn rollback(
         Ok(PromoteOutcome::AbortedNoMaterial) => Err(failed_closed(
             &ctx,
             recovered,
-            MarkerResult::FailedClosed,
             FailReason::RecoveryAmbiguous,
         )),
-        Err(reason) => Err(failed_closed(
-            &ctx,
-            recovered,
-            MarkerResult::FailedClosed,
-            reason,
-        )),
+        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
     }
 }
 
@@ -2478,7 +2741,7 @@ pub fn retire(
     let ctx = context(vm_id, kind, LifecycleAction::Retire, &paths);
 
     let existing = enumerate_and_validate_generation_tree(generations_fd.as_fd())
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
 
     let recorded_high_water = marker.as_ref().map(|m| m.high_water_epoch).unwrap_or(0);
     let marker_claims_active = marker
@@ -2494,8 +2757,24 @@ pub fn retire(
             return Err(failed_closed(
                 &ctx,
                 recovered,
-                MarkerResult::FailedClosed,
                 FailReason::PreviouslyProvisionedMaterialMissing,
+            ));
+        }
+        // Missing marker never implies clean storage, and the
+        // symmetric case matters just as much: never declare
+        // `verified_clean` over a stale, foreign, or otherwise
+        // still-present `current` entry -- regardless of whether a
+        // marker exists at all (an entirely absent marker skips
+        // `verify_marker_against_live_state`'s own current-absence
+        // check inside `open_and_recover`, so this call is the only
+        // place that invariant is enforced in that case).
+        if !current_is_genuinely_absent(secrets_fd.as_fd())
+            .map_err(|reason| failed_closed(&ctx, recovered, reason))?
+        {
+            return Err(failed_closed(
+                &ctx,
+                recovered,
+                FailReason::IdentityCurrentTargetMismatch,
             ));
         }
         return Ok(SecretsLifecycleAuditFields::verified_clean(
@@ -2516,21 +2795,16 @@ pub fn retire(
         phase: RetirePhase::Enumerated,
     };
     validate_retire_intent_semantics(&intent, vm_id, kind)
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     write_txlog(secrets_fd.as_fd(), &TxLog::Retire(intent.clone()))
-        .map_err(|reason| failed_closed(&ctx, recovered, MarkerResult::FailedClosed, reason))?;
+        .map_err(|reason| failed_closed(&ctx, recovered, reason))?;
     match execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), cfg, intent) {
         Ok(()) => Ok(SecretsLifecycleAuditFields::retired(
             &ctx,
             high_water_epoch,
             recovered,
         )),
-        Err(reason) => Err(failed_closed(
-            &ctx,
-            recovered,
-            MarkerResult::FailedClosed,
-            reason,
-        )),
+        Err(reason) => Err(failed_closed(&ctx, recovered, reason)),
     }
 }
 
@@ -4945,5 +5219,841 @@ mod tests {
         assert_eq!(err.reason, FailReason::PreviouslyProvisionedMaterialMissing);
         // Fails closed without deleting anything.
         assert!(gen_dir.exists());
+    }
+
+    // -------------------------------------------------------------
+    // Round-6 finding 1: promotion recovery phase-ordering
+    // -------------------------------------------------------------
+
+    #[test]
+    fn epoch_ready_recovery_rejects_a_tampered_freshly_created_target_before_swapping_current() {
+        // `EpochReady` recovery resuming in a separate invocation must
+        // re-verify the intended target's digest BEFORE swapping
+        // `current` -- a target tampered between `Planned` (in one
+        // process) and `EpochReady` recovery (in another) must never
+        // be activated.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "epoch-ready-tamper-fresh";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        // Tamper the target epoch's material after it was promoted,
+        // simulating drift between the crashed attempt and this
+        // recovery pass.
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::write(gen_dir.join(MATERIAL_FILE_NAME), b"tampered").unwrap();
+
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::EpochReady,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::RecoveryContentMismatch);
+        // `current` was never swapped.
+        assert!(!current_resolves_exactly_to(secrets_fd.as_fd(), 1));
+        assert!(read_marker(secrets_fd.as_fd()).unwrap().is_none());
+    }
+
+    #[test]
+    fn epoch_ready_recovery_rejects_a_tampered_rollback_target_before_swapping_current() {
+        // Rollback's `EpochReady` recovery must re-run the full
+        // owner/mode/ACL/nlink/digest/inode comparison against
+        // `expected_identity` before swapping `current`, not merely
+        // trust that `Planned` already checked it in an earlier
+        // invocation.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "epoch-ready-tamper-rollback";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Capture the *correct* identity of epoch 1 (the rollback
+        // target) before tampering.
+        let expected = capture_identity(generations_fd.as_fd(), 1).unwrap();
+        // Tamper the rollback target's mode after the identity was
+        // captured/recorded into the intent.
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::set_permissions(
+            gen_dir.join(MATERIAL_FILE_NAME),
+            std::fs::Permissions::from_mode(0o777),
+        )
+        .unwrap();
+
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rollback,
+            to_epoch: 1,
+            create_epoch: false,
+            stage_name: random_stage_name(),
+            expected_digest_hex: expected.digest_hex.clone(),
+            expected_identity: Some(expected),
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::EpochReady,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::IdentityModeMismatch);
+        // `current` must still resolve to the pre-rollback active
+        // epoch (2), never having been swapped toward the tampered
+        // target.
+        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 2));
+    }
+
+    #[test]
+    fn current_promoted_recovery_rejects_a_tampered_carry_previous_before_marker_write() {
+        // `CurrentPromoted` recovery must re-verify `carry_previous`'s
+        // on-disk identity before writing it into the marker's
+        // `previous` field -- a `previous` generation tampered between
+        // intent-build time and this recovery pass must never be
+        // asserted as still-valid marker state.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "current-promoted-tamper-previous";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let carry_previous = capture_identity(generations_fd.as_fd(), 1).unwrap();
+        // Tamper epoch 1 (the carried-forward `previous`) after its
+        // identity was captured -- change its content (and therefore
+        // digest) so the tamper is unambiguous regardless of the
+        // material file's original mode.
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::write(gen_dir.join(MATERIAL_FILE_NAME), b"tampered-previous").unwrap();
+
+        let mat = material(b"e2");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 2, &mat.digest_hex())
+            .unwrap();
+        atomic_swap_current(secrets_fd.as_fd(), 2).unwrap();
+
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: Some(carry_previous),
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::CurrentPromoted,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::IdentityDigestMismatch);
+        // The pre-existing (provision-time) marker must be untouched:
+        // no marker claiming epoch 2 active was ever written.
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        assert_eq!(marker.active.unwrap().epoch, 1);
+    }
+
+    #[test]
+    fn marker_committed_recovery_rejects_a_marker_vm_kind_mismatch() {
+        // A marker whose `active`/`previous` line up with the intent
+        // but whose `vm`/`kind` do not must still be rejected --
+        // proves the vm/kind check is independent of the
+        // active/previous comparison.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "mc-vm-kind-mismatch";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let mat = material(b"e1");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 1, &mat.digest_hex())
+            .unwrap();
+        atomic_swap_current(secrets_fd.as_fd(), 1).unwrap();
+        let identity = capture_identity(generations_fd.as_fd(), 1).unwrap();
+        let wrong_kind_marker = MarkerData {
+            v: MARKER_SCHEMA_VERSION,
+            vm: vm.to_owned(),
+            // Wrong kind slug, everything else matches.
+            kind: SecretKind::SecurityKeyChannelState.as_slug().to_owned(),
+            retired: false,
+            high_water_epoch: 1,
+            active: Some(identity),
+            previous: None,
+            first_provisioned_ms: now_ms(),
+            updated_ms: now_ms(),
+        };
+        write_marker(secrets_fd.as_fd(), &wrong_kind_marker).unwrap();
+
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name,
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: None,
+            prune_epoch: None,
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::MarkerCommitted,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::RecoveryAmbiguous);
+    }
+
+    #[test]
+    fn marker_committed_recovery_rejects_a_previous_mismatch() {
+        // Active epoch/digest agree, but the marker's `previous` does
+        // not match `intent.carry_previous` -- must still be rejected
+        // as its own, independent check.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "mc-previous-mismatch";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Marker on disk (from the real rotate) correctly carries
+        // previous = epoch 1. Build an intent claiming a *different*
+        // (nonexistent) previous epoch.
+        let bogus_previous = MaterialIdentity {
+            epoch: 1,
+            dev: 0,
+            ino: 0,
+            uid: 0,
+            gid: 0,
+            mode: 0o600,
+            nlink: 1,
+            has_acl: false,
+            digest_hex: "0".repeat(64),
+        };
+        let mat = material(b"e2");
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: 2,
+            create_epoch: true,
+            stage_name: random_stage_name(),
+            expected_digest_hex: mat.digest_hex(),
+            expected_identity: None,
+            carry_previous: Some(bogus_previous),
+            prune_epoch: None,
+            new_high_water_epoch: 2,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::MarkerCommitted,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::RecoveryAmbiguous);
+    }
+
+    #[test]
+    fn marker_committed_recovery_rejects_pruning_the_markers_own_active_epoch() {
+        // Defense in depth: even though `validate_promote_intent_
+        // semantics` already rejects `prune_epoch == to_epoch`/
+        // `carry_previous.epoch` as an intrinsic intent-shape check,
+        // `MarkerCommitted` recovery must independently re-derive the
+        // same guarantee from the marker actually read from disk.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "mc-prune-collision";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        let active = marker.active.clone().unwrap();
+
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Provision,
+            to_epoch: 1,
+            create_epoch: true,
+            stage_name: random_stage_name(),
+            expected_digest_hex: active.digest_hex.clone(),
+            expected_identity: None,
+            carry_previous: None,
+            // Hand-edited/corrupted txlog: prune targets the marker's
+            // own active epoch.
+            prune_epoch: Some(1),
+            new_high_water_epoch: 1,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::MarkerCommitted,
+        };
+        let err = execute_promote(
+            secrets_fd.as_fd(),
+            generations_fd.as_fd(),
+            &cfg,
+            intent,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err, FailReason::RecoveryAmbiguous);
+        // Nothing was pruned.
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
+    }
+
+    #[test]
+    fn marker_committed_prune_fsync_failure_retains_txlog_for_retry() {
+        // Pruning durability: if `remove_generation` succeeds in
+        // deleting content but its trailing `generations/` directory
+        // fsync fails, the already-durable `MarkerCommitted` txlog
+        // must be retained (never cleared) so a later recovery pass
+        // resumes exactly here and retries the barrier.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "mc-prune-fsync-retry";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        rotate(vm, kind, material(b"e2"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        let active = marker.active.clone().unwrap();
+        let previous = marker.previous.clone();
+
+        // Stage an extra leftover generation the prune step is free
+        // to target so the fsync-failure path is genuinely exercised
+        // through `remove_generation`, not skipped for lack of a
+        // prune target.
+        let stray_mat = material(b"stray");
+        let stray_stage = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stray_stage,
+            &stray_mat.digest_hex(),
+            Some(&stray_mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(
+            generations_fd.as_fd(),
+            &stray_stage,
+            99,
+            &stray_mat.digest_hex(),
+        )
+        .unwrap();
+
+        let intent = PromoteIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            action: LifecycleAction::Rotate,
+            to_epoch: active.epoch,
+            create_epoch: true,
+            stage_name: random_stage_name(),
+            expected_digest_hex: active.digest_hex.clone(),
+            expected_identity: None,
+            carry_previous: previous,
+            prune_epoch: Some(99),
+            new_high_water_epoch: active.epoch,
+            first_provisioned_ms: now_ms(),
+            phase: PromotePhase::MarkerCommitted,
+        };
+        write_txlog(secrets_fd.as_fd(), &TxLog::Promote(intent.clone())).unwrap();
+
+        {
+            let _fault = FsyncFaultGuard::enable();
+            let err = execute_promote(
+                secrets_fd.as_fd(),
+                generations_fd.as_fd(),
+                &cfg,
+                intent,
+                None,
+            )
+            .unwrap_err();
+            assert_eq!(err, FailReason::FsyncFailed);
+        }
+        // The txlog must still be present: the prune failure must not
+        // have caused `remove_txlog` to run.
+        assert!(read_txlog(secrets_fd.as_fd(), vm, kind).unwrap().is_some());
+    }
+
+    // -------------------------------------------------------------
+    // Round-6 finding 2: retire recovery phase-ordering /
+    // phase-authority checks
+    // -------------------------------------------------------------
+
+    #[test]
+    fn enumerated_phase_rejects_a_marker_disagreeing_with_live_state_before_removing_current() {
+        // `execute_retire`'s own `Enumerated` handler (exercised
+        // directly here the way a separate recovery-invocation would
+        // resume it) must re-read and fully validate the marker
+        // against live state before its first mutation
+        // (`remove_current_symlink`) -- not merely trust a validation
+        // that may have run in an earlier, different process
+        // invocation.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "enumerated-marker-mismatch";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Corrupt the marker's recorded digest without touching the
+        // real on-disk generation content.
+        let mut marker = read_marker(secrets_fd.as_fd()).unwrap().unwrap();
+        marker.active.as_mut().unwrap().digest_hex = "0".repeat(64);
+        write_marker(secrets_fd.as_fd(), &marker).unwrap();
+
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: Vec::new(),
+            high_water_epoch: 1,
+            phase: RetirePhase::Enumerated,
+        };
+        let err =
+            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
+        assert_eq!(err, FailReason::IdentityDigestMismatch);
+        // Nothing was deleted: `current` and the generation are both
+        // still intact.
+        assert!(current_resolves_exactly_to(secrets_fd.as_fd(), 1));
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
+    }
+
+    #[test]
+    fn current_removed_phase_rejects_resumption_when_current_still_present() {
+        // Phase-authority check: a txlog resuming at `CurrentRemoved`
+        // asserts, by construction, that `Enumerated` already removed
+        // `current`. A hand-edited/corrupted txlog claiming this
+        // phase over a still-present `current` must fail closed
+        // before deleting any generation.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "current-removed-still-present";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // `current` is deliberately left in place, unlike the
+        // legitimate `CurrentRemoved` precondition.
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: Vec::new(),
+            high_water_epoch: 1,
+            phase: RetirePhase::CurrentRemoved,
+        };
+        let err =
+            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
+        assert_eq!(err, FailReason::RecoveryAmbiguous);
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
+    }
+
+    #[test]
+    fn epochs_removed_phase_rejects_resumption_when_current_still_present() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "epochs-removed-still-present";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: Vec::new(),
+            high_water_epoch: 1,
+            phase: RetirePhase::EpochsRemoved,
+        };
+        let err =
+            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
+        assert_eq!(err, FailReason::RecoveryAmbiguous);
+        let generations_dir = paths.kind_root.join(GENERATIONS_DIR_NAME);
+        assert!(generations_dir.join("1").join(MATERIAL_FILE_NAME).is_file());
+    }
+
+    #[test]
+    fn proven_empty_phase_rejects_resumption_when_tree_is_no_longer_empty() {
+        // Never write the tombstone marker on the strength of a
+        // *previous* invocation's emptiness proof alone: a persisted
+        // txlog resuming at `ProvenEmpty` must re-prove the tree is
+        // still empty immediately before this phase's otherwise-
+        // unconditional mutation.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "proven-empty-reappeared";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Simulate a generation reappearing between `EpochsRemoved`
+        // and this resumed `ProvenEmpty` pass (e.g. a foreign actor,
+        // or a bug elsewhere) by planting one directly.
+        let mat = material(b"reappeared");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 5, &mat.digest_hex())
+            .unwrap();
+
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: Vec::new(),
+            high_water_epoch: 1,
+            phase: RetirePhase::ProvenEmpty,
+        };
+        let err =
+            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
+        assert_eq!(err, FailReason::RetirementNotProvablyEmpty);
+        // No tombstone marker was written.
+        assert!(read_marker(secrets_fd.as_fd()).unwrap().is_none());
+    }
+
+    #[test]
+    fn proven_empty_phase_rejects_resumption_when_current_still_present() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "proven-empty-current-present";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // `current` still resolves to epoch 1 even though the txlog
+        // claims the tree has already been proven empty.
+        let intent = RetireIntent {
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            epochs: vec![1],
+            stage_names: Vec::new(),
+            high_water_epoch: 1,
+            phase: RetirePhase::ProvenEmpty,
+        };
+        let err =
+            execute_retire(secrets_fd.as_fd(), generations_fd.as_fd(), &cfg, intent).unwrap_err();
+        assert_eq!(err, FailReason::RecoveryAmbiguous);
+        assert!(
+            read_marker(secrets_fd.as_fd())
+                .unwrap()
+                .unwrap()
+                .active
+                .is_some()
+        );
+    }
+
+    // -------------------------------------------------------------
+    // Round-6 finding 5: inactive/tombstone marker validation
+    // -------------------------------------------------------------
+
+    #[test]
+    fn open_and_recover_rejects_an_inactive_marker_with_lingering_previous() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "inactive-lingering-previous";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let bogus_previous = MaterialIdentity {
+            epoch: 1,
+            dev: 0,
+            ino: 0,
+            uid: 0,
+            gid: 0,
+            mode: 0o600,
+            nlink: 1,
+            has_acl: false,
+            digest_hex: "0".repeat(64),
+        };
+        let marker = MarkerData {
+            v: MARKER_SCHEMA_VERSION,
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            retired: false,
+            high_water_epoch: 0,
+            active: None,
+            // Inactive marker with a lingering `previous` -- always
+            // tamper/corruption, never a legitimate write-path shape.
+            previous: Some(bogus_previous),
+            first_provisioned_ms: 0,
+            updated_ms: now_ms(),
+        };
+        write_marker(secrets_fd.as_fd(), &marker).unwrap();
+        drop(secrets_fd);
+
+        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::MarkerTamperedOrMissingMaterial);
+    }
+
+    #[test]
+    fn open_and_recover_rejects_a_tombstone_with_zero_high_water() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "tombstone-zero-high-water";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let marker = MarkerData {
+            v: MARKER_SCHEMA_VERSION,
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            // A tombstone claiming `retired == true` must always
+            // carry the real epoch count that was retired.
+            retired: true,
+            high_water_epoch: 0,
+            active: None,
+            previous: None,
+            first_provisioned_ms: 0,
+            updated_ms: now_ms(),
+        };
+        write_marker(secrets_fd.as_fd(), &marker).unwrap();
+        drop(secrets_fd);
+
+        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::MarkerTamperedOrMissingMaterial);
+    }
+
+    #[test]
+    fn open_and_recover_rejects_a_never_provisioned_marker_with_nonzero_high_water() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "never-provisioned-nonzero-high-water";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, _generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let marker = MarkerData {
+            v: MARKER_SCHEMA_VERSION,
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            retired: false,
+            // Never-provisioned but claims a nonzero high-water --
+            // has no legitimate write path.
+            high_water_epoch: 3,
+            active: None,
+            previous: None,
+            first_provisioned_ms: 0,
+            updated_ms: now_ms(),
+        };
+        write_marker(secrets_fd.as_fd(), &marker).unwrap();
+        drop(secrets_fd);
+
+        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::MarkerTamperedOrMissingMaterial);
+    }
+
+    #[test]
+    fn open_and_recover_rejects_an_inactive_marker_over_a_stale_foreign_current() {
+        // Never treat an inactive marker as consistent (let alone
+        // `verified_clean`) over a stale, foreign, or otherwise
+        // still-present `current` entry.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "inactive-stale-current";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        // Plant a foreign `current` pointing at a real-looking, but
+        // never-recorded, generation.
+        let mat = material(b"foreign");
+        let stage_name = random_stage_name();
+        ensure_staged(
+            generations_fd.as_fd(),
+            &cfg,
+            &stage_name,
+            &mat.digest_hex(),
+            Some(&mat),
+        )
+        .unwrap();
+        promote_stage_to_generation(generations_fd.as_fd(), &stage_name, 7, &mat.digest_hex())
+            .unwrap();
+        atomic_swap_current(secrets_fd.as_fd(), 7).unwrap();
+        // Marker claims a clean, never-provisioned state -- disagrees
+        // with the live `current`.
+        let marker = MarkerData {
+            v: MARKER_SCHEMA_VERSION,
+            vm: vm.to_owned(),
+            kind: kind.as_slug().to_owned(),
+            retired: false,
+            high_water_epoch: 0,
+            active: None,
+            previous: None,
+            first_provisioned_ms: 0,
+            updated_ms: now_ms(),
+        };
+        write_marker(secrets_fd.as_fd(), &marker).unwrap();
+        drop(secrets_fd);
+        drop(generations_fd);
+
+        let err = provision(vm, kind, material(b"e1"), &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::IdentityCurrentTargetMismatch);
+    }
+
+    #[test]
+    fn retire_verified_clean_rejects_when_current_present_despite_missing_marker() {
+        // Symmetric to "missing marker never implies clean storage":
+        // when the marker file is entirely absent (so
+        // `verify_marker_against_live_state` never runs at all) and
+        // the physical generation tree is empty, `retire()`'s own
+        // `verified_clean` path must still independently check
+        // `current` itself, rather than declare clean storage over a
+        // stale/foreign `current` entry.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "verified-clean-stale-current";
+        let kind = SecretKind::GuestSigningKey;
+        provision(vm, kind, material(b"e1"), &cfg).unwrap();
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        // Remove the generation content and the marker, but leave
+        // `current` behind pointing at the now-vanished epoch --
+        // exactly the pathological "empty tree, no marker, but
+        // current still present" state.
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::remove_file(gen_dir.join(MATERIAL_FILE_NAME)).unwrap();
+        std::fs::remove_dir(&gen_dir).unwrap();
+        std::fs::remove_file(paths.kind_root.join(MARKER_FILE_NAME)).unwrap();
+
+        let err = retire(vm, kind, &cfg).unwrap_err();
+        assert_eq!(err.reason, FailReason::IdentityCurrentTargetMismatch);
+    }
+
+    // -------------------------------------------------------------
+    // Round-6 finding 6: material read type/size hardening
+    // -------------------------------------------------------------
+
+    #[test]
+    fn capture_identity_rejects_an_oversized_material_file_without_reading_it_whole() {
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "oversized-material-read";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::create_dir(&gen_dir).unwrap();
+        // Plant a file larger than the closed read cap directly
+        // (bypassing `SecretMaterial`'s own constructor-time size
+        // check) to prove the *read layer* itself also refuses to
+        // read an oversized on-disk entry.
+        let oversized = vec![0u8; SecretMaterial::MAX_LEN + 2];
+        std::fs::write(gen_dir.join(MATERIAL_FILE_NAME), &oversized).unwrap();
+
+        let err = capture_identity(generations_fd.as_fd(), 1).unwrap_err();
+        assert_eq!(err, FailReason::PreviouslyProvisionedMaterialMissing);
+    }
+
+    #[test]
+    fn capture_identity_rejects_a_fifo_planted_at_the_material_path() {
+        // A FIFO planted at the material path must be rejected before
+        // any read is attempted -- opened non-blocking specifically
+        // so this can never hang indefinitely.
+        let dir = tempdir().unwrap();
+        let cfg = cfg_at(dir.path());
+        let vm = "fifo-material-read";
+        let kind = SecretKind::GuestSigningKey;
+        let paths = derive_paths(vm, kind, &cfg).unwrap();
+        let (_secrets_fd, generations_fd) = open_or_create_secrets_dir(&paths, &cfg).unwrap();
+        let gen_dir = paths.kind_root.join(GENERATIONS_DIR_NAME).join("1");
+        std::fs::create_dir(&gen_dir).unwrap();
+        let material_path = gen_dir.join(MATERIAL_FILE_NAME);
+        nix::unistd::mkfifo(
+            &material_path,
+            nix::sys::stat::Mode::from_bits_truncate(0o600),
+        )
+        .unwrap();
+
+        let err = capture_identity(generations_fd.as_fd(), 1).unwrap_err();
+        assert_eq!(err, FailReason::PreviouslyProvisionedMaterialMissing);
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
@@ -19,12 +19,32 @@
 //! used by every other path-bearing broker audit record), a SHA-256
 //! `material_digest_hex` fingerprint (so operators can correlate a
 //! rotation to specific delivered material without ever seeing it),
-//! and closed-set result/marker enums.
+//! and closed-set result/marker/reason enums. **`fail_reason` is a
+//! closed enum, not a free-form string** — this is a deliberate
+//! hardening over an earlier draft of this module that carried
+//! `Option<String>` populated from convention-only `&'static str`
+//! constants; nothing outside this file's [`FailReason`] enum can ever
+//! reach the audit surface.
+//!
+//! # Status
+//!
+//! This schema, and the [`crate::ops::secrets_lifecycle`] engine that
+//! produces it, are **not wired into any live broker dispatch path or
+//! `crate::audit::AuditLog` sink**. See that module's "Integration
+//! wiring points" doc section for the exact list of follow-up steps a
+//! future integrator must perform before any of this is observable in
+//! a running broker's audit log.
 
 use serde::{Deserialize, Serialize};
 
 /// Schema version for the secrets-lifecycle terminal audit record.
-pub const SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION: u32 = 1;
+///
+/// Bumped from `1` to `2` for the transaction/recovery + strengthened
+/// identity-binding redesign: `generation` (u32) became `lineage_epoch`
+/// (u64) with a companion `high_water_epoch`, `retained_generations`
+/// became `u64`-keyed, `fail_reason` became a closed enum instead of a
+/// free-form string, and `recovered_prior_transaction` was added.
+pub const SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION: u32 = 2;
 
 /// Bound on `retained_generations` so a single audit record can never
 /// grow unbounded (the operational retention policy in
@@ -124,6 +144,140 @@ pub enum MarkerResult {
     FailedClosed,
 }
 
+/// Closed set of path-free, redaction-safe failure/refusal reasons.
+/// Every [`SecretsLifecycleAuditFields::denied`] /
+/// [`SecretsLifecycleAuditFields::failed`] call site in
+/// `secrets_lifecycle.rs` constructs one of these variants directly —
+/// there is no code path that can place an arbitrary string or a raw
+/// filesystem path onto the audit surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailReason {
+    InvalidVmId,
+    PathDerivationFailed,
+    SecretsDirOpenFailed,
+    MarkerTreeOpenFailed,
+    MarkerWriteFailed,
+    MarkerTamperedOrMissingMaterial,
+    AlreadyProvisioned,
+    AlreadyRetired,
+    NotProvisioned,
+    NoRollbackTarget,
+    PreviouslyProvisionedMaterialMissing,
+    GenerationConflict,
+    MaterialWriteFailed,
+    CurrentSwapFailed,
+    InvalidMaterial,
+    /// The cross-process per-`(vm, kind)` exclusive lock could not be
+    /// acquired within the bounded wait budget.
+    LockUnavailable,
+    /// The durable transaction/recovery log (`txlog`) could not be
+    /// written or fsynced.
+    IntentWriteFailed,
+    /// A leftover `txlog` exists but is not well-formed JSON, fails
+    /// schema validation, or names a `(vm, kind)` other than the one
+    /// it was found under.
+    IntentCorrupt,
+    /// Resuming a leftover in-flight transaction found on-disk content
+    /// that does not match what the transaction log recorded before
+    /// the crash (e.g. a digest mismatch on the staged/committed
+    /// epoch). Recovery refuses to guess and fails closed without
+    /// touching `current` or the marker.
+    RecoveryContentMismatch,
+    /// Resuming a leftover in-flight transaction found the filesystem
+    /// in a state recovery cannot map to any phase of the recorded
+    /// transaction (e.g. `current` points somewhere the log did not
+    /// expect). Recovery fails closed rather than guessing.
+    RecoveryAmbiguous,
+    /// A collision-resistant staging name could not be allocated
+    /// within the bounded retry budget (astronomically unlikely; ever
+    /// observing this indicates a broken randomness source).
+    StagingNameExhausted,
+    /// Retirement's full anchored-tree enumeration found an entry it
+    /// could not account for (unexpected name, unexpected type, or a
+    /// material file with more than one hard link) and refused to
+    /// delete anything.
+    RetirementTreeAnomaly,
+    /// Retirement removed every entry it validated but the generations
+    /// tree was not observably empty afterward.
+    RetirementNotProvablyEmpty,
+    /// The live active-generation directory's owner uid/gid does not
+    /// match the marker's recorded identity.
+    IdentityOwnerMismatch,
+    /// The live active-generation directory's mode does not match the
+    /// marker's recorded identity.
+    IdentityModeMismatch,
+    /// The live active-generation directory carries (or lost) an
+    /// extended POSIX ACL relative to what the marker recorded.
+    IdentityAclMismatch,
+    /// The live active-generation directory's material file link
+    /// count is not exactly 1 (a hard-link plant), or otherwise does
+    /// not match the marker's recorded identity.
+    IdentityLinkCountMismatch,
+    /// The live active-generation material's SHA-256 digest does not
+    /// match the marker's recorded identity.
+    IdentityDigestMismatch,
+    /// The live active-generation material's SHA-256 digest matches
+    /// the marker's recorded identity, but the `(dev, ino)` pair does
+    /// not — a hard-link or directory-swap tamper that byte-content
+    /// comparison alone cannot see (a replacement file with identical
+    /// bytes but a different physical inode).
+    IdentityInodeMismatch,
+    /// `current` does not literally resolve (by name, not just by
+    /// coincidental dev/ino) to the epoch the marker records as active.
+    IdentityCurrentTargetMismatch,
+    /// A newly computed high-water epoch would not be strictly greater
+    /// than the marker's previously committed high-water epoch — a
+    /// monotonicity invariant violation this module refuses to persist.
+    HighWaterRegressed,
+}
+
+impl FailReason {
+    /// Stable slug matching the enum variant's `snake_case` wire form,
+    /// safe for any Debug/log/audit surface (never a path or secret).
+    pub fn as_slug(self) -> &'static str {
+        match self {
+            Self::InvalidVmId => "invalid_vm_id",
+            Self::PathDerivationFailed => "path_derivation_failed",
+            Self::SecretsDirOpenFailed => "secrets_dir_open_failed",
+            Self::MarkerTreeOpenFailed => "marker_tree_open_failed",
+            Self::MarkerWriteFailed => "marker_write_failed",
+            Self::MarkerTamperedOrMissingMaterial => "marker_tampered_or_missing_material",
+            Self::AlreadyProvisioned => "already_provisioned",
+            Self::AlreadyRetired => "already_retired",
+            Self::NotProvisioned => "not_provisioned",
+            Self::NoRollbackTarget => "no_rollback_target",
+            Self::PreviouslyProvisionedMaterialMissing => "previously_provisioned_material_missing",
+            Self::GenerationConflict => "generation_conflict",
+            Self::MaterialWriteFailed => "material_write_failed",
+            Self::CurrentSwapFailed => "current_swap_failed",
+            Self::InvalidMaterial => "invalid_material",
+            Self::LockUnavailable => "lock_unavailable",
+            Self::IntentWriteFailed => "intent_write_failed",
+            Self::IntentCorrupt => "intent_corrupt",
+            Self::RecoveryContentMismatch => "recovery_content_mismatch",
+            Self::RecoveryAmbiguous => "recovery_ambiguous",
+            Self::StagingNameExhausted => "staging_name_exhausted",
+            Self::RetirementTreeAnomaly => "retirement_tree_anomaly",
+            Self::RetirementNotProvablyEmpty => "retirement_not_provably_empty",
+            Self::IdentityOwnerMismatch => "identity_owner_mismatch",
+            Self::IdentityModeMismatch => "identity_mode_mismatch",
+            Self::IdentityAclMismatch => "identity_acl_mismatch",
+            Self::IdentityLinkCountMismatch => "identity_link_count_mismatch",
+            Self::IdentityDigestMismatch => "identity_digest_mismatch",
+            Self::IdentityInodeMismatch => "identity_inode_mismatch",
+            Self::IdentityCurrentTargetMismatch => "identity_current_target_mismatch",
+            Self::HighWaterRegressed => "high_water_regressed",
+        }
+    }
+}
+
+impl std::fmt::Display for FailReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_slug())
+    }
+}
+
 /// Always-present, path-free context threaded through every
 /// constructor so a per-status variant only supplies the fields that
 /// vary.
@@ -149,23 +303,45 @@ pub struct SecretsLifecycleAuditFields {
     pub base_dir_hash: String,
     pub result: LifecycleResult,
     pub marker_result: MarkerResult,
-    /// The active generation number after this action, when one
-    /// exists (`None` after a successful `retire`).
+    /// The active lineage epoch after this action, when one exists
+    /// (`None` after a successful `retire`, and for `Denied`/
+    /// `FailedClosed` results). This is the monotonic identity anchor
+    /// (see `secrets_lifecycle::MarkerData::high_water_epoch`) — never
+    /// simply "current epoch number + 1", so a rotate issued after a
+    /// rollback can never collide with (or silently resurrect) a
+    /// still-materialized older epoch directory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub generation: Option<u32>,
+    pub lineage_epoch: Option<u64>,
+    /// The monotonic high-water epoch recorded by the marker after
+    /// this action (present exactly when `lineage_epoch` is present,
+    /// and additionally present after a successful `retire` so an
+    /// auditor can confirm a subsequent re-provision's first epoch is
+    /// still strictly greater than every epoch this `(vm, kind)` ever
+    /// used). Never decreases across the lifetime of a `(vm, kind)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub high_water_epoch: Option<u64>,
     /// On-disk generations retained for rollback after this action
     /// (excludes the active generation).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub retained_generations: Vec<u32>,
+    pub retained_generations: Vec<u64>,
     /// SHA-256 hex digest of the material this action wrote, when the
     /// action wrote material (`provision`/`rotate`). `None` for
     /// `rollback`/`retire`/failed attempts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub material_digest_hex: Option<String>,
-    /// Closed-set, path-free reason slug. Present exactly when
-    /// `result` is `Denied` or `FailedClosed`.
+    /// Closed-set, path-free failure/refusal reason. Present exactly
+    /// when `result` is `Denied` or `FailedClosed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub fail_reason: Option<String>,
+    pub fail_reason: Option<FailReason>,
+    /// `true` when this action first had to resolve a leftover,
+    /// crash-interrupted transaction (see
+    /// `secrets_lifecycle::recover_in_flight_transaction`) before
+    /// proceeding with the requested action. Always `false` on the
+    /// common, no-crash path; surfaced so an operator can distinguish
+    /// "this rotate ran cleanly" from "this rotate first had to finish
+    /// or unwind a prior crashed rotate".
+    #[serde(default)]
+    pub recovered_prior_transaction: bool,
 }
 
 /// Errors [`SecretsLifecycleAuditFields::validate`] can report. Kept
@@ -175,17 +351,24 @@ pub struct SecretsLifecycleAuditFields {
 pub enum SecretsLifecycleAuditError {
     SchemaVersionMismatch { found: u32 },
     InvalidVmId,
-    MissingGeneration,
-    UnexpectedGeneration,
-    GenerationIsZero,
+    MissingLineageEpoch,
+    UnexpectedLineageEpoch,
+    LineageEpochIsZero,
+    MissingHighWaterEpoch,
+    UnexpectedHighWaterEpoch,
+    HighWaterBelowLineageEpoch,
     RetainedGenerationsTooLarge { len: usize },
     RetainedGenerationsNotUnique,
     RetainedGenerationsIncludeActive,
+    RetainedGenerationsMustBeNonEmpty,
+    RetainedGenerationsMustBeEmpty,
     MissingFailReason,
     UnexpectedFailReason,
+    ActionResultIncompatible,
     MarkerResultInconsistentWithResult,
     InvalidMaterialDigest,
     UnexpectedMaterialDigest,
+    MissingMaterialDigest,
 }
 
 impl std::fmt::Display for SecretsLifecycleAuditError {
@@ -198,9 +381,14 @@ impl std::fmt::Display for SecretsLifecycleAuditError {
                 )
             }
             Self::InvalidVmId => write!(f, "vm_id is empty or contains a path separator"),
-            Self::MissingGeneration => write!(f, "result requires a generation number"),
-            Self::UnexpectedGeneration => write!(f, "result must not carry a generation number"),
-            Self::GenerationIsZero => write!(f, "generation numbers start at 1"),
+            Self::MissingLineageEpoch => write!(f, "result requires a lineage_epoch"),
+            Self::UnexpectedLineageEpoch => write!(f, "result must not carry a lineage_epoch"),
+            Self::LineageEpochIsZero => write!(f, "lineage epochs start at 1"),
+            Self::MissingHighWaterEpoch => write!(f, "result requires a high_water_epoch"),
+            Self::UnexpectedHighWaterEpoch => write!(f, "result must not carry a high_water_epoch"),
+            Self::HighWaterBelowLineageEpoch => {
+                write!(f, "high_water_epoch must be >= lineage_epoch")
+            }
             Self::RetainedGenerationsTooLarge { len } => write!(
                 f,
                 "retained_generations length {len} exceeds {MAX_AUDITED_RETAINED_GENERATIONS}"
@@ -209,8 +397,18 @@ impl std::fmt::Display for SecretsLifecycleAuditError {
             Self::RetainedGenerationsIncludeActive => {
                 write!(f, "retained_generations must exclude the active generation")
             }
+            Self::RetainedGenerationsMustBeNonEmpty => write!(
+                f,
+                "this action/result requires at least one retained generation"
+            ),
+            Self::RetainedGenerationsMustBeEmpty => {
+                write!(f, "this action/result must not carry a retained generation")
+            }
             Self::MissingFailReason => write!(f, "fail_reason required for this result"),
             Self::UnexpectedFailReason => write!(f, "fail_reason forbidden for this result"),
+            Self::ActionResultIncompatible => {
+                write!(f, "result is not a reachable outcome of this action")
+            }
             Self::MarkerResultInconsistentWithResult => {
                 write!(f, "marker_result is inconsistent with result")
             }
@@ -219,6 +417,9 @@ impl std::fmt::Display for SecretsLifecycleAuditError {
             }
             Self::UnexpectedMaterialDigest => {
                 write!(f, "material_digest_hex forbidden for this action/result")
+            }
+            Self::MissingMaterialDigest => {
+                write!(f, "material_digest_hex required for this action/result")
             }
         }
     }
@@ -241,6 +442,13 @@ impl SecretsLifecycleAuditFields {
     /// Validate every cross-field invariant the JSON drift / schema
     /// tests rely on to reject a hand-built invalid record. Every
     /// constructor below returns a record that already passes this.
+    ///
+    /// This enforces a **complete** `action` x `result` x
+    /// `marker_result` compatibility matrix (not just per-field
+    /// presence checks): every `(action, result)` pair not explicitly
+    /// reachable from `secrets_lifecycle.rs` is rejected here too, so
+    /// a hand-built or future-buggy record can never claim an
+    /// impossible combination (e.g. `Provision` producing `RolledBack`).
     pub fn validate(&self) -> Result<(), SecretsLifecycleAuditError> {
         if self.schema_version != SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION {
             return Err(SecretsLifecycleAuditError::SchemaVersionMismatch {
@@ -250,10 +458,10 @@ impl SecretsLifecycleAuditFields {
         if !valid_vm_id(&self.vm_id) {
             return Err(SecretsLifecycleAuditError::InvalidVmId);
         }
-        if let Some(generation) = self.generation
-            && generation == 0
+        if let Some(epoch) = self.lineage_epoch
+            && epoch == 0
         {
-            return Err(SecretsLifecycleAuditError::GenerationIsZero);
+            return Err(SecretsLifecycleAuditError::LineageEpochIsZero);
         }
         if self.retained_generations.len() > MAX_AUDITED_RETAINED_GENERATIONS {
             return Err(SecretsLifecycleAuditError::RetainedGenerationsTooLarge {
@@ -262,36 +470,103 @@ impl SecretsLifecycleAuditFields {
         }
         {
             let mut seen = std::collections::HashSet::new();
-            for generation in &self.retained_generations {
-                if !seen.insert(*generation) {
+            for epoch in &self.retained_generations {
+                if !seen.insert(*epoch) {
                     return Err(SecretsLifecycleAuditError::RetainedGenerationsNotUnique);
                 }
             }
         }
-        if let Some(generation) = self.generation
-            && self.retained_generations.contains(&generation)
+        if let Some(epoch) = self.lineage_epoch
+            && self.retained_generations.contains(&epoch)
         {
             return Err(SecretsLifecycleAuditError::RetainedGenerationsIncludeActive);
         }
+        if let (Some(epoch), Some(high_water)) = (self.lineage_epoch, self.high_water_epoch)
+            && high_water < epoch
+        {
+            return Err(SecretsLifecycleAuditError::HighWaterBelowLineageEpoch);
+        }
+
+        // Action x result reachability matrix: only these pairs are
+        // ever constructed by `secrets_lifecycle.rs`. Anything else
+        // (e.g. `Provision` -> `RolledBack`) is rejected outright,
+        // before the per-result field checks below even run.
+        let action_result_ok = matches!(
+            (self.action, self.result),
+            (LifecycleAction::Provision, LifecycleResult::Created)
+                | (LifecycleAction::Provision, LifecycleResult::Denied)
+                | (LifecycleAction::Provision, LifecycleResult::FailedClosed)
+                | (LifecycleAction::Rotate, LifecycleResult::Rotated)
+                | (LifecycleAction::Rotate, LifecycleResult::Denied)
+                | (LifecycleAction::Rotate, LifecycleResult::FailedClosed)
+                | (LifecycleAction::Rollback, LifecycleResult::RolledBack)
+                | (LifecycleAction::Rollback, LifecycleResult::Denied)
+                | (LifecycleAction::Rollback, LifecycleResult::FailedClosed)
+                | (LifecycleAction::Retire, LifecycleResult::Retired)
+                | (LifecycleAction::Retire, LifecycleResult::VerifiedClean)
+                | (LifecycleAction::Retire, LifecycleResult::FailedClosed)
+        );
+        if !action_result_ok {
+            return Err(SecretsLifecycleAuditError::ActionResultIncompatible);
+        }
 
         match self.result {
-            LifecycleResult::Created | LifecycleResult::Rotated | LifecycleResult::RolledBack => {
-                if self.generation.is_none() {
-                    return Err(SecretsLifecycleAuditError::MissingGeneration);
+            LifecycleResult::Created => {
+                if self.lineage_epoch.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingLineageEpoch);
+                }
+                if self.high_water_epoch.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingHighWaterEpoch);
+                }
+                if !self.retained_generations.is_empty() {
+                    return Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeEmpty);
                 }
                 if self.fail_reason.is_some() {
                     return Err(SecretsLifecycleAuditError::UnexpectedFailReason);
                 }
-                if matches!(
-                    self.marker_result,
-                    MarkerResult::FailedClosed | MarkerResult::Unchanged | MarkerResult::Tombstoned
-                ) {
+                if self.marker_result != MarkerResult::Created {
                     return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
+                }
+                if self.material_digest_hex.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingMaterialDigest);
+                }
+            }
+            LifecycleResult::Rotated | LifecycleResult::RolledBack => {
+                if self.lineage_epoch.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingLineageEpoch);
+                }
+                if self.high_water_epoch.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingHighWaterEpoch);
+                }
+                if self.retained_generations.is_empty() {
+                    return Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeNonEmpty);
+                }
+                if self.fail_reason.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedFailReason);
+                }
+                if self.marker_result != MarkerResult::Verified {
+                    return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
+                }
+                let digest_required = self.result == LifecycleResult::Rotated;
+                match (&self.material_digest_hex, digest_required) {
+                    (None, true) => {
+                        return Err(SecretsLifecycleAuditError::MissingMaterialDigest);
+                    }
+                    (Some(_), false) => {
+                        return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
+                    }
+                    _ => {}
                 }
             }
             LifecycleResult::Retired => {
-                if self.generation.is_some() {
-                    return Err(SecretsLifecycleAuditError::UnexpectedGeneration);
+                if self.lineage_epoch.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedLineageEpoch);
+                }
+                if self.high_water_epoch.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingHighWaterEpoch);
+                }
+                if !self.retained_generations.is_empty() {
+                    return Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeEmpty);
                 }
                 if self.fail_reason.is_some() {
                     return Err(SecretsLifecycleAuditError::UnexpectedFailReason);
@@ -304,8 +579,23 @@ impl SecretsLifecycleAuditFields {
                 }
             }
             LifecycleResult::VerifiedClean => {
+                // Only reachable for `Retire` (already-retired /
+                // never-provisioned) per the action/result matrix
+                // above.
+                if self.lineage_epoch.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedLineageEpoch);
+                }
+                if self.high_water_epoch.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingHighWaterEpoch);
+                }
+                if !self.retained_generations.is_empty() {
+                    return Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeEmpty);
+                }
                 if self.fail_reason.is_some() {
                     return Err(SecretsLifecycleAuditError::UnexpectedFailReason);
+                }
+                if self.marker_result != MarkerResult::Verified {
+                    return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
                 }
                 if self.material_digest_hex.is_some() {
                     return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
@@ -318,6 +608,15 @@ impl SecretsLifecycleAuditFields {
                 if self.marker_result != MarkerResult::Unchanged {
                     return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
                 }
+                if self.lineage_epoch.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedLineageEpoch);
+                }
+                if self.high_water_epoch.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedHighWaterEpoch);
+                }
+                if !self.retained_generations.is_empty() {
+                    return Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeEmpty);
+                }
                 if self.material_digest_hex.is_some() {
                     return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
                 }
@@ -326,20 +625,16 @@ impl SecretsLifecycleAuditFields {
                 if self.fail_reason.is_none() {
                     return Err(SecretsLifecycleAuditError::MissingFailReason);
                 }
+                if self.material_digest_hex.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
+                }
             }
         }
 
-        // Only provision/rotate ever write fresh material.
-        if let Some(digest) = &self.material_digest_hex {
-            if !valid_material_digest_hex(digest) {
-                return Err(SecretsLifecycleAuditError::InvalidMaterialDigest);
-            }
-            if !matches!(
-                self.action,
-                LifecycleAction::Provision | LifecycleAction::Rotate
-            ) {
-                return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
-            }
+        if let Some(digest) = &self.material_digest_hex
+            && !valid_material_digest_hex(digest)
+        {
+            return Err(SecretsLifecycleAuditError::InvalidMaterialDigest);
         }
 
         Ok(())
@@ -354,37 +649,51 @@ impl SecretsLifecycleAuditFields {
             base_dir_hash: ctx.base_dir_hash.clone(),
             result: LifecycleResult::VerifiedClean,
             marker_result: MarkerResult::Unchanged,
-            generation: None,
+            lineage_epoch: None,
+            high_water_epoch: None,
             retained_generations: Vec::new(),
             material_digest_hex: None,
             fail_reason: None,
+            recovered_prior_transaction: false,
         }
     }
 
     /// A fresh generation 1 was provisioned.
-    pub fn provisioned(ctx: &SecretsLifecycleAuditContext, material_digest_hex: String) -> Self {
+    pub fn provisioned(
+        ctx: &SecretsLifecycleAuditContext,
+        high_water_epoch: u64,
+        material_digest_hex: String,
+        recovered_prior_transaction: bool,
+    ) -> Self {
         Self {
             result: LifecycleResult::Created,
             marker_result: MarkerResult::Created,
-            generation: Some(1),
+            lineage_epoch: Some(1),
+            high_water_epoch: Some(high_water_epoch),
             material_digest_hex: Some(material_digest_hex),
+            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
     /// A new generation was created and activated.
+    #[allow(clippy::too_many_arguments)]
     pub fn rotated(
         ctx: &SecretsLifecycleAuditContext,
-        generation: u32,
-        retained_generations: Vec<u32>,
+        lineage_epoch: u64,
+        high_water_epoch: u64,
+        retained_generations: Vec<u64>,
         material_digest_hex: String,
+        recovered_prior_transaction: bool,
     ) -> Self {
         Self {
             result: LifecycleResult::Rotated,
             marker_result: MarkerResult::Verified,
-            generation: Some(generation),
+            lineage_epoch: Some(lineage_epoch),
+            high_water_epoch: Some(high_water_epoch),
             retained_generations,
             material_digest_hex: Some(material_digest_hex),
+            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
@@ -392,43 +701,54 @@ impl SecretsLifecycleAuditFields {
     /// `current` was swapped back to a retained prior generation.
     pub fn rolled_back(
         ctx: &SecretsLifecycleAuditContext,
-        generation: u32,
-        retained_generations: Vec<u32>,
+        lineage_epoch: u64,
+        high_water_epoch: u64,
+        retained_generations: Vec<u64>,
+        recovered_prior_transaction: bool,
     ) -> Self {
         Self {
             result: LifecycleResult::RolledBack,
             marker_result: MarkerResult::Verified,
-            generation: Some(generation),
+            lineage_epoch: Some(lineage_epoch),
+            high_water_epoch: Some(high_water_epoch),
             retained_generations,
+            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
     /// Every generation was removed and the marker tombstoned.
-    pub fn retired(ctx: &SecretsLifecycleAuditContext) -> Self {
+    pub fn retired(
+        ctx: &SecretsLifecycleAuditContext,
+        high_water_epoch: u64,
+        recovered_prior_transaction: bool,
+    ) -> Self {
         Self {
             result: LifecycleResult::Retired,
             marker_result: MarkerResult::Tombstoned,
+            high_water_epoch: Some(high_water_epoch),
+            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
-    /// The action was already satisfied; no mutation occurred.
-    pub fn verified_clean(ctx: &SecretsLifecycleAuditContext, generation: Option<u32>) -> Self {
+    /// The action was already satisfied; no mutation occurred. Only
+    /// reachable for `retire` (never-provisioned or already-retired).
+    pub fn verified_clean(ctx: &SecretsLifecycleAuditContext, high_water_epoch: u64) -> Self {
         Self {
             result: LifecycleResult::VerifiedClean,
             marker_result: MarkerResult::Verified,
-            generation,
+            high_water_epoch: Some(high_water_epoch),
             ..Self::base(ctx)
         }
     }
 
     /// The action was refused before any filesystem mutation.
-    pub fn denied(ctx: &SecretsLifecycleAuditContext, reason: &'static str) -> Self {
+    pub fn denied(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> Self {
         Self {
             result: LifecycleResult::Denied,
             marker_result: MarkerResult::Unchanged,
-            fail_reason: Some(reason.to_owned()),
+            fail_reason: Some(reason),
             ..Self::base(ctx)
         }
     }
@@ -437,12 +757,12 @@ impl SecretsLifecycleAuditFields {
     pub fn failed(
         ctx: &SecretsLifecycleAuditContext,
         marker_result: MarkerResult,
-        reason: &'static str,
+        reason: FailReason,
     ) -> Self {
         Self {
             result: LifecycleResult::FailedClosed,
             marker_result,
-            fail_reason: Some(reason.to_owned()),
+            fail_reason: Some(reason),
             ..Self::base(ctx)
         }
     }
@@ -485,11 +805,66 @@ mod tests {
     }
 
     #[test]
+    fn fail_reason_slugs_are_stable_and_distinct() {
+        let variants = [
+            FailReason::InvalidVmId,
+            FailReason::PathDerivationFailed,
+            FailReason::SecretsDirOpenFailed,
+            FailReason::MarkerTreeOpenFailed,
+            FailReason::MarkerWriteFailed,
+            FailReason::MarkerTamperedOrMissingMaterial,
+            FailReason::AlreadyProvisioned,
+            FailReason::AlreadyRetired,
+            FailReason::NotProvisioned,
+            FailReason::NoRollbackTarget,
+            FailReason::PreviouslyProvisionedMaterialMissing,
+            FailReason::GenerationConflict,
+            FailReason::MaterialWriteFailed,
+            FailReason::CurrentSwapFailed,
+            FailReason::InvalidMaterial,
+            FailReason::LockUnavailable,
+            FailReason::IntentWriteFailed,
+            FailReason::IntentCorrupt,
+            FailReason::RecoveryContentMismatch,
+            FailReason::RecoveryAmbiguous,
+            FailReason::StagingNameExhausted,
+            FailReason::RetirementTreeAnomaly,
+            FailReason::RetirementNotProvablyEmpty,
+            FailReason::IdentityOwnerMismatch,
+            FailReason::IdentityModeMismatch,
+            FailReason::IdentityAclMismatch,
+            FailReason::IdentityLinkCountMismatch,
+            FailReason::IdentityDigestMismatch,
+            FailReason::IdentityInodeMismatch,
+            FailReason::IdentityCurrentTargetMismatch,
+            FailReason::HighWaterRegressed,
+        ];
+        let slugs: Vec<&str> = variants.iter().map(|v| v.as_slug()).collect();
+        let unique: std::collections::HashSet<_> = slugs.iter().collect();
+        assert_eq!(
+            unique.len(),
+            slugs.len(),
+            "every FailReason variant must have a distinct slug"
+        );
+        for slug in &slugs {
+            assert!(
+                slug.bytes().all(|b| b.is_ascii_lowercase() || b == b'_'),
+                "slug {slug:?} must be snake_case ascii only (path-free, redaction-safe)"
+            );
+        }
+    }
+
+    #[test]
     fn provisioned_validates() {
-        let record =
-            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        let record = SecretsLifecycleAuditFields::provisioned(
+            &ctx(LifecycleAction::Provision),
+            1,
+            digest(),
+            false,
+        );
         record.validate().expect("provisioned record must validate");
-        assert_eq!(record.generation, Some(1));
+        assert_eq!(record.lineage_epoch, Some(1));
+        assert_eq!(record.high_water_epoch, Some(1));
         assert!(record.retained_generations.is_empty());
     }
 
@@ -498,8 +873,10 @@ mod tests {
         let record = SecretsLifecycleAuditFields::rotated(
             &ctx(LifecycleAction::Rotate),
             2,
+            2,
             vec![1],
             digest(),
+            false,
         );
         record.validate().expect("rotated record must validate");
 
@@ -512,22 +889,67 @@ mod tests {
     }
 
     #[test]
-    fn rolled_back_validates() {
-        let record =
-            SecretsLifecycleAuditFields::rolled_back(&ctx(LifecycleAction::Rollback), 1, vec![2]);
-        record.validate().expect("rolled back record must validate");
+    fn rotated_requires_nonempty_retained_generations() {
+        let mut record = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            2,
+            2,
+            vec![1],
+            digest(),
+            false,
+        );
+        record.retained_generations.clear();
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeNonEmpty)
+        );
     }
 
     #[test]
-    fn retired_validates_and_forbids_generation() {
-        let record = SecretsLifecycleAuditFields::retired(&ctx(LifecycleAction::Retire));
+    fn rolled_back_validates_and_requires_retained_generation() {
+        let record = SecretsLifecycleAuditFields::rolled_back(
+            &ctx(LifecycleAction::Rollback),
+            1,
+            2,
+            vec![2],
+            false,
+        );
+        record.validate().expect("rolled back record must validate");
+
+        let mut broken = record.clone();
+        broken.retained_generations.clear();
+        assert_eq!(
+            broken.validate(),
+            Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeNonEmpty)
+        );
+    }
+
+    #[test]
+    fn rolled_back_forbids_material_digest() {
+        let mut record = SecretsLifecycleAuditFields::rolled_back(
+            &ctx(LifecycleAction::Rollback),
+            1,
+            2,
+            vec![2],
+            false,
+        );
+        record.material_digest_hex = Some(digest());
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest)
+        );
+    }
+
+    #[test]
+    fn retired_validates_and_forbids_lineage_epoch() {
+        let record = SecretsLifecycleAuditFields::retired(&ctx(LifecycleAction::Retire), 5, false);
         record.validate().expect("retired record must validate");
 
         let mut broken = record.clone();
-        broken.generation = Some(1);
+        broken.lineage_epoch = Some(1);
         assert_eq!(
             broken.validate(),
-            Err(SecretsLifecycleAuditError::UnexpectedGeneration)
+            Err(SecretsLifecycleAuditError::UnexpectedLineageEpoch)
         );
     }
 
@@ -535,7 +957,7 @@ mod tests {
     fn denied_requires_fail_reason_and_unchanged_marker() {
         let record = SecretsLifecycleAuditFields::denied(
             &ctx(LifecycleAction::Rotate),
-            "secrets-lifecycle-not-provisioned",
+            FailReason::NotProvisioned,
         );
         record.validate().expect("denied record must validate");
 
@@ -559,7 +981,7 @@ mod tests {
         let record = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
             MarkerResult::FailedClosed,
-            "secrets-lifecycle-marker-tampered",
+            FailReason::MarkerTamperedOrMissingMaterial,
         );
         record.validate().expect("failed record must validate");
 
@@ -573,19 +995,27 @@ mod tests {
 
     #[test]
     fn schema_version_mismatch_is_rejected() {
-        let mut record =
-            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
-        record.schema_version = 2;
+        let mut record = SecretsLifecycleAuditFields::provisioned(
+            &ctx(LifecycleAction::Provision),
+            1,
+            digest(),
+            false,
+        );
+        record.schema_version = 1;
         assert_eq!(
             record.validate(),
-            Err(SecretsLifecycleAuditError::SchemaVersionMismatch { found: 2 })
+            Err(SecretsLifecycleAuditError::SchemaVersionMismatch { found: 1 })
         );
     }
 
     #[test]
     fn invalid_vm_id_is_rejected() {
-        let mut record =
-            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        let mut record = SecretsLifecycleAuditFields::provisioned(
+            &ctx(LifecycleAction::Provision),
+            1,
+            digest(),
+            false,
+        );
         for bad in ["", "work/vm", "wor\0k"] {
             record.vm_id = bad.to_owned();
             assert_eq!(
@@ -596,13 +1026,34 @@ mod tests {
     }
 
     #[test]
-    fn generation_zero_is_rejected() {
-        let mut record =
-            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
-        record.generation = Some(0);
+    fn lineage_epoch_zero_is_rejected() {
+        let mut record = SecretsLifecycleAuditFields::provisioned(
+            &ctx(LifecycleAction::Provision),
+            1,
+            digest(),
+            false,
+        );
+        record.lineage_epoch = Some(0);
         assert_eq!(
             record.validate(),
-            Err(SecretsLifecycleAuditError::GenerationIsZero)
+            Err(SecretsLifecycleAuditError::LineageEpochIsZero)
+        );
+    }
+
+    #[test]
+    fn high_water_below_lineage_epoch_is_rejected() {
+        let mut record = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            5,
+            5,
+            vec![4],
+            digest(),
+            false,
+        );
+        record.high_water_epoch = Some(4);
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::HighWaterBelowLineageEpoch)
         );
     }
 
@@ -611,8 +1062,10 @@ mod tests {
         let mut record = SecretsLifecycleAuditFields::rotated(
             &ctx(LifecycleAction::Rotate),
             100,
-            (1..=MAX_AUDITED_RETAINED_GENERATIONS as u32 + 1).collect(),
+            100,
+            (1..=MAX_AUDITED_RETAINED_GENERATIONS as u64 + 1).collect(),
             digest(),
+            false,
         );
         assert_eq!(
             record.validate(),
@@ -630,8 +1083,13 @@ mod tests {
 
     #[test]
     fn material_digest_is_scoped_to_provision_and_rotate_actions() {
-        let mut record =
-            SecretsLifecycleAuditFields::rolled_back(&ctx(LifecycleAction::Rollback), 1, vec![2]);
+        let mut record = SecretsLifecycleAuditFields::rolled_back(
+            &ctx(LifecycleAction::Rollback),
+            1,
+            2,
+            vec![2],
+            false,
+        );
         record.material_digest_hex = Some(digest());
         assert_eq!(
             record.validate(),
@@ -640,9 +1098,42 @@ mod tests {
     }
 
     #[test]
+    fn created_and_rotated_require_material_digest() {
+        let mut created = SecretsLifecycleAuditFields::provisioned(
+            &ctx(LifecycleAction::Provision),
+            1,
+            digest(),
+            false,
+        );
+        created.material_digest_hex = None;
+        assert_eq!(
+            created.validate(),
+            Err(SecretsLifecycleAuditError::MissingMaterialDigest)
+        );
+
+        let mut rotated = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            2,
+            2,
+            vec![1],
+            digest(),
+            false,
+        );
+        rotated.material_digest_hex = None;
+        assert_eq!(
+            rotated.validate(),
+            Err(SecretsLifecycleAuditError::MissingMaterialDigest)
+        );
+    }
+
+    #[test]
     fn material_digest_must_be_lowercase_hex_64() {
-        let mut record =
-            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        let mut record = SecretsLifecycleAuditFields::provisioned(
+            &ctx(LifecycleAction::Provision),
+            1,
+            digest(),
+            false,
+        );
         for bad in ["", "AA", &"a".repeat(63), &"g".repeat(64), &"A".repeat(64)] {
             record.material_digest_hex = Some(bad.to_owned());
             assert_eq!(
@@ -653,29 +1144,68 @@ mod tests {
     }
 
     #[test]
+    fn action_result_matrix_rejects_impossible_combinations() {
+        // `Provision` can never produce `Rotated`.
+        let mut impossible = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            2,
+            2,
+            vec![1],
+            digest(),
+            false,
+        );
+        impossible.action = LifecycleAction::Provision;
+        assert_eq!(
+            impossible.validate(),
+            Err(SecretsLifecycleAuditError::ActionResultIncompatible)
+        );
+
+        // `Rollback` can never produce `VerifiedClean` (only `Retire`
+        // reaches that result).
+        let mut impossible2 =
+            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), 3);
+        impossible2.action = LifecycleAction::Rollback;
+        assert_eq!(
+            impossible2.validate(),
+            Err(SecretsLifecycleAuditError::ActionResultIncompatible)
+        );
+    }
+
+    #[test]
     fn serde_round_trip_preserves_every_field() {
         let record = SecretsLifecycleAuditFields::rotated(
             &ctx(LifecycleAction::Rotate),
             3,
+            3,
             vec![2],
             digest(),
+            true,
         );
         let json = serde_json::to_string(&record).expect("serialize");
         let decoded: SecretsLifecycleAuditFields =
             serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, record);
+        assert!(decoded.recovered_prior_transaction);
     }
 
     #[test]
-    fn verified_clean_allows_absent_or_present_generation() {
-        let without =
-            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), None);
-        without
+    fn fail_reason_serde_round_trips_as_closed_enum() {
+        let json = serde_json::to_string(&FailReason::RecoveryContentMismatch).unwrap();
+        assert_eq!(json, "\"recovery_content_mismatch\"");
+        let decoded: FailReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, FailReason::RecoveryContentMismatch);
+        // An arbitrary string is not a valid FailReason: this is the
+        // structural guarantee behind "closed failure reasons".
+        assert!(serde_json::from_str::<FailReason>("\"totally-made-up\"").is_err());
+    }
+
+    #[test]
+    fn verified_clean_never_carries_lineage_epoch() {
+        let record = SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), 7);
+        record
             .validate()
-            .expect("verified clean without generation must validate");
-        let with =
-            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Rotate), Some(4));
-        with.validate()
-            .expect("verified clean with generation must validate");
+            .expect("verified clean record must validate");
+        assert_eq!(record.lineage_epoch, None);
+        assert_eq!(record.high_water_epoch, Some(7));
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
@@ -354,7 +354,13 @@ pub struct SecretsLifecycleAuditFields {
     /// proceeding with the requested action. Always `false` on the
     /// common, no-crash path; surfaced so an operator can distinguish
     /// "this rotate ran cleanly" from "this rotate first had to finish
-    /// or unwind a prior crashed rotate".
+    /// or unwind a prior crashed rotate". Threaded through every
+    /// terminal constructor below, including `verified_clean`,
+    /// `denied`, and `failed` — a business-level denial or a
+    /// mid-transaction failure can both happen *after* a successful
+    /// recovery, and that fact must remain observable on the audit
+    /// surface rather than being silently dropped for any result
+    /// other than the four successful-mutation outcomes.
     #[serde(default)]
     pub recovered_prior_transaction: bool,
 }
@@ -776,28 +782,55 @@ impl SecretsLifecycleAuditFields {
 
     /// The action was already satisfied; no mutation occurred. Only
     /// reachable for `retire` (never-provisioned or already-retired).
-    pub fn verified_clean(ctx: &SecretsLifecycleAuditContext, high_water_epoch: u64) -> Self {
+    /// `recovered_prior_transaction` is still meaningful here: a
+    /// `retire` can drain a leftover crashed transaction during
+    /// `open_and_recover` and *then* observe the physical tree is
+    /// already empty, in which case this is `verified_clean` with
+    /// `recovered_prior_transaction: true`.
+    pub fn verified_clean(
+        ctx: &SecretsLifecycleAuditContext,
+        recovered_prior_transaction: bool,
+        high_water_epoch: u64,
+    ) -> Self {
         Self {
             result: LifecycleResult::VerifiedClean,
             marker_result: MarkerResult::Verified,
             high_water_epoch: Some(high_water_epoch),
+            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
     /// The action was refused before any filesystem mutation.
-    pub fn denied(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> Self {
+    /// `recovered_prior_transaction` reflects whether a leftover
+    /// crashed transaction was already successfully drained by
+    /// `open_and_recover` earlier in the same call before this
+    /// business-level denial was reached (e.g. `rotate` recovering a
+    /// stale transaction and *then* finding no active marker to
+    /// rotate). It is always `false` when the denial happens before
+    /// recovery could have run or succeeded (path derivation, dir
+    /// open, lock acquisition, or recovery itself failing).
+    pub fn denied(
+        ctx: &SecretsLifecycleAuditContext,
+        recovered_prior_transaction: bool,
+        reason: FailReason,
+    ) -> Self {
         Self {
             result: LifecycleResult::Denied,
             marker_result: MarkerResult::Unchanged,
             fail_reason: Some(reason),
+            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
     /// The action aborted partway and failed closed.
+    /// `recovered_prior_transaction` carries the same meaning as in
+    /// [`Self::denied`]: whether a leftover crashed transaction was
+    /// already successfully drained before this failure was reached.
     pub fn failed(
         ctx: &SecretsLifecycleAuditContext,
+        recovered_prior_transaction: bool,
         marker_result: MarkerResult,
         reason: FailReason,
     ) -> Self {
@@ -805,6 +838,7 @@ impl SecretsLifecycleAuditFields {
             result: LifecycleResult::FailedClosed,
             marker_result,
             fail_reason: Some(reason),
+            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
@@ -1001,6 +1035,7 @@ mod tests {
     fn denied_requires_fail_reason_and_unchanged_marker() {
         let record = SecretsLifecycleAuditFields::denied(
             &ctx(LifecycleAction::Rotate),
+            false,
             FailReason::NotProvisioned,
         );
         record.validate().expect("denied record must validate");
@@ -1024,6 +1059,7 @@ mod tests {
     fn failed_closed_requires_fail_reason() {
         let record = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
+            false,
             MarkerResult::FailedClosed,
             FailReason::MarkerTamperedOrMissingMaterial,
         );
@@ -1041,6 +1077,7 @@ mod tests {
     fn failed_closed_rejects_non_failed_closed_marker_result() {
         let mut record = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Retire),
+            false,
             MarkerResult::FailedClosed,
             FailReason::RetirementTreeAnomaly,
         );
@@ -1059,6 +1096,7 @@ mod tests {
     fn failed_closed_rejects_leftover_epoch_or_retained_state() {
         let base = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
+            false,
             MarkerResult::FailedClosed,
             FailReason::HighWaterRegressed,
         );
@@ -1094,6 +1132,7 @@ mod tests {
     fn retire_denied_is_a_reachable_and_valid_pair() {
         let record = SecretsLifecycleAuditFields::denied(
             &ctx(LifecycleAction::Retire),
+            false,
             FailReason::InvalidVmId,
         );
         record
@@ -1293,7 +1332,7 @@ mod tests {
         // `Rollback` can never produce `VerifiedClean` (only `Retire`
         // reaches that result).
         let mut impossible2 =
-            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), 3);
+            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), false, 3);
         impossible2.action = LifecycleAction::Rollback;
         assert_eq!(
             impossible2.validate(),
@@ -1331,11 +1370,47 @@ mod tests {
 
     #[test]
     fn verified_clean_never_carries_lineage_epoch() {
-        let record = SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), 7);
+        let record =
+            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), false, 7);
         record
             .validate()
             .expect("verified clean record must validate");
         assert_eq!(record.lineage_epoch, None);
         assert_eq!(record.high_water_epoch, Some(7));
+    }
+
+    /// `recovered_prior_transaction: true` must be reachable and valid
+    /// for every terminal outcome that can follow a successful
+    /// mid-call recovery, not just the four successful-mutation
+    /// results. A `retire` can drain a crashed transaction and then
+    /// find the tree already empty (`verified_clean`); a `rotate` can
+    /// drain a crashed transaction and then hit a business-level
+    /// denial (`denied`); and a fresh action can drain a crashed
+    /// transaction and then itself fail closed (`failed`).
+    #[test]
+    fn recovered_prior_transaction_true_is_valid_on_every_non_mutation_result() {
+        let clean =
+            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), true, 9);
+        clean
+            .validate()
+            .expect("recovered verified_clean must validate");
+        assert!(clean.recovered_prior_transaction);
+
+        let denied = SecretsLifecycleAuditFields::denied(
+            &ctx(LifecycleAction::Rotate),
+            true,
+            FailReason::NotProvisioned,
+        );
+        denied.validate().expect("recovered denied must validate");
+        assert!(denied.recovered_prior_transaction);
+
+        let failed = SecretsLifecycleAuditFields::failed(
+            &ctx(LifecycleAction::Rotate),
+            true,
+            MarkerResult::FailedClosed,
+            FailReason::MarkerTamperedOrMissingMaterial,
+        );
+        failed.validate().expect("recovered failed must validate");
+        assert!(failed.recovered_prior_transaction);
     }
 }

--- a/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
@@ -35,6 +35,7 @@
 //! future integrator must perform before any of this is observable in
 //! a running broker's audit log.
 
+use d2b_contracts::types::VmId;
 use serde::{Deserialize, Serialize};
 
 /// Schema version for the secrets-lifecycle terminal audit record.
@@ -298,7 +299,13 @@ impl std::fmt::Display for FailReason {
 /// vary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecretsLifecycleAuditContext {
-    pub vm_id: String,
+    /// Typed, opaque per-VM identity (the same [`VmId`] newtype used
+    /// broker-wide) rather than a bare human-readable label: this
+    /// keeps the audit surface bound to a canonical typed identity
+    /// instead of an ad hoc string, even though its `#[serde(
+    /// transparent)]` wire form is unchanged (a plain JSON string) so
+    /// this is not an audit-schema break.
+    pub vm_id: VmId,
     pub kind: SecretKind,
     pub action: LifecycleAction,
     /// FNV1a-64 hash of the per-kind secrets-state directory path
@@ -312,7 +319,9 @@ pub struct SecretsLifecycleAuditContext {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsLifecycleAuditFields {
     pub schema_version: u32,
-    pub vm_id: String,
+    /// Typed, opaque per-VM identity -- see
+    /// [`SecretsLifecycleAuditContext::vm_id`].
+    pub vm_id: VmId,
     pub kind: SecretKind,
     pub action: LifecycleAction,
     pub base_dir_hash: String,
@@ -480,7 +489,7 @@ impl SecretsLifecycleAuditFields {
                 found: self.schema_version,
             });
         }
-        if !valid_vm_id(&self.vm_id) {
+        if !valid_vm_id(self.vm_id.as_str()) {
             return Err(SecretsLifecycleAuditError::InvalidVmId);
         }
         if let Some(epoch) = self.lineage_epoch
@@ -828,15 +837,24 @@ impl SecretsLifecycleAuditFields {
     /// `recovered_prior_transaction` carries the same meaning as in
     /// [`Self::denied`]: whether a leftover crashed transaction was
     /// already successfully drained before this failure was reached.
+    ///
+    /// `marker_result` is deliberately **not** a caller-supplied
+    /// parameter: every reachable `secrets_lifecycle.rs` call site
+    /// already only ever passes `MarkerResult::FailedClosed` (this
+    /// is the *only* result variant `validate` accepts for
+    /// `FailedClosed`, see the match arm below), so accepting an
+    /// arbitrary `MarkerResult` here was dead flexibility that could
+    /// only ever construct an invalid, immediately-`validate`-
+    /// rejected record. Hardcoding it makes that invalid state
+    /// unconstructible instead of merely unreachable-in-practice.
     pub fn failed(
         ctx: &SecretsLifecycleAuditContext,
         recovered_prior_transaction: bool,
-        marker_result: MarkerResult,
         reason: FailReason,
     ) -> Self {
         Self {
             result: LifecycleResult::FailedClosed,
-            marker_result,
+            marker_result: MarkerResult::FailedClosed,
             fail_reason: Some(reason),
             recovered_prior_transaction,
             ..Self::base(ctx)
@@ -850,7 +868,7 @@ mod tests {
 
     fn ctx(action: LifecycleAction) -> SecretsLifecycleAuditContext {
         SecretsLifecycleAuditContext {
-            vm_id: "work".to_owned(),
+            vm_id: VmId::new("work"),
             kind: SecretKind::GuestSigningKey,
             action,
             base_dir_hash: "0123456789abcdef".to_owned(),
@@ -1060,7 +1078,6 @@ mod tests {
         let record = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
             false,
-            MarkerResult::FailedClosed,
             FailReason::MarkerTamperedOrMissingMaterial,
         );
         record.validate().expect("failed record must validate");
@@ -1078,7 +1095,6 @@ mod tests {
         let mut record = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Retire),
             false,
-            MarkerResult::FailedClosed,
             FailReason::RetirementTreeAnomaly,
         );
         record
@@ -1097,7 +1113,6 @@ mod tests {
         let base = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
             false,
-            MarkerResult::FailedClosed,
             FailReason::HighWaterRegressed,
         );
 
@@ -1186,7 +1201,7 @@ mod tests {
             false,
         );
         for bad in ["", "work/vm", "wor\0k"] {
-            record.vm_id = bad.to_owned();
+            record.vm_id = VmId::new(bad);
             assert_eq!(
                 record.validate(),
                 Err(SecretsLifecycleAuditError::InvalidVmId)
@@ -1407,7 +1422,6 @@ mod tests {
         let failed = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
             true,
-            MarkerResult::FailedClosed,
             FailReason::MarkerTamperedOrMissingMaterial,
         );
         failed.validate().expect("recovered failed must validate");

--- a/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
@@ -230,6 +230,19 @@ pub enum FailReason {
     /// than the marker's previously committed high-water epoch — a
     /// monotonicity invariant violation this module refuses to persist.
     HighWaterRegressed,
+    /// An `fsync`/parent-directory-sync of a file or directory this
+    /// module just durably wrote returned an error. Every phase
+    /// advancement in the transaction/recovery state machine is
+    /// blocked on this succeeding — a silently-ignored fsync failure
+    /// would let a "durable" phase transition be lost on crash.
+    FsyncFailed,
+    /// The lock file, its containing directory, or another broker-
+    /// trusted metadata path (never a `material` leaf) was found with
+    /// an owner, group, mode, type, or link count that does not match
+    /// this process's own (trusted broker) identity — i.e. it was not
+    /// created/managed by this code path and must not be trusted for
+    /// mutual exclusion or transaction bookkeeping.
+    BrokerOwnershipViolation,
 }
 
 impl FailReason {
@@ -268,6 +281,8 @@ impl FailReason {
             Self::IdentityInodeMismatch => "identity_inode_mismatch",
             Self::IdentityCurrentTargetMismatch => "identity_current_target_mismatch",
             Self::HighWaterRegressed => "high_water_regressed",
+            Self::FsyncFailed => "fsync_failed",
+            Self::BrokerOwnershipViolation => "broker_ownership_violation",
         }
     }
 }
@@ -360,6 +375,7 @@ pub enum SecretsLifecycleAuditError {
     RetainedGenerationsTooLarge { len: usize },
     RetainedGenerationsNotUnique,
     RetainedGenerationsIncludeActive,
+    RetainedGenerationsContainZero,
     RetainedGenerationsMustBeNonEmpty,
     RetainedGenerationsMustBeEmpty,
     MissingFailReason,
@@ -396,6 +412,9 @@ impl std::fmt::Display for SecretsLifecycleAuditError {
             Self::RetainedGenerationsNotUnique => write!(f, "retained_generations has duplicates"),
             Self::RetainedGenerationsIncludeActive => {
                 write!(f, "retained_generations must exclude the active generation")
+            }
+            Self::RetainedGenerationsContainZero => {
+                write!(f, "retained_generations must not contain epoch 0")
             }
             Self::RetainedGenerationsMustBeNonEmpty => write!(
                 f,
@@ -476,6 +495,9 @@ impl SecretsLifecycleAuditFields {
                 }
             }
         }
+        if self.retained_generations.contains(&0) {
+            return Err(SecretsLifecycleAuditError::RetainedGenerationsContainZero);
+        }
         if let Some(epoch) = self.lineage_epoch
             && self.retained_generations.contains(&epoch)
         {
@@ -504,6 +526,7 @@ impl SecretsLifecycleAuditFields {
                 | (LifecycleAction::Rollback, LifecycleResult::FailedClosed)
                 | (LifecycleAction::Retire, LifecycleResult::Retired)
                 | (LifecycleAction::Retire, LifecycleResult::VerifiedClean)
+                | (LifecycleAction::Retire, LifecycleResult::Denied)
                 | (LifecycleAction::Retire, LifecycleResult::FailedClosed)
         );
         if !action_result_ok {
@@ -624,6 +647,25 @@ impl SecretsLifecycleAuditFields {
             LifecycleResult::FailedClosed => {
                 if self.fail_reason.is_none() {
                     return Err(SecretsLifecycleAuditError::MissingFailReason);
+                }
+                // A failed-closed action never durably activated
+                // anything (finding: "never return an error after
+                // silently activating unrecoverable state"), so it
+                // must never carry epoch/retained-generation state —
+                // and its marker disposition is always exactly
+                // `FailedClosed`, never `Verified`/`Created`/
+                // `Tombstoned`/`Unchanged`.
+                if self.marker_result != MarkerResult::FailedClosed {
+                    return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
+                }
+                if self.lineage_epoch.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedLineageEpoch);
+                }
+                if self.high_water_epoch.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedHighWaterEpoch);
+                }
+                if !self.retained_generations.is_empty() {
+                    return Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeEmpty);
                 }
                 if self.material_digest_hex.is_some() {
                     return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
@@ -838,6 +880,8 @@ mod tests {
             FailReason::IdentityInodeMismatch,
             FailReason::IdentityCurrentTargetMismatch,
             FailReason::HighWaterRegressed,
+            FailReason::FsyncFailed,
+            FailReason::BrokerOwnershipViolation,
         ];
         let slugs: Vec<&str> = variants.iter().map(|v| v.as_slug()).collect();
         let unique: std::collections::HashSet<_> = slugs.iter().collect();
@@ -991,6 +1035,92 @@ mod tests {
             broken.validate(),
             Err(SecretsLifecycleAuditError::MissingFailReason)
         );
+    }
+
+    #[test]
+    fn failed_closed_rejects_non_failed_closed_marker_result() {
+        let mut record = SecretsLifecycleAuditFields::failed(
+            &ctx(LifecycleAction::Retire),
+            MarkerResult::FailedClosed,
+            FailReason::RetirementTreeAnomaly,
+        );
+        record
+            .validate()
+            .expect("baseline failed record must validate");
+
+        record.marker_result = MarkerResult::Verified;
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult)
+        );
+    }
+
+    #[test]
+    fn failed_closed_rejects_leftover_epoch_or_retained_state() {
+        let base = SecretsLifecycleAuditFields::failed(
+            &ctx(LifecycleAction::Rotate),
+            MarkerResult::FailedClosed,
+            FailReason::HighWaterRegressed,
+        );
+
+        let mut with_lineage = base.clone();
+        with_lineage.lineage_epoch = Some(1);
+        assert_eq!(
+            with_lineage.validate(),
+            Err(SecretsLifecycleAuditError::UnexpectedLineageEpoch)
+        );
+
+        let mut with_high_water = base.clone();
+        with_high_water.high_water_epoch = Some(1);
+        assert_eq!(
+            with_high_water.validate(),
+            Err(SecretsLifecycleAuditError::UnexpectedHighWaterEpoch)
+        );
+
+        let mut with_retained = base;
+        with_retained.retained_generations = vec![1];
+        assert_eq!(
+            with_retained.validate(),
+            Err(SecretsLifecycleAuditError::RetainedGenerationsMustBeEmpty)
+        );
+    }
+
+    /// `retire` + `Denied` is a genuinely reachable pair (an invalid
+    /// `vm_id`, or a lock-acquisition failure, denies a retire attempt
+    /// exactly like every other action) — the action/result matrix
+    /// above must accept it, not just the three previously-listed
+    /// retire outcomes.
+    #[test]
+    fn retire_denied_is_a_reachable_and_valid_pair() {
+        let record = SecretsLifecycleAuditFields::denied(
+            &ctx(LifecycleAction::Retire),
+            FailReason::InvalidVmId,
+        );
+        record
+            .validate()
+            .expect("retire+Denied must be a valid, reachable action/result pair");
+        assert_eq!(record.result, LifecycleResult::Denied);
+        assert_eq!(record.action, LifecycleAction::Retire);
+    }
+
+    #[test]
+    fn retained_generations_zero_is_rejected() {
+        let mut record = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            2,
+            2,
+            vec![0],
+            digest(),
+            false,
+        );
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::RetainedGenerationsContainZero)
+        );
+        record.retained_generations = vec![1];
+        record
+            .validate()
+            .expect("nonzero retained generation is valid");
     }
 
     #[test]

--- a/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
@@ -1,0 +1,681 @@
+//! Typed audit schema for realm secrets lifecycle (provision / rotate /
+//! rollback / retire) operations.
+//!
+//! This module mirrors the existing [`crate::ops::store_sync_audit`]
+//! pattern: it is the typed shape of a broker audit record's
+//! `operation_fields` object plus invariant-enforcing constructors and a
+//! [`SecretsLifecycleAuditFields::validate`] pass, kept independent of
+//! [`crate::ops::audit_op`] so the integrator can add exactly one new
+//! `OperationFields::SecretsLifecycle(SecretsLifecycleAuditFields)`
+//! variant there (and a matching `from_operation_value` arm) in a
+//! follow-up commit without this component editing that shared sink.
+//!
+//! Redaction contract: this is the **host-confidential** audit record
+//! (broker audit log is `0640 root:d2bd`, per
+//! `docs/reference/cgroup-delegation.md` § "Audit records"). It
+//! deliberately never carries raw secret material, a raw filesystem
+//! path, or a raw channel-binding/credential byte string — only a
+//! FNV1a-64 `base_dir_hash` (parity with [`crate::ops::hosts::stable_hash_str`]
+//! used by every other path-bearing broker audit record), a SHA-256
+//! `material_digest_hex` fingerprint (so operators can correlate a
+//! rotation to specific delivered material without ever seeing it),
+//! and closed-set result/marker enums.
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version for the secrets-lifecycle terminal audit record.
+pub const SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION: u32 = 1;
+
+/// Bound on `retained_generations` so a single audit record can never
+/// grow unbounded (the operational retention policy in
+/// `secrets_lifecycle.rs` keeps at most one retained generation, but
+/// the audit schema allows a little headroom for a future policy
+/// change without a schema bump).
+pub const MAX_AUDITED_RETAINED_GENERATIONS: usize = 8;
+
+/// Closed set of per-realm secret material kinds this component's
+/// lifecycle covers. Matches the W8 `secrets-lifecycle` component scope:
+/// TPM-bound credentials, guest signing keys, and security-key channel
+/// state. Adding a new kind is a schema-version bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretKind {
+    /// Rotation/retirement bookkeeping layered atop the swtpm-owned
+    /// NVRAM identity (`swtpm_dir.rs` remains the sole owner of the
+    /// physical TPM state dir; this kind never mutates it directly).
+    TpmBoundCredential,
+    /// Per-VM guest signing key material (e.g. an SSH host key
+    /// generation lineage) tracked through provision/rotate/retire.
+    GuestSigningKey,
+    /// Security-key CTAPHID channel state (`channel_binding` +
+    /// `reconnect_generation`) consumed by the guest
+    /// `d2b-sk-frontend` `ComponentSession` policy.
+    SecurityKeyChannelState,
+}
+
+impl SecretKind {
+    /// Stable, path-safe slug used as the on-disk directory component
+    /// and as the audit-record `kind` discriminant's string form for
+    /// any downstream consumer that only speaks JSON.
+    pub fn as_slug(self) -> &'static str {
+        match self {
+            SecretKind::TpmBoundCredential => "tpm-bound-credential",
+            SecretKind::GuestSigningKey => "guest-signing-key",
+            SecretKind::SecurityKeyChannelState => "security-key-channel-state",
+        }
+    }
+}
+
+/// The lifecycle action a single audit record describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleAction {
+    Provision,
+    Rotate,
+    Rollback,
+    Retire,
+}
+
+/// Terminal disposition of a lifecycle action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleResult {
+    /// Fresh generation 1 material was provisioned.
+    Created,
+    /// A new generation was created and `current` was atomically
+    /// swapped to it.
+    Rotated,
+    /// `current` was atomically swapped back to the retained previous
+    /// generation.
+    RolledBack,
+    /// All generations were removed and the marker was tombstoned.
+    Retired,
+    /// The requested action was already satisfied (e.g. `retire` on an
+    /// already-retired kind); no mutation occurred.
+    VerifiedClean,
+    /// The request was refused before any mutation (e.g. `rotate`
+    /// requested for a never-provisioned kind).
+    Denied,
+    /// The step aborted partway and failed closed. Never a silent
+    /// partial mutation.
+    FailedClosed,
+}
+
+/// Terminal disposition of the identity-bound tamper-guard marker for
+/// this action, mirroring the `swtpm_dir.rs` marker-result shape but
+/// kept as an independent type (this module never imports from
+/// `swtpm_dir.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MarkerResult {
+    /// A fresh marker recording the trusted generation identity was
+    /// written.
+    Created,
+    /// An existing marker verified against the live directory's
+    /// current identity.
+    Verified,
+    /// The marker was rewritten to record a completed retirement.
+    Tombstoned,
+    /// The action never reached the marker step (denied before any
+    /// filesystem mutation).
+    Unchanged,
+    /// The marker was absent-after-prior-provision, tampered, or
+    /// otherwise failed identity verification. The action fails closed.
+    FailedClosed,
+}
+
+/// Always-present, path-free context threaded through every
+/// constructor so a per-status variant only supplies the fields that
+/// vary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretsLifecycleAuditContext {
+    pub vm_id: String,
+    pub kind: SecretKind,
+    pub action: LifecycleAction,
+    /// FNV1a-64 hash of the per-kind secrets-state directory path
+    /// (parity with [`crate::ops::hosts::stable_hash_str`]).
+    pub base_dir_hash: String,
+}
+
+/// Path-free, material-free terminal audit record for one secrets
+/// lifecycle attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SecretsLifecycleAuditFields {
+    pub schema_version: u32,
+    pub vm_id: String,
+    pub kind: SecretKind,
+    pub action: LifecycleAction,
+    pub base_dir_hash: String,
+    pub result: LifecycleResult,
+    pub marker_result: MarkerResult,
+    /// The active generation number after this action, when one
+    /// exists (`None` after a successful `retire`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<u32>,
+    /// On-disk generations retained for rollback after this action
+    /// (excludes the active generation).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub retained_generations: Vec<u32>,
+    /// SHA-256 hex digest of the material this action wrote, when the
+    /// action wrote material (`provision`/`rotate`). `None` for
+    /// `rollback`/`retire`/failed attempts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub material_digest_hex: Option<String>,
+    /// Closed-set, path-free reason slug. Present exactly when
+    /// `result` is `Denied` or `FailedClosed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fail_reason: Option<String>,
+}
+
+/// Errors [`SecretsLifecycleAuditFields::validate`] can report. Kept
+/// separate from [`crate::ops::OpError`] because this module has no
+/// dependency on the rest of `ops::` beyond `serde`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SecretsLifecycleAuditError {
+    SchemaVersionMismatch { found: u32 },
+    InvalidVmId,
+    MissingGeneration,
+    UnexpectedGeneration,
+    GenerationIsZero,
+    RetainedGenerationsTooLarge { len: usize },
+    RetainedGenerationsNotUnique,
+    RetainedGenerationsIncludeActive,
+    MissingFailReason,
+    UnexpectedFailReason,
+    MarkerResultInconsistentWithResult,
+    InvalidMaterialDigest,
+    UnexpectedMaterialDigest,
+}
+
+impl std::fmt::Display for SecretsLifecycleAuditError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SchemaVersionMismatch { found } => {
+                write!(
+                    f,
+                    "schema_version {found} != {SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION}"
+                )
+            }
+            Self::InvalidVmId => write!(f, "vm_id is empty or contains a path separator"),
+            Self::MissingGeneration => write!(f, "result requires a generation number"),
+            Self::UnexpectedGeneration => write!(f, "result must not carry a generation number"),
+            Self::GenerationIsZero => write!(f, "generation numbers start at 1"),
+            Self::RetainedGenerationsTooLarge { len } => write!(
+                f,
+                "retained_generations length {len} exceeds {MAX_AUDITED_RETAINED_GENERATIONS}"
+            ),
+            Self::RetainedGenerationsNotUnique => write!(f, "retained_generations has duplicates"),
+            Self::RetainedGenerationsIncludeActive => {
+                write!(f, "retained_generations must exclude the active generation")
+            }
+            Self::MissingFailReason => write!(f, "fail_reason required for this result"),
+            Self::UnexpectedFailReason => write!(f, "fail_reason forbidden for this result"),
+            Self::MarkerResultInconsistentWithResult => {
+                write!(f, "marker_result is inconsistent with result")
+            }
+            Self::InvalidMaterialDigest => {
+                write!(f, "material_digest_hex must be 64 lowercase hex characters")
+            }
+            Self::UnexpectedMaterialDigest => {
+                write!(f, "material_digest_hex forbidden for this action/result")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SecretsLifecycleAuditError {}
+
+fn valid_vm_id(vm_id: &str) -> bool {
+    !vm_id.is_empty() && !vm_id.contains('/') && !vm_id.contains('\0')
+}
+
+fn valid_material_digest_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+impl SecretsLifecycleAuditFields {
+    /// Validate every cross-field invariant the JSON drift / schema
+    /// tests rely on to reject a hand-built invalid record. Every
+    /// constructor below returns a record that already passes this.
+    pub fn validate(&self) -> Result<(), SecretsLifecycleAuditError> {
+        if self.schema_version != SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION {
+            return Err(SecretsLifecycleAuditError::SchemaVersionMismatch {
+                found: self.schema_version,
+            });
+        }
+        if !valid_vm_id(&self.vm_id) {
+            return Err(SecretsLifecycleAuditError::InvalidVmId);
+        }
+        if let Some(generation) = self.generation
+            && generation == 0
+        {
+            return Err(SecretsLifecycleAuditError::GenerationIsZero);
+        }
+        if self.retained_generations.len() > MAX_AUDITED_RETAINED_GENERATIONS {
+            return Err(SecretsLifecycleAuditError::RetainedGenerationsTooLarge {
+                len: self.retained_generations.len(),
+            });
+        }
+        {
+            let mut seen = std::collections::HashSet::new();
+            for generation in &self.retained_generations {
+                if !seen.insert(*generation) {
+                    return Err(SecretsLifecycleAuditError::RetainedGenerationsNotUnique);
+                }
+            }
+        }
+        if let Some(generation) = self.generation
+            && self.retained_generations.contains(&generation)
+        {
+            return Err(SecretsLifecycleAuditError::RetainedGenerationsIncludeActive);
+        }
+
+        match self.result {
+            LifecycleResult::Created | LifecycleResult::Rotated | LifecycleResult::RolledBack => {
+                if self.generation.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingGeneration);
+                }
+                if self.fail_reason.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedFailReason);
+                }
+                if matches!(
+                    self.marker_result,
+                    MarkerResult::FailedClosed | MarkerResult::Unchanged | MarkerResult::Tombstoned
+                ) {
+                    return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
+                }
+            }
+            LifecycleResult::Retired => {
+                if self.generation.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedGeneration);
+                }
+                if self.fail_reason.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedFailReason);
+                }
+                if self.marker_result != MarkerResult::Tombstoned {
+                    return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
+                }
+                if self.material_digest_hex.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
+                }
+            }
+            LifecycleResult::VerifiedClean => {
+                if self.fail_reason.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedFailReason);
+                }
+                if self.material_digest_hex.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
+                }
+            }
+            LifecycleResult::Denied => {
+                if self.fail_reason.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingFailReason);
+                }
+                if self.marker_result != MarkerResult::Unchanged {
+                    return Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult);
+                }
+                if self.material_digest_hex.is_some() {
+                    return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
+                }
+            }
+            LifecycleResult::FailedClosed => {
+                if self.fail_reason.is_none() {
+                    return Err(SecretsLifecycleAuditError::MissingFailReason);
+                }
+            }
+        }
+
+        // Only provision/rotate ever write fresh material.
+        if let Some(digest) = &self.material_digest_hex {
+            if !valid_material_digest_hex(digest) {
+                return Err(SecretsLifecycleAuditError::InvalidMaterialDigest);
+            }
+            if !matches!(
+                self.action,
+                LifecycleAction::Provision | LifecycleAction::Rotate
+            ) {
+                return Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn base(ctx: &SecretsLifecycleAuditContext) -> Self {
+        Self {
+            schema_version: SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION,
+            vm_id: ctx.vm_id.clone(),
+            kind: ctx.kind,
+            action: ctx.action,
+            base_dir_hash: ctx.base_dir_hash.clone(),
+            result: LifecycleResult::VerifiedClean,
+            marker_result: MarkerResult::Unchanged,
+            generation: None,
+            retained_generations: Vec::new(),
+            material_digest_hex: None,
+            fail_reason: None,
+        }
+    }
+
+    /// A fresh generation 1 was provisioned.
+    pub fn provisioned(ctx: &SecretsLifecycleAuditContext, material_digest_hex: String) -> Self {
+        Self {
+            result: LifecycleResult::Created,
+            marker_result: MarkerResult::Created,
+            generation: Some(1),
+            material_digest_hex: Some(material_digest_hex),
+            ..Self::base(ctx)
+        }
+    }
+
+    /// A new generation was created and activated.
+    pub fn rotated(
+        ctx: &SecretsLifecycleAuditContext,
+        generation: u32,
+        retained_generations: Vec<u32>,
+        material_digest_hex: String,
+    ) -> Self {
+        Self {
+            result: LifecycleResult::Rotated,
+            marker_result: MarkerResult::Verified,
+            generation: Some(generation),
+            retained_generations,
+            material_digest_hex: Some(material_digest_hex),
+            ..Self::base(ctx)
+        }
+    }
+
+    /// `current` was swapped back to a retained prior generation.
+    pub fn rolled_back(
+        ctx: &SecretsLifecycleAuditContext,
+        generation: u32,
+        retained_generations: Vec<u32>,
+    ) -> Self {
+        Self {
+            result: LifecycleResult::RolledBack,
+            marker_result: MarkerResult::Verified,
+            generation: Some(generation),
+            retained_generations,
+            ..Self::base(ctx)
+        }
+    }
+
+    /// Every generation was removed and the marker tombstoned.
+    pub fn retired(ctx: &SecretsLifecycleAuditContext) -> Self {
+        Self {
+            result: LifecycleResult::Retired,
+            marker_result: MarkerResult::Tombstoned,
+            ..Self::base(ctx)
+        }
+    }
+
+    /// The action was already satisfied; no mutation occurred.
+    pub fn verified_clean(ctx: &SecretsLifecycleAuditContext, generation: Option<u32>) -> Self {
+        Self {
+            result: LifecycleResult::VerifiedClean,
+            marker_result: MarkerResult::Verified,
+            generation,
+            ..Self::base(ctx)
+        }
+    }
+
+    /// The action was refused before any filesystem mutation.
+    pub fn denied(ctx: &SecretsLifecycleAuditContext, reason: &'static str) -> Self {
+        Self {
+            result: LifecycleResult::Denied,
+            marker_result: MarkerResult::Unchanged,
+            fail_reason: Some(reason.to_owned()),
+            ..Self::base(ctx)
+        }
+    }
+
+    /// The action aborted partway and failed closed.
+    pub fn failed(
+        ctx: &SecretsLifecycleAuditContext,
+        marker_result: MarkerResult,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            result: LifecycleResult::FailedClosed,
+            marker_result,
+            fail_reason: Some(reason.to_owned()),
+            ..Self::base(ctx)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(action: LifecycleAction) -> SecretsLifecycleAuditContext {
+        SecretsLifecycleAuditContext {
+            vm_id: "work".to_owned(),
+            kind: SecretKind::GuestSigningKey,
+            action,
+            base_dir_hash: "0123456789abcdef".to_owned(),
+        }
+    }
+
+    fn digest() -> String {
+        "a".repeat(64)
+    }
+
+    #[test]
+    fn secret_kind_slugs_are_stable_and_distinct() {
+        let slugs = [
+            SecretKind::TpmBoundCredential.as_slug(),
+            SecretKind::GuestSigningKey.as_slug(),
+            SecretKind::SecurityKeyChannelState.as_slug(),
+        ];
+        assert_eq!(
+            slugs,
+            [
+                "tpm-bound-credential",
+                "guest-signing-key",
+                "security-key-channel-state"
+            ]
+        );
+        let unique: std::collections::HashSet<_> = slugs.iter().collect();
+        assert_eq!(unique.len(), slugs.len());
+    }
+
+    #[test]
+    fn provisioned_validates() {
+        let record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        record.validate().expect("provisioned record must validate");
+        assert_eq!(record.generation, Some(1));
+        assert!(record.retained_generations.is_empty());
+    }
+
+    #[test]
+    fn rotated_validates_and_excludes_active_from_retained() {
+        let record = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            2,
+            vec![1],
+            digest(),
+        );
+        record.validate().expect("rotated record must validate");
+
+        let mut broken = record.clone();
+        broken.retained_generations.push(2);
+        assert_eq!(
+            broken.validate(),
+            Err(SecretsLifecycleAuditError::RetainedGenerationsIncludeActive)
+        );
+    }
+
+    #[test]
+    fn rolled_back_validates() {
+        let record =
+            SecretsLifecycleAuditFields::rolled_back(&ctx(LifecycleAction::Rollback), 1, vec![2]);
+        record.validate().expect("rolled back record must validate");
+    }
+
+    #[test]
+    fn retired_validates_and_forbids_generation() {
+        let record = SecretsLifecycleAuditFields::retired(&ctx(LifecycleAction::Retire));
+        record.validate().expect("retired record must validate");
+
+        let mut broken = record.clone();
+        broken.generation = Some(1);
+        assert_eq!(
+            broken.validate(),
+            Err(SecretsLifecycleAuditError::UnexpectedGeneration)
+        );
+    }
+
+    #[test]
+    fn denied_requires_fail_reason_and_unchanged_marker() {
+        let record = SecretsLifecycleAuditFields::denied(
+            &ctx(LifecycleAction::Rotate),
+            "secrets-lifecycle-not-provisioned",
+        );
+        record.validate().expect("denied record must validate");
+
+        let mut broken = record.clone();
+        broken.fail_reason = None;
+        assert_eq!(
+            broken.validate(),
+            Err(SecretsLifecycleAuditError::MissingFailReason)
+        );
+
+        let mut broken_marker = record.clone();
+        broken_marker.marker_result = MarkerResult::FailedClosed;
+        assert_eq!(
+            broken_marker.validate(),
+            Err(SecretsLifecycleAuditError::MarkerResultInconsistentWithResult)
+        );
+    }
+
+    #[test]
+    fn failed_closed_requires_fail_reason() {
+        let record = SecretsLifecycleAuditFields::failed(
+            &ctx(LifecycleAction::Rotate),
+            MarkerResult::FailedClosed,
+            "secrets-lifecycle-marker-tampered",
+        );
+        record.validate().expect("failed record must validate");
+
+        let mut broken = record.clone();
+        broken.fail_reason = None;
+        assert_eq!(
+            broken.validate(),
+            Err(SecretsLifecycleAuditError::MissingFailReason)
+        );
+    }
+
+    #[test]
+    fn schema_version_mismatch_is_rejected() {
+        let mut record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        record.schema_version = 2;
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::SchemaVersionMismatch { found: 2 })
+        );
+    }
+
+    #[test]
+    fn invalid_vm_id_is_rejected() {
+        let mut record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        for bad in ["", "work/vm", "wor\0k"] {
+            record.vm_id = bad.to_owned();
+            assert_eq!(
+                record.validate(),
+                Err(SecretsLifecycleAuditError::InvalidVmId)
+            );
+        }
+    }
+
+    #[test]
+    fn generation_zero_is_rejected() {
+        let mut record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        record.generation = Some(0);
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::GenerationIsZero)
+        );
+    }
+
+    #[test]
+    fn retained_generations_bounds_and_uniqueness() {
+        let mut record = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            100,
+            (1..=MAX_AUDITED_RETAINED_GENERATIONS as u32 + 1).collect(),
+            digest(),
+        );
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::RetainedGenerationsTooLarge {
+                len: MAX_AUDITED_RETAINED_GENERATIONS + 1
+            })
+        );
+
+        record.retained_generations = vec![1, 1];
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::RetainedGenerationsNotUnique)
+        );
+    }
+
+    #[test]
+    fn material_digest_is_scoped_to_provision_and_rotate_actions() {
+        let mut record =
+            SecretsLifecycleAuditFields::rolled_back(&ctx(LifecycleAction::Rollback), 1, vec![2]);
+        record.material_digest_hex = Some(digest());
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::UnexpectedMaterialDigest)
+        );
+    }
+
+    #[test]
+    fn material_digest_must_be_lowercase_hex_64() {
+        let mut record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), digest());
+        for bad in ["", "AA", &"a".repeat(63), &"g".repeat(64), &"A".repeat(64)] {
+            record.material_digest_hex = Some(bad.to_owned());
+            assert_eq!(
+                record.validate(),
+                Err(SecretsLifecycleAuditError::InvalidMaterialDigest)
+            );
+        }
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_every_field() {
+        let record = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            3,
+            vec![2],
+            digest(),
+        );
+        let json = serde_json::to_string(&record).expect("serialize");
+        let decoded: SecretsLifecycleAuditFields =
+            serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn verified_clean_allows_absent_or_present_generation() {
+        let without =
+            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), None);
+        without
+            .validate()
+            .expect("verified clean without generation must validate");
+        let with =
+            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Rotate), Some(4));
+        with.validate()
+            .expect("verified clean with generation must validate");
+    }
+}

--- a/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
+++ b/packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs
@@ -13,18 +13,34 @@
 //! Redaction contract: this is the **host-confidential** audit record
 //! (broker audit log is `0640 root:d2bd`, per
 //! `docs/reference/cgroup-delegation.md` § "Audit records"). It
-//! deliberately never carries raw secret material, a raw filesystem
-//! path, or a raw channel-binding/credential byte string — only a
-//! FNV1a-64 `base_dir_hash` (parity with [`crate::ops::hosts::stable_hash_str`]
-//! used by every other path-bearing broker audit record), a SHA-256
-//! `material_digest_hex` fingerprint (so operators can correlate a
-//! rotation to specific delivered material without ever seeing it),
-//! and closed-set result/marker/reason enums. **`fail_reason` is a
-//! closed enum, not a free-form string** — this is a deliberate
-//! hardening over an earlier draft of this module that carried
-//! `Option<String>` populated from convention-only `&'static str`
-//! constants; nothing outside this file's [`FailReason`] enum can ever
-//! reach the audit surface.
+//! deliberately never carries raw secret material or a raw
+//! channel-binding/credential byte string — only a bounded opaque
+//! typed [`WorkloadId`] (never a human VM-name label or a filesystem
+//! path; see the W8fu6 note below), a SHA-256 `material_digest_hex`
+//! fingerprint (so operators can correlate a rotation to specific
+//! delivered material without ever seeing it), and closed-set
+//! result/marker/reason enums. **`fail_reason` is a closed enum, not a
+//! free-form string** — this is a deliberate hardening over an earlier
+//! draft of this module that carried `Option<String>` populated from
+//! convention-only `&'static str` constants; nothing outside this
+//! file's [`FailReason`] enum can ever reach the audit surface.
+//!
+//! # W8fu6: canonical typed identity, no filesystem path
+//!
+//! Rounds 1-5 bound this schema to a bare [`d2b_contracts::types::VmId`]
+//! human-label string plus an FNV1a-64 `base_dir_hash` of the
+//! filesystem path the old engine derived from it. The W8fu6 rewrite of
+//! [`crate::ops::secrets_lifecycle`] into a pure transaction core over
+//! an injected, storage-agnostic authority port has no filesystem path
+//! at all, and this schema now binds to the canonical
+//! [`d2b_contracts::v2_identity::WorkloadId`] typed identity instead of
+//! a legacy VM-name string: `base_dir_hash` is removed outright (there
+//! is nothing left to hash), and `vm_id` is renamed `workload_id` with
+//! the new type. `WorkloadId`'s wire form is still a plain bounded
+//! opaque 20-character string (never the human-readable workload
+//! name/label it was derived from), so this remains schema-safe for any
+//! JSON consumer that only ever treats the field as an opaque
+//! correlation token.
 //!
 //! # Status
 //!
@@ -35,17 +51,22 @@
 //! future integrator must perform before any of this is observable in
 //! a running broker's audit log.
 
-use d2b_contracts::types::VmId;
+use d2b_contracts::v2_identity::WorkloadId;
 use serde::{Deserialize, Serialize};
 
 /// Schema version for the secrets-lifecycle terminal audit record.
 ///
-/// Bumped from `1` to `2` for the transaction/recovery + strengthened
-/// identity-binding redesign: `generation` (u32) became `lineage_epoch`
-/// (u64) with a companion `high_water_epoch`, `retained_generations`
-/// became `u64`-keyed, `fail_reason` became a closed enum instead of a
-/// free-form string, and `recovered_prior_transaction` was added.
-pub const SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION: u32 = 2;
+/// Bumped from `2` to `3` for the W8fu6 ports-and-adapters rewrite:
+/// `vm_id: VmId` became `workload_id: WorkloadId` (the canonical v2
+/// identity type, replacing a legacy human VM-name string);
+/// `base_dir_hash` was removed outright (the new engine has no
+/// filesystem path to hash); `recovered_prior_transaction` was removed
+/// (the pure CAS-based engine has no separate "recovery" phase — a
+/// fenced writer simply retries, it never "recovers" a crashed
+/// transaction left by itself); and a new `prune_deferred: bool` field
+/// was added, surfacing the new engine's prune-after-commit-debt model
+/// on the audit surface.
+pub const SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION: u32 = 3;
 
 /// Bound on `retained_generations` so a single audit record can never
 /// grow unbounded (the operational retention policy in
@@ -75,9 +96,11 @@ pub enum SecretKind {
 }
 
 impl SecretKind {
-    /// Stable, path-safe slug used as the on-disk directory component
-    /// and as the audit-record `kind` discriminant's string form for
-    /// any downstream consumer that only speaks JSON.
+    /// Stable slug used as the audit-record `kind` discriminant's
+    /// string form for any downstream consumer that only speaks JSON.
+    /// (Rounds 1-5 also used this as an on-disk directory component;
+    /// the W8fu6 storage-agnostic engine has no directory, so this is
+    /// now purely a wire/audit-surface identifier.)
     pub fn as_slug(self) -> &'static str {
         match self {
             SecretKind::TpmBoundCredential => "tpm-bound-credential",
@@ -103,147 +126,131 @@ pub enum LifecycleAction {
 pub enum LifecycleResult {
     /// Fresh generation 1 material was provisioned.
     Created,
-    /// A new generation was created and `current` was atomically
-    /// swapped to it.
+    /// A new generation was created and became the active generation.
     Rotated,
-    /// `current` was atomically swapped back to the retained previous
-    /// generation.
+    /// The active generation was atomically swapped back to the
+    /// retained previous generation.
     RolledBack,
-    /// All generations were removed and the marker was tombstoned.
+    /// Every generation was durably retired.
     Retired,
     /// The requested action was already satisfied (e.g. `retire` on an
-    /// already-retired kind); no mutation occurred.
+    /// already-retired or never-provisioned kind); no mutation
+    /// occurred.
     VerifiedClean,
     /// The request was refused before any mutation (e.g. `rotate`
     /// requested for a never-provisioned kind).
     Denied,
     /// The step aborted partway and failed closed. Never a silent
-    /// partial mutation.
+    /// partial mutation: [`LifecycleResult::FailedClosed`] is only ever
+    /// reachable before a commit durably succeeds, or after a
+    /// post-commit integrity re-check detects tampering and
+    /// quarantines the authority — never as a way to paper over an
+    /// already-durable, already-activated state.
     FailedClosed,
 }
 
-/// Terminal disposition of the identity-bound tamper-guard marker for
-/// this action, mirroring the `swtpm_dir.rs` marker-result shape but
-/// kept as an independent type (this module never imports from
-/// `swtpm_dir.rs`).
+/// Terminal disposition of the identity-binding integrity check for
+/// this action. Rounds 1-5 named this after the on-disk marker file
+/// that recorded a generation's trusted identity; the W8fu6 rewrite
+/// keeps the type name and variant set (per the explicit instruction
+/// to retain closed audit/channel types across the rewrite) but the
+/// meaning generalizes to "the terminal state of this action's
+/// identity-binding checks against the authority port", independent of
+/// whatever concrete marker/metadata representation an adapter uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MarkerResult {
-    /// A fresh marker recording the trusted generation identity was
-    /// written.
+    /// A fresh generation's identity was durably committed for the
+    /// first time.
     Created,
-    /// An existing marker verified against the live directory's
-    /// current identity.
+    /// An existing generation's live digest was independently
+    /// re-verified against the durably committed identity before this
+    /// action mutated anything.
     Verified,
-    /// The marker was rewritten to record a completed retirement.
+    /// The durable state was rewritten to record a completed
+    /// retirement.
     Tombstoned,
-    /// The action never reached the marker step (denied before any
-    /// filesystem mutation).
+    /// The action never reached a mutation step (denied before any
+    /// authority-port write).
     Unchanged,
-    /// The marker was absent-after-prior-provision, tampered, or
-    /// otherwise failed identity verification. The action fails closed.
+    /// The durable state failed a self-consistency or digest
+    /// verification check, or a commit/prune step failed. The action
+    /// fails closed.
     FailedClosed,
 }
 
-/// Closed set of path-free, redaction-safe failure/refusal reasons.
-/// Every [`SecretsLifecycleAuditFields::denied`] /
+/// Closed set of redaction-safe failure/refusal reasons. Every
+/// [`SecretsLifecycleAuditFields::denied`] /
 /// [`SecretsLifecycleAuditFields::failed`] call site in
 /// `secrets_lifecycle.rs` constructs one of these variants directly —
-/// there is no code path that can place an arbitrary string or a raw
-/// filesystem path onto the audit surface.
+/// there is no code path that can place an arbitrary string, a raw
+/// filesystem path, or an adapter-internal error detail onto the audit
+/// surface.
+///
+/// This is a substantially smaller, storage-agnostic set than the
+/// rounds 1-5 filesystem-anchored engine's 27-variant enum: every
+/// variant naming a raw path/lock/fsync/txlog/ACL/inode/link-count
+/// concept was a property of that engine's *own* filesystem adapter,
+/// never observable by the W8fu6 pure transaction core, which only ever
+/// calls the six guarded, typed [`crate::ops::secrets_lifecycle::SecretsAuthorityPort`]
+/// methods. All of that fine-grained tamper/I/O detail is now the
+/// adapter's own internal concern, hidden behind
+/// [`crate::ops::secrets_lifecycle::PortError`] and reported to this
+/// audit surface, when it must be, only via the single opaque
+/// [`FailReason::PortUnavailable`] bucket.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FailReason {
-    InvalidVmId,
-    PathDerivationFailed,
-    SecretsDirOpenFailed,
-    MarkerTreeOpenFailed,
-    MarkerWriteFailed,
-    MarkerTamperedOrMissingMaterial,
+    /// `provision` requested for a `(workload, kind)` that already has
+    /// an active, non-retired generation.
     AlreadyProvisioned,
-    AlreadyRetired,
+    /// `rotate`/`rollback` requested for a `(workload, kind)` with no
+    /// active generation (never provisioned, or already retired).
     NotProvisioned,
+    /// `rollback` requested with no retained prior generation to swap
+    /// back to.
     NoRollbackTarget,
-    PreviouslyProvisionedMaterialMissing,
-    GenerationConflict,
-    MaterialWriteFailed,
-    CurrentSwapFailed,
+    /// The caller-supplied material was empty or exceeded
+    /// [`crate::ops::secrets_lifecycle::SecretMaterial::MAX_LEN`].
+    /// Never actually reachable as an audit record's `fail_reason`:
+    /// [`crate::ops::secrets_lifecycle::SecretMaterial::new`] returns
+    /// this directly to the caller before any
+    /// [`SecretsLifecycleAuditContext`] exists. Kept in this enum
+    /// anyway so every lifecycle failure a caller must handle shares
+    /// one closed vocabulary.
     InvalidMaterial,
-    /// The cross-process per-`(vm, kind)` exclusive lock could not be
-    /// acquired within the bounded wait budget.
-    LockUnavailable,
-    /// The durable transaction/recovery log (`txlog`) could not be
-    /// written or fsynced.
-    IntentWriteFailed,
-    /// A leftover `txlog` exists but is not well-formed JSON, fails
-    /// schema validation, or names a `(vm, kind)` other than the one
-    /// it was found under.
-    IntentCorrupt,
-    /// Resuming a leftover in-flight transaction found on-disk content
-    /// that does not match what the transaction log recorded before
-    /// the crash (e.g. a digest mismatch on the staged/committed
-    /// epoch). Recovery refuses to guess and fails closed without
-    /// touching `current` or the marker.
-    RecoveryContentMismatch,
-    /// Resuming a leftover in-flight transaction found the filesystem
-    /// in a state recovery cannot map to any phase of the recorded
-    /// transaction (e.g. `current` points somewhere the log did not
-    /// expect). Recovery fails closed rather than guessing.
-    RecoveryAmbiguous,
-    /// A collision-resistant staging name could not be allocated
-    /// within the bounded retry budget (astronomically unlikely; ever
-    /// observing this indicates a broken randomness source).
-    StagingNameExhausted,
-    /// Retirement's full anchored-tree enumeration found an entry it
-    /// could not account for (unexpected name, unexpected type, or a
-    /// material file with more than one hard link) and refused to
-    /// delete anything.
-    RetirementTreeAnomaly,
-    /// Retirement removed every entry it validated but the generations
-    /// tree was not observably empty afterward.
-    RetirementNotProvablyEmpty,
-    /// The live active-generation directory's owner uid/gid does not
-    /// match the marker's recorded identity.
-    IdentityOwnerMismatch,
-    /// The live active-generation directory's mode does not match the
-    /// marker's recorded identity.
-    IdentityModeMismatch,
-    /// The live active-generation directory carries (or lost) an
-    /// extended POSIX ACL relative to what the marker recorded.
-    IdentityAclMismatch,
-    /// The live active-generation directory's material file link
-    /// count is not exactly 1 (a hard-link plant), or otherwise does
-    /// not match the marker's recorded identity.
-    IdentityLinkCountMismatch,
-    /// The live active-generation material's SHA-256 digest does not
-    /// match the marker's recorded identity.
-    IdentityDigestMismatch,
-    /// The live active-generation material's SHA-256 digest matches
-    /// the marker's recorded identity, but the `(dev, ino)` pair does
-    /// not — a hard-link or directory-swap tamper that byte-content
-    /// comparison alone cannot see (a replacement file with identical
-    /// bytes but a different physical inode).
-    IdentityInodeMismatch,
-    /// `current` does not literally resolve (by name, not just by
-    /// coincidental dev/ino) to the epoch the marker records as active.
-    IdentityCurrentTargetMismatch,
-    /// A newly computed high-water epoch would not be strictly greater
-    /// than the marker's previously committed high-water epoch — a
-    /// monotonicity invariant violation this module refuses to persist.
-    HighWaterRegressed,
-    /// An `fsync`/parent-directory-sync of a file or directory this
-    /// module just durably wrote returned an error. Every phase
-    /// advancement in the transaction/recovery state machine is
-    /// blocked on this succeeding — a silently-ignored fsync failure
-    /// would let a "durable" phase transition be lost on crash.
-    FsyncFailed,
-    /// The lock file, its containing directory, or another broker-
-    /// trusted metadata path (never a `material` leaf) was found with
-    /// an owner, group, mode, type, or link count that does not match
-    /// this process's own (trusted broker) identity — i.e. it was not
-    /// created/managed by this code path and must not be trusted for
-    /// mutual exclusion or transaction bookkeeping.
-    BrokerOwnershipViolation,
+    /// A generation's independently recomputed live digest did not
+    /// match the durable state's recorded digest for that generation
+    /// — live storage was tampered with, or (post-commit) a concurrent
+    /// writer's later stage attempt clobbered this call's own
+    /// just-committed material. The authority is quarantined before
+    /// this is returned.
+    ChecksumMismatch,
+    /// [`crate::ops::secrets_lifecycle::SecretsAuthorityPort::cas_commit`]
+    /// reported that another writer's transition committed first.
+    /// Nothing was mutated; the caller may re-read and retry.
+    OwnershipFenced,
+    /// The authority already reported (or newly detected and
+    /// self-reported) that this `(workload, kind)` is quarantined.
+    /// Every port call for this pair fails closed until an
+    /// out-of-band clearing operation this module does not expose
+    /// resets it.
+    Quarantined,
+    /// The durable state read from the authority failed its own
+    /// internal self-consistency check (see
+    /// [`crate::ops::secrets_lifecycle::DurableState::validate_self_consistent`]).
+    /// The authority is quarantined before this is returned.
+    StateCorrupt,
+    /// A prior action's pending prune obligation could not be fully
+    /// resolved before this action could proceed. Whatever subset was
+    /// resolvable was durably committed; the caller may retry.
+    PruneDebtUnresolved,
+    /// The authority reported an error internal to its own adapter
+    /// (I/O, its own locking/storage substrate, etc). This module
+    /// never inspects or forwards the adapter's own error detail —
+    /// only this one opaque, closed bucket ever reaches the audit
+    /// surface.
+    PortUnavailable,
 }
 
 impl FailReason {
@@ -251,39 +258,16 @@ impl FailReason {
     /// safe for any Debug/log/audit surface (never a path or secret).
     pub fn as_slug(self) -> &'static str {
         match self {
-            Self::InvalidVmId => "invalid_vm_id",
-            Self::PathDerivationFailed => "path_derivation_failed",
-            Self::SecretsDirOpenFailed => "secrets_dir_open_failed",
-            Self::MarkerTreeOpenFailed => "marker_tree_open_failed",
-            Self::MarkerWriteFailed => "marker_write_failed",
-            Self::MarkerTamperedOrMissingMaterial => "marker_tampered_or_missing_material",
             Self::AlreadyProvisioned => "already_provisioned",
-            Self::AlreadyRetired => "already_retired",
             Self::NotProvisioned => "not_provisioned",
             Self::NoRollbackTarget => "no_rollback_target",
-            Self::PreviouslyProvisionedMaterialMissing => "previously_provisioned_material_missing",
-            Self::GenerationConflict => "generation_conflict",
-            Self::MaterialWriteFailed => "material_write_failed",
-            Self::CurrentSwapFailed => "current_swap_failed",
             Self::InvalidMaterial => "invalid_material",
-            Self::LockUnavailable => "lock_unavailable",
-            Self::IntentWriteFailed => "intent_write_failed",
-            Self::IntentCorrupt => "intent_corrupt",
-            Self::RecoveryContentMismatch => "recovery_content_mismatch",
-            Self::RecoveryAmbiguous => "recovery_ambiguous",
-            Self::StagingNameExhausted => "staging_name_exhausted",
-            Self::RetirementTreeAnomaly => "retirement_tree_anomaly",
-            Self::RetirementNotProvablyEmpty => "retirement_not_provably_empty",
-            Self::IdentityOwnerMismatch => "identity_owner_mismatch",
-            Self::IdentityModeMismatch => "identity_mode_mismatch",
-            Self::IdentityAclMismatch => "identity_acl_mismatch",
-            Self::IdentityLinkCountMismatch => "identity_link_count_mismatch",
-            Self::IdentityDigestMismatch => "identity_digest_mismatch",
-            Self::IdentityInodeMismatch => "identity_inode_mismatch",
-            Self::IdentityCurrentTargetMismatch => "identity_current_target_mismatch",
-            Self::HighWaterRegressed => "high_water_regressed",
-            Self::FsyncFailed => "fsync_failed",
-            Self::BrokerOwnershipViolation => "broker_ownership_violation",
+            Self::ChecksumMismatch => "checksum_mismatch",
+            Self::OwnershipFenced => "ownership_fenced",
+            Self::Quarantined => "quarantined",
+            Self::StateCorrupt => "state_corrupt",
+            Self::PruneDebtUnresolved => "prune_debt_unresolved",
+            Self::PortUnavailable => "port_unavailable",
         }
     }
 }
@@ -299,18 +283,12 @@ impl std::fmt::Display for FailReason {
 /// vary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecretsLifecycleAuditContext {
-    /// Typed, opaque per-VM identity (the same [`VmId`] newtype used
-    /// broker-wide) rather than a bare human-readable label: this
-    /// keeps the audit surface bound to a canonical typed identity
-    /// instead of an ad hoc string, even though its `#[serde(
-    /// transparent)]` wire form is unchanged (a plain JSON string) so
-    /// this is not an audit-schema break.
-    pub vm_id: VmId,
+    /// Canonical typed, opaque workload identity — never a
+    /// human-readable VM-name label or a filesystem path. See the
+    /// module-level "W8fu6" doc section.
+    pub workload_id: WorkloadId,
     pub kind: SecretKind,
     pub action: LifecycleAction,
-    /// FNV1a-64 hash of the per-kind secrets-state directory path
-    /// (parity with [`crate::ops::hosts::stable_hash_str`]).
-    pub base_dir_hash: String,
 }
 
 /// Path-free, material-free terminal audit record for one secrets
@@ -319,33 +297,33 @@ pub struct SecretsLifecycleAuditContext {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsLifecycleAuditFields {
     pub schema_version: u32,
-    /// Typed, opaque per-VM identity -- see
-    /// [`SecretsLifecycleAuditContext::vm_id`].
-    pub vm_id: VmId,
+    /// Canonical typed, opaque workload identity — see
+    /// [`SecretsLifecycleAuditContext::workload_id`].
+    pub workload_id: WorkloadId,
     pub kind: SecretKind,
     pub action: LifecycleAction,
-    pub base_dir_hash: String,
     pub result: LifecycleResult,
     pub marker_result: MarkerResult,
     /// The active lineage epoch after this action, when one exists
     /// (`None` after a successful `retire`, and for `Denied`/
     /// `FailedClosed` results). This is the monotonic identity anchor
-    /// (see `secrets_lifecycle::MarkerData::high_water_epoch`) — never
-    /// simply "current epoch number + 1", so a rotate issued after a
-    /// rollback can never collide with (or silently resurrect) a
-    /// still-materialized older epoch directory.
+    /// (see `secrets_lifecycle::DurableState::high_water_epoch`) —
+    /// never simply "current epoch number + 1", so a rotate issued
+    /// after a rollback can never collide with (or silently resurrect)
+    /// a still-materialized older epoch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lineage_epoch: Option<u64>,
-    /// The monotonic high-water epoch recorded by the marker after
-    /// this action (present exactly when `lineage_epoch` is present,
-    /// and additionally present after a successful `retire` so an
-    /// auditor can confirm a subsequent re-provision's first epoch is
-    /// still strictly greater than every epoch this `(vm, kind)` ever
-    /// used). Never decreases across the lifetime of a `(vm, kind)`.
+    /// The monotonic high-water epoch recorded by the durable state
+    /// after this action (present exactly when `lineage_epoch` is
+    /// present, and additionally present after a successful `retire`
+    /// so an auditor can confirm a subsequent re-provision's first
+    /// epoch is still strictly greater than every epoch this
+    /// `(workload, kind)` ever used). Never decreases across the
+    /// lifetime of a `(workload, kind)`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub high_water_epoch: Option<u64>,
-    /// On-disk generations retained for rollback after this action
-    /// (excludes the active generation).
+    /// Generations retained for rollback after this action (excludes
+    /// the active generation).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub retained_generations: Vec<u64>,
     /// SHA-256 hex digest of the material this action wrote, when the
@@ -357,21 +335,17 @@ pub struct SecretsLifecycleAuditFields {
     /// when `result` is `Denied` or `FailedClosed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fail_reason: Option<FailReason>,
-    /// `true` when this action first had to resolve a leftover,
-    /// crash-interrupted transaction (see
-    /// `secrets_lifecycle::recover_in_flight_transaction`) before
-    /// proceeding with the requested action. Always `false` on the
-    /// common, no-crash path; surfaced so an operator can distinguish
-    /// "this rotate ran cleanly" from "this rotate first had to finish
-    /// or unwind a prior crashed rotate". Threaded through every
-    /// terminal constructor below, including `verified_clean`,
-    /// `denied`, and `failed` — a business-level denial or a
-    /// mid-transaction failure can both happen *after* a successful
-    /// recovery, and that fact must remain observable on the audit
-    /// surface rather than being silently dropped for any result
-    /// other than the four successful-mutation outcomes.
+    /// `true` when this action's own successful commit left at least
+    /// one superseded generation not yet synchronously pruned (the
+    /// authority durably records the debt in
+    /// `secrets_lifecycle::DurableState::pending_prune`; a future
+    /// action for this `(workload, kind)` resolves it before doing its
+    /// own work). Only reachable when `result` is `Rotated` or
+    /// `Retired` — every other result either wrote no new pending-prune
+    /// debt (`Created`, `RolledBack`) or performed no mutation at all
+    /// (`VerifiedClean`, `Denied`, `FailedClosed`).
     #[serde(default)]
-    pub recovered_prior_transaction: bool,
+    pub prune_deferred: bool,
 }
 
 /// Errors [`SecretsLifecycleAuditFields::validate`] can report. Kept
@@ -380,7 +354,6 @@ pub struct SecretsLifecycleAuditFields {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SecretsLifecycleAuditError {
     SchemaVersionMismatch { found: u32 },
-    InvalidVmId,
     MissingLineageEpoch,
     UnexpectedLineageEpoch,
     LineageEpochIsZero,
@@ -400,6 +373,7 @@ pub enum SecretsLifecycleAuditError {
     InvalidMaterialDigest,
     UnexpectedMaterialDigest,
     MissingMaterialDigest,
+    UnexpectedPruneDeferred,
 }
 
 impl std::fmt::Display for SecretsLifecycleAuditError {
@@ -411,7 +385,6 @@ impl std::fmt::Display for SecretsLifecycleAuditError {
                     "schema_version {found} != {SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION}"
                 )
             }
-            Self::InvalidVmId => write!(f, "vm_id is empty or contains a path separator"),
             Self::MissingLineageEpoch => write!(f, "result requires a lineage_epoch"),
             Self::UnexpectedLineageEpoch => write!(f, "result must not carry a lineage_epoch"),
             Self::LineageEpochIsZero => write!(f, "lineage epochs start at 1"),
@@ -455,15 +428,15 @@ impl std::fmt::Display for SecretsLifecycleAuditError {
             Self::MissingMaterialDigest => {
                 write!(f, "material_digest_hex required for this action/result")
             }
+            Self::UnexpectedPruneDeferred => write!(
+                f,
+                "prune_deferred is only reachable for Rotated/Retired results"
+            ),
         }
     }
 }
 
 impl std::error::Error for SecretsLifecycleAuditError {}
-
-fn valid_vm_id(vm_id: &str) -> bool {
-    !vm_id.is_empty() && !vm_id.contains('/') && !vm_id.contains('\0')
-}
 
 fn valid_material_digest_hex(value: &str) -> bool {
     value.len() == 64
@@ -488,9 +461,6 @@ impl SecretsLifecycleAuditFields {
             return Err(SecretsLifecycleAuditError::SchemaVersionMismatch {
                 found: self.schema_version,
             });
-        }
-        if !valid_vm_id(self.vm_id.as_str()) {
-            return Err(SecretsLifecycleAuditError::InvalidVmId);
         }
         if let Some(epoch) = self.lineage_epoch
             && epoch == 0
@@ -522,6 +492,14 @@ impl SecretsLifecycleAuditFields {
             && high_water < epoch
         {
             return Err(SecretsLifecycleAuditError::HighWaterBelowLineageEpoch);
+        }
+        if self.prune_deferred
+            && !matches!(
+                self.result,
+                LifecycleResult::Rotated | LifecycleResult::Retired
+            )
+        {
+            return Err(SecretsLifecycleAuditError::UnexpectedPruneDeferred);
         }
 
         // Action x result reachability matrix: only these pairs are
@@ -700,10 +678,9 @@ impl SecretsLifecycleAuditFields {
     fn base(ctx: &SecretsLifecycleAuditContext) -> Self {
         Self {
             schema_version: SECRETS_LIFECYCLE_AUDIT_SCHEMA_VERSION,
-            vm_id: ctx.vm_id.clone(),
+            workload_id: ctx.workload_id.clone(),
             kind: ctx.kind,
             action: ctx.action,
-            base_dir_hash: ctx.base_dir_hash.clone(),
             result: LifecycleResult::VerifiedClean,
             marker_result: MarkerResult::Unchanged,
             lineage_epoch: None,
@@ -711,7 +688,7 @@ impl SecretsLifecycleAuditFields {
             retained_generations: Vec::new(),
             material_digest_hex: None,
             fail_reason: None,
-            recovered_prior_transaction: false,
+            prune_deferred: false,
         }
     }
 
@@ -720,7 +697,6 @@ impl SecretsLifecycleAuditFields {
         ctx: &SecretsLifecycleAuditContext,
         high_water_epoch: u64,
         material_digest_hex: String,
-        recovered_prior_transaction: bool,
     ) -> Self {
         Self {
             result: LifecycleResult::Created,
@@ -728,20 +704,18 @@ impl SecretsLifecycleAuditFields {
             lineage_epoch: Some(1),
             high_water_epoch: Some(high_water_epoch),
             material_digest_hex: Some(material_digest_hex),
-            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
     /// A new generation was created and activated.
-    #[allow(clippy::too_many_arguments)]
     pub fn rotated(
         ctx: &SecretsLifecycleAuditContext,
         lineage_epoch: u64,
         high_water_epoch: u64,
         retained_generations: Vec<u64>,
         material_digest_hex: String,
-        recovered_prior_transaction: bool,
+        prune_deferred: bool,
     ) -> Self {
         Self {
             result: LifecycleResult::Rotated,
@@ -750,18 +724,19 @@ impl SecretsLifecycleAuditFields {
             high_water_epoch: Some(high_water_epoch),
             retained_generations,
             material_digest_hex: Some(material_digest_hex),
-            recovered_prior_transaction,
+            prune_deferred,
             ..Self::base(ctx)
         }
     }
 
-    /// `current` was swapped back to a retained prior generation.
+    /// The active generation was swapped back to a retained prior
+    /// generation. Never defers a prune (a rollback supersedes
+    /// nothing new; see `secrets_lifecycle::rollback`'s doc comment).
     pub fn rolled_back(
         ctx: &SecretsLifecycleAuditContext,
         lineage_epoch: u64,
         high_water_epoch: u64,
         retained_generations: Vec<u64>,
-        recovered_prior_transaction: bool,
     ) -> Self {
         Self {
             result: LifecycleResult::RolledBack,
@@ -769,94 +744,62 @@ impl SecretsLifecycleAuditFields {
             lineage_epoch: Some(lineage_epoch),
             high_water_epoch: Some(high_water_epoch),
             retained_generations,
-            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
-    /// Every generation was removed and the marker tombstoned.
+    /// Every generation was retired.
     pub fn retired(
         ctx: &SecretsLifecycleAuditContext,
         high_water_epoch: u64,
-        recovered_prior_transaction: bool,
+        prune_deferred: bool,
     ) -> Self {
         Self {
             result: LifecycleResult::Retired,
             marker_result: MarkerResult::Tombstoned,
             high_water_epoch: Some(high_water_epoch),
-            recovered_prior_transaction,
+            prune_deferred,
             ..Self::base(ctx)
         }
     }
 
     /// The action was already satisfied; no mutation occurred. Only
     /// reachable for `retire` (never-provisioned or already-retired).
-    /// `recovered_prior_transaction` is still meaningful here: a
-    /// `retire` can drain a leftover crashed transaction during
-    /// `open_and_recover` and *then* observe the physical tree is
-    /// already empty, in which case this is `verified_clean` with
-    /// `recovered_prior_transaction: true`.
-    pub fn verified_clean(
-        ctx: &SecretsLifecycleAuditContext,
-        recovered_prior_transaction: bool,
-        high_water_epoch: u64,
-    ) -> Self {
+    pub fn verified_clean(ctx: &SecretsLifecycleAuditContext, high_water_epoch: u64) -> Self {
         Self {
             result: LifecycleResult::VerifiedClean,
             marker_result: MarkerResult::Verified,
             high_water_epoch: Some(high_water_epoch),
-            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
-    /// The action was refused before any filesystem mutation.
-    /// `recovered_prior_transaction` reflects whether a leftover
-    /// crashed transaction was already successfully drained by
-    /// `open_and_recover` earlier in the same call before this
-    /// business-level denial was reached (e.g. `rotate` recovering a
-    /// stale transaction and *then* finding no active marker to
-    /// rotate). It is always `false` when the denial happens before
-    /// recovery could have run or succeeded (path derivation, dir
-    /// open, lock acquisition, or recovery itself failing).
-    pub fn denied(
-        ctx: &SecretsLifecycleAuditContext,
-        recovered_prior_transaction: bool,
-        reason: FailReason,
-    ) -> Self {
+    /// The action was refused before any authority-port mutation.
+    pub fn denied(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> Self {
         Self {
             result: LifecycleResult::Denied,
             marker_result: MarkerResult::Unchanged,
             fail_reason: Some(reason),
-            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
 
     /// The action aborted partway and failed closed.
-    /// `recovered_prior_transaction` carries the same meaning as in
-    /// [`Self::denied`]: whether a leftover crashed transaction was
-    /// already successfully drained before this failure was reached.
     ///
     /// `marker_result` is deliberately **not** a caller-supplied
     /// parameter: every reachable `secrets_lifecycle.rs` call site
     /// already only ever passes `MarkerResult::FailedClosed` (this
     /// is the *only* result variant `validate` accepts for
-    /// `FailedClosed`, see the match arm below), so accepting an
+    /// `FailedClosed`, see the match arm above), so accepting an
     /// arbitrary `MarkerResult` here was dead flexibility that could
     /// only ever construct an invalid, immediately-`validate`-
     /// rejected record. Hardcoding it makes that invalid state
     /// unconstructible instead of merely unreachable-in-practice.
-    pub fn failed(
-        ctx: &SecretsLifecycleAuditContext,
-        recovered_prior_transaction: bool,
-        reason: FailReason,
-    ) -> Self {
+    pub fn failed(ctx: &SecretsLifecycleAuditContext, reason: FailReason) -> Self {
         Self {
             result: LifecycleResult::FailedClosed,
             marker_result: MarkerResult::FailedClosed,
             fail_reason: Some(reason),
-            recovered_prior_transaction,
             ..Self::base(ctx)
         }
     }
@@ -868,10 +811,9 @@ mod tests {
 
     fn ctx(action: LifecycleAction) -> SecretsLifecycleAuditContext {
         SecretsLifecycleAuditContext {
-            vm_id: VmId::new("work"),
+            workload_id: WorkloadId::parse("aaaaaaaaaaaaaaaaaaaa").expect("valid fixture id"),
             kind: SecretKind::GuestSigningKey,
             action,
-            base_dir_hash: "0123456789abcdef".to_owned(),
         }
     }
 
@@ -901,39 +843,16 @@ mod tests {
     #[test]
     fn fail_reason_slugs_are_stable_and_distinct() {
         let variants = [
-            FailReason::InvalidVmId,
-            FailReason::PathDerivationFailed,
-            FailReason::SecretsDirOpenFailed,
-            FailReason::MarkerTreeOpenFailed,
-            FailReason::MarkerWriteFailed,
-            FailReason::MarkerTamperedOrMissingMaterial,
             FailReason::AlreadyProvisioned,
-            FailReason::AlreadyRetired,
             FailReason::NotProvisioned,
             FailReason::NoRollbackTarget,
-            FailReason::PreviouslyProvisionedMaterialMissing,
-            FailReason::GenerationConflict,
-            FailReason::MaterialWriteFailed,
-            FailReason::CurrentSwapFailed,
             FailReason::InvalidMaterial,
-            FailReason::LockUnavailable,
-            FailReason::IntentWriteFailed,
-            FailReason::IntentCorrupt,
-            FailReason::RecoveryContentMismatch,
-            FailReason::RecoveryAmbiguous,
-            FailReason::StagingNameExhausted,
-            FailReason::RetirementTreeAnomaly,
-            FailReason::RetirementNotProvablyEmpty,
-            FailReason::IdentityOwnerMismatch,
-            FailReason::IdentityModeMismatch,
-            FailReason::IdentityAclMismatch,
-            FailReason::IdentityLinkCountMismatch,
-            FailReason::IdentityDigestMismatch,
-            FailReason::IdentityInodeMismatch,
-            FailReason::IdentityCurrentTargetMismatch,
-            FailReason::HighWaterRegressed,
-            FailReason::FsyncFailed,
-            FailReason::BrokerOwnershipViolation,
+            FailReason::ChecksumMismatch,
+            FailReason::OwnershipFenced,
+            FailReason::Quarantined,
+            FailReason::StateCorrupt,
+            FailReason::PruneDebtUnresolved,
+            FailReason::PortUnavailable,
         ];
         let slugs: Vec<&str> = variants.iter().map(|v| v.as_slug()).collect();
         let unique: std::collections::HashSet<_> = slugs.iter().collect();
@@ -952,16 +871,13 @@ mod tests {
 
     #[test]
     fn provisioned_validates() {
-        let record = SecretsLifecycleAuditFields::provisioned(
-            &ctx(LifecycleAction::Provision),
-            1,
-            digest(),
-            false,
-        );
+        let record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), 1, digest());
         record.validate().expect("provisioned record must validate");
         assert_eq!(record.lineage_epoch, Some(1));
         assert_eq!(record.high_water_epoch, Some(1));
         assert!(record.retained_generations.is_empty());
+        assert!(!record.prune_deferred);
     }
 
     #[test]
@@ -1002,13 +918,53 @@ mod tests {
     }
 
     #[test]
+    fn rotated_may_defer_a_prune() {
+        let record = SecretsLifecycleAuditFields::rotated(
+            &ctx(LifecycleAction::Rotate),
+            3,
+            3,
+            vec![2],
+            digest(),
+            true,
+        );
+        record
+            .validate()
+            .expect("rotated record with prune_deferred must validate");
+        assert!(record.prune_deferred);
+    }
+
+    #[test]
+    fn prune_deferred_is_rejected_outside_rotated_and_retired() {
+        let mut record = SecretsLifecycleAuditFields::rolled_back(
+            &ctx(LifecycleAction::Rollback),
+            1,
+            2,
+            vec![2],
+        );
+        record.prune_deferred = true;
+        assert_eq!(
+            record.validate(),
+            Err(SecretsLifecycleAuditError::UnexpectedPruneDeferred)
+        );
+
+        let mut denied = SecretsLifecycleAuditFields::denied(
+            &ctx(LifecycleAction::Rotate),
+            FailReason::NotProvisioned,
+        );
+        denied.prune_deferred = true;
+        assert_eq!(
+            denied.validate(),
+            Err(SecretsLifecycleAuditError::UnexpectedPruneDeferred)
+        );
+    }
+
+    #[test]
     fn rolled_back_validates_and_requires_retained_generation() {
         let record = SecretsLifecycleAuditFields::rolled_back(
             &ctx(LifecycleAction::Rollback),
             1,
             2,
             vec![2],
-            false,
         );
         record.validate().expect("rolled back record must validate");
 
@@ -1027,7 +983,6 @@ mod tests {
             1,
             2,
             vec![2],
-            false,
         );
         record.material_digest_hex = Some(digest());
         assert_eq!(
@@ -1050,10 +1005,18 @@ mod tests {
     }
 
     #[test]
+    fn retired_may_defer_a_prune() {
+        let record = SecretsLifecycleAuditFields::retired(&ctx(LifecycleAction::Retire), 5, true);
+        record
+            .validate()
+            .expect("retired record with prune_deferred must validate");
+        assert!(record.prune_deferred);
+    }
+
+    #[test]
     fn denied_requires_fail_reason_and_unchanged_marker() {
         let record = SecretsLifecycleAuditFields::denied(
             &ctx(LifecycleAction::Rotate),
-            false,
             FailReason::NotProvisioned,
         );
         record.validate().expect("denied record must validate");
@@ -1077,8 +1040,7 @@ mod tests {
     fn failed_closed_requires_fail_reason() {
         let record = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
-            false,
-            FailReason::MarkerTamperedOrMissingMaterial,
+            FailReason::StateCorrupt,
         );
         record.validate().expect("failed record must validate");
 
@@ -1094,8 +1056,7 @@ mod tests {
     fn failed_closed_rejects_non_failed_closed_marker_result() {
         let mut record = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Retire),
-            false,
-            FailReason::RetirementTreeAnomaly,
+            FailReason::ChecksumMismatch,
         );
         record
             .validate()
@@ -1112,8 +1073,7 @@ mod tests {
     fn failed_closed_rejects_leftover_epoch_or_retained_state() {
         let base = SecretsLifecycleAuditFields::failed(
             &ctx(LifecycleAction::Rotate),
-            false,
-            FailReason::HighWaterRegressed,
+            FailReason::OwnershipFenced,
         );
 
         let mut with_lineage = base.clone();
@@ -1138,17 +1098,15 @@ mod tests {
         );
     }
 
-    /// `retire` + `Denied` is a genuinely reachable pair (an invalid
-    /// `vm_id`, or a lock-acquisition failure, denies a retire attempt
-    /// exactly like every other action) — the action/result matrix
-    /// above must accept it, not just the three previously-listed
-    /// retire outcomes.
+    /// `retire` + `Denied` is a genuinely reachable pair (a prune-debt
+    /// refusal denies a retire attempt exactly like every other
+    /// action) — the action/result matrix above must accept it, not
+    /// just the three previously-listed retire outcomes.
     #[test]
     fn retire_denied_is_a_reachable_and_valid_pair() {
         let record = SecretsLifecycleAuditFields::denied(
             &ctx(LifecycleAction::Retire),
-            false,
-            FailReason::InvalidVmId,
+            FailReason::PruneDebtUnresolved,
         );
         record
             .validate()
@@ -1179,44 +1137,19 @@ mod tests {
 
     #[test]
     fn schema_version_mismatch_is_rejected() {
-        let mut record = SecretsLifecycleAuditFields::provisioned(
-            &ctx(LifecycleAction::Provision),
-            1,
-            digest(),
-            false,
-        );
-        record.schema_version = 1;
+        let mut record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), 1, digest());
+        record.schema_version = 2;
         assert_eq!(
             record.validate(),
-            Err(SecretsLifecycleAuditError::SchemaVersionMismatch { found: 1 })
+            Err(SecretsLifecycleAuditError::SchemaVersionMismatch { found: 2 })
         );
-    }
-
-    #[test]
-    fn invalid_vm_id_is_rejected() {
-        let mut record = SecretsLifecycleAuditFields::provisioned(
-            &ctx(LifecycleAction::Provision),
-            1,
-            digest(),
-            false,
-        );
-        for bad in ["", "work/vm", "wor\0k"] {
-            record.vm_id = VmId::new(bad);
-            assert_eq!(
-                record.validate(),
-                Err(SecretsLifecycleAuditError::InvalidVmId)
-            );
-        }
     }
 
     #[test]
     fn lineage_epoch_zero_is_rejected() {
-        let mut record = SecretsLifecycleAuditFields::provisioned(
-            &ctx(LifecycleAction::Provision),
-            1,
-            digest(),
-            false,
-        );
+        let mut record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), 1, digest());
         record.lineage_epoch = Some(0);
         assert_eq!(
             record.validate(),
@@ -1272,7 +1205,6 @@ mod tests {
             1,
             2,
             vec![2],
-            false,
         );
         record.material_digest_hex = Some(digest());
         assert_eq!(
@@ -1283,12 +1215,8 @@ mod tests {
 
     #[test]
     fn created_and_rotated_require_material_digest() {
-        let mut created = SecretsLifecycleAuditFields::provisioned(
-            &ctx(LifecycleAction::Provision),
-            1,
-            digest(),
-            false,
-        );
+        let mut created =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), 1, digest());
         created.material_digest_hex = None;
         assert_eq!(
             created.validate(),
@@ -1312,12 +1240,8 @@ mod tests {
 
     #[test]
     fn material_digest_must_be_lowercase_hex_64() {
-        let mut record = SecretsLifecycleAuditFields::provisioned(
-            &ctx(LifecycleAction::Provision),
-            1,
-            digest(),
-            false,
-        );
+        let mut record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), 1, digest());
         for bad in ["", "AA", &"a".repeat(63), &"g".repeat(64), &"A".repeat(64)] {
             record.material_digest_hex = Some(bad.to_owned());
             assert_eq!(
@@ -1347,7 +1271,7 @@ mod tests {
         // `Rollback` can never produce `VerifiedClean` (only `Retire`
         // reaches that result).
         let mut impossible2 =
-            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), false, 3);
+            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), 3);
         impossible2.action = LifecycleAction::Rollback;
         assert_eq!(
             impossible2.validate(),
@@ -1369,15 +1293,15 @@ mod tests {
         let decoded: SecretsLifecycleAuditFields =
             serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, record);
-        assert!(decoded.recovered_prior_transaction);
+        assert!(decoded.prune_deferred);
     }
 
     #[test]
     fn fail_reason_serde_round_trips_as_closed_enum() {
-        let json = serde_json::to_string(&FailReason::RecoveryContentMismatch).unwrap();
-        assert_eq!(json, "\"recovery_content_mismatch\"");
+        let json = serde_json::to_string(&FailReason::ChecksumMismatch).unwrap();
+        assert_eq!(json, "\"checksum_mismatch\"");
         let decoded: FailReason = serde_json::from_str(&json).unwrap();
-        assert_eq!(decoded, FailReason::RecoveryContentMismatch);
+        assert_eq!(decoded, FailReason::ChecksumMismatch);
         // An arbitrary string is not a valid FailReason: this is the
         // structural guarantee behind "closed failure reasons".
         assert!(serde_json::from_str::<FailReason>("\"totally-made-up\"").is_err());
@@ -1385,8 +1309,7 @@ mod tests {
 
     #[test]
     fn verified_clean_never_carries_lineage_epoch() {
-        let record =
-            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), false, 7);
+        let record = SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), 7);
         record
             .validate()
             .expect("verified clean record must validate");
@@ -1394,37 +1317,34 @@ mod tests {
         assert_eq!(record.high_water_epoch, Some(7));
     }
 
-    /// `recovered_prior_transaction: true` must be reachable and valid
-    /// for every terminal outcome that can follow a successful
-    /// mid-call recovery, not just the four successful-mutation
-    /// results. A `retire` can drain a crashed transaction and then
-    /// find the tree already empty (`verified_clean`); a `rotate` can
-    /// drain a crashed transaction and then hit a business-level
-    /// denial (`denied`); and a fresh action can drain a crashed
-    /// transaction and then itself fail closed (`failed`).
+    /// The wire form of `workload_id` stays a bounded opaque 20-byte
+    /// string (never the human-readable workload name it was derived
+    /// from), so a downstream consumer that only speaks JSON still
+    /// sees a plain string field, not a nested object.
     #[test]
-    fn recovered_prior_transaction_true_is_valid_on_every_non_mutation_result() {
-        let clean =
-            SecretsLifecycleAuditFields::verified_clean(&ctx(LifecycleAction::Retire), true, 9);
-        clean
-            .validate()
-            .expect("recovered verified_clean must validate");
-        assert!(clean.recovered_prior_transaction);
-
-        let denied = SecretsLifecycleAuditFields::denied(
-            &ctx(LifecycleAction::Rotate),
-            true,
-            FailReason::NotProvisioned,
+    fn workload_id_serializes_as_a_plain_opaque_string() {
+        let record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), 1, digest());
+        let json = serde_json::to_value(&record).expect("serialize");
+        assert_eq!(
+            json.get("workloadId").and_then(|v| v.as_str()),
+            Some("aaaaaaaaaaaaaaaaaaaa")
         );
-        denied.validate().expect("recovered denied must validate");
-        assert!(denied.recovered_prior_transaction);
+    }
 
-        let failed = SecretsLifecycleAuditFields::failed(
-            &ctx(LifecycleAction::Rotate),
-            true,
-            FailReason::MarkerTamperedOrMissingMaterial,
+    #[test]
+    fn unknown_fields_are_rejected() {
+        let record =
+            SecretsLifecycleAuditFields::provisioned(&ctx(LifecycleAction::Provision), 1, digest());
+        let mut value = serde_json::to_value(&record).expect("serialize");
+        value
+            .as_object_mut()
+            .expect("object")
+            .insert("baseDirHash".to_owned(), serde_json::json!("deadbeef"));
+        let decoded: Result<SecretsLifecycleAuditFields, _> = serde_json::from_value(value);
+        assert!(
+            decoded.is_err(),
+            "a legacy base_dir_hash field must be rejected by deny_unknown_fields"
         );
-        failed.validate().expect("recovered failed must validate");
-        assert!(failed.recovered_prior_transaction);
     }
 }

--- a/packages/d2b-sk-frontend/src/secrets_channel.rs
+++ b/packages/d2b-sk-frontend/src/secrets_channel.rs
@@ -1,18 +1,72 @@
 //! Guest-side lifecycle state for the security-key CTAPHID channel
-//! binding + reconnect generation that
+//! binding + reconnect epoch that
 //! [`crate::services::security_key::SessionConfig`] ultimately
 //! consumes.
 //!
 //! This module is the W8 `secrets-lifecycle` component's guest-side
-//! counterpart to the broker's
-//! `d2b_priv_broker::ops::secrets_lifecycle` engine and
-//! `SecretKind::SecurityKeyChannelState`. It is intentionally a
-//! standalone, in-memory, zero-internal-dependency module (only
+//! counterpart to the broker's `d2b_priv_broker::ops::secrets_lifecycle`
+//! engine and `SecretKind::SecurityKeyChannelState`. It is intentionally
+//! a standalone, in-memory, zero-internal-dependency module (only
 //! `std`) so it can be validated on its own without depending on this
 //! crate's `d2b-session`/`d2b-contracts`/transport wiring, and so a
 //! future integrator can wire it into
 //! [`crate::services::security_key::SessionConfig`] without this
 //! component needing to touch that file.
+//!
+//! # Design summary (post-review v2)
+//!
+//! The prior draft of this module conflated two independent
+//! properties into a single `ChannelGeneration` counter:
+//!
+//!   * the broker's **lineage epoch** — the active generation
+//!     identity from `secrets_lifecycle`'s marker (`MarkerData::active`).
+//!     This value is **rollbackable**: a legitimate `rollback()` moves
+//!     it *backwards* to a previously-retained generation.
+//!   * a **monotonic anti-replay counter** — a value that must never
+//!     go backwards or repeat for the lifetime of this channel state,
+//!     independent of whether the lineage epoch itself moved forward
+//!     or backward.
+//!
+//! Using one counter for both meant a legitimate rollback (which
+//! *must* decrease the lineage epoch) was indistinguishable from a
+//! stale/replayed message (which *must* be rejected). This revision
+//! splits them into [`LineageEpoch`] (rollbackable, no monotonicity
+//! enforced by this module — the broker/authenticator is the
+//! authority for whether a given epoch transition is legitimate) and
+//! [`DeliveryCounter`] (strictly monotonic for the entire lifetime of
+//! a [`ChannelState`], **including across `retire` + re-`provision`**,
+//! enforced here as the sole replay guard).
+//!
+//! Every state transition is tagged with an explicit
+//! [`ChannelAction`] discriminator (`Provision` / `Rotate` /
+//! `Rollback` / `Retire`) carried on the wire alongside the epoch and
+//! counter, rather than inferred from field deltas. [`ChannelState`]
+//! never re-derives "was this a rotate or a rollback" from whether
+//! the epoch went up or down.
+//!
+//! # What this module deliberately does NOT do
+//!
+//!   * **It does not authenticate messages.** [`ChannelUpdate`]
+//!     values are assumed, by the time they reach [`ChannelState::apply`],
+//!     to have already been authenticated (signature/MAC verified,
+//!     origin checked) by the caller using whatever primitive the
+//!     real guest-control/vsock transport specifies. This crate has
+//!     no cryptographic dependency (no `sha2`/`hmac`/`ring`), and
+//!     adding one is out of scope for this component (it would
+//!     require a `Cargo.toml` edit, which this component does not
+//!     own). Wiring in real authentication is an explicit integration
+//!     wiring point below.
+//!   * **It does not define or parse a wire byte format.** A prior
+//!     draft of this module proposed a concrete 40-byte layout
+//!     (`from_wire_bytes`); that was an ad-hoc format finalized
+//!     without closed validation against the broker's actual
+//!     `SecretKind::SecurityKeyChannelState` dispatch/serialization
+//!     (which does not exist yet — `runtime.rs` is out of scope for
+//!     this component). This module now exposes only a typed,
+//!     in-process API ([`ChannelUpdate`] and its named constructors);
+//!     the integrator must define the real wire schema (likely in
+//!     `d2b-contracts`, also out of scope here) and translate it into
+//!     a [`ChannelUpdate`] value, not the other way around.
 //!
 //! # Integration wiring points (deliberately NOT performed here)
 //!
@@ -20,58 +74,76 @@
 //!   2. `services/security_key/mod.rs`'s `SessionConfig::from_env` (or
 //!      a new constructor alongside it) should source its
 //!      `channel_binding`/`reconnect_generation` from a
-//!      [`ChannelState::current`] snapshot — most likely populated by
-//!      a fresh vsock/guest-control message carrying broker-rotated
-//!      `SecretKind::SecurityKeyChannelState` material — instead of
-//!      the static `D2B_SK_CHANNEL_BINDING_HEX`/
-//!      `D2B_SK_RECONNECT_GENERATION` environment variables it reads
-//!      today. Neither `lib.rs` nor `services/security_key/mod.rs` is
-//!      owned by this component.
-//!   3. The exact wire format [`ChannelMaterial::from_wire_bytes`]
-//!      parses (32 bytes of channel binding followed by an 8-byte
-//!      big-endian generation counter) is **a proposal**, not a
-//!      confirmed contract: the integrator must confirm it against
-//!      whatever the broker's future `SecretKind::SecurityKeyChannelState`
-//!      dispatch arm (in `packages/d2b-priv-broker/src/runtime.rs`,
-//!      out of scope here) actually serializes, and adjust or replace
-//!      it before depending on it in production.
+//!      [`ChannelState::with_current`] snapshot instead of the static
+//!      `D2B_SK_CHANNEL_BINDING_HEX`/`D2B_SK_RECONNECT_GENERATION`
+//!      environment variables it reads today. Neither `lib.rs` nor
+//!      `services/security_key/mod.rs` is owned by this component.
+//!   3. A real wire schema for the guest-control message that carries
+//!      `SecretKind::SecurityKeyChannelState` material must be defined
+//!      (in `d2b-contracts` or equivalent) and its receiver must
+//!      authenticate the message (origin + integrity) BEFORE
+//!      constructing a [`ChannelUpdate`] — this module trusts its
+//!      caller on that point and performs no cryptographic
+//!      verification itself.
+//!   4. The broker side (`packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs`,
+//!      out of scope here) needs a dispatch arm that maps its
+//!      `provision`/`rotate`/`rollback`/`retire` outcomes onto the
+//!      same four-way [`ChannelAction`] discriminator, so the two
+//!      sides of the channel share one vocabulary for what happened.
+//!   5. The persistent delivery-counter high-water mark
+//!      ([`ChannelState`]'s internal state) is currently **process
+//!      memory only** — it does not survive a guest process restart.
+//!      If replay protection must also survive a guest reboot (not
+//!      just a broker-side retire/reprovision), the integrator needs
+//!      to persist [`ChannelState`]'s high-water value to guest-local
+//!      storage and restore it at startup before the first `apply`
+//!      call. That storage design is out of scope for this
+//!      zero-dependency, in-memory module.
 
 use std::fmt;
 use std::sync::RwLock;
 
 /// Errors surfaced by every public function in this module. Never
-/// carries a raw byte, path, or generation counter value — only a
+/// carries a raw byte, path, or counter/epoch value — only a
 /// closed-set discriminant, safe for any Debug/log/audit surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChannelStateError {
     InvalidBinding,
-    InvalidGeneration,
-    /// `rotate` was called with a generation that is not strictly
-    /// greater than the currently active one — refused as a possible
-    /// replay/rollback rather than silently accepted.
-    StaleGeneration,
-    /// `rotate`/`current` was called before any `provision`.
+    InvalidLineageEpoch,
+    InvalidDeliveryCounter,
+    /// `apply` was given a `delivery_counter` that is not strictly
+    /// greater than the highest one ever accepted by this
+    /// [`ChannelState`] — refused as a possible replay regardless of
+    /// which [`ChannelAction`] it carries. This check is independent
+    /// of, and applied before, any lineage-epoch or provisioning-state
+    /// validation.
+    StaleDeliveryCounter,
+    /// `rotate`/`rollback`/`current` was called before any `provision`.
     NotProvisioned,
     /// `provision` was called while material is already active
     /// (callers should `rotate` instead).
     AlreadyProvisioned,
-    /// The channel state was retired; `current`/`rotate` refuse to
-    /// resume without an explicit fresh `provision`.
+    /// The channel state was retired; `current`/`rotate`/`rollback`
+    /// refuse to resume without an explicit fresh `provision`.
     Retired,
-    /// `from_wire_bytes` was given a buffer of the wrong length.
-    InvalidWireLength,
+    /// A `Provision`/`Rotate`/`Rollback` update was missing its
+    /// required material, or a `Retire` update unexpectedly carried
+    /// material/a lineage epoch. Unreachable through the public
+    /// [`ChannelUpdate`] constructors; kept as defense in depth.
+    MalformedUpdate,
 }
 
 impl fmt::Display for ChannelStateError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let slug = match self {
             Self::InvalidBinding => "invalid-channel-binding",
-            Self::InvalidGeneration => "invalid-reconnect-generation",
-            Self::StaleGeneration => "stale-reconnect-generation",
+            Self::InvalidLineageEpoch => "invalid-lineage-epoch",
+            Self::InvalidDeliveryCounter => "invalid-delivery-counter",
+            Self::StaleDeliveryCounter => "stale-delivery-counter",
             Self::NotProvisioned => "channel-not-provisioned",
             Self::AlreadyProvisioned => "channel-already-provisioned",
             Self::Retired => "channel-retired",
-            Self::InvalidWireLength => "invalid-channel-material-wire-length",
+            Self::MalformedUpdate => "malformed-channel-update",
         };
         f.write_str(slug)
     }
@@ -79,27 +151,60 @@ impl fmt::Display for ChannelStateError {
 
 impl std::error::Error for ChannelStateError {}
 
-/// Length in bytes of the [`ChannelMaterial::from_wire_bytes`]
-/// proposed wire format: 32 bytes of channel binding plus an 8-byte
-/// big-endian generation counter. See the module-level "Integration
-/// wiring points" note — this exact layout needs integrator
-/// confirmation before any production dependency on it.
-pub const PROPOSED_WIRE_LEN: usize = 32 + 8;
+/// Best-effort, dependency-free zeroization of a byte buffer.
+///
+/// This crate builds under `#![forbid(unsafe_code)]`, so the
+/// `zeroize` crate's volatile-write approach is unavailable here (and
+/// adding the `zeroize` dependency would require a `Cargo.toml` edit,
+/// which this component does not own). [`std::hint::black_box`] is
+/// used to defeat dead-store elimination: without it, an optimizing
+/// compiler could prove the buffer's final writes are never observed
+/// (since the memory is about to be dropped/freed) and elide them
+/// entirely.
+fn best_effort_zero(buf: &mut [u8]) {
+    for byte in buf.iter_mut() {
+        *byte = 0;
+    }
+    std::hint::black_box(buf);
+}
 
 /// A validated, non-zero 32-byte CTAPHID channel-binding value.
-#[derive(Clone, Copy, PartialEq, Eq)]
+///
+/// Deliberately **not** `Copy` or `Clone`: every live instance is a
+/// distinct, independently zeroized buffer. Callers that need the raw
+/// bytes for a final handoff (e.g. to
+/// `crate::services::security_key::SessionConfig::new`) must use
+/// [`expose_bytes`](Self::expose_bytes) explicitly, and are
+/// responsible for zeroizing that returned copy themselves once done.
 pub struct ChannelBinding([u8; 32]);
 
 impl ChannelBinding {
+    /// Wraps `bytes` immediately, before validating them, so that
+    /// **every** exit path from this function — including the
+    /// rejection path below — drops (and therefore zeroizes, via
+    /// [`Drop`]) the candidate buffer rather than leaving a rejected
+    /// buffer to be cleaned up by ordinary non-zeroizing `Drop`.
     pub fn new(bytes: [u8; 32]) -> Result<Self, ChannelStateError> {
-        if bytes == [0; 32] {
+        let candidate = Self(bytes);
+        if candidate.0 == [0u8; 32] {
             return Err(ChannelStateError::InvalidBinding);
         }
-        Ok(Self(bytes))
+        Ok(candidate)
     }
 
-    pub fn into_bytes(self) -> [u8; 32] {
+    /// Explicit, one-shot exposure of the raw bytes for handoff to an
+    /// external consumer that requires an owned `[u8; 32]` (such as
+    /// `SessionConfig::new`). Named deliberately unlike `.clone()` so
+    /// call sites make the exposure visible in review. The caller
+    /// owns zeroizing the returned array once it is no longer needed.
+    pub fn expose_bytes(&self) -> [u8; 32] {
         self.0
+    }
+}
+
+impl Drop for ChannelBinding {
+    fn drop(&mut self) {
+        best_effort_zero(&mut self.0);
     }
 }
 
@@ -111,14 +216,19 @@ impl fmt::Debug for ChannelBinding {
     }
 }
 
-/// A validated, non-zero reconnect-generation counter.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ChannelGeneration(u64);
+/// The broker-side lineage epoch this material was activated at.
+/// **Rollbackable**: a legitimate `Rollback` action moves this value
+/// backwards to a previously-retained generation. This module does
+/// not enforce monotonicity on this value — see the module-level
+/// design summary for why that guard lives on [`DeliveryCounter`]
+/// instead.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct LineageEpoch(u64);
 
-impl ChannelGeneration {
+impl LineageEpoch {
     pub fn new(value: u64) -> Result<Self, ChannelStateError> {
         if value == 0 {
-            return Err(ChannelStateError::InvalidGeneration);
+            return Err(ChannelStateError::InvalidLineageEpoch);
         }
         Ok(Self(value))
     }
@@ -128,82 +238,158 @@ impl ChannelGeneration {
     }
 }
 
-impl fmt::Debug for ChannelGeneration {
+impl fmt::Debug for LineageEpoch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ChannelGeneration")
+        f.debug_tuple("LineageEpoch").field(&"<redacted>").finish()
+    }
+}
+
+/// A strictly-monotonic, replay-guarding delivery sequence number.
+/// Distinct from [`LineageEpoch`]: this value must never repeat or
+/// decrease for the entire lifetime of a [`ChannelState`], **including
+/// across `Retire` followed by a fresh `Provision`** — unlike the
+/// broker's on-disk storage generation counter (which legitimately
+/// restarts at 1 after a retire), the anti-replay high-water mark is
+/// a property of this in-memory channel object, not of the
+/// rollbackable storage state.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DeliveryCounter(u64);
+
+impl DeliveryCounter {
+    pub fn new(value: u64) -> Result<Self, ChannelStateError> {
+        if value == 0 {
+            return Err(ChannelStateError::InvalidDeliveryCounter);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Debug for DeliveryCounter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DeliveryCounter")
             .field(&"<redacted>")
             .finish()
     }
 }
 
-/// One provisioned/rotated channel material snapshot: a binding plus
-/// the generation counter it was delivered at.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct ChannelMaterial {
-    binding: ChannelBinding,
-    generation: ChannelGeneration,
+/// Explicit discriminator for what a [`ChannelUpdate`] represents.
+/// Carried on the wire (once a real wire schema exists — see the
+/// module-level wiring points) rather than inferred from whether the
+/// lineage epoch increased or decreased.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelAction {
+    Provision,
+    Rotate,
+    Rollback,
+    Retire,
 }
 
-impl fmt::Debug for ChannelMaterial {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ChannelMaterial")
-            .field("binding", &"<redacted>")
-            .field("generation", &"<redacted>")
-            .finish()
-    }
+/// A single, already-authenticated (by the caller — see module docs)
+/// state transition to apply to a [`ChannelState`].
+///
+/// Fields are private; the only way to construct a value is through
+/// the named constructors below, which guarantee the
+/// action/epoch/material combination is internally consistent (e.g.
+/// `retire()` can never accidentally carry material).
+///
+/// Not `Clone`/`Copy`: an update owns its [`ChannelBinding`] (when
+/// present) and consumes it exactly once via [`ChannelState::apply`].
+/// If `apply` rejects the update, the update (and its embedded
+/// material, if any) is dropped at the end of that call, which
+/// zeroizes it via `ChannelBinding`'s `Drop` impl — no separate
+/// "zeroize on rejection" code path is needed.
+pub struct ChannelUpdate {
+    action: ChannelAction,
+    lineage_epoch: Option<LineageEpoch>,
+    delivery_counter: DeliveryCounter,
+    material: Option<ChannelBinding>,
 }
 
-impl ChannelMaterial {
-    pub fn new(binding: ChannelBinding, generation: ChannelGeneration) -> Self {
+impl ChannelUpdate {
+    pub fn provision(
+        lineage_epoch: LineageEpoch,
+        delivery_counter: DeliveryCounter,
+        binding: ChannelBinding,
+    ) -> Self {
         Self {
-            binding,
-            generation,
+            action: ChannelAction::Provision,
+            lineage_epoch: Some(lineage_epoch),
+            delivery_counter,
+            material: Some(binding),
         }
     }
 
-    pub fn binding(&self) -> ChannelBinding {
-        self.binding
-    }
-
-    pub fn generation(&self) -> ChannelGeneration {
-        self.generation
-    }
-
-    /// Convenience accessor returning the plain `([u8; 32], u64)`
-    /// shape [`crate::services::security_key::SessionConfig::new`]
-    /// expects, without this module depending on that type directly.
-    pub fn into_session_config_args(self) -> ([u8; 32], u64) {
-        (self.binding.into_bytes(), self.generation.get())
-    }
-
-    /// Parse the **proposed** wire format: 32 bytes of channel
-    /// binding followed by an 8-byte big-endian generation counter.
-    /// See the module-level doc comment — this layout is a proposal
-    /// pending integrator/security confirmation, not a settled
-    /// contract.
-    pub fn from_wire_bytes(bytes: &[u8]) -> Result<Self, ChannelStateError> {
-        if bytes.len() != PROPOSED_WIRE_LEN {
-            return Err(ChannelStateError::InvalidWireLength);
+    pub fn rotate(
+        lineage_epoch: LineageEpoch,
+        delivery_counter: DeliveryCounter,
+        binding: ChannelBinding,
+    ) -> Self {
+        Self {
+            action: ChannelAction::Rotate,
+            lineage_epoch: Some(lineage_epoch),
+            delivery_counter,
+            material: Some(binding),
         }
-        let mut binding_bytes = [0u8; 32];
-        binding_bytes.copy_from_slice(&bytes[..32]);
-        let mut generation_bytes = [0u8; 8];
-        generation_bytes.copy_from_slice(&bytes[32..]);
-        let binding = ChannelBinding::new(binding_bytes)?;
-        let generation = ChannelGeneration::new(u64::from_be_bytes(generation_bytes))?;
-        Ok(Self::new(binding, generation))
+    }
+
+    /// `lineage_epoch` for a legitimate rollback is typically **lower**
+    /// than the epoch currently active — that is expected and is not
+    /// rejected by this module (see the module-level design summary).
+    pub fn rollback(
+        lineage_epoch: LineageEpoch,
+        delivery_counter: DeliveryCounter,
+        binding: ChannelBinding,
+    ) -> Self {
+        Self {
+            action: ChannelAction::Rollback,
+            lineage_epoch: Some(lineage_epoch),
+            delivery_counter,
+            material: Some(binding),
+        }
+    }
+
+    /// Retire carries no material and no lineage epoch — mirrors the
+    /// broker's own `SecretsLifecycleAuditFields::retired` audit shape,
+    /// which likewise omits `lineage_epoch` (there is no longer an
+    /// active generation once retired). A retire message still carries
+    /// a `delivery_counter` so a stale replayed retire cannot be
+    /// distinguished from a fresh one purely by inspection, and so a
+    /// stale *pre-retire* message cannot be replayed after a retire to
+    /// reactivate anything (the replay guard applies uniformly to all
+    /// four actions).
+    pub fn retire(delivery_counter: DeliveryCounter) -> Self {
+        Self {
+            action: ChannelAction::Retire,
+            lineage_epoch: None,
+            delivery_counter,
+            material: None,
+        }
+    }
+
+    pub fn action(&self) -> ChannelAction {
+        self.action
     }
 }
 
 struct Inner {
-    material: Option<ChannelMaterial>,
+    /// `Some((binding, lineage_epoch))` while provisioned/rotated/
+    /// rolled-back and not retired.
+    material: Option<(ChannelBinding, LineageEpoch)>,
     retired: bool,
+    /// Highest `delivery_counter` ever accepted by this object.
+    /// Deliberately **never reset** by `Provision` or `Retire` — see
+    /// [`DeliveryCounter`]'s doc comment.
+    delivery_high_water: u64,
 }
 
 /// In-memory, thread-safe holder for the guest frontend's active
-/// channel material, supporting the same provision/rotate/retire
-/// lifecycle shape as the broker's `secrets_lifecycle` engine (kept
-/// independent — this module has no dependency on that crate).
+/// channel material, supporting the same provision/rotate/rollback/
+/// retire lifecycle shape as the broker's `secrets_lifecycle` engine
+/// (kept independent — this module has no dependency on that crate).
 pub struct ChannelState(RwLock<Inner>);
 
 impl Default for ChannelState {
@@ -217,226 +403,397 @@ impl ChannelState {
         Self(RwLock::new(Inner {
             material: None,
             retired: false,
+            delivery_high_water: 0,
         }))
     }
 
-    /// Provision fresh channel material. Fails with
-    /// [`ChannelStateError::AlreadyProvisioned`] if material is
-    /// already active (use [`rotate`](Self::rotate) instead).
-    pub fn provision(&self, material: ChannelMaterial) -> Result<(), ChannelStateError> {
-        let mut inner = self.0.write().unwrap_or_else(|poison| poison.into_inner());
-        if inner.material.is_some() && !inner.retired {
-            return Err(ChannelStateError::AlreadyProvisioned);
-        }
-        inner.material = Some(material);
-        inner.retired = false;
-        Ok(())
-    }
+    /// Apply an already-authenticated state transition. The
+    /// anti-replay `delivery_counter` check is evaluated first and
+    /// applies uniformly to every [`ChannelAction`]; only if it passes
+    /// does the action-specific provisioning-state validation run.
+    ///
+    /// On any `Err` return, `update` (and any [`ChannelBinding`] it
+    /// carried) has already been dropped and therefore zeroized by
+    /// the time this function returns.
+    pub fn apply(&self, update: ChannelUpdate) -> Result<(), ChannelStateError> {
+        let ChannelUpdate {
+            action,
+            lineage_epoch,
+            delivery_counter,
+            material,
+        } = update;
 
-    /// Rotate to new material. Requires an active (non-retired)
-    /// provisioning and a strictly greater generation than the one
-    /// currently active — a stale or replayed generation is refused
-    /// rather than silently accepted.
-    pub fn rotate(&self, material: ChannelMaterial) -> Result<(), ChannelStateError> {
         let mut inner = self.0.write().unwrap_or_else(|poison| poison.into_inner());
-        if inner.retired {
-            return Err(ChannelStateError::Retired);
+
+        if delivery_counter.get() <= inner.delivery_high_water {
+            return Err(ChannelStateError::StaleDeliveryCounter);
         }
-        match inner.material {
-            None => return Err(ChannelStateError::NotProvisioned),
-            Some(current) if material.generation <= current.generation => {
-                return Err(ChannelStateError::StaleGeneration);
+
+        match action {
+            ChannelAction::Provision => {
+                if inner.material.is_some() && !inner.retired {
+                    return Err(ChannelStateError::AlreadyProvisioned);
+                }
+                let epoch = lineage_epoch.ok_or(ChannelStateError::MalformedUpdate)?;
+                let binding = material.ok_or(ChannelStateError::MalformedUpdate)?;
+                inner.material = Some((binding, epoch));
+                inner.retired = false;
             }
-            Some(_) => {}
+            ChannelAction::Rotate | ChannelAction::Rollback => {
+                if inner.retired {
+                    return Err(ChannelStateError::Retired);
+                }
+                if inner.material.is_none() {
+                    return Err(ChannelStateError::NotProvisioned);
+                }
+                let epoch = lineage_epoch.ok_or(ChannelStateError::MalformedUpdate)?;
+                let binding = material.ok_or(ChannelStateError::MalformedUpdate)?;
+                inner.material = Some((binding, epoch));
+            }
+            ChannelAction::Retire => {
+                if lineage_epoch.is_some() || material.is_some() {
+                    return Err(ChannelStateError::MalformedUpdate);
+                }
+                inner.material = None;
+                inner.retired = true;
+            }
         }
-        inner.material = Some(material);
+
+        inner.delivery_high_water = delivery_counter.get();
         Ok(())
     }
 
-    /// Retire the channel state. Idempotent: retiring an
-    /// already-retired or never-provisioned state simply clears any
-    /// material and marks retired.
-    pub fn retire(&self) {
-        let mut inner = self.0.write().unwrap_or_else(|poison| poison.into_inner());
-        inner.material = None;
-        inner.retired = true;
+    /// Retired-ness and provisioned-ness, without exposing any
+    /// secret material — safe for logging/metrics.
+    pub fn is_retired(&self) -> bool {
+        self.0
+            .read()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .retired
     }
 
-    /// Current active material, if any.
-    pub fn current(&self) -> Result<ChannelMaterial, ChannelStateError> {
+    /// The current anti-replay high-water mark. Not secret; safe to
+    /// persist/log for the guest-restart wiring point described in
+    /// the module docs.
+    pub fn delivery_high_water(&self) -> u64 {
+        self.0
+            .read()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .delivery_high_water
+    }
+
+    /// Access the currently-active binding and lineage epoch via a
+    /// closure, without ever handing out an owned/cloned
+    /// [`ChannelBinding`] from inside the lock. Typical use:
+    ///
+    /// ```ignore
+    /// state.with_current(|binding, epoch| {
+    ///     SessionConfig::new(binding.expose_bytes(), epoch.get())
+    /// })
+    /// ```
+    pub fn with_current<T>(
+        &self,
+        f: impl FnOnce(&ChannelBinding, LineageEpoch) -> T,
+    ) -> Result<T, ChannelStateError> {
         let inner = self.0.read().unwrap_or_else(|poison| poison.into_inner());
         if inner.retired {
             return Err(ChannelStateError::Retired);
         }
-        inner.material.ok_or(ChannelStateError::NotProvisioned)
+        match &inner.material {
+            Some((binding, epoch)) => Ok(f(binding, *epoch)),
+            None => Err(ChannelStateError::NotProvisioned),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::thread;
 
     fn binding(byte: u8) -> ChannelBinding {
         ChannelBinding::new([byte; 32]).expect("valid binding")
     }
 
-    fn generation(value: u64) -> ChannelGeneration {
-        ChannelGeneration::new(value).expect("valid generation")
+    fn epoch(value: u64) -> LineageEpoch {
+        LineageEpoch::new(value).expect("valid epoch")
+    }
+
+    fn counter(value: u64) -> DeliveryCounter {
+        DeliveryCounter::new(value).expect("valid counter")
     }
 
     #[test]
-    fn zero_binding_and_generation_are_rejected() {
+    fn zero_binding_epoch_and_counter_are_rejected() {
         assert_eq!(
             ChannelBinding::new([0; 32]).unwrap_err(),
             ChannelStateError::InvalidBinding
         );
         assert_eq!(
-            ChannelGeneration::new(0).unwrap_err(),
-            ChannelStateError::InvalidGeneration
+            LineageEpoch::new(0).unwrap_err(),
+            ChannelStateError::InvalidLineageEpoch
+        );
+        assert_eq!(
+            DeliveryCounter::new(0).unwrap_err(),
+            ChannelStateError::InvalidDeliveryCounter
         );
     }
 
     #[test]
     fn debug_impls_never_expose_bytes_or_counters() {
         let b = binding(0xAB);
-        let g = generation(7);
-        let m = ChannelMaterial::new(b, g);
+        let e = epoch(7);
+        let c = counter(9);
         assert!(format!("{b:?}").contains("redacted"));
-        assert!(format!("{g:?}").contains("redacted"));
-        let m_debug = format!("{m:?}");
-        assert!(m_debug.contains("redacted"));
-        assert!(!m_debug.contains("171")); // 0xAB decimal
-        assert!(!m_debug.contains('7'));
+        let e_debug = format!("{e:?}");
+        let c_debug = format!("{c:?}");
+        assert!(e_debug.contains("redacted"));
+        assert!(c_debug.contains("redacted"));
+        assert!(!e_debug.contains('7'));
+        assert!(!c_debug.contains('9'));
     }
 
     #[test]
-    fn current_before_provision_is_not_provisioned() {
+    fn with_current_before_provision_is_not_provisioned() {
         let state = ChannelState::new();
         assert_eq!(
-            state.current().unwrap_err(),
+            state.with_current(|_, _| ()).unwrap_err(),
             ChannelStateError::NotProvisioned
         );
     }
 
     #[test]
-    fn provision_then_current_round_trips() {
+    fn provision_then_with_current_round_trips() {
         let state = ChannelState::new();
-        let material = ChannelMaterial::new(binding(1), generation(1));
-        state.provision(material).expect("provision succeeds");
-        assert_eq!(state.current().expect("current succeeds"), material);
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(1), binding(1)))
+            .expect("provision succeeds");
+        let (bytes, epoch_value) = state
+            .with_current(|b, e| (b.expose_bytes(), e.get()))
+            .expect("with_current succeeds");
+        assert_eq!(bytes, [1u8; 32]);
+        assert_eq!(epoch_value, 1);
     }
 
     #[test]
     fn provision_twice_without_retire_is_rejected() {
         let state = ChannelState::new();
         state
-            .provision(ChannelMaterial::new(binding(1), generation(1)))
+            .apply(ChannelUpdate::provision(epoch(1), counter(1), binding(1)))
             .expect("first provision succeeds");
         let err = state
-            .provision(ChannelMaterial::new(binding(2), generation(1)))
+            .apply(ChannelUpdate::provision(epoch(1), counter(2), binding(2)))
             .unwrap_err();
         assert_eq!(err, ChannelStateError::AlreadyProvisioned);
     }
 
     #[test]
-    fn rotate_requires_strictly_increasing_generation() {
+    fn rotate_and_rollback_without_provision_are_not_provisioned() {
         let state = ChannelState::new();
-        state
-            .provision(ChannelMaterial::new(binding(1), generation(5)))
-            .expect("provision succeeds");
-        let stale = state.rotate(ChannelMaterial::new(binding(2), generation(5)));
-        assert_eq!(stale.unwrap_err(), ChannelStateError::StaleGeneration);
-        let older = state.rotate(ChannelMaterial::new(binding(2), generation(4)));
-        assert_eq!(older.unwrap_err(), ChannelStateError::StaleGeneration);
-        state
-            .rotate(ChannelMaterial::new(binding(2), generation(6)))
-            .expect("strictly-increasing rotate succeeds");
-        assert_eq!(state.current().unwrap().generation().get(), 6);
-    }
-
-    #[test]
-    fn rotate_without_provision_is_not_provisioned() {
-        let state = ChannelState::new();
-        let err = state
-            .rotate(ChannelMaterial::new(binding(1), generation(1)))
-            .unwrap_err();
-        assert_eq!(err, ChannelStateError::NotProvisioned);
-    }
-
-    #[test]
-    fn retire_then_current_and_rotate_are_refused() {
-        let state = ChannelState::new();
-        state
-            .provision(ChannelMaterial::new(binding(1), generation(1)))
-            .expect("provision succeeds");
-        state.retire();
-        assert_eq!(state.current().unwrap_err(), ChannelStateError::Retired);
         assert_eq!(
             state
-                .rotate(ChannelMaterial::new(binding(2), generation(2)))
+                .apply(ChannelUpdate::rotate(epoch(1), counter(1), binding(1)))
+                .unwrap_err(),
+            ChannelStateError::NotProvisioned
+        );
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::rollback(epoch(1), counter(1), binding(1)))
+                .unwrap_err(),
+            ChannelStateError::NotProvisioned
+        );
+    }
+
+    #[test]
+    fn rotate_advances_lineage_epoch() {
+        let state = ChannelState::new();
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(1), binding(1)))
+            .expect("provision succeeds");
+        state
+            .apply(ChannelUpdate::rotate(epoch(2), counter(2), binding(2)))
+            .expect("rotate succeeds");
+        let epoch_value = state.with_current(|_, e| e.get()).unwrap();
+        assert_eq!(epoch_value, 2);
+    }
+
+    #[test]
+    fn rollback_may_legitimately_decrease_lineage_epoch() {
+        let state = ChannelState::new();
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(1), binding(1)))
+            .expect("provision succeeds");
+        state
+            .apply(ChannelUpdate::rotate(epoch(2), counter(2), binding(2)))
+            .expect("rotate succeeds");
+        state
+            .apply(ChannelUpdate::rollback(epoch(1), counter(3), binding(1)))
+            .expect("rollback to a lower epoch succeeds");
+        let epoch_value = state.with_current(|_, e| e.get()).unwrap();
+        assert_eq!(epoch_value, 1);
+    }
+
+    #[test]
+    fn stale_or_repeated_delivery_counter_is_rejected_regardless_of_action() {
+        let state = ChannelState::new();
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(5), binding(1)))
+            .expect("provision succeeds");
+
+        // Exact repeat.
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::rotate(epoch(2), counter(5), binding(2)))
+                .unwrap_err(),
+            ChannelStateError::StaleDeliveryCounter
+        );
+        // Older than high-water.
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::rotate(epoch(2), counter(4), binding(2)))
+                .unwrap_err(),
+            ChannelStateError::StaleDeliveryCounter
+        );
+        // A lower lineage epoch (legitimate rollback shape) does not
+        // exempt the message from the delivery-counter replay guard.
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::rollback(epoch(1), counter(5), binding(1)))
+                .unwrap_err(),
+            ChannelStateError::StaleDeliveryCounter
+        );
+    }
+
+    #[test]
+    fn retire_then_current_rotate_and_rollback_are_refused() {
+        let state = ChannelState::new();
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(1), binding(1)))
+            .expect("provision succeeds");
+        state
+            .apply(ChannelUpdate::retire(counter(2)))
+            .expect("retire succeeds");
+        assert!(state.is_retired());
+        assert_eq!(
+            state.with_current(|_, _| ()).unwrap_err(),
+            ChannelStateError::Retired
+        );
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::rotate(epoch(2), counter(3), binding(2)))
+                .unwrap_err(),
+            ChannelStateError::Retired
+        );
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::rollback(epoch(1), counter(3), binding(1)))
                 .unwrap_err(),
             ChannelStateError::Retired
         );
     }
 
     #[test]
-    fn retire_then_reprovision_resets_generation_tracking() {
+    fn retire_then_reprovision_resets_lineage_epoch_but_not_delivery_high_water() {
         let state = ChannelState::new();
         state
-            .provision(ChannelMaterial::new(binding(1), generation(9)))
+            .apply(ChannelUpdate::provision(epoch(1), counter(9), binding(1)))
             .expect("provision succeeds");
-        state.retire();
         state
-            .provision(ChannelMaterial::new(binding(2), generation(1)))
-            .expect("re-provision after retire succeeds");
-        assert_eq!(state.current().unwrap().generation().get(), 1);
+            .apply(ChannelUpdate::retire(counter(10)))
+            .expect("retire succeeds");
+        assert_eq!(state.delivery_high_water(), 10);
+
+        // A fresh provision restarts the lineage epoch at 1 (mirrors
+        // the broker's on-disk generation restart), but a replayed
+        // delivery_counter from BEFORE the retire (or equal to the
+        // retire's own counter) must still be rejected: the anti-replay
+        // high-water mark is a property of this channel object, not
+        // of the rollbackable storage generation, and must survive
+        // retire + reprovision.
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::provision(epoch(1), counter(9), binding(2)))
+                .unwrap_err(),
+            ChannelStateError::StaleDeliveryCounter
+        );
+        assert_eq!(
+            state
+                .apply(ChannelUpdate::provision(epoch(1), counter(10), binding(2)))
+                .unwrap_err(),
+            ChannelStateError::StaleDeliveryCounter
+        );
+
+        // A genuinely fresh, higher counter succeeds and resets the
+        // lineage epoch back to 1.
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(11), binding(2)))
+            .expect("reprovision with a fresh counter succeeds");
+        assert!(!state.is_retired());
+        let epoch_value = state.with_current(|_, e| e.get()).unwrap();
+        assert_eq!(epoch_value, 1);
+        assert_eq!(state.delivery_high_water(), 11);
     }
 
     #[test]
-    fn retire_is_idempotent() {
+    fn retire_is_idempotent_and_still_replay_guarded() {
         let state = ChannelState::new();
-        state.retire();
-        state.retire();
-        assert_eq!(state.current().unwrap_err(), ChannelStateError::Retired);
-    }
-
-    #[test]
-    fn from_wire_bytes_round_trips_and_rejects_bad_length() {
-        let mut wire = [0u8; PROPOSED_WIRE_LEN];
-        wire[..32].copy_from_slice(&[7u8; 32]);
-        wire[32..].copy_from_slice(&42u64.to_be_bytes());
-        let material = ChannelMaterial::from_wire_bytes(&wire).expect("valid wire bytes parse");
-        assert_eq!(material.binding().into_bytes(), [7u8; 32]);
-        assert_eq!(material.generation().get(), 42);
-
+        state
+            .apply(ChannelUpdate::retire(counter(1)))
+            .expect("retire of never-provisioned state succeeds");
+        assert!(state.is_retired());
+        state
+            .apply(ChannelUpdate::retire(counter(2)))
+            .expect("re-retire with a fresh counter succeeds");
         assert_eq!(
-            ChannelMaterial::from_wire_bytes(&wire[..PROPOSED_WIRE_LEN - 1]).unwrap_err(),
-            ChannelStateError::InvalidWireLength
+            state.apply(ChannelUpdate::retire(counter(2))).unwrap_err(),
+            ChannelStateError::StaleDeliveryCounter
         );
     }
 
     #[test]
-    fn from_wire_bytes_rejects_zero_binding_or_generation() {
-        let mut zero_binding = [0u8; PROPOSED_WIRE_LEN];
-        zero_binding[32..].copy_from_slice(&1u64.to_be_bytes());
-        assert_eq!(
-            ChannelMaterial::from_wire_bytes(&zero_binding).unwrap_err(),
-            ChannelStateError::InvalidBinding
-        );
-
-        let mut zero_generation = [0u8; PROPOSED_WIRE_LEN];
-        zero_generation[..32].copy_from_slice(&[3u8; 32]);
-        assert_eq!(
-            ChannelMaterial::from_wire_bytes(&zero_generation).unwrap_err(),
-            ChannelStateError::InvalidGeneration
-        );
+    fn provision_after_reject_leaves_state_unchanged() {
+        let state = ChannelState::new();
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(1), binding(1)))
+            .expect("provision succeeds");
+        // A stale-counter provision attempt must not disturb the
+        // already-active material.
+        let _ = state.apply(ChannelUpdate::provision(epoch(9), counter(1), binding(9)));
+        let bytes = state.with_current(|b, _| b.expose_bytes()).unwrap();
+        assert_eq!(bytes, [1u8; 32]);
     }
 
     #[test]
-    fn into_session_config_args_matches_material() {
-        let material = ChannelMaterial::new(binding(5), generation(3));
-        let (bytes, generation_value) = material.into_session_config_args();
-        assert_eq!(bytes, [5u8; 32]);
-        assert_eq!(generation_value, 3);
+    fn concurrent_apply_with_same_counter_admits_exactly_one_winner() {
+        let state = Arc::new(ChannelState::new());
+        state
+            .apply(ChannelUpdate::provision(epoch(1), counter(1), binding(1)))
+            .expect("provision succeeds");
+
+        let mut handles = Vec::new();
+        for i in 0..8u8 {
+            let state = Arc::clone(&state);
+            handles.push(thread::spawn(move || {
+                state.apply(ChannelUpdate::rotate(epoch(2), counter(2), binding(i + 2)))
+            }));
+        }
+        let results: Vec<Result<(), ChannelStateError>> =
+            handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let successes = results.iter().filter(|r| r.is_ok()).count();
+        assert_eq!(successes, 1, "exactly one concurrent rotate should win");
+        let stale_failures = results
+            .iter()
+            .filter(|r| *r == &Err(ChannelStateError::StaleDeliveryCounter))
+            .count();
+        assert_eq!(stale_failures, 7);
+    }
+
+    #[test]
+    fn action_accessor_matches_constructor() {
+        let update = ChannelUpdate::provision(epoch(1), counter(1), binding(1));
+        assert_eq!(update.action(), ChannelAction::Provision);
+        let update = ChannelUpdate::retire(counter(2));
+        assert_eq!(update.action(), ChannelAction::Retire);
     }
 }

--- a/packages/d2b-sk-frontend/src/secrets_channel.rs
+++ b/packages/d2b-sk-frontend/src/secrets_channel.rs
@@ -1,0 +1,442 @@
+//! Guest-side lifecycle state for the security-key CTAPHID channel
+//! binding + reconnect generation that
+//! [`crate::services::security_key::SessionConfig`] ultimately
+//! consumes.
+//!
+//! This module is the W8 `secrets-lifecycle` component's guest-side
+//! counterpart to the broker's
+//! `d2b_priv_broker::ops::secrets_lifecycle` engine and
+//! `SecretKind::SecurityKeyChannelState`. It is intentionally a
+//! standalone, in-memory, zero-internal-dependency module (only
+//! `std`) so it can be validated on its own without depending on this
+//! crate's `d2b-session`/`d2b-contracts`/transport wiring, and so a
+//! future integrator can wire it into
+//! [`crate::services::security_key::SessionConfig`] without this
+//! component needing to touch that file.
+//!
+//! # Integration wiring points (deliberately NOT performed here)
+//!
+//!   1. `src/lib.rs` needs `pub mod secrets_channel;`.
+//!   2. `services/security_key/mod.rs`'s `SessionConfig::from_env` (or
+//!      a new constructor alongside it) should source its
+//!      `channel_binding`/`reconnect_generation` from a
+//!      [`ChannelState::current`] snapshot — most likely populated by
+//!      a fresh vsock/guest-control message carrying broker-rotated
+//!      `SecretKind::SecurityKeyChannelState` material — instead of
+//!      the static `D2B_SK_CHANNEL_BINDING_HEX`/
+//!      `D2B_SK_RECONNECT_GENERATION` environment variables it reads
+//!      today. Neither `lib.rs` nor `services/security_key/mod.rs` is
+//!      owned by this component.
+//!   3. The exact wire format [`ChannelMaterial::from_wire_bytes`]
+//!      parses (32 bytes of channel binding followed by an 8-byte
+//!      big-endian generation counter) is **a proposal**, not a
+//!      confirmed contract: the integrator must confirm it against
+//!      whatever the broker's future `SecretKind::SecurityKeyChannelState`
+//!      dispatch arm (in `packages/d2b-priv-broker/src/runtime.rs`,
+//!      out of scope here) actually serializes, and adjust or replace
+//!      it before depending on it in production.
+
+use std::fmt;
+use std::sync::RwLock;
+
+/// Errors surfaced by every public function in this module. Never
+/// carries a raw byte, path, or generation counter value — only a
+/// closed-set discriminant, safe for any Debug/log/audit surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelStateError {
+    InvalidBinding,
+    InvalidGeneration,
+    /// `rotate` was called with a generation that is not strictly
+    /// greater than the currently active one — refused as a possible
+    /// replay/rollback rather than silently accepted.
+    StaleGeneration,
+    /// `rotate`/`current` was called before any `provision`.
+    NotProvisioned,
+    /// `provision` was called while material is already active
+    /// (callers should `rotate` instead).
+    AlreadyProvisioned,
+    /// The channel state was retired; `current`/`rotate` refuse to
+    /// resume without an explicit fresh `provision`.
+    Retired,
+    /// `from_wire_bytes` was given a buffer of the wrong length.
+    InvalidWireLength,
+}
+
+impl fmt::Display for ChannelStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let slug = match self {
+            Self::InvalidBinding => "invalid-channel-binding",
+            Self::InvalidGeneration => "invalid-reconnect-generation",
+            Self::StaleGeneration => "stale-reconnect-generation",
+            Self::NotProvisioned => "channel-not-provisioned",
+            Self::AlreadyProvisioned => "channel-already-provisioned",
+            Self::Retired => "channel-retired",
+            Self::InvalidWireLength => "invalid-channel-material-wire-length",
+        };
+        f.write_str(slug)
+    }
+}
+
+impl std::error::Error for ChannelStateError {}
+
+/// Length in bytes of the [`ChannelMaterial::from_wire_bytes`]
+/// proposed wire format: 32 bytes of channel binding plus an 8-byte
+/// big-endian generation counter. See the module-level "Integration
+/// wiring points" note — this exact layout needs integrator
+/// confirmation before any production dependency on it.
+pub const PROPOSED_WIRE_LEN: usize = 32 + 8;
+
+/// A validated, non-zero 32-byte CTAPHID channel-binding value.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ChannelBinding([u8; 32]);
+
+impl ChannelBinding {
+    pub fn new(bytes: [u8; 32]) -> Result<Self, ChannelStateError> {
+        if bytes == [0; 32] {
+            return Err(ChannelStateError::InvalidBinding);
+        }
+        Ok(Self(bytes))
+    }
+
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl fmt::Debug for ChannelBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ChannelBinding")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
+
+/// A validated, non-zero reconnect-generation counter.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ChannelGeneration(u64);
+
+impl ChannelGeneration {
+    pub fn new(value: u64) -> Result<Self, ChannelStateError> {
+        if value == 0 {
+            return Err(ChannelStateError::InvalidGeneration);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Debug for ChannelGeneration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ChannelGeneration")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
+
+/// One provisioned/rotated channel material snapshot: a binding plus
+/// the generation counter it was delivered at.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ChannelMaterial {
+    binding: ChannelBinding,
+    generation: ChannelGeneration,
+}
+
+impl fmt::Debug for ChannelMaterial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChannelMaterial")
+            .field("binding", &"<redacted>")
+            .field("generation", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ChannelMaterial {
+    pub fn new(binding: ChannelBinding, generation: ChannelGeneration) -> Self {
+        Self {
+            binding,
+            generation,
+        }
+    }
+
+    pub fn binding(&self) -> ChannelBinding {
+        self.binding
+    }
+
+    pub fn generation(&self) -> ChannelGeneration {
+        self.generation
+    }
+
+    /// Convenience accessor returning the plain `([u8; 32], u64)`
+    /// shape [`crate::services::security_key::SessionConfig::new`]
+    /// expects, without this module depending on that type directly.
+    pub fn into_session_config_args(self) -> ([u8; 32], u64) {
+        (self.binding.into_bytes(), self.generation.get())
+    }
+
+    /// Parse the **proposed** wire format: 32 bytes of channel
+    /// binding followed by an 8-byte big-endian generation counter.
+    /// See the module-level doc comment — this layout is a proposal
+    /// pending integrator/security confirmation, not a settled
+    /// contract.
+    pub fn from_wire_bytes(bytes: &[u8]) -> Result<Self, ChannelStateError> {
+        if bytes.len() != PROPOSED_WIRE_LEN {
+            return Err(ChannelStateError::InvalidWireLength);
+        }
+        let mut binding_bytes = [0u8; 32];
+        binding_bytes.copy_from_slice(&bytes[..32]);
+        let mut generation_bytes = [0u8; 8];
+        generation_bytes.copy_from_slice(&bytes[32..]);
+        let binding = ChannelBinding::new(binding_bytes)?;
+        let generation = ChannelGeneration::new(u64::from_be_bytes(generation_bytes))?;
+        Ok(Self::new(binding, generation))
+    }
+}
+
+struct Inner {
+    material: Option<ChannelMaterial>,
+    retired: bool,
+}
+
+/// In-memory, thread-safe holder for the guest frontend's active
+/// channel material, supporting the same provision/rotate/retire
+/// lifecycle shape as the broker's `secrets_lifecycle` engine (kept
+/// independent — this module has no dependency on that crate).
+pub struct ChannelState(RwLock<Inner>);
+
+impl Default for ChannelState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChannelState {
+    pub fn new() -> Self {
+        Self(RwLock::new(Inner {
+            material: None,
+            retired: false,
+        }))
+    }
+
+    /// Provision fresh channel material. Fails with
+    /// [`ChannelStateError::AlreadyProvisioned`] if material is
+    /// already active (use [`rotate`](Self::rotate) instead).
+    pub fn provision(&self, material: ChannelMaterial) -> Result<(), ChannelStateError> {
+        let mut inner = self.0.write().unwrap_or_else(|poison| poison.into_inner());
+        if inner.material.is_some() && !inner.retired {
+            return Err(ChannelStateError::AlreadyProvisioned);
+        }
+        inner.material = Some(material);
+        inner.retired = false;
+        Ok(())
+    }
+
+    /// Rotate to new material. Requires an active (non-retired)
+    /// provisioning and a strictly greater generation than the one
+    /// currently active — a stale or replayed generation is refused
+    /// rather than silently accepted.
+    pub fn rotate(&self, material: ChannelMaterial) -> Result<(), ChannelStateError> {
+        let mut inner = self.0.write().unwrap_or_else(|poison| poison.into_inner());
+        if inner.retired {
+            return Err(ChannelStateError::Retired);
+        }
+        match inner.material {
+            None => return Err(ChannelStateError::NotProvisioned),
+            Some(current) if material.generation <= current.generation => {
+                return Err(ChannelStateError::StaleGeneration);
+            }
+            Some(_) => {}
+        }
+        inner.material = Some(material);
+        Ok(())
+    }
+
+    /// Retire the channel state. Idempotent: retiring an
+    /// already-retired or never-provisioned state simply clears any
+    /// material and marks retired.
+    pub fn retire(&self) {
+        let mut inner = self.0.write().unwrap_or_else(|poison| poison.into_inner());
+        inner.material = None;
+        inner.retired = true;
+    }
+
+    /// Current active material, if any.
+    pub fn current(&self) -> Result<ChannelMaterial, ChannelStateError> {
+        let inner = self.0.read().unwrap_or_else(|poison| poison.into_inner());
+        if inner.retired {
+            return Err(ChannelStateError::Retired);
+        }
+        inner.material.ok_or(ChannelStateError::NotProvisioned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding(byte: u8) -> ChannelBinding {
+        ChannelBinding::new([byte; 32]).expect("valid binding")
+    }
+
+    fn generation(value: u64) -> ChannelGeneration {
+        ChannelGeneration::new(value).expect("valid generation")
+    }
+
+    #[test]
+    fn zero_binding_and_generation_are_rejected() {
+        assert_eq!(
+            ChannelBinding::new([0; 32]).unwrap_err(),
+            ChannelStateError::InvalidBinding
+        );
+        assert_eq!(
+            ChannelGeneration::new(0).unwrap_err(),
+            ChannelStateError::InvalidGeneration
+        );
+    }
+
+    #[test]
+    fn debug_impls_never_expose_bytes_or_counters() {
+        let b = binding(0xAB);
+        let g = generation(7);
+        let m = ChannelMaterial::new(b, g);
+        assert!(format!("{b:?}").contains("redacted"));
+        assert!(format!("{g:?}").contains("redacted"));
+        let m_debug = format!("{m:?}");
+        assert!(m_debug.contains("redacted"));
+        assert!(!m_debug.contains("171")); // 0xAB decimal
+        assert!(!m_debug.contains('7'));
+    }
+
+    #[test]
+    fn current_before_provision_is_not_provisioned() {
+        let state = ChannelState::new();
+        assert_eq!(
+            state.current().unwrap_err(),
+            ChannelStateError::NotProvisioned
+        );
+    }
+
+    #[test]
+    fn provision_then_current_round_trips() {
+        let state = ChannelState::new();
+        let material = ChannelMaterial::new(binding(1), generation(1));
+        state.provision(material).expect("provision succeeds");
+        assert_eq!(state.current().expect("current succeeds"), material);
+    }
+
+    #[test]
+    fn provision_twice_without_retire_is_rejected() {
+        let state = ChannelState::new();
+        state
+            .provision(ChannelMaterial::new(binding(1), generation(1)))
+            .expect("first provision succeeds");
+        let err = state
+            .provision(ChannelMaterial::new(binding(2), generation(1)))
+            .unwrap_err();
+        assert_eq!(err, ChannelStateError::AlreadyProvisioned);
+    }
+
+    #[test]
+    fn rotate_requires_strictly_increasing_generation() {
+        let state = ChannelState::new();
+        state
+            .provision(ChannelMaterial::new(binding(1), generation(5)))
+            .expect("provision succeeds");
+        let stale = state.rotate(ChannelMaterial::new(binding(2), generation(5)));
+        assert_eq!(stale.unwrap_err(), ChannelStateError::StaleGeneration);
+        let older = state.rotate(ChannelMaterial::new(binding(2), generation(4)));
+        assert_eq!(older.unwrap_err(), ChannelStateError::StaleGeneration);
+        state
+            .rotate(ChannelMaterial::new(binding(2), generation(6)))
+            .expect("strictly-increasing rotate succeeds");
+        assert_eq!(state.current().unwrap().generation().get(), 6);
+    }
+
+    #[test]
+    fn rotate_without_provision_is_not_provisioned() {
+        let state = ChannelState::new();
+        let err = state
+            .rotate(ChannelMaterial::new(binding(1), generation(1)))
+            .unwrap_err();
+        assert_eq!(err, ChannelStateError::NotProvisioned);
+    }
+
+    #[test]
+    fn retire_then_current_and_rotate_are_refused() {
+        let state = ChannelState::new();
+        state
+            .provision(ChannelMaterial::new(binding(1), generation(1)))
+            .expect("provision succeeds");
+        state.retire();
+        assert_eq!(state.current().unwrap_err(), ChannelStateError::Retired);
+        assert_eq!(
+            state
+                .rotate(ChannelMaterial::new(binding(2), generation(2)))
+                .unwrap_err(),
+            ChannelStateError::Retired
+        );
+    }
+
+    #[test]
+    fn retire_then_reprovision_resets_generation_tracking() {
+        let state = ChannelState::new();
+        state
+            .provision(ChannelMaterial::new(binding(1), generation(9)))
+            .expect("provision succeeds");
+        state.retire();
+        state
+            .provision(ChannelMaterial::new(binding(2), generation(1)))
+            .expect("re-provision after retire succeeds");
+        assert_eq!(state.current().unwrap().generation().get(), 1);
+    }
+
+    #[test]
+    fn retire_is_idempotent() {
+        let state = ChannelState::new();
+        state.retire();
+        state.retire();
+        assert_eq!(state.current().unwrap_err(), ChannelStateError::Retired);
+    }
+
+    #[test]
+    fn from_wire_bytes_round_trips_and_rejects_bad_length() {
+        let mut wire = [0u8; PROPOSED_WIRE_LEN];
+        wire[..32].copy_from_slice(&[7u8; 32]);
+        wire[32..].copy_from_slice(&42u64.to_be_bytes());
+        let material = ChannelMaterial::from_wire_bytes(&wire).expect("valid wire bytes parse");
+        assert_eq!(material.binding().into_bytes(), [7u8; 32]);
+        assert_eq!(material.generation().get(), 42);
+
+        assert_eq!(
+            ChannelMaterial::from_wire_bytes(&wire[..PROPOSED_WIRE_LEN - 1]).unwrap_err(),
+            ChannelStateError::InvalidWireLength
+        );
+    }
+
+    #[test]
+    fn from_wire_bytes_rejects_zero_binding_or_generation() {
+        let mut zero_binding = [0u8; PROPOSED_WIRE_LEN];
+        zero_binding[32..].copy_from_slice(&1u64.to_be_bytes());
+        assert_eq!(
+            ChannelMaterial::from_wire_bytes(&zero_binding).unwrap_err(),
+            ChannelStateError::InvalidBinding
+        );
+
+        let mut zero_generation = [0u8; PROPOSED_WIRE_LEN];
+        zero_generation[..32].copy_from_slice(&[3u8; 32]);
+        assert_eq!(
+            ChannelMaterial::from_wire_bytes(&zero_generation).unwrap_err(),
+            ChannelStateError::InvalidGeneration
+        );
+    }
+
+    #[test]
+    fn into_session_config_args_matches_material() {
+        let material = ChannelMaterial::new(binding(5), generation(3));
+        let (bytes, generation_value) = material.into_session_config_args();
+        assert_eq!(bytes, [5u8; 32]);
+        assert_eq!(generation_value, 3);
+    }
+}

--- a/packages/d2b-sk-frontend/src/secrets_channel.rs
+++ b/packages/d2b-sk-frontend/src/secrets_channel.rs
@@ -19,7 +19,11 @@
 //! properties into a single `ChannelGeneration` counter:
 //!
 //!   * the broker's **lineage epoch** — the active generation
-//!     identity from `secrets_lifecycle`'s marker (`MarkerData::active`).
+//!     identity from `secrets_lifecycle`'s durable state
+//!     (`DurableState::active`'s `GenerationRecord::epoch`, as of the
+//!     W8fu6 ports-and-adapters rewrite; an earlier draft of this doc
+//!     comment referred to a since-removed on-disk `MarkerData::active`
+//!     field from that engine's original filesystem-anchored design).
 //!     This value is **rollbackable**: a legitimate `rollback()` moves
 //!     it *backwards* to a previously-retained generation.
 //!   * a **monotonic anti-replay counter** — a value that must never

--- a/tests/unit/nix/cases/w8-secrets-lifecycle-eval.nix
+++ b/tests/unit/nix/cases/w8-secrets-lifecycle-eval.nix
@@ -1,0 +1,124 @@
+{ flakeRoot, ... }:
+
+let
+  plan = import
+    (flakeRoot + "/tests/unit/nix/eval-cases/w8-integration-wave-plan.nix")
+    { };
+  componentPolicy = import
+    (flakeRoot + "/tests/unit/nix/eval-cases/w8-integration-component-policy.nix");
+  branch = "adr0045-w8-integration-secrets-lifecycle";
+  evaluate = paths:
+    componentPolicy {
+      inherit branch plan;
+      pathsJson = builtins.toJSON paths;
+    };
+  component = plan.components."secrets-lifecycle";
+  ownedFiles = [
+    "docs/how-to/rotate-secrets.md"
+    "docs/reference/secrets-lifecycle.md"
+    "packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs"
+    "packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs"
+    "packages/d2b-sk-frontend/src/secrets_channel.rs"
+    "tests/unit/nix/cases/w8-secrets-lifecycle-eval.nix"
+  ];
+  fullCommit = evaluate ownedFiles;
+  partialCommit = evaluate [
+    "packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs"
+    "packages/d2b-priv-broker/src/ops/secrets_rotation_audit.rs"
+  ];
+  unownedPath = evaluate (ownedFiles ++ [
+    "packages/d2b-priv-broker/src/ops/mod.rs"
+  ]);
+  forbiddenAndUnowned = evaluate [
+    "packages/d2b-priv-broker/src/runtime.rs"
+  ];
+  wrongBranch = componentPolicy {
+    branch = "adr0045-w8-integration-gateway-replacement";
+    inherit plan;
+    pathsJson = builtins.toJSON ownedFiles;
+  };
+in
+{
+  "w8-secrets-lifecycle-eval/component-metadata-matches-the-plan" = {
+    expr = {
+      inherit (component) dependsOn externalDependsOn ownedFiles reservedPaths deletes;
+    };
+    expected = {
+      dependsOn = [ ];
+      externalDependsOn = [ ];
+      inherit ownedFiles;
+      reservedPaths = [
+        "docs/reference/secrets-lifecycle.md"
+        "packages/d2b-priv-broker/src/ops/secrets_lifecycle.rs"
+      ];
+      deletes = [ ];
+    };
+  };
+
+  "w8-secrets-lifecycle-eval/component-is-ready-under-the-current-manifest" = {
+    expr = builtins.elem "secrets-lifecycle" plan.launchSummary.ready;
+    expected = true;
+  };
+
+  "w8-secrets-lifecycle-eval/branch-resolves-to-this-component" = {
+    expr = fullCommit.component;
+    expected = "secrets-lifecycle";
+  };
+
+  "w8-secrets-lifecycle-eval/full-owned-file-commit-is-valid" = {
+    expr = {
+      inherit (fullCommit) valid violations forbiddenViolations unmetDependencies;
+      inherit (fullCommit) blockedExternalDependencies;
+    };
+    expected = {
+      valid = true;
+      violations = [ ];
+      forbiddenViolations = [ ];
+      unmetDependencies = [ ];
+      blockedExternalDependencies = [ ];
+    };
+  };
+
+  "w8-secrets-lifecycle-eval/partial-owned-subset-commit-is-still-valid" = {
+    expr = {
+      inherit (partialCommit) valid violations;
+    };
+    expected = {
+      valid = true;
+      violations = [ ];
+    };
+  };
+
+  "w8-secrets-lifecycle-eval/unowned-path-is-a-violation" = {
+    expr = {
+      inherit (unownedPath) valid violations;
+    };
+    expected = {
+      valid = false;
+      violations = [ "packages/d2b-priv-broker/src/ops/mod.rs" ];
+    };
+  };
+
+  "w8-secrets-lifecycle-eval/runtime-rs-is-both-unowned-and-forbidden" = {
+    expr = {
+      inherit (forbiddenAndUnowned) valid violations forbiddenViolations;
+    };
+    expected = {
+      valid = false;
+      violations = [ "packages/d2b-priv-broker/src/runtime.rs" ];
+      forbiddenViolations = [ "packages/d2b-priv-broker/src/runtime.rs" ];
+    };
+  };
+
+  "w8-secrets-lifecycle-eval/owned-files-never-resolve-under-the-wrong-branch" = {
+    expr = {
+      inherit (wrongBranch) valid component;
+      violations = wrongBranch.violations;
+    };
+    expected = {
+      valid = false;
+      component = "gateway-replacement";
+      violations = ownedFiles;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Implements the ADR 0045 W8 pure secrets transaction core behind an injected generated authority port.

## Detailed changes

- Replaces hand-rolled paths, locks, atomic JSON, and fsync recovery with a pure CAS transaction state machine.
- Uses WorkloadId plus source generation/checksum/ownership-epoch fencing.
- Implements provision, rotate, rollback, retire, quarantine, and prune-debt recovery.
- Retains bounded zeroized material, closed audit v3, and replay-safe channel counters.
- Adds exhaustive crash, race, tamper, and fault tests using a fake authority port.

## Architecture references

- [ADR 0034](https://github.com/vicondoa/d2b/blob/main/docs/adr/0034-storage-lifecycle-restart-and-synchronization.md)
- [ADR 0045](https://github.com/vicondoa/d2b/blob/main/docs/adr/0045-provider-and-transport-framework.md)

## Delivery state

- Base: `adr0045-w8-integration` @ `a213c808`
- Head: `de8387355442154e3b2070d0dd618c5cd6124d68`
- Checks: focused component tests and acceptance review pass
- Integration: waits only for secrets authority adapter