### PR TITLE
labs: make the guest's video capability real and drop the pref that faked it

### DIFF
--- a/changelog.d/venus-lab-record-correction.md
+++ b/changelog.d/venus-lab-record-correction.md
@@ -1,0 +1,21 @@
+### Changed
+
+- The Venus Vulkan Video lab prototype no longer asserts a graphics capability
+  its guest does not have. It previously set
+  `gfx.blacklist.hardwarevideodecoding` so Firefox would skip a VA-API probe the
+  guest could not pass; the guest now passes that probe on the merits and the
+  preference is removed. Decode remains Vulkan Video through Venus, with VA-API
+  answering only the capability question. Firefox is still unmodified.
+- The lab's virglrenderer fork can initialise its video backend and accept the
+  host's non-Mesa VA driver, each behind its own explicit opt-in that is off by
+  default. Without them the fork behaves exactly as upstream does.
+
+### Fixed
+
+- Corrected lab findings documents that described the green-frame presentation
+  defect in the present tense after it had been root-caused and fixed, and that
+  described the GPU-copy path as the intended target when the working
+  configuration selects zero copy.
+- Corrected lab flake comments that stated the opposite of the preferences
+  declared beneath them, including one claiming direct export was enabled while
+  the preference set it to false.

--- a/labs/venus-vulkan-video/README.md
+++ b/labs/venus-vulkan-video/README.md
@@ -19,14 +19,21 @@ layer-validation err : 0
 BLIT failures        : 0
 CmdSubmit3d refusals : 0
 Illegal cmd buffer   : 0
-guest coredumps      : 0
-renderer decode      : decode_cmds=1024 sessions=1
-host NVDEC engine    : nonzero in 28 of 35 samples, mean 2.83%, max 6%
+renderer decode      : decode_cmds=2048 sessions=1
+frames               : 810 total, 6 dropped
+host NVDEC engine    : nonzero in 35 of 35 samples
+picture              : 12,619 distinct colours, mean RGB 152,158,158
 ```
 
 Firefox carries **no patches**. Every change is in guest Mesa, host
 virglrenderer, or lab configuration. `SOLUTION.md` is the full account of what
 was wrong and why each change is needed; the short version is below.
+
+The lab no longer asserts a capability the guest lacks. It previously set
+`gfx.blacklist.hardwarevideodecoding` to skip a VA-API probe the guest could not
+pass, which was a diagnostic rather than a fix. The guest passes that probe on
+the merits now, and the pref is gone - see `SOLUTION.md` section 6a. Decode is
+still Vulkan Video; VA-API only answers the capability question.
 
 ### Reading the NVDEC number
 

--- a/labs/venus-vulkan-video/SOLUTION.md
+++ b/labs/venus-vulkan-video/SOLUTION.md
@@ -267,21 +267,112 @@ The copy path is therefore still wrong even with everything above, and the lab
 selects zero copy. That selection is itself gated: `HW_DECODED_VIDEO_ZERO_COPY`
 is configured only after `gfxPlatformGtk::InitPlatformHardwareVideoConfig()`
 passes an early return that requires `HARDWARE_VIDEO_DECODING` to be enabled,
-and that feature is runtime force-disabled here by a VA-API probe that cannot
-succeed - the virtio-gpu VA driver loads and initialises but advertises no H.264
-profiles.
+and that feature is decided by a VA-API probe.
 
-`gfx.blacklist.hardwarevideodecoding` is set to `1` (`FEATURE_STATUS_OK`) to
-skip that probe. This is honestly a lie told to the browser about a capability
-the guest does not have, and it is written down as one in the flake. It does not
-hand decoding to VA-API: `InitHWDecoderIfAllowed()` tries `InitVulkanDecoder()`
-before `InitVAAPIDecoder()`, so Vulkan still decodes and VA-API is never used
-for a frame.
+That probe used to be unpassable, because the guest's `virtio_gpu` VA driver
+loaded and initialised and then advertised no H.264 profiles. The lab therefore
+set `gfx.blacklist.hardwarevideodecoding` to `1` (`FEATURE_STATUS_OK`) to skip
+it - a lie told to the browser about a capability the guest did not have,
+written down as one in the flake.
 
-Making that capability genuinely true - by finishing virgl's VA-API video path,
-or by V4L2 through `virtio_media` - would remove the need for the pref. Fixing
-the copy path to use per-plane images would remove the need for zero copy. Both
-are open.
+**That pref is gone, and the capability is real.** See section 6a.
+
+`InitHWDecoderIfAllowed()` tries `InitVulkanDecoder()` before
+`InitVAAPIDecoder()`, so VA-API is what makes the capability true and Vulkan
+Video is still what decodes every frame.
+
+Fixing the copy path to use per-plane images would remove the need for zero copy
+in the first place. That one is still open, and the note in section 7 records a
+measurement that narrows it.
+
+---
+
+## 6a. Making the capability honest
+
+The guest advertising no H.264 profiles read like a missing host capability. It
+was not. It was one flag.
+
+Measured in order, each one cheap and each one narrowing the next:
+
+| Question | Answer |
+|---|---|
+| Does the host do VA-API H.264 at all? | Yes - Main, High, ConstrainedBaseline, NVDEC direct backend |
+| Does it still work inside the crosvm GPU sidecar's exact bwrap bind set? | Yes, identical |
+| Is virglrenderer built with video? | Yes, `-Dvideo=true`, so `ENABLE_VIDEO` is defined |
+| Does rutabaga supply the `get_drm_fd` callback video needs? | Yes |
+| Does anything pass `VIRGL_RENDERER_USE_VIDEO`? | **No** |
+
+That last row is the whole defect. `VIRGL_RENDERER_USE_VIDEO` is bit 11 of the
+flags word `virgl_renderer_init()` takes. `rutabaga_gfx` generates the constant
+into `src/generated/virgl_renderer_bindings.rs` and references it nowhere; its
+`VirglRendererFlags` stops at bit 10 and exposes no `use_video()` builder, and
+the inner `u32` is private, so crosvm cannot set the bit even deliberately.
+
+The failure is silent because of where it lands. `virgl_video_init()` is what
+assigns `va_dpy`; `virgl_video_fill_caps()` returns `-1` immediately on a NULL
+`va_dpy`; so the virgl2 capset reaches the guest with `num_video_caps = 0` and
+nothing anywhere reports an error. The guest driver then loads cleanly and
+advertises nothing, which is indistinguishable from a host that cannot decode.
+
+Turning it on exposed a second refusal underneath, and this one is a string
+comparison:
+
+```
+INFO   VA-API version: 1.24
+INFO   Driver version: VA-API NVDEC driver [direct backend]
+ERROR  only supports mesa va drivers now
+```
+
+`virgl_video_init()` rejects every VA driver whose vendor string lacks
+`Mesa Gallium`. libva had initialised and the NVDEC driver had loaded; it was
+turned away on its name. The one host API this path needs is
+`vaExportSurfaceHandle()` with `VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2`, which
+is standard rather than Mesa-specific and which `nvidia-vaapi-driver`
+implements already - it is how that driver hands frames to EGL consumers.
+Upstream's own "now" reads as provisional.
+
+Both are opt-in in the fork, and deliberately **two** knobs rather than one:
+`VIRGL_FORCE_VIDEO` enables video, `VIRGL_VIDEO_ALLOW_ANY_VA_DRIVER` accepts a
+non-Mesa driver. Enabling video and trusting this driver are different
+decisions, and keeping them separable is what makes a later failure
+attributable to one of them. Unset, both refuse exactly as upstream does.
+
+`VIRGL_FORCE_VIDEO` tests its **value**, not its presence, unlike the trace
+knobs in the same file. Those are diagnostics; this gates a capability that
+needs a negative control, and a knob that cannot express "off" is precisely how
+this program already produced one false pass on a locked Firefox pref.
+
+### The result
+
+| `VIRGL_FORCE_VIDEO` | host renderer | guest H.264 profiles |
+|---|---|---|
+| `0` | `Video not enabled` | **0** - driver loads, advertises nothing |
+| `1` | `Video initialised on drm_fd 43` | **3** - ConstrainedBaseline, Main, High |
+
+The off row reproduces the original symptom exactly, on demand. That is what
+makes this causation rather than coincidence.
+
+With the pref removed and the probe passing on the merits:
+
+```
+renderer decode      : decode_cmds=2048 sessions=1
+plane image failures : 0     BLIT failures      : 0
+layer-validation err : 0     CmdSubmit3d        : 0
+Illegal cmd buffer   : 0
+frames               : 810 total, 6 dropped
+host NVDEC           : nonzero in 35 of 35 samples
+picture              : 12,619 distinct colours, mean RGB 152,158,158
+```
+
+`decode_cmds` is the load-bearing number: the negative control established that
+it reads `0` when the Vulkan decoder is off, so a nonzero value means Vulkan
+Video decoded, not VA-API. VA-API's only job here is to answer the probe
+honestly.
+
+The NVDEC percentage sampled higher than earlier runs in this lab. That is
+**not** claimed as an improvement: this sampling window sat entirely inside
+continuous looping playback, where earlier windows included startup, and the
+earlier configuration has not been re-measured under this window. Unattributed.
 
 ---
 
@@ -302,6 +393,15 @@ Recorded because each cost real time and would otherwise be retried.
 - **Turning zero copy off to avoid the failing blit.** Moves
   `GL_INVALID_OPERATION` from the decoder context to the renderer context. Both
   consumers fail on the same badly described surface.
+- **Teaching the blit to find the later plane.** The obvious repair for the copy
+  path is to give the blit the same per-plane image the sampler view gets. It
+  does not work, and the reason is worth recording because the idea is the first
+  one anybody has: with zero copy off, the guest never imports the chroma plane
+  as a separate resource at all. Measured with `VIRGL_TRACE_IMPORT`, that run
+  produced 6482 `plane=0` imports and **zero** `plane=1` imports. There is no
+  plane for the blit to find, so plane-index inference correctly returns -1
+  every time and the blit fails for the original reason. Fixing the copy path
+  means changing what gets imported, not what the blit looks up.
 - **Resolving the plane through GBM.** `virgl_egl_aux_plane_image_from_gbm_bo()`
   is the upstream route and cannot serve here, because crosvm gives
   virglrenderer surfaceless EGL with no GBM device.

--- a/labs/venus-vulkan-video/docs/w6-findings.md
+++ b/labs/venus-vulkan-video/docs/w6-findings.md
@@ -1,20 +1,29 @@
 # W6 - unmodified Firefox decodes H.264 on the host GPU through Venus
 
-> **CORRECTION - this document overstates the result.**
+> **CORRECTION - this document overstated the result when it was written.**
+> **The defect it describes has since been fixed.**
 >
 > The headline below says unmodified Firefox decodes H.264 through Venus. The
-> decode part is true and measured. What is NOT true is any implication that
-> playback works: the decoded frames never reach the screen, and the video area
-> renders as a flat dark green after about half a second.
+> decode part was true and measured. What was NOT true was any implication that
+> playback worked: at the time, the decoded frames never reached the screen and
+> the video area rendered as a flat dark green after about half a second.
 >
-> A single GL blit in Firefox's MediaPDMDecoder context fails with
-> `GL_INVALID_OPERATION`, virglrenderer marks the context as having submitted
-> an illegal command buffer, and all 11,270 subsequent submissions to it are
-> refused. Zero of those errors come from the Venus path.
+> A single GL blit in Firefox's MediaPDMDecoder context failed with
+> `GL_INVALID_OPERATION`, virglrenderer marked the context as having submitted
+> an illegal command buffer, and all 11,270 subsequent submissions to it were
+> refused. Zero of those errors came from the Venus path.
 >
-> See [`green-frame-finding.md`](./green-frame-finding.md). The evidence in
-> this document is correct about what it measured; it measured the wrong thing
-> to support the claim it made.
+> That is now resolved. The root cause was four interlocking defects in how a
+> decoded NV12 frame's second plane crossed the guest/host boundary - three in
+> guest Mesa's virgl winsys, one in virglrenderer - none of them in Venus and
+> none of them in Firefox. Playback is correct on a clean boot, with zero blit
+> failures and zero refused submissions.
+>
+> **Read [`../SOLUTION.md`](../SOLUTION.md) for the current account**;
+> [`green-frame-finding.md`](./green-frame-finding.md) is the contemporaneous
+> investigation log. The evidence in this document is correct about what it
+> measured; it measured the wrong thing to support the claim it made, and that
+> is the part worth keeping.
 
 **Result: it works, with a passing negative control.**
 

--- a/labs/venus-vulkan-video/docs/w7-findings.md
+++ b/labs/venus-vulkan-video/docs/w7-findings.md
@@ -1,17 +1,26 @@
 # W7 - YouTube end to end
 
-> **CORRECTION - this document overstates the result.**
+> **CORRECTION - this document overstated the result when it was written.**
+> **The defect it describes has since been fixed.**
 >
 > YouTube loads, plays and drives real decode commands through Venus, and that
-> much is measured. But the frames do not reach the screen: playback shows
-> roughly half a second of video and then a flat dark green frame.
+> much was measured. But at the time the frames did not reach the screen:
+> playback showed roughly half a second of video and then a flat dark green
+> frame.
 >
-> The cause is a failing Vulkan-to-GL blit in Firefox's compositing path, not
-> anything in Venus. See [`green-frame-finding.md`](./green-frame-finding.md).
+> The cause was a failing Vulkan-to-GL blit in Firefox's compositing path, not
+> anything in Venus. It has since been root-caused to four interlocking defects
+> in how a decoded NV12 frame's second plane crossed the guest/host boundary,
+> and fixed in guest Mesa and virglrenderer. Firefox is still unpatched. See
+> [`../SOLUTION.md`](../SOLUTION.md) for the current account and
+> [`green-frame-finding.md`](./green-frame-finding.md) for the investigation
+> log.
 >
-> This also means the drop-rate numbers below measure a broken presentation
-> path and should not be read as decode performance at all -- a second reason,
-> beyond host contention, that they are not a benchmark.
+> The drop-rate numbers below were taken against that broken presentation path
+> and are not decode performance. They have not been re-measured since the fix,
+> so treat them as a record of what this wave saw rather than as a current
+> figure - a second reason, beyond host contention, that they are not a
+> benchmark.
 
 **Result: YouTube plays in unmodified Firefox with H.264 decoded on the host
 NVIDIA T1000 through Venus.** This is the prototype's stated goal.
@@ -77,11 +86,16 @@ next step is to re-run it on a quiet machine rather than to explain the number.
   decode utilisation, and the extra GPU-copy cost, compared against software
   decode. That pair is directly comparable because both run the same stock
   Firefox 153.
-- **The GPU-copy path is the target by design.** Direct DMA-BUF export stays
-  off for the whole plan (`direct-export.enabled = false`), so some copy cost is
-  expected and zero-copy is a follow-on rather than a success criterion. Whether
-  that copy is what costs 720p under load is exactly what the idle-host
-  measurement would separate.
+- **The GPU-copy path was the target when this was written, and is not the
+  path that shipped.** This wave assumed direct DMA-BUF export stays off
+  (`direct-export.enabled = false`, still true) and concluded that the copy
+  path was therefore the target, with zero-copy a follow-on rather than a
+  success criterion. That inference no longer holds: direct export and
+  Firefox's zero-copy surface handoff are separate decisions, and the working
+  configuration selects **zero copy**. The copy path remains genuinely broken,
+  because its blit goes through the resource's own texture rather than a
+  sampler view and so never reaches the per-plane images that fix the chroma
+  plane. See [`../SOLUTION.md`](../SOLUTION.md) section 6.
 - **The V4L2 comparison remains a legacy, non-comparable baseline.** It can
   only be measured with the Firefox 152 source fork, so it is a version *and*
   build-config difference. It is context, not a threshold.

--- a/labs/venus-vulkan-video/flake.lock
+++ b/labs/venus-vulkan-video/flake.lock
@@ -97,16 +97,16 @@
     "virglrenderer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1785489598,
-        "narHash": "sha256-BnDfWRwbl7a/LbpNj9wPz83WCJRh2yemV/mnw9FSYUw=",
+        "lastModified": 1785500429,
+        "narHash": "sha256-2bUyUlysrY7PSsqvOcFwE1O8uD2YsSATIl7hNoRLwpY=",
         "owner": "vicondoa",
         "repo": "virglrenderer-venus-vulkan-video",
-        "rev": "335be0b7e4f07bdbf0655d69858ad03bc48abb79",
+        "rev": "cc52ccb2f97d0ddff641c62f6b7a1a73b4981d9e",
         "type": "github"
       },
       "original": {
         "owner": "vicondoa",
-        "ref": "vulkan-video",
+        "ref": "virgl-video-enable",
         "repo": "virglrenderer-venus-vulkan-video",
         "type": "github"
       }

--- a/labs/venus-vulkan-video/flake.nix
+++ b/labs/venus-vulkan-video/flake.nix
@@ -35,8 +35,13 @@
       flake = false;
     };
 
+    # Temporarily on virgl-video-enable rather than vulkan-video. That branch
+    # is 335be0b7 (the revision v3 pins) plus the virgl-video enablement, and
+    # deliberately excludes add87c05: the blit change on vulkan-video is
+    # unproven, and compounding it with this would make a measurement of
+    # either one unattributable.
     virglrenderer-src = {
-      url = "github:vicondoa/virglrenderer-venus-vulkan-video/vulkan-video";
+      url = "github:vicondoa/virglrenderer-venus-vulkan-video/virgl-video-enable";
       flake = false;
     };
     mesa-src = {
@@ -147,46 +152,41 @@
       # cairo-gtk3-wayland. The only customization here is preferences, which
       # is explicitly allowed by the prototype's success criteria.
       #
-      # direct-export is ON: see the pref comment below. The GPU-copy path it
-      # replaces is the one that fails.
+      # direct-export is OFF: Firefox only ever requests the modifier-tiled
+      # export shape, and that exact query is refused by the host NVIDIA driver
+      # itself. See the pref comment below. Turning it off selects a non-export
+      # route; which of the two non-export routes Firefox then takes is decided
+      # separately, by whether zero-copy is configured.
       # WebM/VP9 is disabled so YouTube serves H.264 -- required permanently,
       # since no NVIDIA driver implements VK_KHR_video_decode_vp9 and Turing
       # has no AV1 engine.
       labFirefox = guestPkgs.wrapFirefox guestPkgs.firefox-unwrapped {
-        # Set as a real integer, which the policy engine cannot do here.
+        # gfx.blacklist.hardwarevideodecoding is deliberately NOT set here any
+        # more, and that is the point of the virgl-video work.
         #
-        # gfx.blacklist.hardwarevideodecoding has no default declaration, so
-        # the Preferences policy infers a boolean and creates a bool pref.
-        # GetPrefValueForFeature reads it with Preferences::GetInt, which fails
-        # on a bool and skips the override without saying so. A literal pref()
-        # line fixes the type.
+        # It used to be. gfxPlatformGtk's InitPlatformHardwareVideoConfig
+        # returns early unless HARDWARE_VIDEO_DECODING is enabled, and only
+        # past that early return is HW_DECODED_VIDEO_ZERO_COPY configured.
+        # With zero-copy unset, VideoFramePool::ShouldCopySurface returns true
+        # unconditionally and every frame takes the broken copy path. So the
+        # pref was set to 1 (FEATURE_STATUS_OK) to skip the VA-API probe that
+        # gates that feature.
         #
-        # What this buys, and why it is a diagnostic rather than a fix: it
-        # asserts a capability the guest does not have. gfxPlatformGtk's
-        # InitPlatformHardwareVideoConfig returns early unless
-        # HARDWARE_VIDEO_DECODING is enabled, and only past that early return
-        # is HW_DECODED_VIDEO_ZERO_COPY configured. With zero-copy unset,
-        # VideoFramePool::ShouldCopySurface returns true unconditionally, so
-        # every frame takes CopyYUVDataImpl and its per-plane GPU copy -- the
-        # copy that fails, because the chroma plane's imported texture is
-        # single-channel R8 while the destination is R8G8, and
-        # glCopyImageSubData compares underlying textures rather than views.
-        # Luma copies and chroma does not, which is the green cast.
+        # That was a diagnostic rather than a fix, and it was written down as
+        # one: it asserted a capability the guest did not have. The probe could
+        # not pass honestly, because the guest's virtio_gpu VA driver loaded
+        # and initialised and then advertised no H.264 profiles at all.
         #
-        # The probe cannot pass honestly here: the virtio-gpu VA driver loads
-        # and initialises but advertises no H.264 profiles, and
-        # media.hardware-video-decoding.force-enabled is outranked by gfxInfo's
-        # runtime ForceDisable. GfxInfoBase::GetFeatureStatus consults this
-        # pref and returns before GetFeatureStatusImpl, where the probe lives,
-        # so this skips the probe rather than satisfying it. 1 is
-        # FEATURE_STATUS_OK.
+        # It advertises them now. crosvm never passes VIRGL_RENDERER_USE_VIDEO,
+        # so virglrenderer never called virgl_video_init(), so va_dpy stayed
+        # NULL and the virgl2 capset reached the guest with num_video_caps = 0.
+        # With video initialised the guest reports H264 ConstrainedBaseline,
+        # Main and High, so the probe passes on the merits and the assertion is
+        # no longer needed.
         #
-        # Decoding is unaffected: InitHWDecoderIfAllowed tries
-        # InitVulkanDecoder() before InitVAAPIDecoder(), so Vulkan still
-        # decodes and VA-API is never used for a frame.
-        extraPrefs = ''
-          pref("gfx.blacklist.hardwarevideodecoding", 1);
-        '';
+        # Decode is still Vulkan Video, not VA-API: InitHWDecoderIfAllowed
+        # tries InitVulkanDecoder() before InitVAAPIDecoder(), so VA-API is
+        # what makes the capability true, never what decodes a frame.
         extraPolicies = {
           DisableTelemetry = true;
           DisableFirefoxStudies = true;
@@ -238,9 +238,14 @@
             # ffmpeg double-free in vulkan_map_to_drm's error path, which is
             # only reachable when the export fails.
             #
-            # The copy path this selects already decodes in hardware. Its own
-            # defect -- a GL blit that virgl rejects -- is in virglrenderer,
-            # which this lab forks, and is the remaining work.
+            # This selects a non-export route, not specifically the copy route.
+            # Firefox has two non-export routes and picks between them on
+            # whether HW_DECODED_VIDEO_ZERO_COPY is configured; the working
+            # configuration gets zero copy. The copy route is still broken, and
+            # separately so: its blit goes through the resource's own texture
+            # rather than a sampler view, so it never reaches the per-plane
+            # images that fix the chroma plane. That is in virglrenderer, which
+            # this lab forks, and is recorded in SOLUTION.md section 6.
             "media.hardware-video-decoding-vulkan.direct-export.enabled" =
               { Value = false; Status = "default"; };
             # Also NOT locked, for the same reason and a measured one.
@@ -258,12 +263,10 @@
             # preserves that; unlocking it lets the control actually control.
             "media.hardware-video-decoding.force-enabled" =
               { Value = true; Status = "default"; };
-            # NOTE: gfx.blacklist.hardwarevideodecoding is deliberately NOT set
-            # here. The policy engine has no default declaration to infer a
-            # type from and creates it as a boolean, while
-            # GetPrefValueForFeature reads it with Preferences::GetInt, which
-            # fails on a bool and silently skips the override. It is set as a
-            # real integer through extraPrefs below instead.
+            # NOTE: gfx.blacklist.hardwarevideodecoding is no longer set at all,
+            # here or through extraPrefs. It existed to skip a VA-API probe the
+            # guest could not pass; the guest passes it now. See the comment on
+            # labFirefox.
             #
             # Pin zero-copy on rather than leaving it to the blocklist.
             # 0 forces off, 1 forces on, anything else defers to gfxInfo.

--- a/labs/venus-vulkan-video/guest/configuration.nix
+++ b/labs/venus-vulkan-video/guest/configuration.nix
@@ -191,6 +191,13 @@
     grim                  # screenshot the cage output -- see below
     labFirefox
 
+    # vainfo: whether the guest's virtio_gpu VA driver advertises any decode
+    # profile. This distinguishes the two states that otherwise look identical
+    # from inside Firefox -- the driver loading and reporting nothing, versus
+    # the driver reporting H.264 -- and the first of those is what made a
+    # capability the guest genuinely lacked look like a host limitation.
+    libva-utils
+
     # Answers whether Venus can export a decode-output image as a DMA-BUF.
     #
     # Built here rather than compiled ad hoc and copied in, because it has to

--- a/labs/venus-vulkan-video/host/run-lab-vm.sh
+++ b/labs/venus-vulkan-video/host/run-lab-vm.sh
@@ -300,6 +300,30 @@ main() {
             VREND_DEBUG VIRGL_TRACE_DMABUF_IMPORT VIRGL_TRACE_BLIT VIRGL_TRACE_IMPORT VK_LOADER_DEBUG VK_INSTANCE_LAYERS; do
     [ -n "${!ev:-}" ] && bw+=(--setenv "$ev" "${!ev}")
   done
+  # Turn on virglrenderer's video (VA-API) backend.
+  #
+  # crosvm never passes VIRGL_RENDERER_USE_VIDEO: rutabaga_gfx generates the
+  # constant and references it nowhere, and its VirglRendererFlags has no
+  # builder for bit 11. Without it virgl_video_init() never runs, va_dpy stays
+  # NULL, virgl_video_fill_caps() returns early, and the guest's virtio_gpu VA
+  # driver advertises no profiles at all - which looks like a missing host
+  # capability rather than an unset flag.
+  #
+  # Defaulted on rather than forced, so the negative control can turn it off
+  # with VIRGL_FORCE_VIDEO=0. The renderer tests the value, not merely its
+  # presence, so that control genuinely controls.
+  bw+=(--setenv VIRGL_FORCE_VIDEO "${VIRGL_FORCE_VIDEO:-1}")
+  # Accept the host's non-Mesa VA driver.
+  #
+  # virglrenderer refuses any VA driver whose vendor string lacks "Mesa
+  # Gallium". Here that is the only thing between the guest and a decoder:
+  # libva initialises, nvidia-vaapi-driver loads and reports H.264 Main, High
+  # and ConstrainedBaseline, and it is turned away on the string alone.
+  #
+  # Kept separate from VIRGL_FORCE_VIDEO on purpose. Turning video on and
+  # accepting a non-Mesa driver are different decisions, and separable knobs
+  # are what make a later failure attributable to one of them.
+  bw+=(--setenv VIRGL_VIDEO_ALLOW_ANY_VA_DRIVER "${VIRGL_VIDEO_ALLOW_ANY_VA_DRIVER:-1}")
   # The broad /etc bind is needed for the Vulkan loader and NSS config, but it
   # would also expose /etc/d2b to the sidecar -- which the lab isolation
   # contract (AGENTS.md rule 3) forbids. Mask it with an empty tmpfs so the


### PR DESCRIPTION
## What this is

The Venus Vulkan Video prototype already reached hardware decode with an **unmodified Firefox**. But it got there partly by lying to the browser: it set `gfx.blacklist.hardwarevideodecoding` to `FEATURE_STATUS_OK` so Firefox would skip a VA-API probe the guest could not pass, because that probe gates `HW_DECODED_VIDEO_ZERO_COPY` and zero copy is the only working presentation route.

The lie was documented as a lie, which beats hiding it, but it was still an assertion about a capability the guest did not have.

**The guest has the capability now, so the pref is gone.** Firefox remains unpatched.

## Root cause

The guest's `virtio_gpu` VA driver advertising nothing looked like a missing host capability. It was one flag. Measured in order, each step narrowing the next:

| Question | Answer |
|---|---|
| Does the host do VA-API H.264 at all? | Yes - Main, High, ConstrainedBaseline, NVDEC direct backend |
| Does it still work inside the crosvm GPU sidecar's exact bwrap bind set? | Yes, identical |
| Is virglrenderer built with video? | Yes, `-Dvideo=true` |
| Does rutabaga supply the `get_drm_fd` callback video needs? | Yes |
| Does anything pass `VIRGL_RENDERER_USE_VIDEO`? | **No** |

`VIRGL_RENDERER_USE_VIDEO` is bit 11 of the flags word `virgl_renderer_init()` takes. `rutabaga_gfx` generates the constant into its bindings and references it nowhere; `VirglRendererFlags` stops at bit 10, exposes no `use_video()` builder, and keeps its `u32` private, so crosvm cannot set the bit even deliberately.

The failure is silent because of where it lands: `virgl_video_init()` assigns `va_dpy`, `virgl_video_fill_caps()` returns `-1` immediately on a NULL `va_dpy`, so the virgl2 capset reaches the guest with `num_video_caps = 0` and nothing anywhere reports an error.

Enabling it exposed a second refusal, and this one is a string comparison:

```
INFO   VA-API version: 1.24
INFO   Driver version: VA-API NVDEC driver [direct backend]
ERROR  only supports mesa va drivers now
```

libva had initialised and `nvidia-vaapi-driver` had loaded and reported H.264. It was turned away on its name. The only host API this path needs is `vaExportSurfaceHandle()` with `DRM_PRIME_2`, which is standard rather than Mesa-specific and which that driver implements already.

## Shape of the change

Both live in the virglrenderer fork behind their own opt-in, **deliberately two knobs and not one**: enabling video and trusting a non-Mesa driver are different decisions, and separable knobs keep a later failure attributable. Unset, the fork behaves exactly as upstream.

`VIRGL_FORCE_VIDEO` tests its **value**, not its presence, unlike the trace knobs beside it. Those are diagnostics; this gates a capability that needs a negative control, and a knob that cannot say "off" is how this program already bought one false pass on a locked Firefox pref.

The correct upstream fix belongs in `rutabaga_gfx` and crosvm. This reaches the capability without patching a vendored Rust crate and its checksum manifest, and says so in the comment.

## Validation

**Negative control reproduces the original symptom on demand** - this is what makes it causation rather than coincidence:

| `VIRGL_FORCE_VIDEO` | host renderer | guest H.264 profiles |
|---|---|---|
| `0` | `Video not enabled` | **0** - driver loads, advertises nothing |
| `1` | `Video initialised on drm_fd 43` | **3** - ConstrainedBaseline, Main, High |

With the pref removed, on a clean boot:

```
renderer decode      : decode_cmds=2048 sessions=1
plane image failures : 0     BLIT failures      : 0
layer-validation err : 0     CmdSubmit3d        : 0
Illegal cmd buffer   : 0
frames               : 810 total, 6 dropped
host NVDEC           : nonzero in 35 of 35 samples
picture              : 12,619 distinct colours, mean RGB 152,158,158
```

`decode_cmds` is the load-bearing number: an earlier negative control established it reads `0` when the Vulkan decoder is off, so **Vulkan Video still decodes every frame** and VA-API only answers the probe. `InitHWDecoderIfAllowed()` tries `InitVulkanDecoder()` before `InitVAAPIDecoder()`.

Binding proven rather than assumed, per the lab's rule 6: `ldd` confirms crosvm loads exactly the video-enabled virglrenderer build, and the VA-API probe was run *inside* the sidecar's bwrap bind set rather than from a host shell.

Gates: `make check-tier0` PASS, `make test-lint` PASS, `make test-changelog` PASS.

### Not claimed

The NVDEC percentage sampled higher than earlier runs in this lab. That is **not** claimed as an improvement: this window sat entirely inside continuous looping playback where earlier windows included startup, and the old configuration was not re-measured under this window. Recorded as unattributed.

## Fork pinning

The virglrenderer input tracks `virgl-video-enable`, not `vulkan-video`. That branch is `335be0b7` - the revision `v3` already pins - plus these two commits, and it deliberately excludes `add87c05`: the blit change on `vulkan-video` is unproven, and compounding the two would make a measurement of either one unattributable.

## Record corrections

Also corrects the record where it had gone stale:

- `w6-findings.md` and `w7-findings.md` still described the green frame in the present tense after it was root-caused and fixed.
- `w7-findings.md` called the GPU-copy path "the target by design" when the shipped configuration selects zero copy.
- Two `flake.nix` comments stated the opposite of the preferences declared beneath them - one asserting direct export was ON while the pref set it `false`.
- `SOLUTION.md` gains the measurement that closes off the obvious copy-path repair: with zero copy off the guest never imports the chroma plane at all (6482 `plane=0` imports against **zero** `plane=1`), so there is no plane for a blit to find and the fix has to change what is imported, not what the blit looks up.

`w3-findings.md` was reviewed and **left alone**: it makes no playback claim and its four open items are all still open. An earlier note listing it as stale was wrong.

## Status

This remains an isolated experimental prototype, wired into nothing, governed by `labs/venus-vulkan-video/AGENTS.md`. It is not a replacement for the forked-Firefox path yet. The non-Mesa VA driver acceptance is unproven upstream and marked as such in the code, and the GPU-copy path is still broken - zero copy is what works.
