### PR TITLE
ci: cut the PR gate critical path and bring the cache under budget

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -715,9 +715,15 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ runner.temp }}/d2b-realized-cache
-          key: d2b-realized-v1-${{ runner.os }}-${{ matrix.check }}-${{ hashFiles('flake.lock', 'flake.nix', 'pkgs/**') }}
+          key: d2b-realized-v2-${{ runner.os }}-${{ matrix.check }}-${{ hashFiles('flake.lock', 'flake.nix', 'pkgs/**') }}
           restore-keys: |
-            d2b-realized-v1-${{ runner.os }}-${{ matrix.check }}-
+            d2b-realized-v2-${{ runner.os }}-${{ matrix.check }}-
+      - name: Realized-check cache self-test
+        # Two seconds, and it runs where Nix is guaranteed. It pins the copy
+        # shape the restore depends on, whose last regression was invisible:
+        # the entry restored, the copy failed, the shard rebuilt from scratch,
+        # and the step still reported success.
+        run: bash tests/tools/realized-check-cache.sh self-test
       - name: Restore prebuilt check inputs
         # Best-effort: a miss costs the build this cache exists to avoid, and
         # can never produce a wrong result, so it must not fail the shard.

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -82,6 +82,109 @@ jobs:
       - name: Changelog policy gate
         run: make test-changelog
 
+  test-rust-api-surface:
+    needs: [tier0]
+    runs-on: ubuntu-latest
+    # Warm (rust-cache hit): ~8-12 min. Cold (no cache): ~43 min.
+    timeout-minutes: 60
+    env:
+      # CI uses Swatinem/rust-cache (target-dir caching) and NOT sccache. That
+      # is not a preference - sccache is incompatible with this workspace's
+      # integration tests. Its server forwards only a whitelist of environment
+      # variables to rustc, and CARGO_BIN_EXE_<name>, which Cargo injects so an
+      # integration test can locate the binary it exercises, is not on it. Any
+      # test using env!("CARGO_BIN_EXE_...") then fails to compile with
+      # "environment variable ... not defined at compile time"; measured on this
+      # gate, d2b-exec-runner/tests/tty_pty_integration.rs fails exactly that
+      # way. It does not reproduce locally because CARGO_INCREMENTAL is on
+      # there, which makes sccache treat those compilations as non-cacheable and
+      # pass them through untouched.
+      #
+      # sccache remains enabled for local development, where the same shim is
+      # reached through packages/.cargo/config.toml. Only CI opts out.
+      #
+      # CARGO_INCREMENTAL=0 is still set: incremental compilation artifacts are
+      # non-deterministic and bloat the cache without benefit for CI (each PR
+      # run starts from a different commit).
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Free runner disk for Rust gate
+        run: |
+          df -h /
+          avail_kib=$(df -Pk / | awk 'NR == 2 { print $4 }')
+          # Reclaiming the preinstalled Android/dotnet/GHC trees and the Docker
+          # image cache costs real wall time - measured across this workflow's
+          # four Rust-profile jobs it ranged from 43 s to 3 min 48 s, the worst
+          # of which sat on the critical path - and buys about 22 GiB on a
+          # runner image that already arrives with 83-88 GiB free. Nothing in
+          # this gate approaches that, so only pay the cost when an image
+          # actually turns up short. This still fails safe: a fuller image
+          # reclaims exactly as before.
+          threshold_kib=$((70 * 1024 * 1024))
+          if [ "$avail_kib" -ge "$threshold_kib" ]; then
+            echo "free space $((avail_kib / 1024 / 1024)) GiB is at or above the $((threshold_kib / 1024 / 1024)) GiB threshold; skipping reclaim"
+            exit 0
+          fi
+          echo "free space $((avail_kib / 1024 / 1024)) GiB is below the $((threshold_kib / 1024 / 1024)) GiB threshold; reclaiming"
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h /
+      - name: Install pinned Rust toolchain + ripgrep + acl
+        # MUST run BEFORE Swatinem/rust-cache: the cache action reads
+        # `rustc --version` to compute its key hash, so the pinned
+        # toolchain must be the active default when the cache step runs.
+        # Without this, the runner's pre-installed 1.96.0 is hashed,
+        # and the cache is keyed on the wrong compiler version.
+        run: |
+          PINNED=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' packages/rust-toolchain.toml | head -1)
+          rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
+          rustup default "$PINNED"
+          echo "Rust toolchain: $(rustc --version)"
+          sudo apt-get update && sudo apt-get install -y ripgrep acl
+      - name: Rust dependency cache (target dirs + cargo registry)
+        # Swatinem/rust-cache caches dependency artifacts in target dirs
+        # and the cargo registry. It performs all I/O in its own action
+        # process (JavaScript pre/post steps) via @actions/cache - no
+        # ACTIONS_RUNTIME_TOKEN or cache credentials are exposed to `run:`
+        # steps where untrusted crate code (build scripts, proc-macros,
+        # `cargo test`) executes.
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          workspaces: |
+            packages -> target
+            packages/d2b-priv-broker -> target
+            packages/d2b-guest-shell-runner -> target
+          cache-directories: |
+            packages/d2b-priv-broker/target-layer1
+            packages/d2b-priv-broker/target-fakebackends
+            tests/tools/no-bash-ast-walker/target
+            .scratch/rust-test-cache
+          prefix-key: "v2-rust-api-json"
+          shared-key: "test-rust-${{ runner.os }}"
+          # The repository-local trees are keyed on rustc -vV by their owning
+          # tests. Cargo fingerprints compiled inputs on restore, while failed
+          # compile units are never cached and still rerun on every gate.
+          # A single writer keeps concurrent saves from racing one shared key.
+          # The main-workspace Rust shard is that writer; it produces both the
+          # common Cargo target and the slow compiler/rustdoc scratch trees.
+          # Every other Rust job restores the last complete entry. On a cold key
+          # parallel shards may duplicate compilation, but only one entry wins.
+          save-if: "false"
+      - name: Rust compiler-derived API census
+        env:
+          D2B_SKIP_FIXTURE_BUILD: "1"
+        run: make test-rust-api-surface
+
+
   test-rust-main:
     needs: [tier0]
     runs-on: ubuntu-latest
@@ -289,7 +392,7 @@ jobs:
 
 
   test-rust:
-    needs: [test-rust-main, test-rust-remaining]
+    needs: [test-rust-api-surface, test-rust-main, test-rust-remaining]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -297,9 +400,12 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
-      - name: Require both Rust gate shards to pass
+      - name: Require every Rust gate shard to pass
         run: |
           failed=0
+          result='${{ needs.test-rust-api-surface.result }}'
+          echo "test-rust-api-surface=$result"
+          [ "$result" = success ] || failed=1
           result='${{ needs.test-rust-main.result }}'
           echo "test-rust-main=$result"
           [ "$result" = success ] || failed=1

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -605,6 +605,19 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
+      - name: Realized-check input cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ runner.temp }}/d2b-realized-cache
+          key: d2b-realized-v1-${{ runner.os }}-${{ matrix.check }}-${{ hashFiles('flake.lock', 'flake.nix', 'pkgs/**') }}
+          restore-keys: |
+            d2b-realized-v1-${{ runner.os }}-${{ matrix.check }}-
+      - name: Restore prebuilt check inputs
+        # Best-effort: a miss costs the build this cache exists to avoid, and
+        # can never produce a wrong result, so it must not fail the shard.
+        env:
+          D2B_FLAKE_CHECK: ${{ matrix.check }}
+        run: bash tests/tools/realized-check-cache.sh import "$D2B_FLAKE_CHECK" ${{ runner.temp }}/d2b-realized-cache
       - name: Flake check shard (x86_64-linux, realized)
         # D2B_FLAKE_CHECK is passed via the step environment, NOT interpolated
         # into the shell command: a flake check attr name is PR-controlled, so
@@ -613,6 +626,10 @@ jobs:
         env:
           D2B_FLAKE_CHECK: ${{ matrix.check }}
         run: make test-flake
+      - name: Publish built check inputs
+        env:
+          D2B_FLAKE_CHECK: ${{ matrix.check }}
+        run: bash tests/tools/realized-check-cache.sh export "$D2B_FLAKE_CHECK" ${{ runner.temp }}/d2b-realized-cache
 
   flake-eval-x86-outputs:
     needs: [tier0]

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -418,6 +418,9 @@ jobs:
   test-fixture-contracts:
     needs: [tier0]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     # Warm (rust-cache hit): ~8-12 min. Cold (no cache): ~43 min.
     timeout-minutes: 60
     env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1610,14 +1610,16 @@ fields that request panel, agent, or model metadata.
   compiled outputs.
 - `make clean` does that sweep for the current worktree: every cargo
   target directory, the `.scratch/` tree, then `nix-collect-garbage`. It
-  keeps `$SCCACHE_DIR` for the reason above, and touches nothing outside
+  keeps `$SCCACHE_DIR` for the reason above, and deletes no file outside
   the worktree, because sibling worktrees own their artifacts and may
-  have work in flight. It removes a directory only when that directory
-  lies inside the worktree and holds no git-tracked file, so an
-  unexpected match fails closed instead of deleting committed content.
-  Use `D2B_CLEAN_DRY_RUN=1` to see the sweep first; `D2B_CLEAN_SKIP_GC=1`
-  and `D2B_CLEAN_KEEP_SCRATCH=1` narrow it. Collecting old *system*
-  generations still needs the operator-policy `sudo` form below.
+  have work in flight - the store collection is the one step with
+  user-wide reach, and it only reclaims paths nothing still references.
+  A directory is removed only when it lies inside the worktree and holds
+  no git-tracked file, so an unexpected match fails closed instead of
+  deleting committed content. Use `D2B_CLEAN_DRY_RUN=1` to see the sweep
+  first; `D2B_CLEAN_SKIP_GC=1` and `D2B_CLEAN_KEEP_SCRATCH=1` narrow it.
+  Collecting old *system* generations still needs the operator-policy
+  `sudo` form below.
 - `tests/tools/preflight-disk-space.sh` fails the wave when free disk under
   `$ROOT` drops below 10 GiB. Runs after the orphan reapers but BEFORE
   the rust toolchain bootstrap so the fail-closed guard cannot be

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1213,7 +1213,9 @@ with separate debug info also declares a `debug` output that no `--help`
 assertion can need, and carrying those took the same entry to 175 MiB. A
 carried entry can never produce a wrong result, since store paths are
 content-addressed and a changed derivation simply misses and builds, so the
-import is deliberately best-effort and must never fail the shard.
+import is deliberately best-effort and must never fail the shard. Measured on
+the gate, a hit takes that shard from 1010 s to 33 s and builds neither
+package.
 
 Two properties of that script are load-bearing and were each learned the
 expensive way, so do not "simplify" either. It resolves its paths with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1502,6 +1502,24 @@ fields that request panel, agent, or model metadata.
   clear every wrapper spelling because a caching wrapper that exits nonzero
   under concurrent cargo invocations is indistinguishable from the fixture
   failing for the wrong reason.
+- **No linker and no alternative codegen backend are configured, and that is
+  a measured decision rather than an oversight.** Both were tried on this
+  tree and neither earned its place. mold, wired through
+  `target.<triple>.linker` and compared against separately warmed target
+  directories, came out at 6.3 s against 6.7 s on a relink-heavy incremental
+  build and 90 s against 93 s on a warm one - inside the run-to-run noise.
+  The reason is that `[profile.dev] debug = "line-tables-only"` already
+  removed the debug information that makes linking expensive, so the cost
+  mold targets has largely been paid already. Cranelift, over five
+  incremental pairs against a nightly LLVM control, ran 5.8 s against 7.0 s:
+  a real 17% but 1.2 s in absolute terms, and it cannot enter the gate at
+  all, because `packages/rust-toolchain.toml` pins an exact stable release
+  that `tests/test-rust.sh` enforces, so it would mean installing and
+  caching a second toolchain in every Rust job. Reopen either only with a
+  measurement, and note the trap: `tests/test-rust.sh` exports `RUSTFLAGS`,
+  and that environment variable **replaces** `build.rustflags` rather than
+  merging with it, so a linker configured through `rustflags` is silently
+  dead there.
 - Tests that shell out to `cargo` (the capability-seal guards in
   `packages/d2b-bus/`, `packages/d2b-controller-toolkit/` and
   `packages/d2b-resource-api/`) cache their

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1608,6 +1608,16 @@ fields that request panel, agent, or model metadata.
   symlink) so the removal reclaims its multi-GiB build artifacts.
   Rebuilds in a fresh worktree stay cheap because sccache retains the
   compiled outputs.
+- `make clean` does that sweep for the current worktree: every cargo
+  target directory, the `.scratch/` tree, then `nix-collect-garbage`. It
+  keeps `$SCCACHE_DIR` for the reason above, and touches nothing outside
+  the worktree, because sibling worktrees own their artifacts and may
+  have work in flight. It removes a directory only when that directory
+  lies inside the worktree and holds no git-tracked file, so an
+  unexpected match fails closed instead of deleting committed content.
+  Use `D2B_CLEAN_DRY_RUN=1` to see the sweep first; `D2B_CLEAN_SKIP_GC=1`
+  and `D2B_CLEAN_KEEP_SCRATCH=1` narrow it. Collecting old *system*
+  generations still needs the operator-policy `sudo` form below.
 - `tests/tools/preflight-disk-space.sh` fails the wave when free disk under
   `$ROOT` drops below 10 GiB. Runs after the orphan reapers but BEFORE
   the rust toolchain bootstrap so the fail-closed guard cannot be

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1208,9 +1208,24 @@ CI that shard carries its must-build inputs between runs through
 `cache.nixos.org` does not already serve - two packages, about 30 MB - rather
 than a whole-store cache. Keep it that size: the Actions cache is a hard
 repository-wide budget, and this shard is affordable precisely because it is a
-targeted entry. A carried entry can never produce a wrong result, since store
-paths are content-addressed and a changed derivation simply misses and builds,
-so the import is deliberately best-effort and must never fail the shard.
+targeted entry. Publish only each input's **default** output; a package built
+with separate debug info also declares a `debug` output that no `--help`
+assertion can need, and carrying those took the same entry to 175 MiB. A
+carried entry can never produce a wrong result, since store paths are
+content-addressed and a changed derivation simply misses and builds, so the
+import is deliberately best-effort and must never fail the shard.
+
+Two properties of that script are load-bearing and were each learned the
+expensive way, so do not "simplify" either. It resolves its paths with
+`nix-store --query` and restores them **by name from a manifest the export
+writes**, never with `nix derivation show`-plus-jq and never with
+`nix copy --all`. This tree evaluates under Lix and CI installs upstream Nix;
+both of those spellings work under Lix and fail under upstream Nix, and both
+fail as a silent empty result rather than as an error. Each one cost a full
+run whose only symptom was a lane that never got faster. `import` therefore
+decides success by re-querying the store rather than by trusting the copy's
+exit status, and the shard runs `realized-check-cache.sh self-test` - which
+fails closed on a reintroduced `--all` - before the restore.
 
 Do not resolve this by deleting the check. The `--backend` and
 `--vhost-user-media` flags are separately pinned in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,11 +107,19 @@ When a failure only reproduces inside the gate's own toolchain environment,
 use `tests/tools/repro-rust-gate-env.sh <command>` rather than re-running
 `make test-rust`.
 
-CI splits the Rust gate into two independent jobs, `make test-rust-main` and
-`make test-rust-remaining`, behind the stable required `test-rust` rollup
-context. `make test-rust` still runs both partitions exactly once, so it stays
-the local command; reach for a partition target only to rerun the half that
-failed.
+CI splits the Rust gate into three independent jobs, `make
+test-rust-api-surface`, `make test-rust-main` and `make test-rust-remaining`,
+behind the stable required `test-rust` rollup context. `make test-rust` still
+runs all three partitions exactly once, so it stays the local command; reach
+for a partition target only to rerun the part that failed.
+
+The API census is a separate shard because it shares nothing with the
+workspace build: it renders through the separately pinned nightly toolchain in
+`packages/d2b-api-surface/rust-toolchain.toml` into its own target directory
+under `.scratch/rust-test-cache/`, so it neither consumes nor produces
+artifacts that fmt, clippy or nextest use. Its cost is rustdoc rendering rather
+than dependency compilation, so it does not need a cache entry of its own; do
+not give it one. `test-rust-main` remains the single rust-cache writer.
 
 ```bash
 # Focused Layer-1 jobs, in tests/layer1-jobs.json local phase order.
@@ -1191,6 +1199,25 @@ iteration step, and CI also runs
 `nix flake check --no-build --all-systems --no-write-lock-file`
 inside the example directory without coupling the root flake to the
 sibling input.
+
+A **realized** flake check (currently only `video-binary-contract`, listed in
+`D2B_FLAKE_REALIZED_CHECKS` in `tests/tools/flake-check-classes.sh`) is built
+rather than merely instantiated, so it compiles the patched VMM packages. In
+CI that shard carries its must-build inputs between runs through
+`tests/tools/realized-check-cache.sh`, which publishes only the outputs
+`cache.nixos.org` does not already serve - two packages, about 30 MB - rather
+than a whole-store cache. Keep it that size: the Actions cache is a hard
+repository-wide budget, and this shard is affordable precisely because it is a
+targeted entry. A carried entry can never produce a wrong result, since store
+paths are content-addressed and a changed derivation simply misses and builds,
+so the import is deliberately best-effort and must never fail the shard.
+
+Do not resolve this by deleting the check. The `--backend` and
+`--vhost-user-media` flags are separately pinned in
+`nixos-modules/processes-json.nix` and in the golden argv under
+`tests/golden/runner-shape/`, but those pin what d2b *emits*; the realized
+check pins what the binary *accepts*, which is what catches an upstream bump
+dropping a flag.
 
 ## Versioning & changelog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1503,13 +1503,30 @@ fields that request panel, agent, or model metadata.
   under concurrent cargo invocations is indistinguishable from the fixture
   failing for the wrong reason.
 - Tests that shell out to `cargo` (the capability-seal guards in
-  `packages/d2b-bus/` and `packages/d2b-controller-toolkit/`) cache their
+  `packages/d2b-bus/`, `packages/d2b-controller-toolkit/` and
+  `packages/d2b-resource-api/`) cache their
   scratch trees between runs, keyed on a hash of `rustc -vV`. Compiled
   artifacts are not portable across compiler versions, and the gate's
   pinned toolchain routinely differs from a dev shell's, so an unkeyed
-  cache lets one poison the other. Those persistent caches live under
+  cache lets one poison the other. The first two live under
   `.scratch/rust-test-cache/`, which CI restores as one cache surface. They
   are several GB per worktree; delete that subtree to reclaim the space.
+- The `d2b-resource-api` seal instead caches to
+  `.scratch/resource-api-external-seals-<key>/`, deliberately outside that
+  restored surface. Its tree is 767 MB, and the Actions cache is a hard
+  repository-wide budget that is already fully subscribed, so carrying it
+  would evict entries whose cold rebuild costs far more than this fixture's
+  40 s. Do not move it under `rust-test-cache/` without first showing the
+  budget has room.
+- That seal proves the resource API compiled under forced `cfg(test)`, which
+  a warm tree would otherwise skip - so it discards that one crate's cargo
+  fingerprints before checking, keeping its dependencies warm. Both the
+  marker and the rustc wrapper live at fixed paths inside the tree: cargo
+  fingerprints `RUSTC_WRAPPER`, so a per-run wrapper path silently
+  invalidates everything and restores the cold build. The arrangement is
+  fail-closed - the marker is deleted at the start of every run, so if the
+  forcing ever stops working the marker is absent and the seal fails rather
+  than passing without proof.
 - The persistent-shell helper is intentionally excluded from the main
   Rust workspace at `packages/d2b-guest-shell-runner/`. Run it by
   manifest path (and with `--features real-libshpool` when checking the

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SHELL := $(CURDIR)/tests/tools/scrub-shell-environment
 .PHONY: pre-tag smoke-lite i3-check \
         check check-static check-ci check-all check-fast check-tier0 \
         test test-unit \
-        test-lint test-rust test-rust-main test-rust-remaining \
+        test-lint test-rust test-rust-api-surface test-rust-main test-rust-remaining \
         test-fixture-contracts test-proofs test-flake test-nix-unit \
         test-performance-budgets test-adr-index-coverage test-ci-coverage \
         test-flake-list test-flake-partition \
@@ -109,8 +109,12 @@ test-lint:
 test-rust:
 	bash tests/test-rust.sh
 
-## test-rust-main / test-rust-remaining - CI shards of the comprehensive gate.
-## Local developers should run test-rust, which executes both once in order.
+## test-rust-api-surface / test-rust-main / test-rust-remaining - CI shards of
+## the comprehensive gate. Local developers should run test-rust, which executes
+## all three once in order.
+test-rust-api-surface:
+	bash tests/test-rust.sh api-surface
+
 test-rust-main:
 	bash tests/test-rust.sh main-workspace
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL := $(CURDIR)/tests/tools/scrub-shell-environment
         heavy-test-integration heavy-test-host-integration heavy-test-hardware \
         layer1-workflow layer1-workflow-check \
         ledger-regen check-inventory pr-checklist-gate nix-unit-pin flake-matrix-pin \
-        api-surface-pin runtime-ledger-pin
+        api-surface-pin runtime-ledger-pin clean
 
 # Current Nix system double, used to address per-system flake.checks attrs.
 # Falls back to x86_64-linux if `nix` is unavailable (e.g. a docs-only host).
@@ -628,3 +628,15 @@ test-runtime-ledger:
 	    --ledger "$$ledger" --expected-census "$$census" ); \
 	finished_at="$$(date +%s)"; \
 	echo "test-runtime-ledger: complete (duration: $$((finished_at - started_at))s)"
+
+# ===========================================================================
+# Disk hygiene.
+#
+#   make clean   Remove this worktree's cargo target directories and scratch
+#                tree, then collect unreferenced Nix store paths. The shared
+#                sccache directory is deliberately kept, so the next build
+#                re-links rather than recompiling from scratch.
+#
+# Knobs: D2B_CLEAN_DRY_RUN=1, D2B_CLEAN_SKIP_GC=1, D2B_CLEAN_KEEP_SCRATCH=1.
+clean:
+	bash tests/tools/clean-worktree.sh

--- a/changelog.d/ci-gate-cost.md
+++ b/changelog.d/ci-gate-cost.md
@@ -1,0 +1,25 @@
+### Changed
+
+- The pull-request gate no longer rebuilds a patched crosvm and a patched
+  cloud-hypervisor from source on every run in order to check two of their
+  command-line flags. The two outputs those checks need are carried between
+  runs instead, at 30 MB, so the shard that set the gate's wall time stops
+  doing so. A carried entry that no longer matches simply builds as before,
+  because store paths change with the derivation.
+- The compiler-derived API census runs as its own gate shard. It renders
+  through a separately pinned toolchain into its own target directory and
+  shares no artifacts with the workspace build it previously ran inside, so
+  sequencing it there only lengthened the longest shard. `make test-rust`
+  still runs every shard once in order, and `make test-rust-api-surface`
+  matches the existing per-shard targets.
+- The API census builds its dependency graph once rather than twice. Its
+  public pass and its private-and-hidden pass differ only in flags that
+  affect rendering, not in the dependencies they compile, so they now share
+  one target directory. This halves both the time that pass costs on a cold
+  tree and the disk it occupies.
+- The privileged broker's default and layer1-bootstrap test passes no longer
+  run a `cargo check` immediately before their `cargo test`. The two are
+  distinct compilation modes that share no artifacts, so the check reported
+  the same errors slightly earlier at the cost of running the compiler twice.
+  Measured cold, that is 153 s against 89 s for an identical result. The
+  fake-backends pass never had one.

--- a/changelog.d/ci-gate-cost.md
+++ b/changelog.d/ci-gate-cost.md
@@ -23,3 +23,11 @@
   the same errors slightly earlier at the cost of running the compiler twice.
   Measured cold, that is 153 s against 89 s for an identical result. The
   fake-backends pass never had one.
+- The resource API's external capability seal reuses its fixture build between
+  runs, keyed on the compiler that produced it, rather than rebuilding roughly
+  a gigabyte of dependencies every time. Measured locally at 40 s against 2 s.
+  The seal's proof is unchanged: it still demonstrates that the crate compiled
+  under forced `cfg(test)`, by discarding that one crate's fingerprints while
+  its dependencies stay warm, and it now discards the marker recording that
+  compile at the start of every run - so if the forcing were ever to stop
+  working the seal fails rather than passing without proof.

--- a/changelog.d/ci-gate-cost.md
+++ b/changelog.d/ci-gate-cost.md
@@ -23,6 +23,14 @@
   the same errors slightly earlier at the cost of running the compiler twice.
   Measured cold, that is 153 s against 89 s for an identical result. The
   fake-backends pass never had one.
+- The gate's Nix-store cache entry can now be replaced when its key changes.
+  The job was already configured to purge the entry it supersedes, but the
+  workflow granted no permission to delete one, so the purge failed after the
+  replacement had been saved and the superseded entry stayed resident forever.
+  Two such entries were resident at roughly 1.25 GiB each against a hard
+  repository-wide budget, and overrunning that budget evicts entries other
+  jobs depend on. The permission is granted to that job alone, which is the
+  only one that deletes anything.
 - The resource API's external capability seal reuses its fixture build between
   runs, keyed on the compiler that produced it, rather than rebuilding roughly
   a gigabyte of dependencies every time. Measured locally at 40 s against 2 s.

--- a/changelog.d/ci-gate-cost.md
+++ b/changelog.d/ci-gate-cost.md
@@ -40,3 +40,15 @@
   its dependencies stay warm, and it now discards the marker recording that
   compile at the start of every run - so if the forcing were ever to stop
   working the seal fails rather than passing without proof.
+
+### Added
+
+- `make clean` removes this worktree's cargo target directories and its
+  scratch tree, then collects unreferenced Nix store paths. The shared
+  sccache directory is kept deliberately, so the next build re-links instead
+  of recompiling from scratch. A directory is only removed when it lies
+  inside the worktree and holds no git-tracked file, so an unexpected match
+  fails closed rather than deleting committed content. `D2B_CLEAN_DRY_RUN=1`
+  reports what would go without removing it; `D2B_CLEAN_SKIP_GC=1` and
+  `D2B_CLEAN_KEEP_SCRATCH=1` narrow the sweep. Measured on a working
+  worktree: 63 GB reclaimed.

--- a/changelog.d/ci-gate-cost.md
+++ b/changelog.d/ci-gate-cost.md
@@ -4,8 +4,9 @@
   cloud-hypervisor from source on every run in order to check two of their
   command-line flags. The two outputs those checks need are carried between
   runs instead, at 30 MB, so the shard that set the gate's wall time stops
-  doing so. A carried entry that no longer matches simply builds as before,
-  because store paths change with the derivation.
+  doing so. Measured on the gate: that shard falls from 1010 s to 33 s, with
+  no build of either package. A carried entry that no longer matches simply
+  builds as before, because store paths change with the derivation.
 - The compiler-derived API census runs as its own gate shard. It renders
   through a separately pinned toolchain into its own target directory and
   shares no artifacts with the workspace build it previously ran inside, so

--- a/changelog.d/ci-gate-cost.md
+++ b/changelog.d/ci-gate-cost.md
@@ -51,4 +51,4 @@
   fails closed rather than deleting committed content. `D2B_CLEAN_DRY_RUN=1`
   reports what would go without removing it; `D2B_CLEAN_SKIP_GC=1` and
   `D2B_CLEAN_KEEP_SCRATCH=1` narrow the sweep. Measured on a working
-  worktree: 63 GB reclaimed.
+  worktree: 68 GB reclaimed.

--- a/packages/d2b-resource-api/tests/external_seals.rs
+++ b/packages/d2b-resource-api/tests/external_seals.rs
@@ -1,46 +1,95 @@
 use std::{
+    collections::hash_map::DefaultHasher,
     fs,
+    hash::{Hash as _, Hasher as _},
     os::unix::fs::PermissionsExt as _,
     path::{Path, PathBuf},
     process::Command,
 };
 
-/// Owns the repository-local compiler scratch so it is removed on every exit
-/// path, including a panicking assertion. Removing it only on success leaves a
-/// uniquely-named target tree behind whenever cargo fails, and a repeatedly
-/// failing gate accumulates them until it trips the disk-space preflight.
-struct ScratchGuard(PathBuf);
+/// A repository-local compiler scratch that persists between runs, keyed on the
+/// compiler that produced it. Compiled artifacts are not portable across
+/// compiler versions, so an unkeyed tree lets one toolchain poison another.
+///
+/// This tree is deliberately **not** under `.scratch/rust-test-cache`, which the
+/// CI rust-cache carries between jobs. It measures 767 MB, and the Actions cache
+/// is a hard repository-wide budget that is already fully subscribed; buying a
+/// warm fixture here would evict entries whose cold rebuild costs far more than
+/// this fixture does. The saving below is therefore a local one, and CI keeps
+/// paying the cold build.
+struct Scratch(PathBuf);
 
-impl ScratchGuard {
-    /// Drop does not run when the process is killed by a signal - nextest's
-    /// slow-timeout terminate, SIGKILL and OOM all skip it - so a tree can
-    /// outlive its run and be adopted by a later one that reuses the PID. That
-    /// would hand the seal a warm target dir plus a stale
-    /// `resource-api-cfg-test-active` marker, and `cfg_test_marker.is_file()`
-    /// would pass without a compile having happened. Remove any existing tree
-    /// before creating, so adoption cannot occur.
+impl Scratch {
     fn new(path: PathBuf) -> Self {
-        // Fail closed, matching Scratch::ephemeral in d2b-bus. Swallowing the
-        // error would let a tree that could not be removed (EACCES on a
-        // mode-changed entry, EBUSY, a racing writer) be adopted anyway, since
-        // create_dir_all succeeds on an existing directory - reinstating the
-        // very hole this guard closes.
-        match fs::remove_dir_all(&path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => panic!(
-                "could not discard a stranded scratch tree at {}; adopting it would let the \
-                 cfg(test) marker pass without a compile: {error}",
-                path.display()
-            ),
+        if std::env::var_os("D2B_EXTERNAL_SEALS_FRESH").is_some() && path.exists() {
+            fs::remove_dir_all(&path).expect("discard repository-local compiler scratch");
         }
+        fs::create_dir_all(&path).expect("create repository-local scratch");
         Self(path)
     }
 }
 
-impl Drop for ScratchGuard {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.0);
+/// Hash `rustc -vV` so a toolchain change lands in a different tree rather than
+/// reusing artifacts the new compiler cannot read.
+fn toolchain_cache_key() -> String {
+    let version = Command::new(std::env::var("RUSTC").as_deref().unwrap_or("rustc"))
+        .arg("-vV")
+        .output()
+        .expect("query the active rustc version");
+    assert!(
+        version.status.success(),
+        "rustc -vV failed; a scratch tree keyed on an unknown toolchain could be reused across \
+         incompatible compilers"
+    );
+    let mut hasher = DefaultHasher::new();
+    version.stdout.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Force the next `cargo check` to recompile `d2b-resource-api`, whatever the
+/// tree already holds, by discarding its fingerprints. The dependencies below it
+/// stay warm, which is the whole saving.
+///
+/// This exists because the seal's proof is that the crate compiled under forced
+/// `cfg(test)`, recorded by the rustc shim writing a marker. A warm tree would
+/// otherwise skip that compile, and the marker would never be written - measured
+/// directly: warm without this call leaves the marker absent, warm with it
+/// present, and a cold tree writes it as it always did.
+///
+/// So the failure mode is fail-closed by construction. If this ever stops
+/// forcing the compile - cargo relocates its fingerprints, renames the unit, or
+/// the glob simply stops matching - the marker is absent and the assertion at
+/// the end of the test fails. It cannot cause the seal to pass without proof.
+/// Matching nothing is not an error: on a cold tree there is nothing to discard
+/// and the compile happens regardless.
+fn force_resource_api_recompile(target: &Path) {
+    let fingerprints = target.join("debug/.fingerprint");
+    let entries = match fs::read_dir(&fingerprints) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => panic!(
+            "could not read {} to force a fresh cfg(test) compile: {error}",
+            fingerprints.display()
+        ),
+    };
+    for entry in entries {
+        let entry = entry.expect("read a cargo fingerprint directory entry");
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with("d2b-resource-api"))
+        {
+            // Fail closed: a fingerprint that survives leaves the unit fresh, and
+            // the marker assertion would then report an absent compile as a seal
+            // failure. Surface the real cause here instead.
+            fs::remove_dir_all(entry.path()).unwrap_or_else(|error| {
+                panic!(
+                    "could not discard the cargo fingerprint at {}; the forced cfg(test) compile \
+                     would be skipped: {error}",
+                    entry.path().display()
+                )
+            });
+        }
     }
 }
 
@@ -104,24 +153,31 @@ fn dependent_cannot_mint_admission_or_session_capabilities() {
     let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let repository_root = crate_root.parent().unwrap().parent().unwrap();
     let fixture = crate_root.join("tests/ui/external-seals");
-    // Per-process and uncached, deliberately: the cfg_test_marker assertion
-    // below proves the crate was compiled under forced cfg(test), and a warm
-    // target dir would skip that compile and leave a stale marker satisfying
-    // the assertion without proving anything.
-    //
-    // Owned by a guard so the tree is removed on every exit path. Removing it
-    // only on success strands a uniquely-named multi-gigabyte tree per failing
-    // run, and preflight-disk-space.sh fails the wave below 10 GiB free.
-    let scratch_guard = ScratchGuard::new(repository_root.join(".scratch").join(format!(
+    let scratch = Scratch::new(repository_root.join(".scratch").join(format!(
         "resource-api-external-seals-{}",
-        std::process::id()
+        toolchain_cache_key()
     )));
-    let scratch = scratch_guard.0.clone();
+    let scratch = scratch.0.clone();
     let target = scratch.join("target");
     let temp = scratch.join("tmp");
     fs::create_dir_all(&temp).expect("create repository-local compiler scratch");
+    // Both paths must be stable across runs. Cargo fingerprints RUSTC_WRAPPER,
+    // so a per-run wrapper path would invalidate the whole tree and give back
+    // the cold build this cache exists to avoid.
     let rustc_wrapper = scratch.join("force-resource-api-cfg-test.sh");
     let cfg_test_marker = scratch.join("resource-api-cfg-test-active");
+    // Discard any marker a previous run left, so the assertion at the end of
+    // this test can only be satisfied by a compile that happened during it.
+    match fs::remove_file(&cfg_test_marker) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => panic!(
+            "could not discard the cfg(test) marker at {}; a stale one would satisfy the seal \
+             without a compile: {error}",
+            cfg_test_marker.display()
+        ),
+    }
+    force_resource_api_recompile(&target);
     fs::write(
         &rustc_wrapper,
         r#"#!/bin/sh
@@ -198,7 +254,4 @@ exec "$rustc" "$@"
         cfg_test_marker.is_file(),
         "the resource API was not compiled under forced cfg(test)"
     );
-
-    // ScratchGuard removes the tree on drop, including on a panicking
-    // assertion above, so there is no explicit cleanup here.
 }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -194,6 +194,14 @@ are not portable across compiler versions. CI restores that directory as one
 cache surface. When adding such a test, key its subtree the same way and reuse
 the compilation but not any output whose freshness the test asserts on.
 
+One test is deliberately outside that surface. The `d2b-resource-api` external
+seal caches to `.scratch/resource-api-external-seals-<key>/`, keyed the same
+way but **not** under `rust-test-cache/`, because its tree is several hundred
+megabytes and the Actions cache is a hard repository-wide budget. It is a
+local-loop cache only, and CI pays its cold build every run by design. Put a
+new cargo-shelling test under `rust-test-cache/` unless its tree is large
+enough to make that trade, and say which trade you made.
+
 When a failure reproduces only inside the gate's toolchain environment, use
 `tests/tools/repro-rust-gate-env.sh <command>` instead of re-running the whole
 gate.

--- a/tests/layer1-jobs.json
+++ b/tests/layer1-jobs.json
@@ -28,6 +28,7 @@
       "test-performance-budgets",
       "test-lint",
       "test-changelog",
+      "test-rust-api-surface",
       "test-rust-main",
       "test-rust-remaining",
       "test-rust",
@@ -116,6 +117,19 @@
       "timeoutMinutes": 10,
       "runsOn": "ubuntu-latest"
     },
+    "test-rust-api-surface": {
+      "displayName": "Rust compiler-derived API census",
+      "makeTarget": "test-rust-api-surface",
+      "localEnv": {
+        "D2B_SKIP_FIXTURE_BUILD": "1"
+      },
+      "ciKind": "rust",
+      "ciJobId": "test-rust-api-surface",
+      "ciOnly": true,
+      "needs": ["tier0"],
+      "timeoutMinutes": 60,
+      "runsOn": "ubuntu-latest"
+    },
     "test-rust-main": {
       "displayName": "Rust main workspace gate",
       "makeTarget": "test-rust-main",
@@ -143,14 +157,14 @@
       "runsOn": "ubuntu-latest"
     },
     "test-rust": {
-      "displayName": "Require both Rust gate shards to pass",
+      "displayName": "Require every Rust gate shard to pass",
       "makeTarget": "test-rust",
       "localEnv": {
         "D2B_SKIP_FIXTURE_BUILD": "1"
       },
       "ciKind": "rust-rollup",
       "ciJobId": "test-rust",
-      "needs": ["test-rust-main", "test-rust-remaining"],
+      "needs": ["test-rust-api-surface", "test-rust-main", "test-rust-remaining"],
       "timeoutMinutes": 5,
       "runsOn": "ubuntu-latest"
     },

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -27,18 +27,18 @@ rust_mode="${1:-all}"
 case "$rust_mode" in
   all)
     [ "$#" -eq 0 ] || {
-      fail "usage: tests/test-rust.sh [main-workspace|remaining-suite|fixture-contracts]" || true
+      fail "usage: tests/test-rust.sh [api-surface|main-workspace|remaining-suite|fixture-contracts]" || true
       exit 2
     }
     ;;
-  main-workspace|remaining-suite|fixture-contracts)
+  api-surface|main-workspace|remaining-suite|fixture-contracts)
     [ "$#" -eq 1 ] || {
-      fail "usage: tests/test-rust.sh [main-workspace|remaining-suite|fixture-contracts]" || true
+      fail "usage: tests/test-rust.sh [api-surface|main-workspace|remaining-suite|fixture-contracts]" || true
       exit 2
     }
     ;;
   *)
-    fail "usage: tests/test-rust.sh [main-workspace|remaining-suite|fixture-contracts]" || true
+    fail "usage: tests/test-rust.sh [api-surface|main-workspace|remaining-suite|fixture-contracts]" || true
     exit 2
     ;;
 esac
@@ -508,15 +508,28 @@ if [ "$fixture_contracts_only" = 1 ]; then
   exit 0
 fi
 
+# The compiler-derived API census. Its own CI shard, because it shares nothing
+# with the workspace build that would make serialising it behind one worthwhile:
+# it renders through a separately pinned nightly toolchain into its own target
+# directory, so it neither consumes nor produces artifacts that clippy and
+# nextest use. Measured on the pull-request gate it ran 209 s inside a 878 s
+# main shard whose peer shard finished 172 s earlier, so that 209 s sat directly
+# on the gate's critical path while a runner stood idle. Splitting it moves the
+# work sideways rather than removing it: total runner minutes barely change, the
+# longest path shortens by roughly the whole 209 s.
+#
+# One compiler-owned workspace build replaces the old test's serial
+# package-by-package HTML rustdoc loop. This is enforcing and cannot skip.
+run_api_surface_gate() {
+  log "--> compiler-derived API surface"
+  bash "$ROOT/tests/tools/api-surface-json.sh"
+  log "test-rust api-surface OK (duration: $((SECONDS - suite_started))s)"
+}
+
 run_main_workspace_gate() {
   log "--> cargo fmt --check"
   cargo fmt --manifest-path "$manifest" --all --check
   ok "cargo fmt --check"
-
-  # One compiler-owned workspace build replaces the old test's serial
-  # package-by-package HTML rustdoc loop. This is enforcing and cannot skip.
-  log "--> compiler-derived API surface"
-  bash "$ROOT/tests/tools/api-surface-json.sh"
 
 # --locked so a stale committed Cargo.lock fails the gate instead of being
 # silently regenerated. flake.nix vendors the committed lockfile, so a lock
@@ -718,6 +731,9 @@ ok "assert-pinned-tests"
 }
 
 case "$rust_mode" in
+  api-surface)
+    run_api_surface_gate
+    ;;
   main-workspace)
     run_main_workspace_gate
     ;;
@@ -725,6 +741,7 @@ case "$rust_mode" in
     run_remaining_suite_gate
     ;;
   all)
+    run_api_surface_gate
     run_main_workspace_gate
     run_remaining_suite_gate
     log "test-rust OK (duration: $((SECONDS - suite_started))s)"

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -404,14 +404,19 @@ run_nextest_companions() {
 # covers doctests and harness=false binaries without needing companions. Making
 # the broker process-per-test safe would mean reworking test setup inside a
 # critical, privileged, protected subsystem for no measurable gain.
+#
+# No stream runs `cargo check` before its `cargo test`. Check and test are
+# distinct compilation modes that share no artifacts, so a check ahead of a test
+# on the same target directory is time spent twice for one result. Measured cold
+# on the layer1 stream: 153 s with the check against 89 s without, for an
+# identical outcome and an unchanged test phase (85 s against 89 s). The
+# fake-backends stream never had one, which is why it was already the fastest.
 broker_stream_default() {
   cargo metadata --format-version 1 --manifest-path "$broker_manifest" >/dev/null
-  CARGO_TARGET_DIR="$broker_target_dir" cargo check --workspace --manifest-path "$broker_manifest"
   rm -f -- "$broker_target_dir"/debug/deps/socket_activation-* 2>/dev/null || true
   CARGO_TARGET_DIR="$broker_target_dir" cargo test --workspace --manifest-path "$broker_manifest"
 }
 broker_stream_layer1() {
-  CARGO_TARGET_DIR="$broker_layer1_target_dir" cargo check --workspace --manifest-path "$broker_manifest" --features layer1-bootstrap
   CARGO_TARGET_DIR="$broker_layer1_target_dir" cargo test --workspace --manifest-path "$broker_manifest" --features layer1-bootstrap
 }
 broker_stream_fakebackends() {

--- a/tests/tools/api-surface-json.sh
+++ b/tests/tools/api-surface-json.sh
@@ -51,12 +51,27 @@ case "$target_root" in
     exit 2
     ;;
 esac
-public_target="$target_root/public"
-private_target="$target_root/private"
+# One target directory for both censuses. They differ only in RUSTDOCFLAGS,
+# which fingerprints the rustdoc units and so still re-renders every workspace
+# lib, but does NOT fingerprint the rustc units that compile the dependency
+# graph. Separate directories therefore compiled that graph twice: measured on
+# this workspace, the two trees held byte-identical dependency artifact sets
+# (1879 files each, all names matching) for 2.6 GB of pure duplication. That
+# cost is paid twice over, once as wall time on any cold run and once as
+# footprint in the repository-wide Actions cache budget that
+# .scratch/rust-test-cache is restored from.
+census_target="$target_root/census"
+
+# Reclaim the pre-merge layout. A restored cache still carries these, and left
+# alone they would keep charging the cache budget for a tree nothing reads.
+rm -rf "$target_root/public" "$target_root/private"
 
 # Delete only rendered JSON. Cargo's compiled intermediate artifacts remain
 # reusable, but a stale or extra blob cannot satisfy the exact metadata census.
-rm -rf "$public_target/doc" "$private_target/doc"
+# Sharing one directory makes this mandatory between the two passes, not just
+# before the first: the copy below globs whatever *.json is present, so a blob
+# left by the public pass could otherwise be counted as private output.
+rm -rf "$census_target/doc"
 
 log "--> rustdoc JSON public workspace census ($pin)"
 # Raw cargo/rustdoc stderr names absolute scratch paths, source text, and
@@ -71,13 +86,17 @@ public_rc=0
     CARGO_BUILD_RUSTC_WRAPPER= \
     RUSTDOCFLAGS="-D warnings -Z unstable-options --output-format json" \
     cargo "+$pin" doc --locked --workspace --lib --no-deps \
-      --target-dir "$public_target"
+      --target-dir "$census_target"
 ) >"$scratch/public-rustdoc.log" 2>&1 || public_rc=$?
 [ "$public_rc" = 0 ] || {
   fail "api-surface public rustdoc JSON census failed (exit $public_rc); rerun 'make api-surface-pin' locally for compiler diagnostics" || true
   exit 1
 }
-find "$public_target/doc" -maxdepth 1 -type f -name '*.json' -exec cp -t "$public_dir" -- {} +
+find "$census_target/doc" -maxdepth 1 -type f -name '*.json' -exec cp -t "$public_dir" -- {} +
+
+# Discard the public render before the private pass. Both passes emit into the
+# same doc directory now, and the copy above has already taken what it needs.
+rm -rf "$census_target/doc"
 
 log "--> rustdoc JSON private + hidden workspace census ($pin)"
 private_rc=0
@@ -89,13 +108,13 @@ private_rc=0
     CARGO_BUILD_RUSTC_WRAPPER= \
     RUSTDOCFLAGS="-D warnings -Z unstable-options --output-format json --document-private-items --document-hidden-items" \
     cargo "+$pin" doc --locked --workspace --lib --no-deps \
-      --target-dir "$private_target"
+      --target-dir "$census_target"
 ) >"$scratch/private-rustdoc.log" 2>&1 || private_rc=$?
 [ "$private_rc" = 0 ] || {
   fail "api-surface private rustdoc JSON census failed (exit $private_rc); rerun 'make api-surface-pin' locally for compiler diagnostics" || true
   exit 1
 }
-find "$private_target/doc" -maxdepth 1 -type f -name '*.json' -exec cp -t "$private_dir" -- {} +
+find "$census_target/doc" -maxdepth 1 -type f -name '*.json' -exec cp -t "$private_dir" -- {} +
 
 bash "$ROOT/tests/tools/gen-api-surface-metadata.sh" \
   "$public_dir" "$private_dir" "$metadata"

--- a/tests/tools/clean-worktree.sh
+++ b/tests/tools/clean-worktree.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Reclaim this worktree's disk: cargo target directories, the scratch tree,
+# and unreferenced Nix store paths.
+#
+# Deliberately NOT removed:
+#   - the shared sccache directory ($SCCACHE_DIR, default
+#     ~/.cache/d2b-sccache). It is what keeps a rebuild after this target
+#     cheap, and it is shared across every worktree.
+#   - anything outside this worktree. Sibling worktrees own their own
+#     artifacts and may have work in flight.
+#
+# Environment knobs:
+#   D2B_CLEAN_SKIP_GC=1        skip nix-collect-garbage
+#   D2B_CLEAN_KEEP_SCRATCH=1   keep .scratch/
+#   D2B_CLEAN_DRY_RUN=1        report what would be removed, remove nothing
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+dry_run="${D2B_CLEAN_DRY_RUN:-0}"
+total_bytes=0
+
+log() { printf '%s\n' "$*"; }
+
+# A path is safe to remove only when it sits inside this worktree AND holds
+# no git-tracked file. The tracked-file check is the load-bearing guard: it
+# is what makes an unexpected match (a source directory that happens to be
+# named "target", a future layout change) fail closed rather than delete
+# committed content.
+assert_removable() {
+  local path="$1" resolved
+  resolved="$(readlink -f -- "$path")"
+
+  case "$resolved" in
+    "$ROOT"/?*) : ;;
+    *)
+      printf 'clean: refusing to remove %s: outside %s\n' "$resolved" "$ROOT" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ -n "$(git ls-files -- "$path")" ]; then
+    printf 'clean: refusing to remove %s: contains git-tracked files\n' "$path" >&2
+    exit 1
+  fi
+}
+
+remove_path() {
+  local path="$1" bytes
+  [ -e "$path" ] || return 0
+  assert_removable "$path"
+
+  bytes="$(du -sb -- "$path" 2>/dev/null | cut -f1)"
+  [ -n "$bytes" ] || bytes=0
+  total_bytes=$((total_bytes + bytes))
+
+  if [ "$dry_run" = "1" ]; then
+    log "  would remove $(numfmt --to=iec --suffix=B -- "$bytes")	${path#./}"
+    return 0
+  fi
+
+  log "  removing $(numfmt --to=iec --suffix=B -- "$bytes")	${path#./}"
+  rm -rf -- "$path"
+}
+
+log "clean: cargo target directories"
+# A directory named `target` counts as a cargo target directory when it sits
+# beside a Cargo.toml or carries cargo's own CACHEDIR.TAG marker. Nested
+# target directories are pruned: removing the outer one takes them with it.
+#
+# .scratch is excluded here and handled as a single unit below. The warm test
+# caches under it are target directories, but they live and die with the
+# scratch tree - counting them separately would double-count the reclaim, and
+# removing them individually would gut the caches that
+# D2B_CLEAN_KEEP_SCRATCH exists to preserve.
+while IFS= read -r dir; do
+  [ -f "${dir%/target}/Cargo.toml" ] || [ -f "$dir/CACHEDIR.TAG" ] || continue
+  remove_path "$dir"
+done < <(find . -type d \( -path ./.git -o -path ./.scratch \) -prune -o \
+  -type d -name target -prune -print | sort)
+
+if [ "${D2B_CLEAN_KEEP_SCRATCH:-0}" = "1" ]; then
+  log "clean: keeping .scratch (D2B_CLEAN_KEEP_SCRATCH=1)"
+else
+  log "clean: scratch tree"
+  remove_path ./.scratch
+fi
+
+log "clean: reclaimed $(numfmt --to=iec --suffix=B -- "$total_bytes") from this worktree"
+
+if [ "${D2B_CLEAN_SKIP_GC:-0}" = "1" ]; then
+  log "clean: skipping nix-collect-garbage (D2B_CLEAN_SKIP_GC=1)"
+  exit 0
+fi
+
+if [ "$dry_run" = "1" ]; then
+  log "clean: would run nix-collect-garbage"
+  exit 0
+fi
+
+if ! command -v nix-collect-garbage >/dev/null 2>&1; then
+  log "clean: nix-collect-garbage not on PATH, skipping store collection"
+  exit 0
+fi
+
+# User-scoped collection only. Deleting old *system* generations needs sudo
+# and is operator policy rather than a repository target; AGENTS.md documents
+# `sudo nix-collect-garbage --delete-older-than 7d` for that.
+log "clean: collecting unreferenced Nix store paths"
+nix-collect-garbage

--- a/tests/tools/clean-worktree.sh
+++ b/tests/tools/clean-worktree.sh
@@ -66,9 +66,15 @@ remove_path() {
 }
 
 log "clean: cargo target directories"
-# A directory named `target` counts as a cargo target directory when it sits
-# beside a Cargo.toml or carries cargo's own CACHEDIR.TAG marker. Nested
-# target directories are pruned: removing the outer one takes them with it.
+# A cargo target directory is one named `target` or `target-<suffix>` (the
+# broker workspace uses `target-layer1` and `target-fakebackends` for its
+# separate test passes) that either sits beside a Cargo.toml or carries
+# cargo's own CACHEDIR.TAG marker. Nested target directories are pruned:
+# removing the outer one takes them with it.
+#
+# The name match is deliberately broad and the validation narrow. A source
+# directory that happened to match would still have to clear the
+# tracked-file guard in assert_removable, which it cannot.
 #
 # .scratch is excluded here and handled as a single unit below. The warm test
 # caches under it are target directories, but they live and die with the
@@ -76,10 +82,10 @@ log "clean: cargo target directories"
 # removing them individually would gut the caches that
 # D2B_CLEAN_KEEP_SCRATCH exists to preserve.
 while IFS= read -r dir; do
-  [ -f "${dir%/target}/Cargo.toml" ] || [ -f "$dir/CACHEDIR.TAG" ] || continue
+  [ -f "$(dirname -- "$dir")/Cargo.toml" ] || [ -f "$dir/CACHEDIR.TAG" ] || continue
   remove_path "$dir"
 done < <(find . -type d \( -path ./.git -o -path ./.scratch \) -prune -o \
-  -type d -name target -prune -print | sort)
+  -type d \( -name target -o -name 'target-*' \) -prune -print | sort)
 
 if [ "${D2B_CLEAN_KEEP_SCRATCH:-0}" = "1" ]; then
   log "clean: keeping .scratch (D2B_CLEAN_KEEP_SCRATCH=1)"

--- a/tests/tools/layer1-jobs.py
+++ b/tests/tools/layer1-jobs.py
@@ -22,6 +22,7 @@ TEMPLATE = ROOT / "tests" / "ci" / "layer1-workflow.template.yml"
 WORKFLOW = ROOT / ".github" / "workflows" / "pr-l1-static-fast.yml"
 SELF_TEST = ROOT / "tests" / "unit" / "meta" / "ci-runner-regression.py"
 CHECKOUT = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+CACHE = "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830"
 INSTALL_NIX = "cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077"
 RUST_CACHE = "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32"
 # Caches /nix through the GitHub Actions cache. The developer host has a local
@@ -156,6 +157,13 @@ NIX_CACHE_FORMAT = "v1"
 # f-string replacement field is ordinary Python source, not escaped f-string
 # text, and would emit four literal braces - an invalid GitHub expression.
 MATRIX_CHECK_SCOPE = "-${{ matrix.check }}"
+# Where the realized lane's targeted binary cache lives. Deliberately under the
+# runner temp directory rather than the workspace: a volatile file inside $ROOT
+# races the source capture that flake evaluation performs, which is the same
+# reason tests/lib.sh keeps its bookkeeping out of the repository root. Written
+# with single braces because this is ordinary module-level source, not f-string
+# text - see MATRIX_CHECK_SCOPE above for the same hazard.
+REALIZED_CACHE_DIR = "${{ runner.temp }}/d2b-realized-cache"
 
 
 def nix_cache_hash_files(job: dict[str, Any]) -> str:
@@ -568,7 +576,25 @@ def flake_x86_realized_job(job: dict[str, Any]) -> str:
     No gdb step here. The eval lane installs it for the segfault retry path in
     test-flake.sh, and that path is unreachable for a realized shard - those
     fail hard on any nonzero status instead of retrying.
+
+    The shard carries a targeted binary cache rather than a whole-store one.
+    Measured on this tree, the single realized check has five direct build
+    inputs and cache.nixos.org already serves three of them; only the two
+    patched VMM packages must ever be built, and they export to about 30 MB of
+    compressed NAR. Caching just those recovers the entire ~16 min compile for
+    an entry small enough not to compete for the repository's ~10 GB budget -
+    unlike the 4G-capped store cache the fixture job needs, which is why
+    NIX_CACHED_JOBS deliberately does not extend to this lane.
+
+    A stale entry is harmless: store paths are content-addressed, so a changed
+    derivation has a changed output path, the restored entry cannot satisfy it,
+    and the shard builds exactly as it does today. The key therefore only has
+    to be good enough for a useful hit rate, and restore-keys are safe.
     """
+    cache_key = (
+        "d2b-realized-v1-${{ runner.os }}-${{ matrix.check }}-"
+        "${{ hashFiles('flake.lock', 'flake.nix', 'pkgs/**') }}"
+    )
     return f"""  {job["ciJobId"]}:
 {needs_line(job)}    runs-on: {job["runsOn"]}
     timeout-minutes: {job["timeoutMinutes"]}
@@ -582,6 +608,19 @@ def flake_x86_realized_job(job: dict[str, Any]) -> str:
         with:
           persist-credentials: false
 {nix_setup_step(job, MATRIX_CHECK_SCOPE)}
+      - name: Realized-check input cache
+        uses: {CACHE}
+        with:
+          path: {REALIZED_CACHE_DIR}
+          key: {cache_key}
+          restore-keys: |
+            d2b-realized-v1-${{{{ runner.os }}}}-${{{{ matrix.check }}}}-
+      - name: Restore prebuilt check inputs
+        # Best-effort: a miss costs the build this cache exists to avoid, and
+        # can never produce a wrong result, so it must not fail the shard.
+        env:
+          D2B_FLAKE_CHECK: ${{{{ matrix.check }}}}
+        run: bash tests/tools/realized-check-cache.sh import "$D2B_FLAKE_CHECK" {REALIZED_CACHE_DIR}
       - name: {job["displayName"]}
         # D2B_FLAKE_CHECK is passed via the step environment, NOT interpolated
         # into the shell command: a flake check attr name is PR-controlled, so
@@ -589,7 +628,11 @@ def flake_x86_realized_job(job: dict[str, Any]) -> str:
         # vector. test-flake.sh additionally rejects names outside [A-Za-z0-9._-].
         env:
           D2B_FLAKE_CHECK: ${{{{ matrix.check }}}}
-        run: make test-flake"""
+        run: make test-flake
+      - name: Publish built check inputs
+        env:
+          D2B_FLAKE_CHECK: ${{{{ matrix.check }}}}
+        run: bash tests/tools/realized-check-cache.sh export "$D2B_FLAKE_CHECK" {REALIZED_CACHE_DIR}"""
 
 
 def flake_x86_outputs_job(job: dict[str, Any]) -> str:

--- a/tests/tools/layer1-jobs.py
+++ b/tests/tools/layer1-jobs.py
@@ -308,10 +308,34 @@ def heavy_gate_step(job: dict[str, Any]) -> str:
     )
 
 
+def job_permissions(job: dict[str, Any]) -> str:
+    """Per-job token scope, granted only where a step provably needs it.
+
+    The workflow default is `contents: read`, which is what almost every job
+    wants. A Nix-store entry is the exception: cache-nix-action's `purge`
+    replaces the previous entry for a key prefix, and deleting an Actions cache
+    goes through the REST API, which needs `actions: write`. Without it the
+    purge fails with "Resource not accessible by integration" - and it fails
+    after the new entry has already been saved, so every key change orphans the
+    entry it was meant to replace. Measured on v3, that left two
+    `nix-v1-Linux-test-fixture-contracts-` entries resident at about 1.25 GiB
+    each, one of them permanently unreachable, against a hard 10 GiB
+    repository-wide budget whose overrun evicts entries other jobs depend on.
+
+    Scoped to the job rather than the workflow: nothing else here deletes a
+    cache. Fork pull requests receive a read-only token regardless, so this
+    grants nothing across a trust boundary; it takes effect on same-repository
+    pushes, which is where the entry being replaced actually lives.
+    """
+    if job["ciJobId"] not in NIX_CACHED_JOBS:
+        return ""
+    return "    permissions:\n      contents: read\n      actions: write\n"
+
+
 def rust_job(job: dict[str, Any]) -> str:
     return f"""  {job["ciJobId"]}:
 {needs_line(job)}    runs-on: {job["runsOn"]}
-    # Warm (rust-cache hit): ~8-12 min. Cold (no cache): ~43 min.
+{job_permissions(job)}    # Warm (rust-cache hit): ~8-12 min. Cold (no cache): ~43 min.
     timeout-minutes: {job["timeoutMinutes"]}
     env:
       # CI uses Swatinem/rust-cache (target-dir caching) and NOT sccache. That

--- a/tests/tools/layer1-jobs.py
+++ b/tests/tools/layer1-jobs.py
@@ -592,7 +592,9 @@ def flake_x86_realized_job(job: dict[str, Any]) -> str:
     to be good enough for a useful hit rate, and restore-keys are safe.
     """
     cache_key = (
-        "d2b-realized-v1-${{ runner.os }}-${{ matrix.check }}-"
+        # v2 carries a path manifest alongside the binary cache; v1 entries
+        # have none and cannot be restored by the current importer.
+        "d2b-realized-v2-${{ runner.os }}-${{ matrix.check }}-"
         "${{ hashFiles('flake.lock', 'flake.nix', 'pkgs/**') }}"
     )
     return f"""  {job["ciJobId"]}:
@@ -614,7 +616,13 @@ def flake_x86_realized_job(job: dict[str, Any]) -> str:
           path: {REALIZED_CACHE_DIR}
           key: {cache_key}
           restore-keys: |
-            d2b-realized-v1-${{{{ runner.os }}}}-${{{{ matrix.check }}}}-
+            d2b-realized-v2-${{{{ runner.os }}}}-${{{{ matrix.check }}}}-
+      - name: Realized-check cache self-test
+        # Two seconds, and it runs where Nix is guaranteed. It pins the copy
+        # shape the restore depends on, whose last regression was invisible:
+        # the entry restored, the copy failed, the shard rebuilt from scratch,
+        # and the step still reported success.
+        run: bash tests/tools/realized-check-cache.sh self-test
       - name: Restore prebuilt check inputs
         # Best-effort: a miss costs the build this cache exists to avoid, and
         # can never produce a wrong result, so it must not fail the shard.

--- a/tests/tools/realized-check-cache.sh
+++ b/tests/tools/realized-check-cache.sh
@@ -72,10 +72,9 @@ check_name_is_safe() {
 }
 
 # Keep only the paths that are valid in the local store. A derivation can
-# declare outputs that a given build never realizes - the two patched packages
-# each declare a `debug` output that is absent unless separateDebugInfo
-# produced one - and `nix copy` fails on a path it cannot read. Publishing is
-# best-effort over whatever this run actually produced.
+# declare an output that a given build never realizes, and `nix copy` fails on
+# a path it cannot read. Publishing is best-effort over whatever this run
+# actually produced.
 select_local_paths() {
   local path
   while read -r path; do
@@ -84,6 +83,47 @@ select_local_paths() {
       printf '%s\n' "$path"
     fi
   done
+}
+
+# Print the store path of a derivation's default output, or every output when
+# the default one cannot be identified.
+#
+# Nix names a derivation's default output after the derivation itself and
+# appends `-<outputName>` to each of the others, so the default output is the
+# one whose store-path name equals the derivation's name. Selecting it matters
+# because a package built with separate debug info also produces a `debug`
+# output, and nothing a realized check asserts can need one: measured on
+# `video-binary-contract`, whose two must-build inputs it selects only `out`
+# from, those two debug outputs were 145 of the entry's 175 MiB. Publishing
+# only the default outputs takes the same entry to 30 MB.
+#
+# A derivation whose `outputs` omit `out` names its default output
+# `<name>-<first>` instead, and then nothing matches. That case keeps every
+# output rather than none: omitting a needed path costs a full rebuild, while
+# carrying a few unneeded ones costs only bytes, so the ambiguous case errs
+# towards completeness.
+default_output_paths() {
+  local drv=$1 name outs kept out out_name
+  name=${drv##*/}
+  name=${name#*-}
+  name=${name%.drv}
+
+  outs=$(nix-store --query --outputs "$drv")
+  kept=""
+  for out in $outs; do
+    out_name=${out##*/}
+    out_name=${out_name#*-}
+    if [ "$out_name" = "$name" ]; then
+      kept=$out
+    fi
+  done
+
+  if [ -n "$kept" ]; then
+    printf '%s\n' "$kept"
+  else
+    # shellcheck disable=SC2086 # deliberate split: one output path per word
+    printf '%s\n' $outs
+  fi
 }
 
 # Print the output paths of a check's direct build inputs that the upstream
@@ -106,7 +146,7 @@ must_build_paths() {
     "${flake_ref}#checks.${native}.${check}.drvPath")
 
   for input in $(nix-store --query --references "$drv" | grep '\.drv$'); do
-    for out in $(nix-store --query --outputs "$input"); do
+    for out in $(default_output_paths "$input"); do
       # A path upstream already has is not worth a slot in our entry.
       if ! nix path-info --store "$UPSTREAM_SUBSTITUTER" "$out" >/dev/null 2>&1; then
         printf '%s\n' "$out"

--- a/tests/tools/realized-check-cache.sh
+++ b/tests/tools/realized-check-cache.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# tests/tools/realized-check-cache.sh - a targeted binary cache for the flake
+# checks that must be BUILT rather than instantiated.
+#
+#   bash tests/tools/realized-check-cache.sh import <check> <dir>
+#   bash tests/tools/realized-check-cache.sh export <check> <dir>
+#   bash tests/tools/realized-check-cache.sh plan   <check>
+#
+# Why this exists. `video-binary-contract` is the only realized check, and it
+# spends about sixteen minutes compiling a patched crosvm and a patched
+# cloud-hypervisor so it can run each binary's `--help` and grep one flag out
+# of the output. Measured on this tree, that compile has five direct build
+# inputs, three of which (bash, gnugrep, stdenv) cache.nixos.org already
+# serves. Only the two patched packages must ever be built, and their combined
+# runtime closure exports to about 30 MB of zstd-compressed NAR.
+#
+# So the whole cost is recoverable by carrying those two outputs between runs.
+# That is a far smaller object than a whole-store cache: the store cache the
+# fixture-contract job uses is capped at 4G uncompressed, and the repository
+# only gets ~10 GB of Actions cache in total (see NIX_CACHED_JOBS in
+# tests/tools/layer1-jobs.py for why that budget forbids fanning store caches
+# out across every nix job). A ~30 MB entry does not meaningfully compete for
+# that budget, which is what makes caching this lane affordable at all.
+#
+# Why it cannot go wrong. Nix store paths are content-addressed by derivation
+# hash, and `import` restores paths by exact name. Change a patch under pkgs/,
+# bump flake.lock, or alter the derivation any other way, and the output path
+# changes with it; the stale entry then simply fails to satisfy the new path
+# and the build runs as before. A stale or wrong cache therefore costs a miss,
+# never a wrong result - so the cache key only has to be good enough for a
+# decent hit rate, and does not have to be sound.
+#
+# `import` is best-effort by design and never fails the job: not restoring a
+# cache must degrade to the current behaviour (build it) rather than turn a
+# green gate red.
+#
+# This is CI plumbing rather than a test case, so it lives under tests/tools/
+# and needs no migration-ledger entry.
+
+set -euo pipefail
+
+HERE=$(dirname "$(readlink -f "$0")")
+ROOT=${ROOT:-$(cd "$HERE/../.." && pwd)}
+
+# shellcheck source=tests/lib.sh
+. "$ROOT/tests/lib.sh"
+
+# shellcheck source=tests/tools/flake-check-classes.sh
+. "$HERE/flake-check-classes.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: realized-check-cache.sh <import|export|plan> <check> [dir]
+
+  import <check> <dir>  restore every path held in <dir> into the local store
+  export <check> <dir>  publish <check>'s must-build inputs into <dir>
+  plan   <check>        print the store paths export would publish
+EOF
+  return 2
+}
+
+# The substituter consulted to decide whether an input is worth carrying
+# ourselves. A path this store already serves is cheaper to fetch than to
+# cache, so it is excluded from the entry.
+UPSTREAM_SUBSTITUTER=${D2B_UPSTREAM_SUBSTITUTER:-https://cache.nixos.org}
+
+check_name_is_safe() {
+  case "$1" in
+    '' | *[!A-Za-z0-9._-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Keep only the paths that are valid in the local store. A derivation can
+# declare outputs that a given build never realizes - the two patched packages
+# each declare a `debug` output that is absent unless separateDebugInfo
+# produced one - and `nix copy` fails on a path it cannot read. Publishing is
+# best-effort over whatever this run actually produced.
+select_local_paths() {
+  local path
+  while read -r path; do
+    [ -n "$path" ] || continue
+    if nix path-info "$path" >/dev/null 2>&1; then
+      printf '%s\n' "$path"
+    fi
+  done
+}
+
+# Print the output paths of a check's direct build inputs that the upstream
+# substituter does not already serve. Those are exactly the paths whose absence
+# forces a local compile.
+must_build_paths() {
+  local check=$1 flake_ref native drv input out
+  flake_ref=$(d2b_flake_ref "$ROOT")
+  native=$(nix eval --raw --impure --expr builtins.currentSystem)
+
+  drv=$(nix eval --raw --quiet --no-warn-dirty \
+    "${flake_ref}#checks.${native}.${check}.drvPath")
+
+  for input in $(nix derivation show "$drv" | jq -r '.[].inputDrvs | keys[]'); do
+    for out in $(nix derivation show "$input" | jq -r '.[].outputs[].path'); do
+      # A path upstream already has is not worth a slot in our entry.
+      if ! nix path-info --store "$UPSTREAM_SUBSTITUTER" "$out" >/dev/null 2>&1; then
+        printf '%s\n' "$out"
+      fi
+    done
+  done
+}
+
+cmd_plan() {
+  local check=$1
+  must_build_paths "$check"
+}
+
+cmd_import() {
+  local check=$1 dir=$2
+  : "$check"
+
+  if [ ! -d "$dir" ]; then
+    log "  realized-check cache: no entry at $dir; the check will build normally"
+    return 0
+  fi
+
+  # Best effort on purpose: a failed restore must cost time, never correctness.
+  # --no-check-sigs because this store is written by this same workflow rather
+  # than by a signing party, and its contents are only ever consumed by exact
+  # store path.
+  if nix copy --no-check-sigs --all --from "file://$dir" 2>/dev/null; then
+    log "  realized-check cache: restored $dir"
+  else
+    log "  realized-check cache: restore from $dir failed; building normally"
+  fi
+  return 0
+}
+
+cmd_export() {
+  local check=$1 dir=$2 paths
+
+  paths=$(must_build_paths "$check" | select_local_paths)
+  if [ -z "$paths" ]; then
+    log "  realized-check cache: nothing to publish for $check"
+    return 0
+  fi
+
+  # Publish into a fresh directory. A restore-keys hit can seed this with an
+  # older run's paths, and appending to that would let the entry accumulate
+  # every historical build without bound. Only the current paths are useful,
+  # since anything else can no longer satisfy this derivation.
+  rm -rf -- "$dir"
+  mkdir -p "$dir"
+  # shellcheck disable=SC2086
+  nix copy --to "file://$dir?compression=zstd" $paths
+  log "  realized-check cache: published $(printf '%s\n' "$paths" | wc -l) path(s) to $dir"
+}
+
+main() {
+  [ $# -ge 2 ] || usage
+
+  local mode=$1 check=$2
+  shift 2
+
+  check_name_is_safe "$check" ||
+    fail "realized-check cache: check name '$check' has characters outside [A-Za-z0-9._-]"
+
+  d2b_flake_check_is_realized "$check" ||
+    fail "realized-check cache: '$check' is not a realized check"
+
+  case "$mode" in
+    plan)
+      cmd_plan "$check"
+      ;;
+    import | export)
+      [ $# -ge 1 ] || usage
+      "cmd_$mode" "$check" "$1"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/tools/realized-check-cache.sh
+++ b/tests/tools/realized-check-cache.sh
@@ -143,7 +143,7 @@ must_build_paths() {
   flake_ref=$(d2b_flake_ref "$ROOT")
   native=$(nix eval --raw --impure --expr builtins.currentSystem)
 
-  drv=$(nix eval --raw --quiet --no-warn-dirty \
+  drv=$(nix eval --raw --impure --quiet --no-warn-dirty \
     "${flake_ref}#checks.${native}.${check}.drvPath")
 
   for input in $(nix-store --query --references "$drv" | grep '\.drv$'); do
@@ -168,7 +168,7 @@ cmd_plan() {
 MANIFEST_NAME=d2b-cached-paths
 
 cmd_import() {
-  local check=$1 dir=$2 manifest paths path want missing
+  local check=$1 dir=$2 manifest paths path needed missing
   : "$check"
   manifest="$dir/$MANIFEST_NAME"
 
@@ -178,6 +178,18 @@ cmd_import() {
   fi
 
   paths=$(tr '\n' ' ' <"$manifest")
+
+  # Count what the store lacks *before* copying. Only a path that is missing
+  # now can be restored by this copy, so this is the only baseline against
+  # which the copy can be said to have worked. Counting solely afterwards
+  # would report success whenever the paths happened to be present for some
+  # other reason, which is the same shape of false negative that let a broken
+  # restore run undetected for a full run.
+  needed=0
+  while read -r path; do
+    [ -n "$path" ] || continue
+    nix path-info "$path" >/dev/null 2>&1 || needed=$((needed + 1))
+  done <"$manifest"
 
   # Copy the manifest's paths by name rather than asking the source store to
   # enumerate itself. `nix copy --all` reads as the obvious spelling and works
@@ -199,25 +211,29 @@ cmd_import() {
   nix copy --no-check-sigs --from "file://$dir" $paths || true
 
   # Report on what the store actually holds now rather than on the copy's exit
-  # status. Whether the entry contributed is precisely the question of whether
-  # these paths are valid, and deciding it here means any future way for the
-  # restore to stop working - an unsupported operation, a corrupt entry, a
-  # path the export never published - surfaces as this one warning instead of
-  # as a lane that is mysteriously still slow.
-  want=0
+  # status, and against the pre-copy baseline rather than against the manifest.
+  # Whether the entry contributed is precisely the question of whether the
+  # paths it was supposed to supply became valid, and deciding it here means
+  # any future way for the restore to stop working - an unsupported operation,
+  # a corrupt entry, a path the export never published - surfaces as this one
+  # warning instead of as a lane that is mysteriously still slow.
   missing=0
   while read -r path; do
     [ -n "$path" ] || continue
-    want=$((want + 1))
     nix path-info "$path" >/dev/null 2>&1 || missing=$((missing + 1))
   done <"$manifest"
 
+  if [ "$needed" -eq 0 ]; then
+    log "  realized-check cache: every path already valid; nothing to restore"
+    return 0
+  fi
+
   if [ "$missing" -eq 0 ]; then
-    log "  realized-check cache: restored $want path(s) from $dir"
+    log "  realized-check cache: restored $needed path(s) from $dir"
   else
-    log "  realized-check cache: $missing of $want path(s) missing after restore; building normally"
+    log "  realized-check cache: $missing of $needed path(s) still missing after restore; building normally"
     printf '::warning::realized-check cache restored %s of %s path(s) for %s; this run rebuilds it\n' \
-      "$((want - missing))" "$want" "$check"
+      "$((needed - missing))" "$needed" "$check"
   fi
   return 0
 }

--- a/tests/tools/realized-check-cache.sh
+++ b/tests/tools/realized-check-cache.sh
@@ -89,6 +89,14 @@ select_local_paths() {
 # Print the output paths of a check's direct build inputs that the upstream
 # substituter does not already serve. Those are exactly the paths whose absence
 # forces a local compile.
+#
+# This deliberately uses `nix-store --query`, whose plain-text output has been
+# stable for years, rather than `nix derivation show` and jq. The JSON shape of
+# the latter differs between Nix implementations - this tree evaluates under
+# Lix while CI installs upstream Nix - and a shape mismatch there fails as an
+# empty result rather than as an error, which published an empty entry once
+# already. The references of a .drv are its input derivations and input
+# sources, so selecting the `.drv` ones gives exactly the direct build inputs.
 must_build_paths() {
   local check=$1 flake_ref native drv input out
   flake_ref=$(d2b_flake_ref "$ROOT")
@@ -97,8 +105,8 @@ must_build_paths() {
   drv=$(nix eval --raw --quiet --no-warn-dirty \
     "${flake_ref}#checks.${native}.${check}.drvPath")
 
-  for input in $(nix derivation show "$drv" | jq -r '.[].inputDrvs | keys[]'); do
-    for out in $(nix derivation show "$input" | jq -r '.[].outputs[].path'); do
+  for input in $(nix-store --query --references "$drv" | grep '\.drv$'); do
+    for out in $(nix-store --query --outputs "$input"); do
       # A path upstream already has is not worth a slot in our entry.
       if ! nix path-info --store "$UPSTREAM_SUBSTITUTER" "$out" >/dev/null 2>&1; then
         printf '%s\n' "$out"
@@ -138,7 +146,14 @@ cmd_export() {
 
   paths=$(must_build_paths "$check" | select_local_paths)
   if [ -z "$paths" ]; then
+    # Not fatal - publishing nothing costs a rebuild, never a wrong result, and
+    # failing here would turn a passing check red. But it means the next run
+    # pays the full build, so say so loudly enough to be noticed: this went
+    # unnoticed once, as a silent empty entry, and the only symptom was the
+    # lane never getting faster.
     log "  realized-check cache: nothing to publish for $check"
+    printf '::warning::realized-check cache published nothing for %s; the next run rebuilds it\n' \
+      "$check"
     return 0
   fi
 

--- a/tests/tools/realized-check-cache.sh
+++ b/tests/tools/realized-check-cache.sh
@@ -50,11 +50,12 @@ ROOT=${ROOT:-$(cd "$HERE/../.." && pwd)}
 
 usage() {
   cat >&2 <<'EOF'
-usage: realized-check-cache.sh <import|export|plan> <check> [dir]
+usage: realized-check-cache.sh <import|export|plan|self-test> [check] [dir]
 
   import <check> <dir>  restore every path held in <dir> into the local store
   export <check> <dir>  publish <check>'s must-build inputs into <dir>
   plan   <check>        print the store paths export would publish
+  self-test             round-trip an entry through a scratch store
 EOF
   return 2
 }
@@ -160,23 +161,63 @@ cmd_plan() {
   must_build_paths "$check"
 }
 
-cmd_import() {
-  local check=$1 dir=$2
-  : "$check"
+# The list of store paths an entry holds, written by `export` and consumed by
+# `import`. It is named so it cannot collide with the binary-cache layout Nix
+# writes into the same directory (`nix-cache-info`, `*.narinfo`, `nar/`), and
+# Nix ignores files it does not recognise.
+MANIFEST_NAME=d2b-cached-paths
 
-  if [ ! -d "$dir" ]; then
+cmd_import() {
+  local check=$1 dir=$2 manifest paths path want missing
+  : "$check"
+  manifest="$dir/$MANIFEST_NAME"
+
+  if [ ! -s "$manifest" ]; then
     log "  realized-check cache: no entry at $dir; the check will build normally"
     return 0
   fi
 
+  paths=$(tr '\n' ' ' <"$manifest")
+
+  # Copy the manifest's paths by name rather than asking the source store to
+  # enumerate itself. `nix copy --all` reads as the obvious spelling and works
+  # under Lix, which implements queryAllValidPaths for a local binary cache,
+  # but upstream Nix - which is what CI installs - does not support that
+  # operation on a binary-cache store and fails the whole copy. That divergence
+  # cost a full run: the entry restored, the copy failed, and the check rebuilt
+  # from scratch while the step still reported success.
+  #
   # Best effort on purpose: a failed restore must cost time, never correctness.
   # --no-check-sigs because this store is written by this same workflow rather
   # than by a signing party, and its contents are only ever consumed by exact
   # store path.
-  if nix copy --no-check-sigs --all --from "file://$dir" 2>/dev/null; then
-    log "  realized-check cache: restored $dir"
+  #
+  # stderr is deliberately not discarded. The failure above was invisible
+  # precisely because it was, and a restore that silently stops working has no
+  # symptom other than the lane quietly never getting faster.
+  # shellcheck disable=SC2086 # deliberate split: one store path per word
+  nix copy --no-check-sigs --from "file://$dir" $paths || true
+
+  # Report on what the store actually holds now rather than on the copy's exit
+  # status. Whether the entry contributed is precisely the question of whether
+  # these paths are valid, and deciding it here means any future way for the
+  # restore to stop working - an unsupported operation, a corrupt entry, a
+  # path the export never published - surfaces as this one warning instead of
+  # as a lane that is mysteriously still slow.
+  want=0
+  missing=0
+  while read -r path; do
+    [ -n "$path" ] || continue
+    want=$((want + 1))
+    nix path-info "$path" >/dev/null 2>&1 || missing=$((missing + 1))
+  done <"$manifest"
+
+  if [ "$missing" -eq 0 ]; then
+    log "  realized-check cache: restored $want path(s) from $dir"
   else
-    log "  realized-check cache: restore from $dir failed; building normally"
+    log "  realized-check cache: $missing of $want path(s) missing after restore; building normally"
+    printf '::warning::realized-check cache restored %s of %s path(s) for %s; this run rebuilds it\n' \
+      "$((want - missing))" "$want" "$check"
   fi
   return 0
 }
@@ -205,10 +246,58 @@ cmd_export() {
   mkdir -p "$dir"
   # shellcheck disable=SC2086
   nix copy --to "file://$dir?compression=zstd" $paths
+  printf '%s\n' "$paths" >"$dir/$MANIFEST_NAME"
   log "  realized-check cache: published $(printf '%s\n' "$paths" | wc -l) path(s) to $dir"
 }
 
+# A round trip through the exact copy shape `import` uses, plus a guard on the
+# spelling that broke it. `nix copy --all` reads as the natural way to drain a
+# restored entry and passes under Lix, so nothing local catches its
+# reintroduction; upstream Nix rejects the operation on a binary-cache store
+# and the only symptom is a lane that silently never gets faster.
+cmd_self_test() {
+  local work path cache store restored banned
+
+  # Assembled rather than written out, so this line does not match itself.
+  banned='nix copy'
+  if grep -vE '^[[:space:]]*#' "$0" | grep -q -- "$banned .*--all"; then
+    fail "realized-check cache: --all cannot enumerate a binary-cache store under upstream Nix"
+  fi
+
+  work=$(mktemp -d)
+  # shellcheck disable=SC2064 # expand now: $work must not change before EXIT
+  trap "rm -rf -- '$work'" EXIT
+
+  printf 'realized-check cache self test\n' >"$work/probe"
+  path=$(nix-store --add "$work/probe")
+  cache="$work/cache"
+  store="$work/store"
+  mkdir -p "$store"
+
+  nix copy --to "file://$cache?compression=zstd" "$path"
+  printf '%s\n' "$path" >"$cache/$MANIFEST_NAME"
+  [ -s "$cache/$MANIFEST_NAME" ] ||
+    fail "realized-check cache: export wrote no manifest"
+
+  restored=$(tr '\n' ' ' <"$cache/$MANIFEST_NAME")
+  # shellcheck disable=SC2086 # deliberate split: one store path per word
+  nix copy --no-check-sigs --from "file://$cache" --to "$store" $restored ||
+    fail "realized-check cache: manifest round trip failed"
+
+  [ -e "$store$path" ] ||
+    fail "realized-check cache: $path absent from the restored store"
+
+  log "realized-check cache self-test OK"
+}
+
 main() {
+  [ $# -ge 1 ] || usage
+
+  if [ "$1" = "self-test" ]; then
+    cmd_self_test
+    return 0
+  fi
+
   [ $# -ge 2 ] || usage
 
   local mode=$1 check=$2

--- a/tests/unit/meta/ci-runner-regression.py
+++ b/tests/unit/meta/ci-runner-regression.py
@@ -198,7 +198,7 @@ set -euo pipefail
         with self.assertRaises(SystemExit):
             layer1_jobs.validate_job_id("bad-${{ github.token }}", "test")
 
-    def test_rust_gate_is_two_required_shards_with_one_stable_rollup(self) -> None:
+    def test_rust_gate_is_three_required_shards_with_one_stable_rollup(self) -> None:
         layer1_jobs = load_layer1_jobs()
         manifest = layer1_jobs.load_manifest()
         workflow = layer1_jobs.render_workflow(manifest)
@@ -206,14 +206,16 @@ set -euo pipefail
         rust_rollup = manifest["jobs"]["test-rust"]
         self.assertEqual(
             rust_rollup["needs"],
-            ["test-rust-main", "test-rust-remaining"],
+            ["test-rust-api-surface", "test-rust-main", "test-rust-remaining"],
         )
         self.assertEqual(rust_rollup["ciKind"], "rust-rollup")
+        self.assertIn("run: make test-rust-api-surface", workflow)
         self.assertIn("run: make test-rust-main", workflow)
         self.assertIn("run: make test-rust-remaining", workflow)
+        self.assertIn("test-rust-api-surface=$result", workflow)
         self.assertIn("test-rust-main=$result", workflow)
         self.assertIn("test-rust-remaining=$result", workflow)
-        self.assertEqual(workflow.count('[ "$result" = success ] || failed=1'), 2)
+        self.assertEqual(workflow.count('[ "$result" = success ] || failed=1'), 3)
         self.assertIn('[ "$failed" -eq 0 ] || exit 1', workflow)
         self.assertEqual(manifest["ci"]["rollupNeeds"].count("test-rust"), 1)
 


### PR DESCRIPTION
## What this changes

Cuts the `pr-l1-static-fast` gate's critical path from ~16 min to ~11 min, cuts
its total runner minutes by ~27%, and brings the repository back under the
10 GiB Actions cache limit it had been exceeding. Every change here was
measured before and after; anything that did not move its metric was reverted
rather than kept on the theory that it should have helped.

Two of the three duplicate-work categories that motivated this turned out to be
real, and are fixed. The third turned out not to exist.

## Measured outcome

Per-job wall time, from the Actions jobs API rather than from estimates:

| Job | Before | After |
| --- | --- | --- |
| `flake-eval-x86-realized (video-binary-contract)` | 944 s | **33 s** |
| `test-rust-main` | 878 s | 651 s |
| `test-rust-remaining` | 706 s | 669 s |
| `test-rust-api-surface` (new shard) | - | 339 s |
| `test-fixture-contracts` | 653 s | 625 s |

Critical path 944 s to 669 s. Sum of those lanes 3181 s to 2317 s. Whole-gate
wall time 18m36s to **12m32s**.

Actions cache: 10.24 GiB across 8 entries, over the 10 GiB limit and evicting
continuously, down to **8.96 GiB across 6**.

## Is the caching actually contributing?

Asked as a separate question, because a cache that hits and restores nothing
looks identical to one that works. Confirmed on the latest run, per entry:

| Entry | Result |
| --- | --- |
| `d2b-realized-v2-…bd5be3ce…` (33 MiB) | exact primary-key hit, `restored 2 path(s)`, **zero** crosvm or cloud-hypervisor build lines, 35 s job |
| `v2-rust-api-json-…21820c02-650f5f18` (2222 MiB) | exact primary-key hit, restored |
| `nix-v1-…test-fixture-contracts-40fc1dc7…` (1254 MiB) | exact primary-key hit, restored |

All three hit their **primary** key rather than a `restore-keys` prefix, so an
unchanged tree does not mint a replacement entry. The realized lane's log
confirms the corollary directly: `Cache hit occurred on the primary key … not
saving cache`. The same key served two consecutive runs, so the entry is neither
spuriously invalidated nor redundantly re-saved.

The realized lane's only remaining build work is the check derivation itself
plus three trivial `user-environment.drv`. Both VMM closures come from cache.

## The changes

**The realized flake check was rebuilding two VMMs to run two `--help`
invocations.** `flake-eval-x86-realized` asserts that patched crosvm accepts
`--backend` and patched cloud-hypervisor accepts `--vhost-user-media`. It had no
Nix store cache at all, so it built both from source every run. It now carries
the two built outputs in a 33 MiB Actions entry.

Scoping first: `nix path-info` confirmed the check selects only the `out` output
of its two inputs, so there was no wider dependency graph to trim, only the
build to avoid. That same look showed the entry was carrying two `-debug`
outputs as dead weight, 145 of 175 MiB, which selecting default outputs drops.

**The API-surface census built its dependency graph twice.** The public and
private rustdoc passes used separate target directories, so the shared
dependency build ran once each. Sharing the directory took that build from 50 s
to 12 s and the footprint from 2.6 GB + 2.7 GB to 1.4 GB. The census then moved
into its own shard, which is what rebalanced `test-rust-main`.

**The broker streams ran `cargo check --workspace` immediately before
`cargo test --workspace`.** `cargo test` subsumes it. Removing it took the
layer1 stream from 153 s to 89 s cold. The default stream's intervening
`rm -f .../socket_activation-*` was checked first and does not depend on the
check having produced those artifacts.

**The resource-API seal deleted its fixture tree on every exit**, guaranteeing a
cold build locally and in CI. It now uses the same toolchain-keyed warm cache as
the bus and controller-toolkit harnesses: 43 s every run becomes 40 s cold and
2-3 s warm. This is a local-loop win; the tree is several hundred megabytes, so
it deliberately stays off the Actions cache budget, and `tests/AGENTS.md` records
that trade.

**Cache entries were being orphaned rather than replaced.** `cache-nix-action`'s
purge deletes through the Actions REST API, which needs `actions: write`; the
workflow granted only `contents: read`. The purge failed *after* the replacement
was saved, so every key change stranded ~1.25 GiB permanently. Two such entries
are resident on `v3` today. The permission is now granted **job-scoped**, to
`test-fixture-contracts` only, rather than at workflow level.

## Rejected on measurement

Both were implemented, measured, and removed.

- **mold.** 6.33 s vs 6.67 s on a relink-heavy build; 90 s vs 93 s warm. Noise.
  `debug = "line-tables-only"` had already removed the link cost that would have
  made a linker swap worthwhile.
- **Cranelift.** 17% on the incremental build (7.0 s vs 5.8 s, 1.2 s absolute)
  against a 25% bar, and *worse* cold at 81 s vs 210 s. Separately blocked by
  the exact-version toolchain pin, since it ships only as a nightly component.

Both negative results are recorded in `AGENTS.md` so they are not re-litigated.

## Disproven, so not implemented

- **The `cargo-deny` / `cargo-audit` duplication.** All six invocations total
  **12 s**, and the claimed drift between the Nix and shell ignore lists does
  not exist.
- **A shared binary cache.** Superseded. The realized cache gets the same result
  with no external service, no account, and no token anywhere in CI.

## The defect this turned up, and why the verification step is in the diff

The realized cache **hit on its first eligible run and saved nothing.** The
Actions entry restored 10 s into the job and the shard still took 921 s, because
`nix copy --all --from file://...` cannot enumerate a binary-cache store under
upstream Nix. It works under Lix, which is what this tree evaluates under, so it
passed every local test and failed only where it ran. `2>/dev/null` hid it.

That was the second Lix-versus-upstream divergence to cost a full CI run, and
both failed the same way: an empty or failed result that still exits 0. The
first was `nix derivation show | jq`, which published an empty entry.

So the restore no longer trusts an exit status. It counts what the store lacks
*before* copying, copies, recounts, and judges against that baseline; both
empty-publish and partial-restore raise `::warning::` annotations; and a
`self-test` subcommand fails closed if `--all` reappears. The self-test passes
on upstream Nix in CI, which is the point.

**A stale entry cannot produce a wrong result.** Nix store paths are
content-addressed by derivation hash and the restore copies exact paths by name.
Any change to `pkgs/`, `flake.lock`, or the derivation changes the path, so a
stale entry simply fails to satisfy the build and the build runs as before. A
stale cache costs a miss, never a wrong answer.

## Local disk: `make clean`

Auditing the gate meant surveying what builds actually cost locally, which
turned up 68 GB of reclaimable artifacts in one worktree and 197 GB in a
sibling. The disk hygiene contract already required deleting a worktree's
target directories before removing it and running `nix-collect-garbage` after
a wave merge; both were manual, so neither reliably happened.

`make clean` performs that sweep: every cargo target directory, the
`.scratch/` tree, then user-scoped `nix-collect-garbage`. It keeps
`$SCCACHE_DIR`, which is shared across worktrees and is what makes the next
build re-link rather than recompile, and it deletes no file outside the
worktree because siblings may have work in flight.

The load-bearing guard is that a directory is removed only when it lies
inside the worktree and holds no git-tracked file. No tracked file lives under
any target directory today, so the check costs nothing now and fails closed if
that ever changes. Verified against the shipped guard:

```
REFUSED : docs                  contains git-tracked files
REFUSED : Makefile              contains git-tracked files
REFUSED : /tmp                  outside <worktree root>
ALLOWED : .scratch
ALLOWED : packages/target
ALLOWED : packages/d2b-priv-broker/target-layer1
```

`D2B_CLEAN_DRY_RUN=1` reports the sweep without performing it;
`D2B_CLEAN_SKIP_GC=1` and `D2B_CLEAN_KEEP_SCRATCH=1` narrow it.

## Validation

- `make check` green at the head commit: 12 enforcing jobs, 1 advisory
- `make test-integration` green (container tier, 4 s)
- `make check-tier0`, `make test-lint`, `make layer1-workflow-check`,
  `make test-ci-coverage`, `layer1-jobs self-test` green
- `shellcheck --severity=warning tests/tools/realized-check-cache.sh` clean
- `realized-check-cache.sh self-test` OK; negative control with `--all`
  reintroduced fails correctly
- All three CI workflows green on the head commit
- Cache export proven on a cold run: `published 2 path(s)`, entry saved at 33 MiB
- Cache hit proven on the two runs since: 33 s and 35 s, `restored 2 path(s)`,
  zero VMM build lines

`make test-host-integration` was not run. It is the runNixOSTest VM tier and
nothing in this change touches a NixOS module, a systemd unit, or any runtime
path it exercises; the diff is confined to CI workflow generation, test
drivers, one Rust test's fixture caching, and docs.

## Known limitation

The purge permission is confirmed granted, and confirmed scoped. On this PR's
run the two jobs report:

| Job | Granted |
| --- | --- |
| `test-fixture-contracts` | `Actions: write`, `Contents: read`, `Metadata: read` |
| `test-rust-main` | `Contents: read`, `Metadata: read` |

and the purge step ran without the `Resource not accessible by integration`
error that the `v3` log shows. What is *not* proven here is a purge that
actually deletes something: this branch changes no `.nix` file, so its key
matches `v3`, the run hits the primary key, and there is no superseded entry on
this ref to remove. The DELETE call itself first exercises on the next `v3` push
that changes a `.nix` file.

## Not done

`assert-pinned-tests.sh` remains the largest single duplicate at 196 s: three
`cargo nextest list` invocations, and `nextest list` compiles test binaries.
Moving it into `test-rust-main` makes the longest shard longer, and
`Swatinem/rust-cache` cleans workspace-crate artifacts before saving. No fix
identified; recorded rather than guessed at.
