### PR TITLE
tests: avoid duplicate policy scans

### DIFF
--- a/changelog.d/test-fixture-contracts-speed.md
+++ b/changelog.d/test-fixture-contracts-speed.md
@@ -1,0 +1,5 @@
+### Changed
+
+- `make test-fixture-contracts` no longer reruns fixture-independent policy
+  binaries already enforced by `make test-policy`, avoiding duplicated
+  repository-wide source and documentation scans.

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -106,9 +106,10 @@ The default `test-rust` includes the fixture-dependent contract and CLI
 surfaces once when Nix is available. The Layer-1 graph sets
 `D2B_SKIP_FIXTURE_BUILD=1`, leaving those surfaces to the separate enforcing
 `D2B_ENABLE_FIXTURE_BUILD=1 make test-fixture-contracts` lane; selected
-hermetic policy files may still have separate enforcing entrypoints such as
-`test-policy`. The focused `test-rust-main` target retains the same
-conditional fixture behavior.
+hermetic policy files have separate enforcing entrypoints under `test-policy`
+and are excluded from the fixture lane through the shared list in
+`tests/lib.sh`. The focused `test-rust-main` target retains the same conditional
+fixture behavior.
 
 ### The API census shard
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -54,8 +54,9 @@ Layer-1 orchestration so the separate enforcing
 the contract and CLI surfaces. The fixture target materializes `D2B_FIXTURES`
 from evaluated Nix artifact data and invoking it without the enable variable
 fails rather than skipping. Selected hermetic policy files may also have
-explicit enforcing entrypoints under `test-policy`; check its driver before
-citing one.
+explicit enforcing entrypoints under `test-policy`; those binaries are excluded
+from `test-fixture-contracts` so the Layer-1 graph runs their repository scans
+once. Check the shared list in `tests/lib.sh` before citing one.
 
 `test-policy` also runs `guest-workspace-drift`. It fails when the guest crates
 copied by `mkGuestRustPackagesSrc` diverge from

--- a/tests/README.md
+++ b/tests/README.md
@@ -171,8 +171,9 @@ runs the fixture-dependent contract and CLI tests. The default `test-rust` and
 focused `test-rust-main` include those surfaces once when Nix is available;
 `D2B_SKIP_FIXTURE_BUILD=1` omits them for the Layer-1 graph so this separate
 lane does not duplicate work. Selected hermetic policy files may have separate
-enforcing entrypoints under `test-policy`; inspect that target before citing
-one.
+enforcing entrypoints under `test-policy`; the shared list in `tests/lib.sh` is
+excluded from the fixture lane so those repository scans execute once. Inspect
+that target before citing one.
 
 ### Rust DAG budget and execution evidence
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -58,6 +58,8 @@ export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-10G}"
 # Hermetic d2b-contract-tests policy binaries owned by `make test-policy`.
 # The fixture-contract lane excludes these exact binaries so the Layer-1 graph
 # does not run their repository-wide source and documentation scans twice.
+# ShellCheck analyzes this sourced library without either consuming driver.
+# shellcheck disable=SC2034
 readonly -a D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES=(
   policy_dash_gate
   policy_adr046_work_items

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -55,6 +55,20 @@ export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cache/d2b-sccache}"
 # for the host's free-space envelope.
 export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-10G}"
 
+# Hermetic d2b-contract-tests policy binaries owned by `make test-policy`.
+# The fixture-contract lane excludes these exact binaries so the Layer-1 graph
+# does not run their repository-wide source and documentation scans twice.
+readonly -a D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES=(
+  policy_dash_gate
+  policy_adr046_work_items
+  policy_changelog_gate
+  policy_adr046_spec_literals
+  policy_adr046_envelopes
+  policy_provider_crates
+  policy_resource_mutation_seal
+  policy_docs
+)
+
 d2b_repo_root() {
   printf '%s\n' "${ROOT:-${FLAKE:-$(dirname "$_LIB_HERE")}}"
 }

--- a/tests/test-policy.sh
+++ b/tests/test-policy.sh
@@ -159,17 +159,11 @@ run_policy_gate "ci-coverage"               tests/unit/meta/ci-coverage.sh
 # Fixture-independent contract-test policy binaries. These prove the dash ban,
 # the ADR 0046 manifest-drift bijection, the changelog gate, and the ADR 0046
 # spec-literal drift lints (datetime precision, ResourceType grammar, retry
-# scalar shape) actually work. They are excluded from `make test-rust`'s
-# `cargo test --workspace` run and skipped there under D2B_SKIP_FIXTURE_BUILD,
-# so this mandatory target is their only guaranteed execution point.
-run_policy_cargo_binary "policy-dash-gate"        policy_dash_gate
-run_policy_cargo_binary "policy-adr046-work-items" policy_adr046_work_items
-run_policy_cargo_binary "policy-changelog-gate"   policy_changelog_gate
-run_policy_cargo_binary "policy-adr046-spec-literals" policy_adr046_spec_literals
-run_policy_cargo_binary "policy-adr046-envelopes"     policy_adr046_envelopes
-run_policy_cargo_binary "policy-provider-crates"     policy_provider_crates
-run_policy_cargo_binary "policy-resource-mutation-seal" policy_resource_mutation_seal
-run_policy_cargo_binary "policy-docs" policy_docs
+# scalar shape) actually work. The shared list is excluded from the fixture
+# lane, so this mandatory target is their one Layer-1 execution point.
+for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do
+  run_policy_cargo_binary "${testname//_/-}" "$testname"
+done
 run_guest_workspace_guard
 
 [ "$rc" -eq 0 ] || exit 1

--- a/tests/test-rust.sh
+++ b/tests/test-rust.sh
@@ -523,8 +523,12 @@ guest_shell_runner_gate() {
 }
 
 run_fixture_contract_tests() {
-  local eval_root system flake_ref eval_rc
+  local eval_root system flake_ref eval_rc testname
+  local fixture_contract_filter='not binary(video_binary_contract)'
   rust_surface_start rust-contract-tests
+  for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do
+    fixture_contract_filter+=" and not binary($testname)"
+  done
   eval_root=$(d2b_mktemp ".d2b-eval-fixtures.XXXXXX")
   # The feature-rich full fixture is graphics-gated to x86_64-linux, so
   # eval-fixtures.sh exits 3 elsewhere. Leave D2B_FIXTURES_FULL empty there so
@@ -549,7 +553,7 @@ run_fixture_contract_tests() {
   D2B_FIXTURES="$contract_fixtures" D2B_FIXTURES_FULL="$contract_fixtures_full" \
   CARGO_TARGET_DIR="$fixture_target_dir" \
     cargo nextest run --test-threads "$D2B_RUST_NEXTEST_THREADS" --manifest-path "$manifest" -p d2b-contract-tests \
-      -E 'not binary(video_binary_contract)'
+      -E "$fixture_contract_filter"
   D2B_FIXTURES="$contract_fixtures" D2B_FIXTURES_FULL="$contract_fixtures_full" \
   CARGO_TARGET_DIR="$fixture_target_dir" \
     run_nextest_companions "contract crate" "$manifest" -p d2b-contract-tests

--- a/tests/unit/meta/ci-runner-regression.py
+++ b/tests/unit/meta/ci-runner-regression.py
@@ -1382,6 +1382,51 @@ printf '%s\n' "$sanitized_line"
         self.assertIn("run_private_census &", api_driver)
         self.assertIn('if [ "$api_jobs" -ge 2 ]', api_driver)
 
+    def test_fixture_contracts_exclude_policy_binaries_owned_by_test_policy(self) -> None:
+        library = (ROOT / "tests" / "lib.sh").read_text(encoding="utf-8")
+        policy_driver = (ROOT / "tests" / "test-policy.sh").read_text(
+            encoding="utf-8"
+        )
+        rust_driver = RUST_DRIVER.read_text(encoding="utf-8")
+        binaries = [
+            "policy_dash_gate",
+            "policy_adr046_work_items",
+            "policy_changelog_gate",
+            "policy_adr046_spec_literals",
+            "policy_adr046_envelopes",
+            "policy_provider_crates",
+            "policy_resource_mutation_seal",
+            "policy_docs",
+        ]
+
+        self.assertIn(
+            "readonly -a D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES=(",
+            library,
+        )
+        for binary in binaries:
+            self.assertEqual(
+                library.count(f"  {binary}\n"),
+                1,
+                f"{binary} must appear exactly once in the shared policy-binary list",
+            )
+        self.assertIn(
+            'for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do',
+            policy_driver,
+        )
+        self.assertIn(
+            'run_policy_cargo_binary "${testname//_/-}" "$testname"',
+            policy_driver,
+        )
+        self.assertIn(
+            'for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do',
+            rust_driver,
+        )
+        self.assertIn(
+            'fixture_contract_filter+=" and not binary($testname)"',
+            rust_driver,
+        )
+        self.assertIn('-E "$fixture_contract_filter"', rust_driver)
+
     def test_api_surface_scratch_creation_works_without_existing_parent(self) -> None:
         with tempfile.TemporaryDirectory(prefix="api-scratch-parent.") as raw_dir:
             root = pathlib.Path(raw_dir) / "repo"


### PR DESCRIPTION
## Summary

- Keep the eight fixture-independent `d2b-contract-tests` policy binaries in one shared inventory owned by `make test-policy`.
- Exclude those binaries from `make test-fixture-contracts`, removing 184 duplicate policy cases while retaining 308 fixture-selected contract cases.
- Document and regression-test the single-owner orchestration so future policy additions cannot silently return to both lanes.

The slow `policy_adr046_spec_literals` cases are ordinary scanner tests, not compile-fail tests. Its only Cargo subprocess is `cargo metadata`; external compile-fail suites are outside the fixture-contract lane.

## Testing checklist (mandatory)

- [ ] **`make check` passes locally** - Not run locally; CI will execute the full Layer-1 graph.
- [x] **`make test-integration` passes on the host before PR creation** - N/A: pure test-orchestration, policy, and documentation change with no daemon, broker, NixOS module, runtime, network, or generated-artifact behavior change.
- [x] **`make test-host-integration` passes on the host before PR creation** - N/A: pure test-orchestration, policy, and documentation change with no daemon, broker, NixOS module, runtime, network, or generated-artifact behavior change.
- [x] **Manual `make test-hardware` run** - N/A: no device/passthrough or full-microVM-boot surface touched.
- [x] **New/changed tests are wired into a `make` target** and have rows in `tests/migration-ledger.toml` - Existing meta coverage was extended; no test entrypoint was added. `make check-inventory` passed with 180 rows.
- [ ] **Docs + CI updated in lockstep** - Contributor and test documentation is updated; the full doc+CI-reference gate was not run locally. The workflow graph is unchanged.

## Validation

- `bash -n tests/lib.sh tests/test-policy.sh tests/test-rust.sh`
- Targeted `CiRunnerRegressionTests` cases: 2 passed
- Nextest filter census: 493 total contract cases, 184 policy-owned cases excluded, 308 fixture-selected cases retained, zero excluded-policy cases selected
- `make check-inventory`: passed

## Notes

- Release notes are in `changelog.d/test-fixture-contracts-speed.md`.
- The active ADR wave worktree was not modified.