### PR TITLE
labs: locate where the guest VA-API decode terminates

### DIFF
--- a/changelog.d/venus-lab-va-terminus.md
+++ b/changelog.d/venus-lab-va-terminus.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- Located where the Venus Vulkan Video lab prototype's guest VA-API decode
+  terminates, closing a question the previous entry left open. Counting the
+  virgl decode path the way the Venus path was already counted shows the guest
+  sends decode commands and every buffer-creation and render call on the host
+  succeeds, after which the call that commits the decode is rejected by the
+  host driver for every frame with a decoding error. That accounts for the idle
+  hardware decoder, the impossibly fast throughput, and the absence of any error
+  visible to the guest.
+- Reclassified virglrenderer's Mesa-only video driver restriction from
+  conservative to load bearing. Exporting a decoded surface uses a standard
+  interface the host driver implements, which is why the restriction looked
+  removable, but consuming the renderer's picture parameters and slice data is
+  the part that fails. The lab's override is retained as an investigation tool
+  with a warning naming the failing call and status, not as a capability.

--- a/labs/venus-vulkan-video/SOLUTION.md
+++ b/labs/venus-vulkan-video/SOLUTION.md
@@ -433,13 +433,82 @@ Changed:
   Vulkan, it would be selecting on an advertisement this lab has now measured
   against. It does not select it today.
 
-Open, and deliberately not guessed at here: where the guest VA path actually
-terminates. The caps reach the guest, which is why the profiles appear, but the
-decode does not reach NVDEC. Whether virgl's video protocol is carrying the
-decode at all, and what those 135,090 frames contained, is unmeasured. The next
-step is to instrument both ends of a single guest VA decode, which is the method
-that resolved the plane defects and the method whose absence produced the
-overstatement above.
+### Where it terminates
+
+That question is now answered, by counting the virgl decode path the way the
+Venus one was already counted. Adding the counter took one small change; not
+having it is why the earlier claim went unchallenged.
+
+The guest is not the problem. Commands flow all the way across:
+
+```
+VIRGL-VIDEO-EVIDENCE decode_bitstream=2048 failed=0 last_err=0
+```
+
+The guest sends decode commands, virglrenderer receives them, and every
+`vaCreateBuffer` and `vaRenderPicture` succeeds. Then:
+
+```
+ERROR  end picture failed, err = 0x17
+```
+
+2790 of them in one run, no other error code. `0x17` is
+`VA_STATUS_ERROR_DECODING_ERROR`. The submission stage succeeds and
+`vaEndPicture` - the call that actually commits the decode - is rejected by
+`nvidia-vaapi-driver` for every frame.
+
+That explains all three observations at once: NVDEC stays idle because no
+decode is ever committed; the path runs 5.7x faster than real hardware because
+nothing decodes; and the guest sees no error because the failure is entirely
+host side and never travels back.
+
+It also means the counter that read `failed=0` was measuring the wrong stage.
+It counts `decode_bitstream`, which is `vaRenderPicture`; the failure is one
+call later. A counter placed one stage short of the failure reports success
+just as confidently as a correct one.
+
+### The upstream check was load bearing after all
+
+The `Mesa Gallium` refusal was overridden on the reading that it looked
+conservative: the only host API this path needs to return a frame is
+`vaExportSurfaceHandle()` with `DRM_PRIME_2`, which is standard and which
+`nvidia-vaapi-driver` implements.
+
+That reading was wrong, and this is what wrong looks like when it is measured
+rather than argued. Export was never the hard part. **Consuming
+virglrenderer's picture parameters and slice data is**, and this driver will
+not. Upstream's "only supports mesa va drivers now" is a real constraint on
+this driver, not an unreviewed leftover.
+
+The override is kept, reclassified from unproven to known-failing, because the
+failure is now precisely located and worth being able to reproduce. Its warning
+names the call, the status code and the conclusion.
+
+Keeping it separate from `VIRGL_FORCE_VIDEO` is what made this attributable at
+all: video initialisation was correct and stayed correct, and the driver was
+the thing that did not work. A single combined knob would have left both
+suspects alive.
+
+### Consequences for the pref
+
+`gfx.blacklist.hardwarevideodecoding` stays removed, and the reasoning is now
+fully in the open rather than resting on an assumption:
+
+- Firefox decodes through Vulkan Video, which is measured as hardware backed.
+  It never uses VA-API for a frame.
+- Removing the pref stops bypassing the probe, which is strictly more
+  transparent than asserting `FEATURE_STATUS_OK` over it.
+- The advertisement Firefox reads is nonetheless **not** hardware backed on
+  this host, and that is now a measured fact rather than an open question.
+
+The residual risk is unchanged and narrow: a Firefox that preferred VA-API over
+Vulkan would select on an advertisement whose decode fails. It does not, because
+`InitHWDecoderIfAllowed()` tries `InitVulkanDecoder()` first.
+
+Making the advertisement honest means making `vaEndPicture` succeed on a
+non-Mesa driver, which is upstream work in virglrenderer's picture-parameter
+and slice-data construction, not configuration. It is not required for this
+prototype, whose decode path is Vulkan Video.
 
 ---
 

--- a/labs/venus-vulkan-video/flake.lock
+++ b/labs/venus-vulkan-video/flake.lock
@@ -97,11 +97,11 @@
     "virglrenderer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1785500429,
-        "narHash": "sha256-2bUyUlysrY7PSsqvOcFwE1O8uD2YsSATIl7hNoRLwpY=",
+        "lastModified": 1785511641,
+        "narHash": "sha256-xdbvml8iTenOun3NNH8l/oDyk73XN5Exg4yG19K7owA=",
         "owner": "vicondoa",
         "repo": "virglrenderer-venus-vulkan-video",
-        "rev": "cc52ccb2f97d0ddff641c62f6b7a1a73b4981d9e",
+        "rev": "c93b82a1a67f566919c6fe49df976622843226bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Why

PR #354 left one question deliberately open rather than guessing: *where does the guest VA-API decode actually terminate?* It said the next step was to instrument both ends of a single guest VA decode. This does that.

## The answer

**The guest is not the problem.** Commands cross the boundary intact:

```
VIRGL-VIDEO-EVIDENCE decode_bitstream=2048 failed=0 last_err=0
```

Every `vaCreateBuffer` and `vaRenderPicture` on the host succeeds. Then:

```
ERROR  end picture failed, err = 0x17
```

**2,790 of them in one run, no other error code.** `0x17` is `VA_STATUS_ERROR_DECODING_ERROR`. The submission stage succeeds and `vaEndPicture` - the call that actually commits the decode - is rejected by `nvidia-vaapi-driver` for every frame.

That accounts for all three earlier observations at once:

- **NVDEC stays idle** because no decode is ever committed
- **The path runs 5.7x faster than real hardware** because nothing decodes
- **The guest sees no error** because the failure is entirely host side and never travels back

## A methodological note worth keeping

The counter I added read `failed=0`. It was measuring the **wrong stage**: it counts `decode_bitstream`, which is `vaRenderPicture`, and the failure is one call later at `vaEndPicture`.

A counter placed one stage short of a failure reports success just as confidently as a correct one. That is the second time in this investigation an instrument agreed with a wrong claim.

## The upstream check was load bearing after all

I overrode virglrenderer's `Mesa Gallium` refusal on the reading that it looked conservative: the only host API this path needs to return a frame is `vaExportSurfaceHandle()` with `DRM_PRIME_2`, which is standard and which `nvidia-vaapi-driver` implements.

That reading was wrong, and now it is wrong *by measurement* rather than by argument. **Export was never the hard part.** Consuming virglrenderer's picture parameters and slice data is, and this driver will not.

The override is **kept but reclassified** from "unproven" to "known-failing", because the failure is now precisely located and worth being able to reproduce. Its warning names the failing call, the status code, and the conclusion.

Keeping it separate from `VIRGL_FORCE_VIDEO` is what made this attributable at all: video initialisation was correct throughout, and the driver was the thing that did not work. One combined knob would have left both suspects alive.

## Consequences for the pref

`gfx.blacklist.hardwarevideodecoding` **stays removed**, with the reasoning now fully in the open:

- Firefox decodes through **Vulkan Video**, measured as hardware backed, and never uses VA-API for a frame.
- Not bypassing the probe is strictly more transparent than asserting `FEATURE_STATUS_OK` over it.
- The advertisement Firefox reads is still not hardware backed - but that is now a **measured fact with a named cause**, not an open question.

Residual risk is unchanged and narrow: a Firefox preferring VA-API over Vulkan would select on an advertisement whose decode fails. It does not, because `InitHWDecoderIfAllowed()` tries `InitVulkanDecoder()` first.

Making the advertisement honest means making `vaEndPicture` succeed on a non-Mesa driver, which is upstream work in virglrenderer's picture-parameter and slice-data construction, not configuration. It is not required for this prototype, whose decode path is Vulkan Video.

## Validation

Instrumentation, docs and comments; no change to the decode path Firefox uses. `make check-tier0` PASS, `make test-lint` PASS, `make test-changelog` PASS.

Runtime evidence gathered on the live lab against the T1000, then stopped and reaped.
