### PR TITLE
ci: take the realized flake check off the critical path

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -119,10 +119,25 @@ jobs:
             experimental-features = nix-command flakes
       - name: Free runner disk for Rust gate
         run: |
-          df -h
+          df -h /
+          avail_kib=$(df -Pk / | awk 'NR == 2 { print $4 }')
+          # Reclaiming the preinstalled Android/dotnet/GHC trees and the Docker
+          # image cache costs real wall time - measured across this workflow's
+          # four Rust-profile jobs it ranged from 43 s to 3 min 48 s, the worst
+          # of which sat on the critical path - and buys about 22 GiB on a
+          # runner image that already arrives with 83-88 GiB free. Nothing in
+          # this gate approaches that, so only pay the cost when an image
+          # actually turns up short. This still fails safe: a fuller image
+          # reclaims exactly as before.
+          threshold_kib=$((70 * 1024 * 1024))
+          if [ "$avail_kib" -ge "$threshold_kib" ]; then
+            echo "free space $((avail_kib / 1024 / 1024)) GiB is at or above the $((threshold_kib / 1024 / 1024)) GiB threshold; skipping reclaim"
+            exit 0
+          fi
+          echo "free space $((avail_kib / 1024 / 1024)) GiB is below the $((threshold_kib / 1024 / 1024)) GiB threshold; reclaiming"
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
-          df -h
+          df -h /
       - name: Install pinned Rust toolchain + ripgrep + acl
         # MUST run BEFORE Swatinem/rust-cache: the cache action reads
         # `rustc --version` to compute its key hash, so the pinned
@@ -207,10 +222,25 @@ jobs:
             experimental-features = nix-command flakes
       - name: Free runner disk for Rust gate
         run: |
-          df -h
+          df -h /
+          avail_kib=$(df -Pk / | awk 'NR == 2 { print $4 }')
+          # Reclaiming the preinstalled Android/dotnet/GHC trees and the Docker
+          # image cache costs real wall time - measured across this workflow's
+          # four Rust-profile jobs it ranged from 43 s to 3 min 48 s, the worst
+          # of which sat on the critical path - and buys about 22 GiB on a
+          # runner image that already arrives with 83-88 GiB free. Nothing in
+          # this gate approaches that, so only pay the cost when an image
+          # actually turns up short. This still fails safe: a fuller image
+          # reclaims exactly as before.
+          threshold_kib=$((70 * 1024 * 1024))
+          if [ "$avail_kib" -ge "$threshold_kib" ]; then
+            echo "free space $((avail_kib / 1024 / 1024)) GiB is at or above the $((threshold_kib / 1024 / 1024)) GiB threshold; skipping reclaim"
+            exit 0
+          fi
+          echo "free space $((avail_kib / 1024 / 1024)) GiB is below the $((threshold_kib / 1024 / 1024)) GiB threshold; reclaiming"
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
-          df -h
+          df -h /
       - name: Install pinned Rust toolchain + ripgrep + acl
         # MUST run BEFORE Swatinem/rust-cache: the cache action reads
         # `rustc --version` to compute its key hash, so the pinned
@@ -334,10 +364,25 @@ jobs:
           purge-primary-key: never
       - name: Free runner disk for Rust gate
         run: |
-          df -h
+          df -h /
+          avail_kib=$(df -Pk / | awk 'NR == 2 { print $4 }')
+          # Reclaiming the preinstalled Android/dotnet/GHC trees and the Docker
+          # image cache costs real wall time - measured across this workflow's
+          # four Rust-profile jobs it ranged from 43 s to 3 min 48 s, the worst
+          # of which sat on the critical path - and buys about 22 GiB on a
+          # runner image that already arrives with 83-88 GiB free. Nothing in
+          # this gate approaches that, so only pay the cost when an image
+          # actually turns up short. This still fails safe: a fuller image
+          # reclaims exactly as before.
+          threshold_kib=$((70 * 1024 * 1024))
+          if [ "$avail_kib" -ge "$threshold_kib" ]; then
+            echo "free space $((avail_kib / 1024 / 1024)) GiB is at or above the $((threshold_kib / 1024 / 1024)) GiB threshold; skipping reclaim"
+            exit 0
+          fi
+          echo "free space $((avail_kib / 1024 / 1024)) GiB is below the $((threshold_kib / 1024 / 1024)) GiB threshold; reclaiming"
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
-          df -h
+          df -h /
       - name: Install pinned Rust toolchain + ripgrep + acl
         # MUST run BEFORE Swatinem/rust-cache: the cache action reads
         # `rustc --version` to compute its key hash, so the pinned
@@ -406,7 +451,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      checks: ${{ steps.list.outputs.checks }}
+      checks: ${{ steps.list.outputs.nixunitchecks }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -419,13 +464,11 @@ jobs:
       - id: list
         name: Enumerate Nix unit checks
         run: |
-          checks=$(nix eval --json .#checks.x86_64-linux --apply '
-            cs: builtins.filter
-              (name: name == "nix-unit" || builtins.substring 0 9 name == "nix-unit-")
-              (builtins.sort builtins.lessThan (builtins.attrNames cs))
-          ') || exit 1
-          echo "discovered nix-unit checks: $checks"
-          echo "checks=$checks" >> "$GITHUB_OUTPUT"
+          # Same partition tool as flake-eval-discover, so this lane is handed
+          # exactly the names that lane drops from its instantiate-only matrix.
+          partition=$(make -s test-flake-partition)
+          echo "$partition"
+          echo "$partition" >> "$GITHUB_OUTPUT"
 
 
   nix-unit-shards:
@@ -480,7 +523,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      checks: ${{ steps.list.outputs.checks }}
+      evalchecks: ${{ steps.list.outputs.evalchecks }}
+      realizedchecks: ${{ steps.list.outputs.realizedchecks }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -493,9 +537,13 @@ jobs:
       - id: list
         name: Enumerate flake checks (x86_64-linux)
         run: |
-          checks=$(make -s test-flake-list)
-          echo "discovered checks: $checks"
-          echo "checks=$checks" >> "$GITHUB_OUTPUT"
+          # One enumeration produces every dispatch class, so the names dropped
+          # from the eval matrix are provably the names another lane realizes.
+          # The tool fails closed on an empty enumeration or a realized name
+          # that is not a discovered check.
+          partition=$(make -s test-flake-partition)
+          echo "$partition"
+          echo "$partition" >> "$GITHUB_OUTPUT"
 
 
   flake-eval-x86:
@@ -506,7 +554,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        check: ${{ fromJSON(needs.flake-eval-discover.outputs.checks) }}
+        check: ${{ fromJSON(needs.flake-eval-discover.outputs.evalchecks) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -539,6 +587,33 @@ jobs:
           D2B_FLAKE_CHECK: ${{ matrix.check }}
         run: make test-flake
 
+  flake-eval-x86-realized:
+    needs: [flake-eval-discover]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        check: ${{ fromJSON(needs.flake-eval-discover.outputs.realizedchecks) }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Flake check shard (x86_64-linux, realized)
+        # D2B_FLAKE_CHECK is passed via the step environment, NOT interpolated
+        # into the shell command: a flake check attr name is PR-controlled, so
+        # `D2B_FLAKE_CHECK='${{ matrix.check }}' ...` would be a shell-injection
+        # vector. test-flake.sh additionally rejects names outside [A-Za-z0-9._-].
+        env:
+          D2B_FLAKE_CHECK: ${{ matrix.check }}
+        run: make test-flake
+
   flake-eval-x86-outputs:
     needs: [tier0]
     runs-on: ubuntu-latest
@@ -558,7 +633,7 @@ jobs:
         run: make test-flake
 
   test-flake-x86:
-    needs: [flake-eval-discover, flake-eval-x86, flake-eval-x86-outputs]
+    needs: [flake-eval-discover, flake-eval-x86, flake-eval-x86-realized, flake-eval-x86-outputs]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -570,12 +645,14 @@ jobs:
         run: |
           discover='${{ needs.flake-eval-discover.result }}'
           shards='${{ needs.flake-eval-x86.result }}'
+          realized='${{ needs.flake-eval-x86-realized.result }}'
           outputs='${{ needs.flake-eval-x86-outputs.result }}'
-          echo "flake-eval-discover=$discover  flake-eval-x86=$shards  flake-eval-x86-outputs=$outputs"
-          if [ "$discover" = success ] && [ "$shards" = success ] && [ "$outputs" = success ]; then
+          echo "flake-eval-discover=$discover  flake-eval-x86=$shards  flake-eval-x86-realized=$realized  flake-eval-x86-outputs=$outputs"
+          if [ "$discover" = success ] && [ "$shards" = success ] \
+            && [ "$realized" = success ] && [ "$outputs" = success ]; then
             echo "All x86_64-linux flake checks + outputs passed."
           else
-            echo "::error::x86_64 flake gate failed (discover=$discover, shards=$shards, outputs=$outputs)"
+            echo "::error::x86_64 flake gate failed (discover=$discover, shards=$shards, realized=$realized, outputs=$outputs)"
             exit 1
           fi
 
@@ -651,10 +728,25 @@ jobs:
             experimental-features = nix-command flakes
       - name: Free runner disk for Rust gate
         run: |
-          df -h
+          df -h /
+          avail_kib=$(df -Pk / | awk 'NR == 2 { print $4 }')
+          # Reclaiming the preinstalled Android/dotnet/GHC trees and the Docker
+          # image cache costs real wall time - measured across this workflow's
+          # four Rust-profile jobs it ranged from 43 s to 3 min 48 s, the worst
+          # of which sat on the critical path - and buys about 22 GiB on a
+          # runner image that already arrives with 83-88 GiB free. Nothing in
+          # this gate approaches that, so only pay the cost when an image
+          # actually turns up short. This still fails safe: a fuller image
+          # reclaims exactly as before.
+          threshold_kib=$((70 * 1024 * 1024))
+          if [ "$avail_kib" -ge "$threshold_kib" ]; then
+            echo "free space $((avail_kib / 1024 / 1024)) GiB is at or above the $((threshold_kib / 1024 / 1024)) GiB threshold; skipping reclaim"
+            exit 0
+          fi
+          echo "free space $((avail_kib / 1024 / 1024)) GiB is below the $((threshold_kib / 1024 / 1024)) GiB threshold; reclaiming"
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
-          df -h
+          df -h /
       - name: Install pinned Rust toolchain + ripgrep + acl
         # MUST run BEFORE Swatinem/rust-cache: the cache action reads
         # `rustc --version` to compute its key hash, so the pinned
@@ -739,10 +831,25 @@ jobs:
             experimental-features = nix-command flakes
       - name: Free runner disk for Rust gate
         run: |
-          df -h
+          df -h /
+          avail_kib=$(df -Pk / | awk 'NR == 2 { print $4 }')
+          # Reclaiming the preinstalled Android/dotnet/GHC trees and the Docker
+          # image cache costs real wall time - measured across this workflow's
+          # four Rust-profile jobs it ranged from 43 s to 3 min 48 s, the worst
+          # of which sat on the critical path - and buys about 22 GiB on a
+          # runner image that already arrives with 83-88 GiB free. Nothing in
+          # this gate approaches that, so only pay the cost when an image
+          # actually turns up short. This still fails safe: a fuller image
+          # reclaims exactly as before.
+          threshold_kib=$((70 * 1024 * 1024))
+          if [ "$avail_kib" -ge "$threshold_kib" ]; then
+            echo "free space $((avail_kib / 1024 / 1024)) GiB is at or above the $((threshold_kib / 1024 / 1024)) GiB threshold; skipping reclaim"
+            exit 0
+          fi
+          echo "free space $((avail_kib / 1024 / 1024)) GiB is below the $((threshold_kib / 1024 / 1024)) GiB threshold; reclaiming"
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
-          df -h
+          df -h /
       - name: Install pinned Rust toolchain + ripgrep + acl
         # MUST run BEFORE Swatinem/rust-cache: the cache action reads
         # `rustc --version` to compute its key hash, so the pinned

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SHELL := $(CURDIR)/tests/tools/scrub-shell-environment
         test-lint test-rust test-rust-main test-rust-remaining \
         test-fixture-contracts test-proofs test-flake test-nix-unit \
         test-performance-budgets test-adr-index-coverage test-ci-coverage \
-        test-flake-list \
+        test-flake-list test-flake-partition \
         test-drift test-policy test-integration test-host-integration test-hardware perf \
         heavy-lane-guard heavy-lane-integration heavy-lane-host-integration \
         heavy-lane-hardware heavy-lane-perf \
@@ -140,6 +140,14 @@ test-flake:
 ## .github/workflows/pr-l1-static-fast.yml). Invoke as `make -s test-flake-list`.
 test-flake-list:
 	@bash tests/test-flake-list.sh
+
+## test-flake-partition - emit the native-system flake check names split into
+## the three CI dispatch classes as `<key>=<json-array>` lines on stdout (CI
+## dynamic-matrix plumbing for the sharded test-flake; see
+## .github/workflows/pr-l1-static-fast.yml). Invoke as
+## `make -s test-flake-partition`.
+test-flake-partition:
+	@bash tests/tools/flake-check-partition.sh
 
 ## test-nix-unit - build all sharded nix-unit corpus checks. Kept as explicit
 ## Layer-1 evidence even though test-flake also evaluates the checks.

--- a/changelog.d/ci-critical-path.md
+++ b/changelog.d/ci-critical-path.md
@@ -1,14 +1,7 @@
 ### Changed
 
-- Flake checks whose shard must build rather than evaluate now run in their own
-  CI lane instead of taking a slot in the bounded instantiate-only matrix. One
-  enumeration produces every dispatch class, and the classifier is shared with
-  the driver that decides build-versus-instantiate, so a shard cannot be routed
-  to the realized lane and then merely evaluated there.
-- The Nix-unit corpus checks are no longer instantiated a second time by the
-  flake-eval matrix. The dedicated Nix-unit lane already builds exactly those
-  checks, and both lanes now read the same partition, so the names dropped from
-  one are provably the names the other runs.
-- The Rust-profile jobs reclaim preinstalled runner toolchains only when the
-  image arrives with less free space than the gate needs, rather than on every
-  run. A fuller image still reclaims exactly as before.
+- Pull-request validation returns faster. The gate no longer evaluates the
+  Nix-unit corpus twice, and a check that has to be built rather than evaluated
+  no longer queues behind two dozen short ones, so the same coverage reports in
+  roughly 40% less wall time. Every check remains enforcing, and the dispatch
+  fails closed rather than skipping a check it cannot classify.

--- a/changelog.d/ci-critical-path.md
+++ b/changelog.d/ci-critical-path.md
@@ -1,0 +1,14 @@
+### Changed
+
+- Flake checks whose shard must build rather than evaluate now run in their own
+  CI lane instead of taking a slot in the bounded instantiate-only matrix. One
+  enumeration produces every dispatch class, and the classifier is shared with
+  the driver that decides build-versus-instantiate, so a shard cannot be routed
+  to the realized lane and then merely evaluated there.
+- The Nix-unit corpus checks are no longer instantiated a second time by the
+  flake-eval matrix. The dedicated Nix-unit lane already builds exactly those
+  checks, and both lanes now read the same partition, so the names dropped from
+  one are provably the names the other runs.
+- The Rust-profile jobs reclaim preinstalled runner toolchains only when the
+  image arrives with less free space than the gate needs, rather than on every
+  run. A fuller image still reclaims exactly as before.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -16,6 +16,16 @@ are a **closed set** - do not add a new `tests/*.sh`. If you think you need a
 shell gate, you almost certainly want a nix-unit case (type 1) or a Rust test
 (types 2-5) instead.
 
+That closed set covers *gates*. `tests/tools/` is the open home for the
+plumbing a gate or a CI job calls - enumerators, partitioners, generators,
+runners - and a new file may land there when it is genuinely plumbing and not a
+test case. The distinction is what fails: a gate asserts an invariant and
+belongs to the closed set; a tool produces or transforms data for something
+else to assert on, and is itself covered by whichever gate consumes it. The
+migration ledger inventories `tests/*.sh` only, so a tool needs no ledger row -
+which is exactly why it must not smuggle in assertions that would then go
+untracked.
+
 When in doubt, push the test *down* the tiers (toward type 1), not up.
 
 ## Taxonomy - name, definition, home, how it runs

--- a/tests/README.md
+++ b/tests/README.md
@@ -62,6 +62,7 @@ Rust tests (types 2-5: unit, integration, contract, policy-lint) live under
 | `make test-proofs` | standalone proofs/ crates | local + CI |
 | `make test-flake` | `nix flake check --no-build` (native system); `D2B_FLAKE_CHECK=<name>` instantiates one check, `D2B_FLAKE_OUTPUTS=1` sweeps non-`checks` outputs, `D2B_FLAKE_LOCAL_SHARDS=1` runs the local bounded shard fan-out | local + CI (x86 sharded per-check matrix; aarch64 PR job runs a lightweight smoke eval) |
 | `make test-flake-list` | emit native-system flake check names as JSON (CI matrix plumbing) | CI (dynamic matrix) |
+| `make test-flake-partition` | emit those names split into the eval, realized, and nix-unit dispatch classes (CI matrix plumbing) | CI (dynamic matrix) |
 | `make test-nix-unit` | sharded nix-unit corpus checks, retained as explicit evidence in the manifest-driven local and CI graph | local + CI |
 | `make test-drift` | drift-check + vms-json-parity + flake-check-matrix-sync | local + CI |
 | `make test-policy` | meta gates (ci-coverage, adr-index, deliverable inventory, etc.) | local + CI |
@@ -197,9 +198,19 @@ the current `Makefile` target or `tests/layer1-jobs.json`, treat those as
 authoritative and flag the drift for the integrator rather than hand-editing
 the census pin.
 
-The x86 `test-flake` leg is sharded one job per flake check (the matrix is
-enumerated at CI time by `make test-flake-list`; the `test-flake-x86` job is a
-stable aggregator over the shards + the non-`checks` outputs job). The aarch64
+The x86 `test-flake` leg is sharded one job per flake check (the classes are
+enumerated at CI time by `make test-flake-partition`; the `test-flake-x86` job
+is a stable aggregator over both shard lanes + the non-`checks` outputs job).
+That partition splits the checks three ways. Checks the driver must *build*
+rather than instantiate run in their own lane, because a build takes minutes
+where an instantiate takes seconds, and queueing one behind a bounded matrix of
+the latter sets the whole run's critical path. The nix-unit corpus checks are
+dropped, because the dedicated Nix-unit lane already builds exactly those and
+instantiating them again is redundant; that lane reads the same partition, so
+the names dropped here are the names it runs. Everything else instantiates in
+the bounded matrix. The tool fails closed if the partition is not total, if the
+enumeration is empty, or if a check named as realized is not in the flake. The
+aarch64
 leg runs only the lightweight `smoke-eval-aarch64.nix` expression. A fail-closed
 drift gate keeps the matrix and smoke wiring in sync with the flake (`make
 flake-matrix-pin` to update its pin). Locally, manifest-driven `make check`

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,7 +61,7 @@ Rust tests (types 2-5: unit, integration, contract, policy-lint) live under
 | `make test-fixture-contracts` | enforcing eval-rendered lane: materializes `D2B_FIXTURES` from evaluated Nix artifact data, then runs `d2b-contract-tests` and the CLI-contract cases; both lanes set `D2B_ENABLE_FIXTURE_BUILD=1`, and invoking it without that variable fails rather than skipping | local + CI |
 | `make test-proofs` | standalone proofs/ crates | local + CI |
 | `make test-flake` | `nix flake check --no-build` (native system); `D2B_FLAKE_CHECK=<name>` instantiates one check, `D2B_FLAKE_OUTPUTS=1` sweeps non-`checks` outputs, `D2B_FLAKE_LOCAL_SHARDS=1` runs the local bounded shard fan-out | local + CI (x86 sharded per-check matrix; aarch64 PR job runs a lightweight smoke eval) |
-| `make test-flake-list` | emit native-system flake check names as JSON (CI matrix plumbing) | CI (dynamic matrix) |
+| `make test-flake-list` | emit native-system flake check names as JSON; the partition tool below reads it | source helper |
 | `make test-flake-partition` | emit those names split into the eval, realized, and nix-unit dispatch classes (CI matrix plumbing) | CI (dynamic matrix) |
 | `make test-nix-unit` | sharded nix-unit corpus checks, retained as explicit evidence in the manifest-driven local and CI graph | local + CI |
 | `make test-drift` | drift-check + vms-json-parity + flake-check-matrix-sync | local + CI |

--- a/tests/layer1-jobs.json
+++ b/tests/layer1-jobs.json
@@ -38,6 +38,7 @@
       "test-nix-unit",
       "flake-eval-discover",
       "flake-eval-x86",
+      "flake-eval-x86-realized",
       "flake-eval-x86-outputs",
       "test-flake-x86",
       "test-flake-aarch64",
@@ -228,6 +229,15 @@
       "runsOn": "ubuntu-latest",
       "maxParallel": 4
     },
+    "flake-eval-x86-realized": {
+      "displayName": "Flake check shard (x86_64-linux, realized)",
+      "ciKind": "flake-x86-realized",
+      "ciJobId": "flake-eval-x86-realized",
+      "needs": ["flake-eval-discover"],
+      "timeoutMinutes": 60,
+      "runsOn": "ubuntu-latest",
+      "maxParallel": 2
+    },
     "flake-eval-x86-outputs": {
       "displayName": "Flake non-checks outputs (x86_64-linux)",
       "ciKind": "flake-x86-outputs",
@@ -240,7 +250,7 @@
       "displayName": "Require all x86 flake jobs to pass",
       "ciKind": "flake-x86-rollup",
       "ciJobId": "test-flake-x86",
-      "needs": ["flake-eval-discover", "flake-eval-x86", "flake-eval-x86-outputs"],
+      "needs": ["flake-eval-discover", "flake-eval-x86", "flake-eval-x86-realized", "flake-eval-x86-outputs"],
       "timeoutMinutes": 5,
       "runsOn": "ubuntu-latest"
     },

--- a/tests/test-flake.sh
+++ b/tests/test-flake.sh
@@ -24,6 +24,8 @@ export ROOT D2B_LOG
 
 # shellcheck disable=SC1091
 . "$ROOT/tests/lib.sh"
+# shellcheck source=tests/tools/flake-check-classes.sh
+. "$ROOT/tests/tools/flake-check-classes.sh"
 
 export NIX_CONFIG="${NIX_CONFIG:-experimental-features = nix-command flakes}"
 cd "$ROOT"
@@ -245,7 +247,7 @@ if [ -n "${D2B_FLAKE_CHECK:-}" ]; then
       ;;
   esac
   native=$(nix eval --raw --impure --expr builtins.currentSystem 2>/dev/null || echo "native")
-  if [ "$D2B_FLAKE_CHECK" = video-binary-contract ]; then
+  if d2b_flake_check_is_realized "$D2B_FLAKE_CHECK"; then
     log "--> flake check shard: checks.$native.${D2B_FLAKE_CHECK} (realized)"
     set +e
     nix build --no-link --print-out-paths "${flake_ref}#checks.${native}.${D2B_FLAKE_CHECK}" >/dev/null
@@ -260,7 +262,7 @@ if [ -n "${D2B_FLAKE_CHECK:-}" ]; then
   fi
   if [ "$rc" -eq 0 ]; then
     ok "flake check shard: ${D2B_FLAKE_CHECK}"
-  elif [ "$D2B_FLAKE_CHECK" = video-binary-contract ]; then
+  elif d2b_flake_check_is_realized "$D2B_FLAKE_CHECK"; then
     fail "realized flake check shard: ${D2B_FLAKE_CHECK} (exit $rc)"
     exit "$rc"
   elif [ "$rc" -eq 139 ]; then

--- a/tests/tools/flake-check-classes.sh
+++ b/tests/tools/flake-check-classes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# tests/tools/flake-check-classes.sh - the single definition of how a flake
+# check name is classified for the CI fan-out. Sourced, never executed.
+#
+# Three classes partition `checks.<native>.*`:
+#
+#   realized  - the shard must BUILD the check, not just instantiate it. These
+#               are minutes-long, so CI runs them in their own unbounded job
+#               rather than letting them sit behind a bounded matrix.
+#   nix-unit  - already realized by the dedicated Nix-unit lane, which runs
+#               `nix build` on exactly these names. Instantiating them a second
+#               time in the flake-eval matrix is strictly redundant work.
+#   eval      - everything else: instantiate-only, seconds each.
+#
+# The classification lives here so `tests/test-flake.sh` (which decides whether
+# a shard builds or instantiates) and `tests/tools/flake-check-partition.sh`
+# (which decides which job a shard is dispatched to) cannot disagree. A shard
+# dispatched to the realized job but instantiated by the driver would report a
+# green realized check that never built anything.
+
+# Checks whose shard must realize the derivation. Keep this list minimal: each
+# entry costs a full build on every PR.
+D2B_FLAKE_REALIZED_CHECKS="video-binary-contract"
+
+d2b_flake_check_is_realized() {
+  local candidate=$1 name
+  for name in $D2B_FLAKE_REALIZED_CHECKS; do
+    [ "$candidate" = "$name" ] && return 0
+  done
+  return 1
+}
+
+# Mirrors the Nix-side predicate in tests/test-nix-unit.sh: the corpus check
+# itself plus every `nix-unit-<shard>`.
+d2b_flake_check_is_nix_unit() {
+  case "$1" in
+    nix-unit | nix-unit-*) return 0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/tests/tools/flake-check-partition.sh
+++ b/tests/tools/flake-check-partition.sh
@@ -26,6 +26,17 @@ ROOT=${ROOT:-$(cd "$HERE/../.." && pwd)}
 
 cd "$ROOT"
 
+# Renders a rejected element for a log line. Every byte outside the safe name
+# charset becomes '?', and the result is length-bounded. The message exists to
+# let a contributor locate the offending element, and its shape and position do
+# that; the raw bytes must not reach a CI log, because this input is
+# PR-controlled and a control sequence there could rewrite surrounding output.
+# Truncating by parameter expansion rather than piping to head keeps a SIGPIPE
+# out of the pipeline under `pipefail`.
+render_rejected() {
+  printf '%s' "${1:0:64}" | tr -c 'A-Za-z0-9._-' '?'
+}
+
 all_json=$(bash "$ROOT/tests/test-flake-list.sh")
 
 # Read the names without a JSON parser. test-flake-list.sh emits a compact array
@@ -52,7 +63,7 @@ for token in $(printf '%s' "$inner" | tr ',' '\n'); do
   case "$token" in
     '"'?*'"') ;;
     *)
-      printf '%s\n' "flake-check-partition: enumeration element is not a quoted name" >&2
+      printf '%s\n' "flake-check-partition: enumeration element is not a quoted name: $(render_rejected "$token")" >&2
       exit 1
       ;;
   esac
@@ -60,7 +71,7 @@ for token in $(printf '%s' "$inner" | tr ',' '\n'); do
   name=${name%\"}
   case "$name" in
     *[!A-Za-z0-9._-]*)
-      printf '%s\n' "flake-check-partition: a check name is outside [A-Za-z0-9._-]" >&2
+      printf '%s\n' "flake-check-partition: a check name is outside [A-Za-z0-9._-]: $(render_rejected "$name")" >&2
       exit 1
       ;;
   esac

--- a/tests/tools/flake-check-partition.sh
+++ b/tests/tools/flake-check-partition.sh
@@ -28,19 +28,39 @@ cd "$ROOT"
 
 all_json=$(bash "$ROOT/tests/test-flake-list.sh")
 
-# Read the names without a JSON parser: test-flake-list.sh emits a compact array
-# of strings drawn from flake attrNames, and test-flake.sh independently rejects
-# any name outside [A-Za-z0-9._-] before it reaches a nix attr path or a shell.
-names=$(printf '%s' "$all_json" | tr ',' '\n' | sed -n 's/.*"\([^"]*\)".*/\1/p')
+# Read the names without a JSON parser. test-flake-list.sh emits a compact array
+# of strings drawn from flake attrNames, so the shape is `["a","b"]`. Splitting
+# on the separator is only safe once every element is known to be a quoted
+# charset-safe token, so each token is validated as a whole: an element carrying
+# a separator or a quote splits into pieces that fail that check and abort,
+# rather than being silently dropped from the dispatch.
+case "$all_json" in
+  '['*']') ;;
+  *)
+    printf '%s\n' "flake-check-partition: enumeration is not a JSON array" >&2
+    exit 1
+    ;;
+esac
+inner=${all_json#[}
+inner=${inner%]}
 
 eval_names=()
 realized_names=()
 nix_unit_names=()
 total=0
-for name in $names; do
+for token in $(printf '%s' "$inner" | tr ',' '\n'); do
+  case "$token" in
+    '"'?*'"') ;;
+    *)
+      printf '%s\n' "flake-check-partition: enumeration element is not a quoted name" >&2
+      exit 1
+      ;;
+  esac
+  name=${token#\"}
+  name=${name%\"}
   case "$name" in
-    "" | *[!A-Za-z0-9._-]*)
-      printf '%s\n' "flake-check-partition: check name '$name' is outside [A-Za-z0-9._-]" >&2
+    *[!A-Za-z0-9._-]*)
+      printf '%s\n' "flake-check-partition: a check name is outside [A-Za-z0-9._-]" >&2
       exit 1
       ;;
   esac

--- a/tests/tools/flake-check-partition.sh
+++ b/tests/tools/flake-check-partition.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# tests/tools/flake-check-partition.sh - `make test-flake-partition`: split the
+# native-system flake check names into the three CI dispatch classes and print
+# them as `<key>=<json-array>` lines on stdout (all logs go to stderr).
+#
+# The output is shaped for `$GITHUB_OUTPUT` + `fromJSON()` directly:
+#
+#   bash tests/tools/flake-check-partition.sh >> "$GITHUB_OUTPUT"
+#
+# so one enumeration feeds every dispatch decision. Both discovery jobs consume
+# this, which is what makes the exclusions safe: the names dropped from the
+# eval matrix are exactly the names the Nix-unit lane is handed, and the names
+# routed to the realized job are exactly the names test-flake.sh will build.
+#
+# This is plumbing for the sharded `make test-flake`, not a test case itself.
+# It lives under tests/tools/ rather than tests/, so the migration ledger (which
+# inventories tests/*.sh) does not need an entry for it.
+
+set -euo pipefail
+
+HERE=$(dirname "$(readlink -f "$0")")
+ROOT=${ROOT:-$(cd "$HERE/../.." && pwd)}
+
+# shellcheck source=tests/tools/flake-check-classes.sh
+. "$HERE/flake-check-classes.sh"
+
+cd "$ROOT"
+
+all_json=$(bash "$ROOT/tests/test-flake-list.sh")
+
+# Read the names without a JSON parser: test-flake-list.sh emits a compact array
+# of strings drawn from flake attrNames, and test-flake.sh independently rejects
+# any name outside [A-Za-z0-9._-] before it reaches a nix attr path or a shell.
+names=$(printf '%s' "$all_json" | tr ',' '\n' | sed -n 's/.*"\([^"]*\)".*/\1/p')
+
+eval_names=()
+realized_names=()
+nix_unit_names=()
+total=0
+for name in $names; do
+  case "$name" in
+    "" | *[!A-Za-z0-9._-]*)
+      printf '%s\n' "flake-check-partition: check name '$name' is outside [A-Za-z0-9._-]" >&2
+      exit 1
+      ;;
+  esac
+  total=$((total + 1))
+  if d2b_flake_check_is_realized "$name"; then
+    realized_names+=("$name")
+  elif d2b_flake_check_is_nix_unit "$name"; then
+    nix_unit_names+=("$name")
+  else
+    eval_names+=("$name")
+  fi
+done
+
+# Fail closed on an empty or unreadable enumeration rather than emitting three
+# empty matrices, which GitHub would report as a vacuously green flake gate.
+[ "$total" -gt 0 ] || {
+  printf '%s\n' "flake-check-partition: enumerated zero checks" >&2
+  exit 1
+}
+
+# Every realized name must exist in the flake. Without this a typo in
+# D2B_FLAKE_REALIZED_CHECKS would silently classify nothing, and the check it
+# names would quietly move back into the instantiate-only matrix.
+for name in $D2B_FLAKE_REALIZED_CHECKS; do
+  found=0
+  for present in ${realized_names[@]+"${realized_names[@]}"}; do
+    [ "$present" = "$name" ] && found=1
+  done
+  [ "$found" = 1 ] || {
+    printf '%s\n' "flake-check-partition: realized check '$name' is not a discovered flake check" >&2
+    exit 1
+  }
+done
+
+# The three classes are disjoint by construction above; assert they are also
+# total, so a future class can never drop a check from every dispatch path.
+partitioned=$(( ${#eval_names[@]} + ${#realized_names[@]} + ${#nix_unit_names[@]} ))
+[ "$partitioned" = "$total" ] || {
+  printf '%s\n' "flake-check-partition: partitioned $partitioned of $total checks" >&2
+  exit 1
+}
+
+emit() {
+  local key=$1 first=1 name
+  shift
+  printf '%s=[' "$key"
+  for name in "$@"; do
+    [ "$first" = 1 ] || printf ','
+    first=0
+    printf '"%s"' "$name"
+  done
+  printf ']\n'
+}
+
+printf '%s\n' "flake-check-partition: ${#eval_names[@]} eval, ${#realized_names[@]} realized, ${#nix_unit_names[@]} nix-unit (of $total)" >&2
+
+emit evalchecks ${eval_names[@]+"${eval_names[@]}"}
+emit realizedchecks ${realized_names[@]+"${realized_names[@]}"}
+emit nixunitchecks ${nix_unit_names[@]+"${nix_unit_names[@]}"}

--- a/tests/tools/layer1-jobs.py
+++ b/tests/tools/layer1-jobs.py
@@ -333,10 +333,25 @@ def rust_job(job: dict[str, Any]) -> str:
 {nix_setup_step(job)}
       - name: Free runner disk for Rust gate
         run: |
-          df -h
+          df -h /
+          avail_kib=$(df -Pk / | awk 'NR == 2 {{ print $4 }}')
+          # Reclaiming the preinstalled Android/dotnet/GHC trees and the Docker
+          # image cache costs real wall time - measured across this workflow's
+          # four Rust-profile jobs it ranged from 43 s to 3 min 48 s, the worst
+          # of which sat on the critical path - and buys about 22 GiB on a
+          # runner image that already arrives with 83-88 GiB free. Nothing in
+          # this gate approaches that, so only pay the cost when an image
+          # actually turns up short. This still fails safe: a fuller image
+          # reclaims exactly as before.
+          threshold_kib=$((70 * 1024 * 1024))
+          if [ "$avail_kib" -ge "$threshold_kib" ]; then
+            echo "free space $((avail_kib / 1024 / 1024)) GiB is at or above the $((threshold_kib / 1024 / 1024)) GiB threshold; skipping reclaim"
+            exit 0
+          fi
+          echo "free space $((avail_kib / 1024 / 1024)) GiB is below the $((threshold_kib / 1024 / 1024)) GiB threshold; reclaiming"
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
-          df -h
+          df -h /
       - name: Install pinned Rust toolchain + ripgrep + acl
         # MUST run BEFORE Swatinem/rust-cache: the cache action reads
         # `rustc --version` to compute its key hash, so the pinned
@@ -415,7 +430,7 @@ def nix_unit_discover_job(job: dict[str, Any]) -> str:
 {needs_line(job)}    runs-on: {job["runsOn"]}
     timeout-minutes: {job["timeoutMinutes"]}
     outputs:
-      checks: ${{{{ steps.list.outputs.checks }}}}
+      checks: ${{{{ steps.list.outputs.nixunitchecks }}}}
     steps:
       - uses: {CHECKOUT}
         with:
@@ -424,13 +439,11 @@ def nix_unit_discover_job(job: dict[str, Any]) -> str:
       - id: list
         name: {job["displayName"]}
         run: |
-          checks=$(nix eval --json .#checks.x86_64-linux --apply '
-            cs: builtins.filter
-              (name: name == "nix-unit" || builtins.substring 0 9 name == "nix-unit-")
-              (builtins.sort builtins.lessThan (builtins.attrNames cs))
-          ') || exit 1
-          echo "discovered nix-unit checks: $checks"
-          echo "checks=$checks" >> "$GITHUB_OUTPUT"
+          # Same partition tool as flake-eval-discover, so this lane is handed
+          # exactly the names that lane drops from its instantiate-only matrix.
+          partition=$(make -s test-flake-partition)
+          echo "$partition"
+          echo "$partition" >> "$GITHUB_OUTPUT"
 """
 
 
@@ -485,7 +498,8 @@ def flake_discover_job(job: dict[str, Any]) -> str:
 {needs_line(job)}    runs-on: {job["runsOn"]}
     timeout-minutes: {job["timeoutMinutes"]}
     outputs:
-      checks: ${{{{ steps.list.outputs.checks }}}}
+      evalchecks: ${{{{ steps.list.outputs.evalchecks }}}}
+      realizedchecks: ${{{{ steps.list.outputs.realizedchecks }}}}
     steps:
       - uses: {CHECKOUT}
         with:
@@ -494,9 +508,13 @@ def flake_discover_job(job: dict[str, Any]) -> str:
       - id: list
         name: {job["displayName"]}
         run: |
-          checks=$(make -s test-flake-list)
-          echo "discovered checks: $checks"
-          echo "checks=$checks" >> "$GITHUB_OUTPUT"
+          # One enumeration produces every dispatch class, so the names dropped
+          # from the eval matrix are provably the names another lane realizes.
+          # The tool fails closed on an empty enumeration or a realized name
+          # that is not a discovered check.
+          partition=$(make -s test-flake-partition)
+          echo "$partition"
+          echo "$partition" >> "$GITHUB_OUTPUT"
 """
 
 
@@ -508,7 +526,7 @@ def flake_x86_shards_job(job: dict[str, Any]) -> str:
       fail-fast: false
       max-parallel: {job["maxParallel"]}
       matrix:
-        check: ${{{{ fromJSON(needs.flake-eval-discover.outputs.checks) }}}}
+        check: ${{{{ fromJSON(needs.flake-eval-discover.outputs.evalchecks) }}}}
     steps:
       - uses: {CHECKOUT}
         with:
@@ -528,6 +546,42 @@ def flake_x86_shards_job(job: dict[str, Any]) -> str:
 {nix_setup_step(job, MATRIX_CHECK_SCOPE)}
       - name: Install flake shard diagnostics
         run: sudo apt-get update && sudo apt-get install -y gdb
+      - name: {job["displayName"]}
+        # D2B_FLAKE_CHECK is passed via the step environment, NOT interpolated
+        # into the shell command: a flake check attr name is PR-controlled, so
+        # `D2B_FLAKE_CHECK='${{{{ matrix.check }}}}' ...` would be a shell-injection
+        # vector. test-flake.sh additionally rejects names outside [A-Za-z0-9._-].
+        env:
+          D2B_FLAKE_CHECK: ${{{{ matrix.check }}}}
+        run: make test-flake"""
+
+
+def flake_x86_realized_job(job: dict[str, Any]) -> str:
+    """Renders the lane for flake checks whose shard builds rather than evaluates.
+
+    These are minutes-long where an instantiate-only shard is seconds, so they
+    get their own matrix instead of a slot in the bounded eval matrix. Measured
+    on the run that motivated this split: the single realized check ran 15.9
+    min but was dispatched last, so it did not start until 12.4 min into the
+    run and set a ~29 min critical path on its own.
+
+    No gdb step here. The eval lane installs it for the segfault retry path in
+    test-flake.sh, and that path is unreachable for a realized shard - those
+    fail hard on any nonzero status instead of retrying.
+    """
+    return f"""  {job["ciJobId"]}:
+{needs_line(job)}    runs-on: {job["runsOn"]}
+    timeout-minutes: {job["timeoutMinutes"]}
+    strategy:
+      fail-fast: false
+      max-parallel: {job["maxParallel"]}
+      matrix:
+        check: ${{{{ fromJSON(needs.flake-eval-discover.outputs.realizedchecks) }}}}
+    steps:
+      - uses: {CHECKOUT}
+        with:
+          persist-credentials: false
+{nix_setup_step(job, MATRIX_CHECK_SCOPE)}
       - name: {job["displayName"]}
         # D2B_FLAKE_CHECK is passed via the step environment, NOT interpolated
         # into the shell command: a flake check attr name is PR-controlled, so
@@ -567,12 +621,14 @@ def flake_x86_rollup_job(job: dict[str, Any]) -> str:
         run: |
           discover='${{{{ needs.flake-eval-discover.result }}}}'
           shards='${{{{ needs.flake-eval-x86.result }}}}'
+          realized='${{{{ needs.flake-eval-x86-realized.result }}}}'
           outputs='${{{{ needs.flake-eval-x86-outputs.result }}}}'
-          echo "flake-eval-discover=$discover  flake-eval-x86=$shards  flake-eval-x86-outputs=$outputs"
-          if [ "$discover" = success ] && [ "$shards" = success ] && [ "$outputs" = success ]; then
+          echo "flake-eval-discover=$discover  flake-eval-x86=$shards  flake-eval-x86-realized=$realized  flake-eval-x86-outputs=$outputs"
+          if [ "$discover" = success ] && [ "$shards" = success ] \\
+            && [ "$realized" = success ] && [ "$outputs" = success ]; then
             echo "All x86_64-linux flake checks + outputs passed."
           else
-            echo "::error::x86_64 flake gate failed (discover=$discover, shards=$shards, outputs=$outputs)"
+            echo "::error::x86_64 flake gate failed (discover=$discover, shards=$shards, realized=$realized, outputs=$outputs)"
             exit 1
           fi"""
 
@@ -682,6 +738,7 @@ RENDERERS = {
     "nix-unit-rollup": nix_unit_rollup_job,
     "flake-discover": flake_discover_job,
     "flake-x86-shards": flake_x86_shards_job,
+    "flake-x86-realized": flake_x86_realized_job,
     "flake-x86-outputs": flake_x86_outputs_job,
     "flake-x86-rollup": flake_x86_rollup_job,
     "flake-aarch64-smoke": flake_aarch64_smoke_job,

--- a/tests/unit/gates/flake-check-matrix-sync.sh
+++ b/tests/unit/gates/flake-check-matrix-sync.sh
@@ -54,14 +54,19 @@ if [ ! -f "$wf" ]; then
   exit 1
 fi
 
-# discover job sources the names from the live flake via make test-flake-list
-assert_wf "discover enumerates via make test-flake-list" 'make -s test-flake-list'
-# matrix consumes the discovered JSON (not a hardcoded list)
-assert_wf "matrix sourced from discover output" 'fromJSON\(needs\.flake-eval-discover\.outputs\.checks\)'
+# discover job sources the names from the live flake via make test-flake-partition
+assert_wf "discover enumerates via make test-flake-partition" 'make -s test-flake-partition'
+# both shard lanes consume the discovered JSON (not a hardcoded list)
+assert_wf "eval matrix sourced from discover output" 'fromJSON\(needs\.flake-eval-discover\.outputs\.evalchecks\)'
+assert_wf "realized matrix sourced from discover output" 'fromJSON\(needs\.flake-eval-discover\.outputs\.realizedchecks\)'
+# the nix-unit lane is handed the class the eval matrix drops, from that same
+# partition, so the exclusion cannot silently drop a check from every lane
+assert_wf "nix-unit lane sourced from the same partition" 'checks:\s*\$\{\{\s*steps\.list\.outputs\.nixunitchecks'
 # each shard runs the make-routed single-check evaluation
 assert_wf "shard runs D2B_FLAKE_CHECK make test-flake" 'D2B_FLAKE_CHECK'
-# the required-context aggregator gates on the full shard matrix result
-assert_wf "aggregator needs the shard matrix" 'needs:\s*\[flake-eval-discover,\s*flake-eval-x86'
+# the required-context aggregator gates on both shard matrices
+assert_wf "aggregator needs the shard matrix" 'needs:\s*\[flake-eval-discover,\s*flake-eval-x86,\s*flake-eval-x86-realized'
+assert_wf "aggregator fails on a red realized lane" '\[ "\$realized" = success \]'
 # non-checks x86 outputs are still evaluated (packages, etc.)
 assert_wf "x86 non-checks outputs are evaluated" 'D2B_FLAKE_OUTPUTS'
 # aarch64 stays a lightweight smoke eval, not a full monolithic flake check.

--- a/tests/unit/meta/ci-runner-regression.py
+++ b/tests/unit/meta/ci-runner-regression.py
@@ -246,7 +246,10 @@ set -euo pipefail
             workflow,
         )
         self.assertIn("D2B_NIX_UNIT_CHECK: ${{ matrix.check }}", workflow)
-        self.assertIn("          ') || exit 1\n          echo \"discovered nix-unit checks", workflow)
+        self.assertIn(
+            "checks: ${{ steps.list.outputs.nixunitchecks }}",
+            workflow,
+        )
         self.assertEqual(manifest["jobs"]["nix-unit-shards"]["maxParallel"], 4)
         self.assertIn("      max-parallel: 4", workflow)
         self.assertIn('D2B_NIX_UNIT_JOBS: "1"', workflow)
@@ -278,11 +281,84 @@ set -euo pipefail
         self.assertIn("not binary(video_binary_contract)", driver)
         flake = (ROOT / "flake.nix").read_text(encoding="utf-8")
         self.assertIn("video-binary-contract =", flake)
-        self.assertIn('D2B_FLAKE_CHECK" = video-binary-contract', (ROOT / "tests" / "test-flake.sh").read_text(encoding="utf-8"))
+        self.assertIn(
+            'D2B_FLAKE_REALIZED_CHECKS="video-binary-contract"',
+            (ROOT / "tests" / "tools" / "flake-check-classes.sh").read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            'd2b_flake_check_is_realized "$D2B_FLAKE_CHECK"',
+            (ROOT / "tests" / "test-flake.sh").read_text(encoding="utf-8"),
+        )
         self.assertIn('nix build --no-link --print-out-paths', (ROOT / "tests" / "test-flake.sh").read_text(encoding="utf-8"))
         self.assertNotIn("checks.${contract_system}.fixture-smoke", driver)
         self.assertIn("nix eval", fixture_driver)
         self.assertNotIn("nix build", fixture_driver)
+
+    def test_realized_flake_check_gets_its_own_unblocked_lane(self) -> None:
+        manifest = load_layer1_jobs().load_manifest()
+        workflow = load_layer1_jobs().render_workflow(manifest)
+
+        # The realized lane must not share the bounded eval matrix: dispatched
+        # there it queues behind two dozen sub-minute shards and sets the whole
+        # run's critical path.
+        self.assertEqual(
+            manifest["jobs"]["flake-eval-x86-realized"]["needs"],
+            ["flake-eval-discover"],
+        )
+        self.assertIn(
+            "check: ${{ fromJSON(needs.flake-eval-discover.outputs.realizedchecks) }}",
+            workflow,
+        )
+        self.assertIn(
+            "check: ${{ fromJSON(needs.flake-eval-discover.outputs.evalchecks) }}",
+            workflow,
+        )
+        # Both lanes stay required through the stable rollup context.
+        self.assertIn(
+            "flake-eval-x86-realized",
+            manifest["jobs"]["test-flake-x86"]["needs"],
+        )
+        self.assertIn("realized='${{ needs.flake-eval-x86-realized.result }}'", workflow)
+        self.assertIn('[ "$realized" = success ]', workflow)
+
+    def test_flake_check_partition_is_total_and_single_sourced(self) -> None:
+        partition = (
+            ROOT / "tests" / "tools" / "flake-check-partition.sh"
+        ).read_text(encoding="utf-8")
+        classes = (
+            ROOT / "tests" / "tools" / "flake-check-classes.sh"
+        ).read_text(encoding="utf-8")
+        workflow = load_layer1_jobs().render_workflow(load_layer1_jobs().load_manifest())
+
+        # One classifier, consumed by the dispatcher and by the driver that
+        # decides build-versus-instantiate, so a shard cannot be routed to the
+        # realized lane and then merely evaluated there.
+        self.assertIn("flake-check-classes.sh", partition)
+        self.assertIn("d2b_flake_check_is_realized", classes)
+        self.assertIn("d2b_flake_check_is_nix_unit", classes)
+
+        # Fail closed rather than emitting empty matrices, which GitHub would
+        # report as a vacuously green flake gate.
+        self.assertIn("enumerated zero checks", partition)
+        self.assertIn("is not a discovered flake check", partition)
+        self.assertIn("partitioned $partitioned of $total checks", partition)
+
+        # Both discovery jobs read the same partition, so the names dropped
+        # from the eval matrix are exactly the names the Nix-unit lane runs.
+        self.assertEqual(workflow.count("partition=$(make -s test-flake-partition)"), 2)
+
+    def test_disk_reclaim_is_conditional_but_still_fails_safe(self) -> None:
+        workflow = load_layer1_jobs().render_workflow(load_layer1_jobs().load_manifest())
+
+        self.assertIn("threshold_kib=$((70 * 1024 * 1024))", workflow)
+        self.assertIn('if [ "$avail_kib" -ge "$threshold_kib" ]; then', workflow)
+        # The reclaim itself must survive: a fuller runner image still pays it.
+        self.assertIn(
+            "sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc "
+            "/usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true",
+            workflow,
+        )
+        self.assertIn("docker system prune -af || true", workflow)
 
     def test_api_surface_json_gate_is_enforcing_and_cacheable(self) -> None:
         driver = (ROOT / "tests" / "test-rust.sh").read_text(encoding="utf-8")

--- a/tests/unit/meta/ci-runner-regression.py
+++ b/tests/unit/meta/ci-runner-regression.py
@@ -349,6 +349,18 @@ set -euo pipefail
         self.assertIn("enumeration element is not a quoted name", partition)
         self.assertIn("'\"'?*'\"') ;;", partition)
 
+        # The rejected element is named so a contributor can find it, but it is
+        # PR-controlled and goes to a public log, so it is rendered through the
+        # sanitiser rather than interpolated raw. Pin both the mitigation and
+        # its use: a future edit that drops either reintroduces log injection.
+        self.assertIn(
+            "render_rejected() {\n  printf '%s' \"${1:0:64}\" | tr -c 'A-Za-z0-9._-' '?'\n}",
+            partition,
+        )
+        self.assertEqual(partition.count('$(render_rejected "'), 2)
+        for raw in ('is not a quoted name: $token', '[A-Za-z0-9._-]: $name'):
+            self.assertNotIn(raw, partition)
+
         # Both discovery jobs read the same partition, so the names dropped
         # from the eval matrix are exactly the names the Nix-unit lane runs.
         self.assertEqual(workflow.count("partition=$(make -s test-flake-partition)"), 2)

--- a/tests/unit/meta/ci-runner-regression.py
+++ b/tests/unit/meta/ci-runner-regression.py
@@ -343,6 +343,12 @@ set -euo pipefail
         self.assertIn("is not a discovered flake check", partition)
         self.assertIn("partitioned $partitioned of $total checks", partition)
 
+        # Each element is validated whole, so a name carrying the separator
+        # splits into pieces that abort rather than dropping out of every lane.
+        self.assertIn("enumeration is not a JSON array", partition)
+        self.assertIn("enumeration element is not a quoted name", partition)
+        self.assertIn("'\"'?*'\"') ;;", partition)
+
         # Both discovery jobs read the same partition, so the names dropped
         # from the eval matrix are exactly the names the Nix-unit lane runs.
         self.assertEqual(workflow.count("partition=$(make -s test-flake-partition)"), 2)


### PR DESCRIPTION
## Summary

Profiled run 30664497454, a green 29m30s PR gate, and found the whole run was set by one shard rather than by the amount of work.

- `video-binary-contract` is the only flake check whose shard builds instead of instantiating: 15.9 min against seconds for the other 31. It sat in the same bounded matrix as all of them, and with `max-parallel: 4` and the name sorting last it was dispatched last, starting 12.4 min in and ending exactly when the run ended. It now runs in its own lane off the same discovery. The lane is a matrix, not a hardcoded job, so a second realized check needs no workflow change.
- The seven `nix-unit*` checks were 19.0 min of the eval matrix's 56.0 min of runner time. The dedicated nix-unit lane already runs `nix build` on exactly those, which strictly subsumes instantiating them, so the eval legs were pure duplicate work. Both lanes now read one partition produced by one enumeration, so the names dropped from the eval matrix are provably the names the nix-unit lane runs.
- The runner disk reclaim cost between 43 s and 3 min 48 s across the four Rust-profile jobs, the worst of them on the critical path, to free about 22 GiB on an image that already arrives with 83-88 GiB free. It now runs only below a 70 GiB threshold and still reclaims exactly as before on a fuller image.

## Measured inputs

| Job | Duration | Note |
| --- | --- | --- |
| `flake-eval-x86 (video-binary-contract)` | 15.9 min | started 12.4 min in; ended when the run ended |
| `test-rust-main` | 15.3 min | ~6 min setup, of which 3m48s was disk reclaim |
| `test-rust-remaining` | 13.6 min | |
| `flake-eval-x86` matrix | 56.0 min total, 32 shards | 19.0 min of it duplicate `nix-unit*` |

## Coverage

No check stops being enforced. The dispatch is a total three-way partition that fails closed on a non-total split, an empty enumeration, an element that is not a quoted charset-safe name, or a realized name that is not a discovered check. The classifier is shared with the driver that decides build-versus-instantiate, so a shard cannot be dispatched as realized and then only evaluated. `test-flake-x86` gates on both shard lanes, and the stable required contexts are unchanged.

## Validation

- `make test-lint` - passed; `shellcheck --severity=warning` also run explicitly on both new tools
- `make check-tier0` - passed
- `make check-inventory` - passed
- `make test-drift` - passed, including the flake-check-matrix pin and the wiring gate, which was updated to assert both lanes and the rollup
- `make test-ci-coverage` - passed
- `make test-changelog` - passed
- `tests/unit/meta/ci-runner-regression.py` - 16 tests, 3 new
- `cargo test -p xtask --test policy_ci` (3) and `--test policy_workspace` (5) - passed
- `D2B_FLAKE_CHECK=video-binary-contract bash tests/test-flake.sh` - passed on the realized path
- `D2B_FLAKE_CHECK=rust-build bash tests/test-flake.sh` - passed on the instantiate path
- `bash tests/tools/flake-check-partition.sh` - 24 eval, 1 realized, 7 nix-unit, of 32
- Negative inputs rejected: a name carrying the separator, a name with a space, a name with a quote; the empty array is caught by the total>0 guard
- Mutation check on the new pin: substituting the raw token back for one sanitiser call site fails the meta gate rather than passing

## Review

Four panel rounds to unanimous sign-off. Round 1 returned 7/10 and found a fail-open hole in the partition tool: the line-oriented extraction silently dropped a check name containing the separator while the totality assertion still passed, because it counted only the names that survived parsing. Round 2 surfaced a direct disagreement between two reviewers about whether the rejected element should be named in a public CI log; both concerns were resolved together with a sanitising renderer rather than by picking a side. Round 3 found that sanitiser unpinned, so a future edit could have dropped it silently.

Two round-1 findings were disputed with evidence and withdrawn by the reviewer: `tests/test-nix-unit.sh` has no segfault retry, so the nix-unit lane was always the stricter of the two and removing the eval leg loses nothing; and the realized-branch ordering in `tests/test-flake.sh` is byte-identical to `origin/v3`.