### PR TITLE
labs: name the exact blocker behind the guest VA-API decode failure

### DIFF
--- a/changelog.d/venus-lab-va-endpicture.md
+++ b/changelog.d/venus-lab-va-endpicture.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- Named the exact blocker behind the Venus Vulkan Video lab prototype's guest
+  VA-API decode failure, rather than leaving it as upstream work of unknown
+  size. The host driver rejects the decode at its hardware entry point with an
+  invalid-value error because virglrenderer supplies no per-slice decode
+  parameters, and it supplies none because the virgl video wire format carries
+  only a slice count and no per-slice size, offset, type, or first-macroblock
+  field. Drivers that re-parse the bitstream themselves do not need those
+  fields, which is why the format never carried them and why the restriction to
+  those drivers is accurate rather than merely cautious. Lifting it requires
+  extending the wire format across guest and host for every codec, which is a
+  protocol change and is not needed by this prototype, whose decode path is
+  Vulkan Video.

--- a/labs/venus-vulkan-video/SOLUTION.md
+++ b/labs/venus-vulkan-video/SOLUTION.md
@@ -506,9 +506,68 @@ Vulkan would select on an advertisement whose decode fails. It does not, because
 `InitHWDecoderIfAllowed()` tries `InitVulkanDecoder()` first.
 
 Making the advertisement honest means making `vaEndPicture` succeed on a
-non-Mesa driver, which is upstream work in virglrenderer's picture-parameter
-and slice-data construction, not configuration. It is not required for this
-prototype, whose decode path is Vulkan Video.
+non-Mesa driver. That is not configuration, and it is not a small fix.
+
+### Why, exactly
+
+The driver's own log names the failing call:
+
+```
+nvEndPicture cuvidDecodePicture failed: 1
+```
+
+`cuvidDecodePicture` is NVDEC's entry point and `1` is
+`CUDA_ERROR_INVALID_VALUE`. Surfaces are created without complaint
+(`nvCreateSurfaces2 Creating surface 1280x720, format 1`), so the rejection is
+the picture itself.
+
+virglrenderer's `h264_fill_slice_param()` sets two fields and leaves the rest
+commented out:
+
+```c
+//vasp->slice_data_size;
+//vasp->slice_data_offset;
+//vasp->slice_data_flag;
+//vasp->slice_data_bit_offset;
+//vasp->first_mb_in_slice;
+//vasp->slice_type;
+ITEM_SET(vasp, desc, num_ref_idx_l0_active_minus1);
+ITEM_SET(vasp, desc, num_ref_idx_l1_active_minus1);
+```
+
+That looks like laziness. It is not. **The data is not on the wire.** The
+protocol's `virgl_h264_picture_desc` carries exactly one slice-related field:
+
+```c
+uint32_t slice_count;
+```
+
+A count. No per-slice size, offset, type, or first-macroblock. So
+`h264_fill_slice_param()` cannot populate those fields, because the guest never
+sent them.
+
+### Why that is fine for Mesa and fatal for NVDEC
+
+The virgl video protocol was designed against Mesa's VA drivers, which hand the
+bitstream to hardware that parses slice headers itself. A driver that re-parses
+does not need per-slice VA parameters, so the protocol never carried them.
+
+NVDEC does not re-parse. `nvidia-vaapi-driver` builds `CUVIDPICPARAMS` from the
+VA slice parameters, gets zeros where offsets and sizes belong, and
+`cuvidDecodePicture` correctly rejects it.
+
+So the constraint is **architectural, not a bug**. Upstream's
+"only supports mesa va drivers now" is an accurate statement about what the
+protocol can express. Lifting it requires extending the virgl video wire format
+to carry per-slice parameters, across guest Mesa and virglrenderer, for every
+codec - a protocol change, not a patch.
+
+The lab's decision rule covers exactly this case: when forwarding is blocked by
+a fundamental limitation, stop and document the exact blocker rather than
+inventing a second architecture. This is that blocker, named to the field.
+
+None of it is required here. This prototype decodes through Vulkan Video, which
+is a different path with its own wire format, and which works.
 
 ---
 

--- a/labs/venus-vulkan-video/host/run-lab-vm.sh
+++ b/labs/venus-vulkan-video/host/run-lab-vm.sh
@@ -324,6 +324,13 @@ main() {
   # accepting a non-Mesa driver are different decisions, and separable knobs
   # are what make a later failure attributable to one of them.
   bw+=(--setenv VIRGL_VIDEO_ALLOW_ANY_VA_DRIVER "${VIRGL_VIDEO_ALLOW_ANY_VA_DRIVER:-1}")
+  # nvidia-vaapi-driver's own diagnostic channel.
+  #
+  # It rejects vaEndPicture with 0x17 (VA_STATUS_ERROR_DECODING_ERROR) for
+  # every frame virglrenderer submits. VA-API status codes carry no detail, so
+  # the driver's own log is the only place the reason exists. Off unless the
+  # caller asks, since it prints per frame.
+  [ -n "${NVD_LOG:-}" ] && bw+=(--setenv NVD_LOG "$NVD_LOG")
   # The broad /etc bind is needed for the Vulkan loader and NSS config, but it
   # would also expose /etc/d2b to the sidecar -- which the lab isolation
   # contract (AGENTS.md rule 3) forbids. Mask it with an empty tmpfs so the


### PR DESCRIPTION
## Why

PR #355 located the failure at `vaEndPicture` and called the fix "upstream work in picture-parameter and slice-data construction". True, but unhelpfully vague about its size. Asking `nvidia-vaapi-driver` directly, through its own diagnostic channel, makes it precise.

## The blocker, named to the field

```
nvEndPicture cuvidDecodePicture failed: 1
```

`cuvidDecodePicture` is NVDEC's entry point; `1` is `CUDA_ERROR_INVALID_VALUE`. Surfaces are created without complaint (`nvCreateSurfaces2 Creating surface 1280x720, format 1`), so the rejection is **the picture itself**.

virglrenderer's `h264_fill_slice_param()` sets two fields and leaves the rest commented out:

```c
//vasp->slice_data_size;
//vasp->slice_data_offset;
//vasp->slice_data_flag;
//vasp->slice_data_bit_offset;
//vasp->first_mb_in_slice;
//vasp->slice_type;
ITEM_SET(vasp, desc, num_ref_idx_l0_active_minus1);
ITEM_SET(vasp, desc, num_ref_idx_l1_active_minus1);
```

That reads like laziness. **It is not. The data is not on the wire.** The protocol's `virgl_h264_picture_desc` carries exactly one slice-related field:

```c
uint32_t slice_count;
```

A count. No per-slice size, offset, type, or first-macroblock. So the function *cannot* populate those fields - the guest never sent them.

## Why that is fine for Mesa and fatal for NVDEC

The virgl video protocol was designed against Mesa's VA drivers, which hand the bitstream to hardware that parses slice headers itself. A driver that re-parses needs no per-slice VA parameters, so the wire format never carried them.

NVDEC does not re-parse. `nvidia-vaapi-driver` builds `CUVIDPICPARAMS` from those parameters, gets zeros where offsets and sizes belong, and correctly rejects it.

**So the constraint is architectural, not a bug.** Upstream's "only supports mesa va drivers now" is an accurate statement about what the protocol can express, not an unreviewed leftover. Lifting it means extending the virgl video wire format to carry per-slice parameters, across guest Mesa and virglrenderer, for every codec - a protocol change, not a patch.

The lab's own decision rule covers exactly this case: when forwarding is blocked by a fundamental limitation, stop and document the exact blocker rather than inventing a second architecture. This is that blocker.

## Unaffected

None of this is required for the prototype. Firefox decodes through **Vulkan Video** - a different path with its own wire format - and that works, is hardware-backed, and is unpatched.

## Change

- `SOLUTION.md`: the blocker, quoted to the struct field, with why Mesa is unaffected.
- `run-lab-vm.sh`: `NVD_LOG` added to the sidecar env passthrough. VA-API status codes carry no detail, so the driver's own log is the only place the reason exists. Off unless the caller asks, since it prints per frame.

## Validation

Documentation plus one opt-in diagnostic env passthrough; no change to any decode path. `make check-tier0` PASS, `make test-lint` PASS, `make test-changelog` PASS.

Evidence gathered on the live lab against the T1000, then stopped and reaped.
