### PR TITLE
labs: correct an overstated capability claim about the guest's VA-API decode

### DIFF
--- a/changelog.d/venus-lab-va-honesty.md
+++ b/changelog.d/venus-lab-va-honesty.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Corrected an overstated claim in the Venus Vulkan Video lab prototype. Enabling
+  the virgl video backend makes the guest advertise H.264 through VA-API, and
+  that is what Firefox's capability probe reads, but the advertisement was
+  described as a proven capability without the measurement that would establish
+  it. A guest VA-API decode has since been measured against the same decode on
+  the host: the host engaged the hardware decoder at 94 to 98 percent while the
+  guest engaged it at zero percent on every sample, running well faster than the
+  hardware itself. Removing the preference therefore replaces a bypassed probe
+  with an unverified advertisement rather than a demonstrated capability. What
+  decodes is unchanged and unaffected: Firefox decodes through Vulkan Video,
+  which is measured as hardware backed, and never through VA-API.

--- a/labs/venus-vulkan-video/README.md
+++ b/labs/venus-vulkan-video/README.md
@@ -31,9 +31,16 @@ was wrong and why each change is needed; the short version is below.
 
 The lab no longer asserts a capability the guest lacks. It previously set
 `gfx.blacklist.hardwarevideodecoding` to skip a VA-API probe the guest could not
-pass, which was a diagnostic rather than a fix. The guest passes that probe on
-the merits now, and the pref is gone - see `SOLUTION.md` section 6a. Decode is
-still Vulkan Video; VA-API only answers the capability question.
+pass, which was a diagnostic rather than a fix. The guest advertises H.264
+through VA-API now, so Firefox reaches its own conclusion instead of having the
+probe bypassed, and the pref is gone.
+
+Read one limit with that: the guest's VA-API decode has since been measured
+**not** to reach the host decode engine, where the same probe on the host
+reaches 94-98%. So the advertisement Firefox reads has not been shown to be
+hardware backed. It does not affect what decodes - that is Vulkan Video, and it
+is genuinely hardware backed - but the pref removal rests on a weaker footing
+than "the capability is real". See `SOLUTION.md` section 6a.
 
 ### Reading the NVDEC number
 

--- a/labs/venus-vulkan-video/SOLUTION.md
+++ b/labs/venus-vulkan-video/SOLUTION.md
@@ -352,7 +352,7 @@ this program already produced one false pass on a locked Firefox pref.
 The off row reproduces the original symptom exactly, on demand. That is what
 makes this causation rather than coincidence.
 
-With the pref removed and the probe passing on the merits:
+With the pref removed and the probe passing on what the driver reports:
 
 ```
 renderer decode      : decode_cmds=2048 sessions=1
@@ -366,13 +366,80 @@ picture              : 12,619 distinct colours, mean RGB 152,158,158
 
 `decode_cmds` is the load-bearing number: the negative control established that
 it reads `0` when the Vulkan decoder is off, so a nonzero value means Vulkan
-Video decoded, not VA-API. VA-API's only job here is to answer the probe
-honestly.
+Video decoded, not VA-API.
 
 The NVDEC percentage sampled higher than earlier runs in this lab. That is
 **not** claimed as an improvement: this sampling window sat entirely inside
 continuous looping playback, where earlier windows included startup, and the
 earlier configuration has not been re-measured under this window. Unattributed.
+
+### Correction: the guest's VA-API decode is not hardware backed
+
+An earlier revision of this section said the probe now passes "on the merits"
+and called the capability real without qualification. That was overstated, and
+the measurement that should have accompanied the claim contradicts it.
+
+What was actually established is that the guest **advertises** H.264 through
+VA-API, and that the advertisement is what Firefox's probe reads. Whether that
+advertisement is honest all the way to the decode engine is a separate question,
+and it was not asked before the claim was made.
+
+Asked afterwards, with the same probe run on both stacks:
+
+| Decode | Frames | Speed | Host NVDEC |
+|---|---:|---:|---:|
+| Host-native VA-API | 72,180 | 46x | **94-98%** |
+| Guest VA-API through virgl | 135,090 | 264x | **0%, every sample** |
+
+The host row is the control, and it earns its keep twice: it proves the
+instrument attributes NVDEC correctly, and it proves `nvidia-vaapi-driver`
+drives the engine. So the guest row is not a measurement artefact.
+
+The speed is the tell. The guest path ran **5.7x faster than the real hardware
+decoder** while reporting 0 decode errors. Nothing beats the decode engine by
+5.7x while using it, so whatever the guest is doing, it is not that.
+
+Two readings that were wrong along the way, recorded because both are easy to
+repeat:
+
+- **`h264 (native)` in the stream mapping does not mean software.** With
+  `-hwaccel`, "native" names the *decoder*; the hwaccel backend does the work.
+  `pix_fmt: vaapi` is the field that actually answers the question.
+- **`-hwaccel_output_format vaapi` exiting 0 does not prove hardware decode.**
+  It proves VA-API surfaces were produced, not that a decode engine produced
+  them.
+
+### What this does and does not change
+
+Unaffected, and still measured:
+
+- Firefox carries no patches.
+- Firefox decodes through **Vulkan Video**, not VA-API. `InitHWDecoderIfAllowed()`
+  tries `InitVulkanDecoder()` before `InitVAAPIDecoder()`, `decode_cmds` is
+  nonzero, and host NVDEC is nonzero during Firefox playback. That path is
+  genuinely hardware backed.
+- Removing `gfx.blacklist.hardwarevideodecoding` is still the right move and
+  still works: Firefox now reaches its own conclusion from what the driver
+  reports, instead of having the probe bypassed. Playback is correct with zero
+  errors on every surface.
+
+Changed:
+
+- The justification is weaker than claimed. The pref removal replaced "assert a
+  capability the guest does not have" with "rely on a capability the guest
+  advertises but has not been shown to possess". That is an improvement, not the
+  clean result the earlier wording described.
+- The residual risk is narrow but real: if Firefox ever selected VA-API ahead of
+  Vulkan, it would be selecting on an advertisement this lab has now measured
+  against. It does not select it today.
+
+Open, and deliberately not guessed at here: where the guest VA path actually
+terminates. The caps reach the guest, which is why the profiles appear, but the
+decode does not reach NVDEC. Whether virgl's video protocol is carrying the
+decode at all, and what those 135,090 frames contained, is unmeasured. The next
+step is to instrument both ends of a single guest VA decode, which is the method
+that resolved the plane defects and the method whose absence produced the
+overstatement above.
 
 ---
 

--- a/labs/venus-vulkan-video/flake.nix
+++ b/labs/venus-vulkan-video/flake.nix
@@ -181,12 +181,18 @@
         # so virglrenderer never called virgl_video_init(), so va_dpy stayed
         # NULL and the virgl2 capset reached the guest with num_video_caps = 0.
         # With video initialised the guest reports H264 ConstrainedBaseline,
-        # Main and High, so the probe passes on the merits and the assertion is
-        # no longer needed.
+        # Main and High, so Firefox reaches its own conclusion from what the
+        # driver reports instead of having the probe bypassed.
         #
-        # Decode is still Vulkan Video, not VA-API: InitHWDecoderIfAllowed
-        # tries InitVulkanDecoder() before InitVAAPIDecoder(), so VA-API is
-        # what makes the capability true, never what decodes a frame.
+        # That advertisement has NOT been shown to be hardware backed. A guest
+        # VA-API decode was later measured against the same decode on the host:
+        # the host reached 94-98% NVDEC, the guest reached 0% on every sample
+        # while running 5.7x faster than the real decoder. So this removes a
+        # bypass rather than establishing a capability. See SOLUTION.md 6a.
+        #
+        # It does not affect what decodes. InitHWDecoderIfAllowed tries
+        # InitVulkanDecoder() before InitVAAPIDecoder(), so Vulkan Video decodes
+        # every frame and VA-API is never used for one.
         extraPolicies = {
           DisableTelemetry = true;
           DisableFirefoxStudies = true;


### PR DESCRIPTION
## Why

PR #353 said the guest's video capability was "real" and that Firefox's probe passes "on the merits". **That was overstated, and this withdraws it.**

What #353 actually established is that the guest **advertises** H.264 through VA-API, and that the advertisement is what the probe reads. Whether that advertisement is honest all the way to the decode engine is a separate question. I did not ask it before making the claim.

## Asked afterwards

Same probe, both stacks:

| Decode | Frames | Speed | Host NVDEC |
|---|---:|---:|---:|
| Host-native VA-API | 72,180 | 46x | **94-98%** |
| Guest VA-API through virgl | 135,090 | 264x | **0%, every sample** |

The host row is the control, and it earns its keep twice: it proves the instrument attributes NVDEC correctly, and it proves `nvidia-vaapi-driver` drives the engine. So the guest row is not an artefact of either.

**The speed is the tell.** The guest path ran **5.7x faster than the real hardware decoder** while reporting zero decode errors. Nothing beats the decode engine by 5.7x while using it.

## Two wrong readings on the way here

Recorded because both are easy to repeat, and I asserted one of them:

- **`h264 (native)` in ffmpeg's stream mapping does not mean software.** With `-hwaccel`, "native" names the *decoder*; the hwaccel backend does the work. `pix_fmt: vaapi` is the field that answers the question. I initially read this as a software fallback and was wrong.
- **`-hwaccel_output_format vaapi` exiting 0 does not prove hardware decode.** It proves VA-API surfaces were produced, not what produced them. I initially cited this as proof and was wrong.

## What does not change

All still measured, all unaffected:

- Firefox carries **no patches**.
- Firefox decodes through **Vulkan Video**, not VA-API. `InitHWDecoderIfAllowed()` tries `InitVulkanDecoder()` before `InitVAAPIDecoder()`, `decode_cmds` is nonzero, and host NVDEC is nonzero during Firefox playback. **That path is genuinely hardware backed.**
- Removing `gfx.blacklist.hardwarevideodecoding` is still correct and still works. Playback is correct with zero errors on every surface.

## What does change

The **justification**. The pref removal replaces "assert a capability the guest does not have" with "rely on a capability the guest advertises and has not been shown to possess". That is an improvement over a bypassed probe, but it is not the clean result #353's wording described.

Residual risk is narrow: if Firefox ever preferred VA-API over Vulkan it would be selecting on an advertisement now measured against. It does not today.

## Left open, deliberately not guessed at

Where the guest VA path actually terminates. The caps reach the guest, which is why the profiles appear, but the decode does not reach NVDEC, and what those 135,090 frames contained is unmeasured.

The next step is to instrument both ends of a single guest VA decode - the method that resolved the plane defects in #352, and the method whose absence produced the overstatement this PR withdraws.

## Validation

Documentation and comments only; no behaviour change. `make check-tier0` PASS, `make test-lint` PASS, `make test-changelog` PASS.
