### PR TITLE
tests: reduce policy gate duplicate work

### DIFF
--- a/changelog.d/test-policy-speed.md
+++ b/changelog.d/test-policy-speed.md
@@ -3,3 +3,6 @@
 - Reuse normalized documentation text across ADR 0046 spike-measurement policy
   checks instead of rebuilding it for every site, inventory pattern, and
   negative control.
+- Run the fixture-independent Rust policy binaries through one Cargo invocation
+  while retaining fail-closed evidence that every selected binary executed
+  nonzero tests.

--- a/changelog.d/test-policy-speed.md
+++ b/changelog.d/test-policy-speed.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Reuse normalized documentation text across ADR 0046 spike-measurement policy
+  checks instead of rebuilding it for every site, inventory pattern, and
+  negative control.

--- a/packages/d2b-contract-tests/tests/policy_adr046_spec_literals.rs
+++ b/packages/d2b-contract-tests/tests/policy_adr046_spec_literals.rs
@@ -1053,9 +1053,9 @@ impl MeasurementDocuments {
     }
 
     fn normalized_iter(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.documents.iter().map(|(path, document)| {
-            (path.as_str(), document.normalized.as_str())
-        })
+        self.documents
+            .iter()
+            .map(|(path, document)| (path.as_str(), document.normalized.as_str()))
     }
 }
 

--- a/packages/d2b-contract-tests/tests/policy_adr046_spec_literals.rs
+++ b/packages/d2b-contract-tests/tests/policy_adr046_spec_literals.rs
@@ -1009,6 +1009,56 @@ fn normalized_whitespace(content: &str) -> String {
     content.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+#[derive(Clone)]
+struct MeasurementDocument {
+    content: String,
+    normalized: String,
+}
+
+impl MeasurementDocument {
+    fn new(content: String) -> Self {
+        let normalized = normalized_whitespace(&content);
+        Self {
+            content,
+            normalized,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct MeasurementDocuments {
+    documents: BTreeMap<String, MeasurementDocument>,
+}
+
+impl MeasurementDocuments {
+    fn insert(&mut self, path: String, content: String) {
+        self.documents
+            .insert(path, MeasurementDocument::new(content));
+    }
+
+    fn contains_key(&self, path: &str) -> bool {
+        self.documents.contains_key(path)
+    }
+
+    fn content(&self, path: &str) -> Option<&str> {
+        self.documents
+            .get(path)
+            .map(|document| document.content.as_str())
+    }
+
+    fn normalized(&self, path: &str) -> Option<&str> {
+        self.documents
+            .get(path)
+            .map(|document| document.normalized.as_str())
+    }
+
+    fn normalized_iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.documents.iter().map(|(path, document)| {
+            (path.as_str(), document.normalized.as_str())
+        })
+    }
+}
+
 #[derive(Debug)]
 struct CanonicalMeasurement {
     outcome: String,
@@ -1106,20 +1156,19 @@ fn collect_measurement_documents(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-fn measurement_documents() -> BTreeMap<String, String> {
+fn measurement_documents() -> MeasurementDocuments {
     let root = repo_root();
     let mut paths = vec![root.join("CHANGELOG.md")];
     collect_measurement_documents(&root.join("docs"), &mut paths);
     paths.sort();
-    paths
-        .into_iter()
-        .map(|path| {
-            let relative = rel_display(&path);
-            let content = std::fs::read_to_string(&path)
-                .unwrap_or_else(|err| panic!("cannot read {relative}: {err}"));
-            (relative, content)
-        })
-        .collect()
+    let mut documents = MeasurementDocuments::default();
+    for path in paths {
+        let relative = rel_display(&path);
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("cannot read {relative}: {err}"));
+        documents.insert(relative, content);
+    }
+    documents
 }
 
 fn spike_measurement_specs() -> Vec<MeasurementSpec> {
@@ -1664,7 +1713,7 @@ fn spike_measurement_specs() -> Vec<MeasurementSpec> {
 fn validate_spike_measurement(
     spec: &MeasurementSpec,
     canonical: &CanonicalMeasurement,
-    documents: &BTreeMap<String, String>,
+    documents: &MeasurementDocuments,
 ) -> Vec<String> {
     let mut errors = Vec::new();
     if canonical.outcome != spec.expected_outcome {
@@ -1681,7 +1730,7 @@ fn validate_spike_measurement(
     }
 
     for site in &spec.sites {
-        let Some(content) = documents.get(site.path) else {
+        let Some(content) = documents.normalized(site.path) else {
             errors.push(format!("{}: missing derived site {}", spec.name, site.path));
             continue;
         };
@@ -1698,9 +1747,8 @@ fn validate_spike_measurement(
             }
             DerivedExpectation::OutcomeSummary(summary) => summary,
         };
-        let actual = normalized_whitespace(content)
-            .matches(&normalized_whitespace(needle))
-            .count();
+        let normalized_needle = normalized_whitespace(needle);
+        let actual = content.matches(&normalized_needle).count();
         if actual != site.copies {
             errors.push(format!(
                 "{}: {} must contain {:?} exactly {} time(s), found {actual}",
@@ -1712,9 +1760,9 @@ fn validate_spike_measurement(
     for pattern in &spec.inventory_patterns {
         let regex = Regex::new(pattern.regex).expect("valid measurement inventory regex");
         let occurrences = documents
-            .iter()
+            .normalized_iter()
             .filter_map(|(path, content)| {
-                let count = regex.find_iter(&normalized_whitespace(content)).count();
+                let count = regex.find_iter(content).count();
                 (count > 0).then_some((path, count))
             })
             .collect::<Vec<_>>();
@@ -1739,7 +1787,7 @@ fn validate_spike_measurement(
     errors
 }
 
-fn validate_spike_measurements(results: &str, documents: &BTreeMap<String, String>) -> Vec<String> {
+fn validate_spike_measurements(results: &str, documents: &MeasurementDocuments) -> Vec<String> {
     let specs = spike_measurement_specs();
     let canonical_row_count = results
         .lines()
@@ -2385,7 +2433,7 @@ fn spike_measurement_contracts_match_and_reject_mutations() {
         let canonical = canonical_measurement(&results, spec.threshold)
             .unwrap_or_else(|error| panic!("{}: {error}", spec.name));
         let original = documents
-            .get(spec.mutation_path)
+            .content(spec.mutation_path)
             .unwrap_or_else(|| panic!("missing mutation site {}", spec.mutation_path));
         assert!(
             original.contains(spec.mutation_needle),

--- a/tests/test-policy.sh
+++ b/tests/test-policy.sh
@@ -76,48 +76,67 @@ run_policy_gate() {
   fi
 }
 
-# Run one fixture-independent contract-test policy binary and fail closed unless
-# it actually executed at least one test. This is the orchestration assertion:
-# a binary that is skipped, filtered to nothing, or reports zero tests would
-# make the policy gate a silent no-op, which is exactly the fail-open hole this
-# target closes. D2B_SKIP_FIXTURE_BUILD is deliberately NOT honored here - these
-# binaries read committed repository artifacts, not D2B_FIXTURES.
-run_policy_cargo_binary() {
-  local label="$1" testname="$2"
-  local out status result_line passed failed
-  log "--> $label"
+# Run every fixture-independent contract-test policy binary through one Cargo
+# invocation, then fail closed unless each binary actually executed at least
+# one test. One `cargo test` builds the selected targets together and avoids
+# repeating Cargo startup and target discovery for every binary; Cargo still
+# runs the libtest binaries sequentially.
+#
+# D2B_SKIP_FIXTURE_BUILD is deliberately NOT honored here - these binaries read
+# committed repository artifacts, not D2B_FIXTURES.
+run_policy_cargo_binaries() {
+  local out status testname label result_line passed failed
+  local -a cargo_args=()
+  for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do
+    cargo_args+=(--test "$testname")
+  done
+  log "--> fixture-independent policy binaries"
   set +e
   out=$(
     cd "$ROOT/packages" \
-      && CARGO_TERM_COLOR=never cargo test -p d2b-contract-tests --test "$testname" 2>&1
+      && CARGO_TERM_COLOR=never cargo test -p d2b-contract-tests "${cargo_args[@]}" 2>&1
   )
   status=$?
   set -e
   printf '%s\n' "$out" | sed 's/^/    /' >&2
   if [ "$status" -ne 0 ]; then
-    fail "$label (cargo exit $status)"
+    fail "fixture-independent policy binaries (cargo exit $status)"
     rc=1
     return
   fi
-  result_line=$(printf '%s\n' "$out" | grep -E '^test result:' | tail -1)
-  if [ -z "$result_line" ]; then
-    fail "$label produced no test-result line; the binary did not run"
-    rc=1
-    return
-  fi
-  passed=$(printf '%s\n' "$result_line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' | head -1)
-  failed=$(printf '%s\n' "$result_line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' | head -1)
-  if [ -z "$passed" ] || [ "$passed" -lt 1 ]; then
-    fail "$label ran 0 tests (skipped or filtered); the policy gate would be a no-op"
-    rc=1
-    return
-  fi
-  if [ -n "$failed" ] && [ "$failed" -ne 0 ]; then
-    fail "$label reported $failed failing test(s)"
-    rc=1
-    return
-  fi
-  ok "$label ($passed passed)"
+  for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do
+    label=${testname//_/-}
+    result_line=$(
+      printf '%s\n' "$out" | awk -v target="Running tests/$testname.rs " '
+        index($0, target) {
+          found = 1
+          next
+        }
+        found && /^test result:/ {
+          print
+          exit
+        }
+      '
+    )
+    if [ -z "$result_line" ]; then
+      fail "$label produced no test-result line; the binary did not run"
+      rc=1
+      continue
+    fi
+    passed=$(printf '%s\n' "$result_line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' | head -1)
+    failed=$(printf '%s\n' "$result_line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' | head -1)
+    if [ -z "$passed" ] || [ "$passed" -lt 1 ]; then
+      fail "$label ran 0 tests (skipped or filtered); the policy gate would be a no-op"
+      rc=1
+      continue
+    fi
+    if [ -n "$failed" ] && [ "$failed" -ne 0 ]; then
+      fail "$label reported $failed failing test(s)"
+      rc=1
+      continue
+    fi
+    ok "$label ($passed passed)"
+  done
 }
 
 run_guest_workspace_guard() {
@@ -161,9 +180,7 @@ run_policy_gate "ci-coverage"               tests/unit/meta/ci-coverage.sh
 # spec-literal drift lints (datetime precision, ResourceType grammar, retry
 # scalar shape) actually work. The shared list is excluded from the fixture
 # lane, so this mandatory target is their one Layer-1 execution point.
-for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do
-  run_policy_cargo_binary "${testname//_/-}" "$testname"
-done
+run_policy_cargo_binaries
 run_guest_workspace_guard
 
 [ "$rc" -eq 0 ] || exit 1

--- a/tests/unit/meta/ci-runner-regression.py
+++ b/tests/unit/meta/ci-runner-regression.py
@@ -1410,13 +1410,22 @@ printf '%s\n' "$sanitized_line"
                 f"{binary} must appear exactly once in the shared policy-binary list",
             )
         self.assertIn(
-            'for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do',
+            "run_policy_cargo_binaries()",
             policy_driver,
         )
         self.assertIn(
-            'run_policy_cargo_binary "${testname//_/-}" "$testname"',
+            'cargo_args+=(--test "$testname")',
             policy_driver,
         )
+        self.assertIn(
+            'cargo test -p d2b-contract-tests "${cargo_args[@]}"',
+            policy_driver,
+        )
+        self.assertIn(
+            'target="Running tests/$testname.rs "',
+            policy_driver,
+        )
+        self.assertEqual(policy_driver.count("run_policy_cargo_binaries\n"), 1)
         self.assertIn(
             'for testname in "${D2B_FIXTURE_INDEPENDENT_POLICY_BINARIES[@]}"; do',
             rust_driver,


### PR DESCRIPTION
## Summary

- Normalize the 13.1 MiB ADR 0046 measurement-document corpus once and reuse it across site checks, inventory patterns, and negative controls.
- Run all eight fixture-independent policy binaries through one Cargo invocation while retaining fail-closed evidence that every binary executed nonzero tests.
- Keep libtest execution rather than nextest: measured nextest process-per-test execution was slower and duplicated corpus loading.

The dominant spike-measurement test dropped from approximately 50.7 seconds to under 8 seconds. The warm `tests/test-policy.sh` path dropped from 40 seconds to 14 seconds.

## Testing checklist (mandatory)

- [ ] **`make check` passes locally** - Not run locally; CI will execute the full Layer-1 graph.
- [x] **`make test-integration` passes on the host before PR creation** - N/A: pure test implementation and orchestration change with no daemon, broker, NixOS module, runtime, network, or generated-artifact behavior change.
- [x] **`make test-host-integration` passes on the host before PR creation** - N/A: pure test implementation and orchestration change with no daemon, broker, NixOS module, runtime, network, or generated-artifact behavior change.
- [x] **Manual `make test-hardware` run** - N/A: no device/passthrough or full-microVM-boot surface touched.
- [x] **New/changed tests are wired into a `make` target** and have rows in `tests/migration-ledger.toml` - Existing policy and meta coverage was changed; no test entrypoint was added. `make check-inventory` passed with 180 rows.
- [x] **Docs + CI updated in lockstep** - No workflow graph or user-facing documentation contract changed; the existing orchestration regression was updated and passed.

## Validation

- `make test-policy`: passed; 14.2 seconds warm
- `make check-tier0` with Nix-provided ShellCheck: passed
- Targeted `CiRunnerRegressionTests.test_fixture_contracts_exclude_policy_binaries_owned_by_test_policy`: passed
- `cargo fmt -p d2b-contract-tests -- --check`: passed
- `make test-changelog`: passed
- `make check-inventory`: passed

## Notes

- Release notes are in `changelog.d/test-policy-speed.md`.
- The xtask Provider integration-layout check remains separate because it enforces a distinct contract.