### PR TITLE
labs: correct the measurement that ruled out the copy-path repair

### DIFF
--- a/changelog.d/venus-lab-copypath.md
+++ b/changelog.d/venus-lab-copypath.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Corrected a measurement in the Venus Vulkan Video lab prototype that ruled out
+  the obvious repair for its GPU-copy presentation path. The record stated that
+  forcing that path leaves the second image plane unimported, so nothing existed
+  for the copy to find. Re-measuring shows the plane is imported. The two runs
+  reached the same path by different mechanisms, one by removing a graphics
+  capability preference and one by turning the surface preference off, and only
+  the first suppresses the separate import. The repair is therefore unresolved
+  rather than ruled out. The re-measurement also confirms the failure is no
+  longer catastrophic: the copy still fails, but it no longer poisons the
+  rendering context or causes submissions to be refused, and playback continues.
+  The prototype is unaffected either way, since it uses the zero-copy path.

--- a/labs/venus-vulkan-video/SOLUTION.md
+++ b/labs/venus-vulkan-video/SOLUTION.md
@@ -589,14 +589,33 @@ Recorded because each cost real time and would otherwise be retried.
   `GL_INVALID_OPERATION` from the decoder context to the renderer context. Both
   consumers fail on the same badly described surface.
 - **Teaching the blit to find the later plane.** The obvious repair for the copy
-  path is to give the blit the same per-plane image the sampler view gets. It
-  does not work, and the reason is worth recording because the idea is the first
-  one anybody has: with zero copy off, the guest never imports the chroma plane
-  as a separate resource at all. Measured with `VIRGL_TRACE_IMPORT`, that run
-  produced 6482 `plane=0` imports and **zero** `plane=1` imports. There is no
-  plane for the blit to find, so plane-index inference correctly returns -1
-  every time and the blit fails for the original reason. Fixing the copy path
-  means changing what gets imported, not what the blit looks up.
+  path is to give the blit the same per-plane image the sampler view gets. An
+  attempt at it failed, and the reason recorded here was that the guest never
+  imports the chroma plane separately when zero copy is off - measured with
+  `VIRGL_TRACE_IMPORT` as 6482 `plane=0` imports and zero `plane=1`.
+
+  **That reason was wrong, or at least not general.** Re-measured later, forcing
+  the copy path with `media.ffmpeg.vaapi.force-surface-zero-copy = 0`, the same
+  trace shows **6867 `plane=0` and 1372 `plane=1`**. The chroma plane is
+  imported separately, so there *is* a plane for a blit to find.
+
+  The two runs entered the copy path by different doors, and that is the whole
+  difference. The earlier one removed `gfx.blacklist.hardwarevideodecoding`, so
+  `HW_DECODED_VIDEO_ZERO_COPY` was never configured and `ShouldCopySurface()`
+  returned true unconditionally. The later one leaves the feature configured and
+  turns the surface pref off. Same destination, different import behaviour, and
+  nothing in either run announces which door was used.
+
+  So the copy-path repair is **unresolved rather than refuted**, and worth
+  retrying against the pref route. What that run does establish is that the
+  failure is no longer catastrophic: 881 blit failures, but zero illegal command
+  buffers and zero `CmdSubmit3d` refusals, where the original defect poisoned
+  the context and refused 11,270 submissions. Playback reached 510 frames with
+  2 dropped.
+
+  The generalisable lesson is narrower than the original claim and more useful:
+  **"force the copy path" is not one configuration.** A measurement of it has to
+  say which mechanism selected it.
 - **Resolving the plane through GBM.** `virgl_egl_aux_plane_image_from_gbm_bo()`
   is the upstream route and cannot serve here, because crosvm gives
   virglrenderer surfaceless EGL with no GBM device.


### PR DESCRIPTION
## Why

`SOLUTION.md` said the obvious repair for the GPU-copy presentation path **cannot work**, because forcing that path leaves the chroma plane unimported so nothing exists for a blit to find. It cited `VIRGL_TRACE_IMPORT`: 6482 `plane=0`, **zero** `plane=1`.

That is wrong, or at least not general.

## The re-measurement

Forcing the copy path with `media.ffmpeg.vaapi.force-surface-zero-copy = 0`, the same trace shows:

```
6867 plane=0
1372 plane=1
```

**The chroma plane is imported separately.** There *is* a plane for a blit to find.

## Why the two runs disagree

They entered the copy path by different doors, and that is the whole difference:

| Run | Mechanism | `plane=1` imports |
|---|---|---:|
| Earlier | Removed `gfx.blacklist.hardwarevideodecoding`, so `HW_DECODED_VIDEO_ZERO_COPY` was never configured and `ShouldCopySurface()` returned true unconditionally | **0** |
| This one | Feature stays configured; surface pref turned off | **1372** |

Same destination, different import behaviour, and **nothing in either run announces which door was used**.

So the repair is **unresolved rather than refuted**, and worth retrying against the pref route rather than being written off.

## A second, welcome finding

The failure is no longer catastrophic. This run: **881 blit failures, but zero illegal command buffers and zero `CmdSubmit3d` refusals** - where the original defect poisoned the context and refused 11,270 submissions. Playback reached 510 frames with 2 dropped rather than freezing on a green frame.

The earlier plane fixes bounded this failure even where they did not repair it.

## The generalisable lesson

Narrower than the original claim and more useful: **"force the copy path" is not one configuration.** A measurement of it has to say which mechanism selected it. The original entry did not, which is how a result true of one route got recorded as a property of the path.

## Unaffected

The prototype uses zero copy, which works. Firefox remains unpatched and decodes through Vulkan Video.

## Validation

Documentation only. The experiment's `force-surface-zero-copy = 0` was reverted before commit and the staged `flake.nix` diff is empty, confirming it.

`make check-tier0` PASS, `make test-lint` PASS, `make test-changelog` PASS. Runtime evidence gathered on the live lab against the T1000, then stopped and reaped.
