### PR TITLE
tests: reduce Nix evaluation memory

### DIFF
--- a/changelog.d/test-nix-eval-memory.md
+++ b/changelog.d/test-nix-eval-memory.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Reduce Nix-unit evaluation memory by sharing focused realm, workload,
+  resource, gateway, niri, and observability fixtures while retaining full
+  integration coverage.

--- a/changelog.d/test-nix-eval-memory.md
+++ b/changelog.d/test-nix-eval-memory.md
@@ -3,3 +3,5 @@
 - Reduce Nix-unit evaluation memory by sharing focused realm, workload,
   resource, gateway, niri, and observability fixtures while retaining full
   integration coverage.
+- Share the configured local-VM workload predicate between limit validation
+  and private workload emission.

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -868,29 +868,10 @@ let
         (lib.filter (row: row.kind == "unsafe-local") realmWorkloadRows);
       localVmConfiguredCount = builtins.length
         (lib.filter hasConfiguredLocalVmLaunch realmWorkloadRows);
-    in [
-      {
-        assertion = unsafeLocalCount <= 256;
-        message = ''
-          d2b declares more than the supported maximum of 256 enabled
-          unsafe-local workloads.
-        '';
-      }
-      {
-        assertion = localVmConfiguredCount <= 256;
-        message = ''
-          d2b declares more than the supported maximum of 256 enabled local-vm
-          workloads with configured launch.
-        '';
-      }
-      {
-        assertion = unsafeLocalCount + localVmConfiguredCount <= 512;
-        message = ''
-          d2b declares more than the supported maximum of 512 private configured
-          workloads.
-        '';
-      }
-    ];
+    in
+    d2bLib.privateConfiguredWorkloadCountAssertions {
+      inherit unsafeLocalCount localVmConfiguredCount;
+    };
 
   gatewayStateBoundaryAssertions =
     lib.mapAttrsToList

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -161,15 +161,6 @@ let
   # (Same-VM references across realms share a CID by design and are not
   # flagged here; the global vmVsockCidCollisions check covers per-VM uniqueness.)
   realmWorkloadRows = realmIndex.workloads.enabled;
-  hasConfiguredLocalVmLaunch = row:
-    let
-      declared = cfg.realms.${row.realmName}.workloads.${row.workloadName};
-    in
-    row.kind == "local-vm"
-    && row.launcherEnabled
-    && (declared.launcher.items != { }
-      || declared.launcher.defaultItem != null
-      || declared.shell.enable);
   nixosWorkloadRows =
     lib.filter
       (row:
@@ -864,14 +855,12 @@ let
 
   privateConfiguredWorkloadCountAssertions =
     let
-      unsafeLocalCount = builtins.length
-        (lib.filter (row: row.kind == "unsafe-local") realmWorkloadRows);
-      localVmConfiguredCount = builtins.length
-        (lib.filter hasConfiguredLocalVmLaunch realmWorkloadRows);
+      counts = d2bLib.privateConfiguredWorkloadCounts {
+        rows = realmWorkloadRows;
+        realms = cfg.realms;
+      };
     in
-    d2bLib.privateConfiguredWorkloadCountAssertions {
-      inherit unsafeLocalCount localVmConfiguredCount;
-    };
+    d2bLib.privateConfiguredWorkloadCountAssertions counts;
 
   gatewayStateBoundaryAssertions =
     lib.mapAttrsToList

--- a/nixos-modules/lib.nix
+++ b/nixos-modules/lib.nix
@@ -18,6 +18,24 @@ let
     total = 512;
   };
 
+  hasConfiguredLocalVmLaunch = { realms }: row:
+    let
+      declared = realms.${row.realmName}.workloads.${row.workloadName};
+    in
+    row.kind == "local-vm"
+    && row.launcherEnabled
+    && (declared.launcher.items != { }
+      || declared.launcher.defaultItem != null
+      || declared.shell.enable);
+
+  privateConfiguredWorkloadCounts = { rows, realms }:
+    {
+      unsafeLocalCount = builtins.length
+        (lib.filter (row: row.kind == "unsafe-local") rows);
+      localVmConfiguredCount = builtins.length
+        (lib.filter (hasConfiguredLocalVmLaunch { inherit realms; }) rows);
+    };
+
   privateConfiguredWorkloadCountAssertions =
     { unsafeLocalCount
     , localVmConfiguredCount
@@ -111,6 +129,7 @@ in
 rec {
   inherit hex2;
   inherit d2bReadAudioState;
+  inherit hasConfiguredLocalVmLaunch privateConfiguredWorkloadCounts;
   inherit privateConfiguredWorkloadLimits privateConfiguredWorkloadCountAssertions;
 
   cleanRustPackagesSource = packagesPath:

--- a/nixos-modules/lib.nix
+++ b/nixos-modules/lib.nix
@@ -12,6 +12,41 @@ let
     let s = lib.toHexString i;
     in if lib.stringLength s == 1 then "0${s}" else s;
 
+  privateConfiguredWorkloadLimits = {
+    unsafeLocal = 256;
+    localVmConfigured = 256;
+    total = 512;
+  };
+
+  privateConfiguredWorkloadCountAssertions =
+    { unsafeLocalCount
+    , localVmConfiguredCount
+    , limits ? privateConfiguredWorkloadLimits
+    }:
+    [
+      {
+        assertion = unsafeLocalCount <= limits.unsafeLocal;
+        message = ''
+          d2b declares more than the supported maximum of ${toString limits.unsafeLocal} enabled
+          unsafe-local workloads.
+        '';
+      }
+      {
+        assertion = localVmConfiguredCount <= limits.localVmConfigured;
+        message = ''
+          d2b declares more than the supported maximum of ${toString limits.localVmConfigured} enabled local-vm
+          workloads with configured launch.
+        '';
+      }
+      {
+        assertion = unsafeLocalCount + localVmConfiguredCount <= limits.total;
+        message = ''
+          d2b declares more than the supported maximum of ${toString limits.total} private configured
+          workloads.
+        '';
+      }
+    ];
+
   # d2b_read_audio_state <vm>
   # ------------------------------------------------------------
   # Fail-closed reader for /var/lib/d2b/<vm>/audio-state.json.
@@ -76,6 +111,7 @@ in
 rec {
   inherit hex2;
   inherit d2bReadAudioState;
+  inherit privateConfiguredWorkloadLimits privateConfiguredWorkloadCountAssertions;
 
   cleanRustPackagesSource = packagesPath:
     lib.cleanSourceWith {

--- a/nixos-modules/unsafe-local-workloads-json.nix
+++ b/nixos-modules/unsafe-local-workloads-json.nix
@@ -3,21 +3,12 @@
 
 let
   cfg = config.d2b;
+  d2bLib = import ./lib.nix { inherit lib; };
   unsafeLocalWorkloads = lib.filter
     (workload: workload.kind == "unsafe-local")
     cfg._index.realms.workloads.enabled;
-  hasConfiguredLocalVmLaunch = workload:
-    let
-      declared =
-        cfg.realms.${workload.realmName}.workloads.${workload.workloadName};
-    in
-    workload.kind == "local-vm"
-    && workload.launcherEnabled
-    && (declared.launcher.items != { }
-      || declared.launcher.defaultItem != null
-      || declared.shell.enable);
   localVmWorkloads = lib.filter
-    hasConfiguredLocalVmLaunch
+    (d2bLib.hasConfiguredLocalVmLaunch { realms = cfg.realms; })
     cfg._index.realms.workloads.enabled;
 
   privateItem = item:

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -273,9 +273,11 @@ option/assertion cases and add focused env/VM layers only where the contract
 needs them. Retain at least one full positive and one full negative
 `nixosSystem` integration path per affected module family. Identical scenario
 configurations share one evaluated thunk while preserving one case per
-contract. Cardinality boundaries use a pure production assertion helper plus
-an actual negative module-wiring probe; do not materialize hundreds of typed
-submodules solely to test a fixed count.
+contract. Cardinality boundaries use three tiers: pure limit/helper checks, a pure
+production counter composed with the helper at boundary rows, and a small
+real-wiring config pinning declarations -> index -> counter -> assertion
+records. Do not force an internal `_index` value or materialize hundreds of
+typed submodules solely to test a fixed count.
 
 `D2B_NIX_UNIT_CHECK` remains the manual single-shard selector. When
 set, it exits through the selected Nix check before eval-jobs bootstrap or

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -267,6 +267,16 @@ aggregate has no real FAIL line, one final fallback diagnostic remains
 attributable to that result attribute.
 Command progress uses the fixed path-free `d2b` flake label.
 
+Nix-unit fixtures must not inherit environments, VMs, components, or rendered
+artifact surfaces that the case does not assert. Keep a schema-only base for
+option/assertion cases and add focused env/VM layers only where the contract
+needs them. Retain at least one full positive and one full negative
+`nixosSystem` integration path per affected module family. Identical scenario
+configurations share one evaluated thunk while preserving one case per
+contract. Cardinality boundaries use a pure production assertion helper plus
+an actual negative module-wiring probe; do not materialize hundreds of typed
+submodules solely to test a fixed count.
+
 `D2B_NIX_UNIT_CHECK` remains the manual single-shard selector. When
 set, it exits through the selected Nix check before eval-jobs bootstrap or
 resource accounting. Hosted CI retains the pre-change discovery and

--- a/tests/unit/nix/cases/index.nix
+++ b/tests/unit/nix/cases/index.nix
@@ -4,7 +4,7 @@ let
   x86 = system == "x86_64-linux";
   resourceContracts = import ../../../../nixos-modules/resources.nix { inherit lib; };
 
-  fixture = { lib, ... }: {
+  resourceBase = {
     boot.loader.grub.enable = false;
     boot.loader.systemd-boot.enable = false;
     boot.initrd.includeDefaultModules = false;
@@ -16,6 +16,12 @@ let
     d2b.site = {
       waylandUser = "alice";
       launcherUsers = [ "alice" ];
+    };
+  };
+
+  fixture = { lib, ... }: {
+    imports = [ resourceBase ];
+    d2b.site = {
       yubikey.enable = true;
       allowUnsafeEastWest = true;
     };
@@ -176,13 +182,13 @@ let
       };
     };
   };
-  resourceCfg = (mkEval [ fixture resourceFixture ]).config;
+  resourceCfg = (mkEval [ resourceBase resourceFixture ]).config;
   resourceIndex = resourceCfg.d2b._index.zones;
   failureMessages = module:
     map (assertion: assertion.message)
       (lib.filter (assertion: lib.hasPrefix "d2b.zones." assertion.message)
         (lib.filter (assertion: !assertion.assertion)
-          (mkEval [ fixture module ]).config.assertions));
+          (mkEval [ resourceBase module ]).config.assertions));
   resourceContractEvidence = {
     zoneNames = resourceIndex.names;
     work = resourceIndex.byName.work;
@@ -279,22 +285,22 @@ let
       };
     };
     malformed = {
-      badType = (builtins.tryEval ((mkEval [ fixture {
+      badType = (builtins.tryEval ((mkEval [ resourceBase {
         d2b.zones.work.resources.app.type = "Unknown";
       } ]).config.system.build.toplevel)).success;
-      badRef = (builtins.tryEval ((mkEval [ fixture {
+      badRef = (builtins.tryEval ((mkEval [ resourceBase {
         d2b.zones.work.resources.app = {
           type = "Provider";
           metadata.ownerRef = "user/alice";
         };
       } ]).config.system.build.toplevel)).success;
-      excessiveCpu = (builtins.tryEval ((mkEval [ fixture {
+      excessiveCpu = (builtins.tryEval ((mkEval [ resourceBase {
         d2b.zones.work.resources.app = {
           type = "Provider";
           spec.budget.cpu.limit = "1024001m";
         };
       } ]).config.system.build.toplevel)).success;
-      excessiveMemory = (builtins.tryEval ((mkEval [ fixture {
+      excessiveMemory = (builtins.tryEval ((mkEval [ resourceBase {
         d2b.zones.work.resources.app = {
           type = "Provider";
           spec.budget.memory.limit = "4097GiB";

--- a/tests/unit/nix/cases/multi-env-daemon-backed.nix
+++ b/tests/unit/nix/cases/multi-env-daemon-backed.nix
@@ -59,7 +59,7 @@ let
   demoCfg = (mkEval [ configMod ]).config;
   daemonCfg = (mkEval [ configMod daemonExtra ]).config;
 
-  hostJson = builtins.fromJSON daemonCfg.d2b._bundle.hostJson.jsonText;
+  hostJson = daemonCfg.d2b._bundle.hostJson.data;
   envOf = name: builtins.head (builtins.filter (e: e.env == name) hostJson.environments);
   work = envOf "work";
   personal = envOf "personal";

--- a/tests/unit/nix/cases/niri-vm-borders.nix
+++ b/tests/unit/nix/cases/niri-vm-borders.nix
@@ -19,7 +19,7 @@
 lib.optionalAttrs (system == "x86_64-linux") (
 
 let
-  base = { lib, ... }: {
+  hostBase = { ... }: {
     boot.loader.grub.enable = false;
     boot.loader.systemd-boot.enable = false;
     boot.initrd.includeDefaultModules = false;
@@ -35,6 +35,9 @@ let
       lanSubnet = "10.20.0.0/24";
       uplinkSubnet = "192.0.2.0/30";
     };
+  };
+
+  workVm = { lib, ... }: {
     d2b.vms.work = {
       enable = true;
       env = "work";
@@ -47,6 +50,9 @@ let
         users.users.alice = { isNormalUser = true; uid = 1000; };
       };
     };
+  };
+
+  headlessVm = { lib, ... }: {
     d2b.vms.headless = {
       enable = true;
       env = "work";
@@ -57,6 +63,9 @@ let
         users.users.alice = { isNormalUser = true; uid = 1000; };
       };
     };
+  };
+
+  workAadVm = { lib, ... }: {
     d2b.vms."work-aad" = {
       enable = true;
       env = "work";
@@ -68,6 +77,9 @@ let
         users.users.alice = { isNormalUser = true; uid = 1000; };
       };
     };
+  };
+
+  mediaVm = { ... }: {
     d2b.vms.media = {
       runtime.kind = "qemu-media";
       env = "work";
@@ -75,8 +87,12 @@ let
     };
   };
 
-  etcOf = overrides: (mkEval ([ base ] ++ overrides)).config.environment.etc;
-  cfgOf = overrides: (mkEval ([ base ] ++ overrides)).config;
+  evalWith = vmLayers: overrides: mkEval ([ hostBase ] ++ vmLayers ++ overrides);
+  etcWith = vmLayers: overrides: (evalWith vmLayers overrides).config.environment.etc;
+  cfgWith = vmLayers: overrides: (evalWith vmLayers overrides).config;
+  hostEtcOf = overrides: etcWith [ ] overrides;
+  etcOf = overrides: etcWith [ workVm ] overrides;
+  cfgOf = overrides: cfgWith [ workVm ] overrides;
   kdlKey = "d2b/niri-vm-borders.kdl";
   jsonKey = "d2b/ui-colors.json";
   cssKey = "d2b/ui-colors.css";
@@ -94,8 +110,8 @@ let
     in
     if positions == [ ] then null else builtins.elemAt argv ((builtins.head positions) + 1);
 
-  disabledEtc = etcOf [ ];
-  uiEtc = etcOf [ ({ ... }: { d2b.site.ui.enable = true; }) ];
+  disabledEtc = hostEtcOf [ ];
+  uiEtc = etcWith [ workVm workAadVm ] [ ({ ... }: { d2b.site.ui.enable = true; }) ];
   uiJson = builtins.fromJSON (jsonText uiEtc);
   uiCss = cssText uiEtc;
   newNiriEtc = etcOf [ ({ ... }: { d2b.site.ui.compositors.niri.enable = true; }) ];
@@ -106,7 +122,9 @@ let
       d2b.vms.work.graphics.waylandProxy.border.enable = false;
     })
   ]);
-  enabledEtc = etcOf [ ({ ... }: { d2b.site.niriVmBorders.enable = true; }) ];
+  enabledEtc = etcWith [ workVm headlessVm mediaVm ] [
+    ({ ... }: { d2b.site.niriVmBorders.enable = true; })
+  ];
   enabledKdl = kdlText enabledEtc;
   colorKdl = kdlText (etcOf [
     ({ ... }: {
@@ -124,14 +142,14 @@ let
       d2b.vms.work.graphics.waylandProxy.border.enable = false;
     })
   ]);
-  qemuMediaColorKdl = kdlText (etcOf [
+  qemuMediaColorKdl = kdlText (etcWith [ mediaVm ] [
     ({ ... }: {
       d2b.site.niriVmBorders.enable = true;
       d2b.vms.media.graphics.waylandProxy.border.enable = false;
       d2b.vms.media.qemuMedia.window.niriBorderColor = "#800080";
     })
   ]);
-  customEtc = etcOf [
+  customEtc = hostEtcOf [
     ({ ... }: {
       d2b.site.niriVmBorders.enable = true;
       d2b.site.niriVmBorders.outputPath = "/etc/d2b/custom-borders.kdl";

--- a/tests/unit/nix/cases/observability.nix
+++ b/tests/unit/nix/cases/observability.nix
@@ -59,12 +59,28 @@ let
       ];
     };
 
+  # Scenario keys preserve assertion granularity while sharing the full
+  # nixosSystem evaluation across projections.
+  scenarios = {
+    default = { ... }: { };
+    observability-disabled = { ... }: { d2b.observability.enable = false; };
+    observability-enabled = { ... }: { d2b.observability.enable = true; };
+    observability-enabled-corp-vm = { ... }: {
+      d2b.observability.enable = true;
+      d2b.vms.corp-vm.observability.enable = true;
+    };
+  };
+
   evalCase = caseSpec:
     let
       kind = caseSpec.kind or (if caseSpec ? extract || caseSpec ? expectedExtract then "expect-success" else "expect-failure");
       caseSystem = caseSpec.system or shared.defaultSystem;
       override = caseSpec.override or ({ ... }: { });
-      nixos = mkNixos { inherit caseSystem override; };
+      nixos =
+        if caseSpec ? scenario then
+          evaluatedScenarios.${caseSpec.scenario}.${caseSystem}
+        else
+          mkNixos { inherit caseSystem override; };
       failureAttempt =
         if kind == "expect-failure" then
           builtins.tryEval nixos.config.assertions
@@ -122,12 +138,13 @@ let
 
   caseSpecs = {
     obs-disabled-default = {
+      scenario = "default";
       extract = nixos: (manifest nixos)._observability.enabled;
       expectedExtract = false;
     };
 
     obs-default-off-no-units = {
-      override = { ... }: { d2b.observability.enable = false; };
+      scenario = "observability-disabled";
       extract = nixos: {
         otelServiceNames = sortStrings (
           builtins.filter
@@ -140,7 +157,7 @@ let
     };
 
     obs-enabled-defaults = {
-      override = { ... }: { d2b.observability.enable = true; };
+      scenario = "observability-enabled";
       extract = nixos:
         let
           manifestData = manifest nixos;
@@ -245,7 +262,7 @@ let
     };
 
     obs-manifest-fields = {
-      override = { ... }: { d2b.observability.enable = true; };
+      scenario = "observability-enabled";
       extract = nixos:
         let vmObs = lib.attrByPath [ "corp-vm" "observability" ] { } (manifest nixos);
         in {
@@ -263,10 +280,7 @@ let
     };
 
     obs-relay-acl-surface = {
-      override = { ... }: {
-        d2b.observability.enable = true;
-        d2b.vms.corp-vm.observability.enable = true;
-      };
+      scenario = "observability-enabled-corp-vm";
       extract = nixos:
         let
           processes = nixos.config.d2b._bundle.processesJson.data;
@@ -379,10 +393,7 @@ let
     };
 
     obs-alerting-surface = {
-      override = { ... }: {
-        d2b.observability.enable = true;
-        d2b.vms.corp-vm.observability.enable = true;
-      };
+      scenario = "observability-enabled-corp-vm";
       extract = nixos:
         let
           obsVm = nixos.config.d2b.observability.vmName;
@@ -412,16 +423,13 @@ let
     };
 
     obs-vm-toggle-default-off = {
-      override = { ... }: { d2b.observability.enable = true; };
+      scenario = "observability-enabled";
       extract = nixos: lib.attrByPath [ "corp-vm" "observability" "enabled" ] null (manifest nixos);
       expectedExtract = false;
     };
 
     obs-journal-default-on = {
-      override = { ... }: {
-        d2b.observability.enable = true;
-        d2b.vms.corp-vm.observability.enable = true;
-      };
+      scenario = "observability-enabled-corp-vm";
       extract = nixos:
         let workGuest = nixos.config.d2b._computed.corp-vm.config;
         in
@@ -473,7 +481,7 @@ let
     };
 
     obs-cli-traces-default-on = {
-      override = { ... }: { d2b.observability.enable = true; };
+      scenario = "observability-enabled";
       extract = nixos: nixos.config.d2b.observability.cli.traces.enable;
       expectedExtract = true;
       aux = nixos: { cliDrvPath = (cliPkg nixos).drvPath; };
@@ -490,14 +498,14 @@ let
     };
 
     obs-cli-trace-attr-allowlist = {
-      override = { ... }: { d2b.observability.enable = true; };
+      scenario = "observability-enabled";
       extract = _nixos: true;
       expectedExtract = true;
       aux = nixos: { cliDrvPath = (cliPkg nixos).drvPath; };
     };
 
     obs-reserved-prefix-exempt = {
-      override = { ... }: { d2b.observability.enable = true; };
+      scenario = "observability-enabled";
       extract = nixos: builtins.hasAttr "sys-obs" nixos.config.d2b.vms;
       expectedExtract = true;
     };
@@ -509,6 +517,7 @@ let
     };
 
     obs-dashboards-schema = {
+      scenario = "default";
       extract = _nixos: {
         dashboardFileCount = builtins.length dashboardPaths;
         retiredDashboardDirIsEmpty = dashboardPaths == [ ];
@@ -520,10 +529,7 @@ let
     };
 
     obs-rules-promtool = {
-      override = { ... }: {
-        d2b.observability.enable = true;
-        d2b.vms.corp-vm.observability.enable = true;
-      };
+      scenario = "observability-enabled-corp-vm";
       extract = nixos:
         let
           obsVm = nixos.config.d2b.observability.vmName;
@@ -545,10 +551,7 @@ let
     };
 
     obs-metric-references = {
-      override = { ... }: {
-        d2b.observability.enable = true;
-        d2b.vms.corp-vm.observability.enable = true;
-      };
+      scenario = "observability-enabled-corp-vm";
       extract = nixos:
         let
           obsVm = nixos.config.d2b.observability.vmName;
@@ -580,10 +583,7 @@ let
     };
 
     obs-scrape-job-stability = {
-      override = { ... }: {
-        d2b.observability.enable = true;
-        d2b.vms.corp-vm.observability.enable = true;
-      };
+      scenario = "observability-enabled-corp-vm";
       extract = nixos:
         let
           obsVm = nixos.config.d2b.observability.vmName;
@@ -609,10 +609,7 @@ let
     };
 
     obs-stability = {
-      override = { ... }: {
-        d2b.observability.enable = true;
-        d2b.vms.corp-vm.observability.enable = true;
-      };
+      scenario = "observability-enabled-corp-vm";
       extract = nixos:
         let
           obsVm = nixos.config.d2b.observability.vmName;
@@ -683,7 +680,7 @@ let
     # ----- ADR 0033: host collector parity + hostname identity -----
 
     obs-host-collector-default-off = {
-      override = { ... }: { d2b.observability.enable = true; };
+      scenario = "observability-enabled";
       extract = nixos:
         let
           cfg = nixos.config.d2b.observability._internal.hostCollectorConfig;
@@ -885,6 +882,21 @@ let
       expectedSubstring = "the host OTel collector only";
     };
   };
+
+  scenarioSystems =
+    lib.unique (map (caseSpec: caseSpec.system or shared.defaultSystem) (builtins.attrValues caseSpecs));
+  evaluatedScenarios = builtins.mapAttrs
+    (_scenarioName: scenarioOverride:
+      builtins.listToAttrs (map
+        (caseSystem: {
+          name = caseSystem;
+          value = mkNixos {
+            inherit caseSystem;
+            override = scenarioOverride;
+          };
+        })
+        scenarioSystems))
+    scenarios;
 
   evaluated = builtins.mapAttrs (_name: spec: evalCase spec) caseSpecs;
 

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -318,12 +318,24 @@ let
       { unsafe = 256; localVm = 257; expected = false; }
     ];
 
-  limitProbeBase = lib.recursiveUpdate workloadBase {
+  wiringProbeFixture = lib.recursiveUpdate workloadBase {
     d2b.daemonExperimental.enable = true;
     d2b.realms.host = {
       allowedUsers = [ "alice" ];
       policy.allowUnsafeLocal = true;
       workloads.tools = {
+        enable = true;
+        kind = "unsafe-local";
+        launcher = {
+          enable = true;
+          items.run = {
+            type = "exec";
+            argv = [ "true" ];
+          };
+        };
+      };
+      workloads.scripts = {
+        enable = true;
         kind = "unsafe-local";
         launcher = {
           enable = true;
@@ -340,6 +352,7 @@ let
       network.envs = [ "work" ];
       allowedUsers = [ "alice" ];
       workloads.laptop = {
+        enable = true;
         kind = "local-vm";
         legacyVmName = "corpbox";
         launcher = {
@@ -350,71 +363,72 @@ let
           };
         };
       };
+      workloads.desktop = {
+        enable = true;
+        kind = "local-vm";
+        launcher = {
+          enable = true;
+          items.run = {
+            type = "exec";
+            argv = [ "true" ];
+          };
+        };
+      };
     };
   };
-  limitProbeBaseCfg = (mkEval [ limitProbeBase ]).config;
-  limitProbeRows = limitProbeBaseCfg.d2b._index.realms.workloads.enabled;
-  limitProbeUnsafeRow = lib.findFirst
-    (row: row.kind == "unsafe-local")
-    null
-    limitProbeRows;
-  limitProbeLocalVmRow = lib.findFirst
-    (row: row.kind == "local-vm")
-    null
-    limitProbeRows;
-
-  # Force compact copies of one real index row so the production assertion
-  # path sees boundary counts without expanding hundreds of workload modules.
-  limitProbeCfgWithRows = rows:
-    (mkEval [
-      limitProbeBase
-      ({ ... }: {
-        d2b._index = lib.mkForce (
-          lib.recursiveUpdate limitProbeBaseCfg.d2b._index {
-            realms.workloads.enabled = rows;
-          }
-        );
+  wiringProbeCfg = (mkEval [ wiringProbeFixture ]).config;
+  wiringProbeRows = wiringProbeCfg.d2b._index.realms.workloads.enabled;
+  wiringProbeDeclaredRows = realmName:
+    lib.mapAttrsToList
+      (workloadName: workload: {
+        realmName = realmName;
+        name = workloadName;
+        kind = workload.kind;
       })
-    ]).config;
-  limitProbeUnsafeCfg =
-    limitProbeCfgWithRows (lib.replicate 257 limitProbeUnsafeRow);
-  limitProbeLocalVmCfg =
-    limitProbeCfgWithRows (lib.replicate 257 limitProbeLocalVmRow);
-  limitProbeTotalCfg =
-    limitProbeCfgWithRows (
-      (lib.replicate 257 limitProbeUnsafeRow)
-      ++ (lib.replicate 256 limitProbeLocalVmRow)
+      (lib.filterAttrs
+        (_: workload: workload.enable)
+        wiringProbeCfg.d2b.realms.${realmName}.workloads);
+  wiringProbeIndexRows = map
+    (row: {
+      realmName = row.realmName;
+      name = row.workloadName;
+      kind = row.kind;
+    })
+    wiringProbeRows;
+  wiringProbeRowsMatch =
+    lib.sortOn (row: "${row.realmName}/${row.name}") wiringProbeIndexRows
+    == lib.sortOn (row: "${row.realmName}/${row.name}") (
+      wiringProbeDeclaredRows "host"
+      ++ wiringProbeDeclaredRows "work"
     );
-  productionAssertionMatches = cfg: needles: expectedMessage:
+  wiringProbeUnsafeLocalCount = builtins.length
+    (lib.filter (row: row.kind == "unsafe-local") wiringProbeRows);
+  wiringProbeLocalVmConfiguredCount = builtins.length
+    (lib.filter
+      (row: row.kind == "local-vm" && row.launcherItems != [ ])
+      wiringProbeRows);
+  wiringProbeCountsMatch = {
+    unsafeLocal = wiringProbeUnsafeLocalCount;
+    localVmConfigured = wiringProbeLocalVmConfiguredCount;
+  } == {
+    unsafeLocal = 2;
+    localVmConfigured = 2;
+  };
+  wiringProbeAssertionMatches = expectedMessage:
     let
       record = lib.findFirst
-        (assertion:
-          assertion.assertion == false
-          && lib.all
-            (needle: lib.hasInfix needle assertion.message)
-            needles)
+        (assertion: assertion.message == expectedMessage)
         null
-        cfg.assertions;
+        wiringProbeCfg.assertions;
     in
     record != null
-    && record.assertion == false
-    && record.message == expectedMessage;
-  productionUnsafeOverflow = productionAssertionMatches
-    limitProbeUnsafeCfg
-    [ "maximum of 256" "unsafe-local workloads" ]
-    expectedUnsafeLimitMessage;
-  productionLocalVmOverflow = productionAssertionMatches
-    limitProbeLocalVmCfg
-    [ "maximum of 256" "local-vm" "configured launch" ]
-    expectedLocalVmLimitMessage;
-  productionTotalUnsafeOverflow = productionAssertionMatches
-    limitProbeTotalCfg
-    [ "maximum of 256" "unsafe-local workloads" ]
-    expectedUnsafeLimitMessage;
-  productionTotalOverflow = productionAssertionMatches
-    limitProbeTotalCfg
-    [ "maximum of 512" "private configured" "workloads" ]
-    expectedTotalLimitMessage;
+    && record.assertion == true;
+  wiringProbeProductionAssertions =
+    lib.all wiringProbeAssertionMatches [
+      expectedUnsafeLimitMessage
+      expectedLocalVmLimitMessage
+      expectedTotalLimitMessage
+    ];
 
   # ── helpers ─────────────────────────────────────────────────────────────────
   failureMessages = modules:
@@ -628,15 +642,16 @@ in
         privateLimitsExact
         && privateUnsafeBoundaryChecks
         && privateTotalBoundaryChecks
-        && productionUnsafeOverflow
-        && productionTotalUnsafeOverflow
-        && productionTotalOverflow;
+        && wiringProbeRowsMatch
+        && wiringProbeCountsMatch
+        && wiringProbeProductionAssertions;
       localVmOverflow =
         privateLimitsExact
         && privateLocalVmBoundaryChecks
         && privateTotalBoundaryChecks
-        && productionLocalVmOverflow
-        && productionTotalOverflow;
+        && wiringProbeRowsMatch
+        && wiringProbeCountsMatch
+        && wiringProbeProductionAssertions;
     };
     expected = {
       unsafeOverflow = true;

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -367,17 +367,35 @@ let
         enable = true;
         kind = "local-vm";
         launcher = {
-          enable = true;
+          enable = false;
           items.run = {
             type = "exec";
             argv = [ "true" ];
           };
         };
       };
+      workloads.shellonly = {
+        enable = true;
+        kind = "local-vm";
+        launcher = {
+          enable = true;
+          defaultItem = null;
+          items = { };
+        };
+        shell.enable = true;
+      };
     };
   };
   wiringProbeCfg = (mkEval [ wiringProbeFixture ]).config;
   wiringProbeRows = wiringProbeCfg.d2b._index.realms.workloads.enabled;
+  wiringProbeUnsafeRow = lib.findFirst
+    (row: row.kind == "unsafe-local")
+    null
+    wiringProbeRows;
+  wiringProbeLocalVmRow = lib.findFirst
+    (row: row.kind == "local-vm" && row.workloadName == "laptop")
+    null
+    wiringProbeRows;
   wiringProbeDeclaredRows = realmName:
     lib.mapAttrsToList
       (workloadName: workload: {
@@ -388,6 +406,20 @@ let
       (lib.filterAttrs
         (_: workload: workload.enable)
         wiringProbeCfg.d2b.realms.${realmName}.workloads);
+  wiringProbeExpectedDeclarations = [
+    { realmName = "host"; name = "scripts"; kind = "unsafe-local"; }
+    { realmName = "host"; name = "tools"; kind = "unsafe-local"; }
+    { realmName = "work"; name = "desktop"; kind = "local-vm"; }
+    { realmName = "work"; name = "laptop"; kind = "local-vm"; }
+    { realmName = "work"; name = "shellonly"; kind = "local-vm"; }
+  ];
+  wiringProbeDeclarationsMatch =
+    lib.sortOn (row: "${row.realmName}/${row.name}") (
+      wiringProbeDeclaredRows "host"
+      ++ wiringProbeDeclaredRows "work"
+    )
+    == lib.sortOn (row: "${row.realmName}/${row.name}")
+      wiringProbeExpectedDeclarations;
   wiringProbeIndexRows = map
     (row: {
       realmName = row.realmName;
@@ -401,19 +433,64 @@ let
       wiringProbeDeclaredRows "host"
       ++ wiringProbeDeclaredRows "work"
     );
-  wiringProbeUnsafeLocalCount = builtins.length
-    (lib.filter (row: row.kind == "unsafe-local") wiringProbeRows);
-  wiringProbeLocalVmConfiguredCount = builtins.length
-    (lib.filter
-      (row: row.kind == "local-vm" && row.launcherItems != [ ])
-      wiringProbeRows);
-  wiringProbeCountsMatch = {
-    unsafeLocal = wiringProbeUnsafeLocalCount;
-    localVmConfigured = wiringProbeLocalVmConfiguredCount;
-  } == {
-    unsafeLocal = 2;
-    localVmConfigured = 2;
+  wiringProbeCounts = d2bLib.privateConfiguredWorkloadCounts {
+    rows = wiringProbeRows;
+    realms = wiringProbeCfg.d2b.realms;
   };
+  wiringProbeCountsMatch = wiringProbeCounts == {
+    unsafeLocalCount = 2;
+    localVmConfiguredCount = 2;
+  };
+  privateProductionAssertionAt = index: rows:
+    let
+      counts = d2bLib.privateConfiguredWorkloadCounts {
+        inherit rows;
+        realms = wiringProbeCfg.d2b.realms;
+      };
+    in
+    builtins.elemAt
+      (d2bLib.privateConfiguredWorkloadCountAssertions counts)
+      index;
+  privateProductionAssertionMatches =
+    index: rows: expected: message:
+    let
+      record = privateProductionAssertionAt index rows;
+    in
+    record.assertion == expected && record.message == message;
+  privateProductionUnsafeBoundaryChecks = lib.all
+    (probe: privateProductionAssertionMatches
+      0
+      (lib.replicate probe.count wiringProbeUnsafeRow)
+      probe.expected
+      expectedUnsafeLimitMessage)
+    [
+      { count = 255; expected = true; }
+      { count = 256; expected = true; }
+      { count = 257; expected = false; }
+    ];
+  privateProductionLocalVmBoundaryChecks = lib.all
+    (probe: privateProductionAssertionMatches
+      1
+      (lib.replicate probe.count wiringProbeLocalVmRow)
+      probe.expected
+      expectedLocalVmLimitMessage)
+    [
+      { count = 255; expected = true; }
+      { count = 256; expected = true; }
+      { count = 257; expected = false; }
+    ];
+  privateProductionTotalBoundaryChecks = lib.all
+    (probe: privateProductionAssertionMatches
+      2
+      ((lib.replicate probe.unsafe wiringProbeUnsafeRow)
+        ++ (lib.replicate probe.localVm wiringProbeLocalVmRow))
+      probe.expected
+      expectedTotalLimitMessage)
+    [
+      { unsafe = 255; localVm = 256; expected = true; }
+      { unsafe = 256; localVm = 256; expected = true; }
+      { unsafe = 256; localVm = 257; expected = false; }
+    ];
   wiringProbeAssertionMatches = expectedMessage:
     let
       record = lib.findFirst
@@ -642,6 +719,9 @@ in
         privateLimitsExact
         && privateUnsafeBoundaryChecks
         && privateTotalBoundaryChecks
+        && privateProductionUnsafeBoundaryChecks
+        && privateProductionTotalBoundaryChecks
+        && wiringProbeDeclarationsMatch
         && wiringProbeRowsMatch
         && wiringProbeCountsMatch
         && wiringProbeProductionAssertions;
@@ -649,6 +729,9 @@ in
         privateLimitsExact
         && privateLocalVmBoundaryChecks
         && privateTotalBoundaryChecks
+        && privateProductionLocalVmBoundaryChecks
+        && privateProductionTotalBoundaryChecks
+        && wiringProbeDeclarationsMatch
         && wiringProbeRowsMatch
         && wiringProbeCountsMatch
         && wiringProbeProductionAssertions;

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -24,8 +24,8 @@
 { mkEval, lib, ... }:
 
 let
-  # ── shared base ────────────────────────────────────────────────────────────
-  hostBase = {
+  # ── shared schema base ─────────────────────────────────────────────────────
+  workloadSchemaBase = {
     boot.loader.grub.enable = false;
     boot.loader.systemd-boot.enable = false;
     boot.initrd.includeDefaultModules = false;
@@ -39,32 +39,19 @@ let
       waylandUser = "alice";
       launcherUsers = [ "alice" ];
     };
+  };
 
+  # ── focused integration bases ──────────────────────────────────────────────
+  workloadBase = lib.recursiveUpdate workloadSchemaBase {
     d2b.envs.home = {
       lanSubnet = "10.10.0.0/24";
       uplinkSubnet = "192.0.2.0/30";
-    };
-    d2b.envs.dev = {
-      lanSubnet = "10.20.0.0/24";
-      uplinkSubnet = "198.51.100.0/30";
     };
     d2b.envs.work = {
       lanSubnet = "10.30.0.0/24";
       uplinkSubnet = "203.0.113.0/30";
     };
 
-    d2b.vms.homebox = {
-      env = "home";
-      index = 10;
-      ssh.user = "alice";
-      config.users.users.alice = { isNormalUser = true; uid = 1000; };
-    };
-    d2b.vms.devbox = {
-      env = "dev";
-      index = 10;
-      ssh.user = "alice";
-      config.users.users.alice = { isNormalUser = true; uid = 1000; };
-    };
     d2b.vms.corpbox = {
       env = "work";
       index = 10;
@@ -73,9 +60,29 @@ let
     };
   };
 
+  homeVmBase = lib.recursiveUpdate workloadSchemaBase {
+    d2b.envs.home = {
+      lanSubnet = "10.10.0.0/24";
+      uplinkSubnet = "192.0.2.0/30";
+    };
+    d2b.vms.homebox = {
+      env = "home";
+      index = 10;
+      ssh.user = "alice";
+      config.users.users.alice = { isNormalUser = true; uid = 1000; };
+    };
+  };
+
+  workEnvBase = lib.recursiveUpdate workloadSchemaBase {
+    d2b.envs.work = {
+      lanSubnet = "10.30.0.0/24";
+      uplinkSubnet = "203.0.113.0/30";
+    };
+  };
+
   # ── workload fixture ────────────────────────────────────────────────────────
   # One realm ("work.home") with two workloads: one with a legacyVmName, one without.
-  workloadFixture = lib.recursiveUpdate hostBase {
+  workloadFixture = lib.recursiveUpdate workloadBase {
     d2b.realms.home = {
       name = "Home";
       env = "home";
@@ -204,7 +211,7 @@ let
     ];
   }).config.d2b._bundle.unsafeLocalWorkloadsJson.data;
 
-  unsafeLocalFixture = lib.recursiveUpdate hostBase {
+  unsafeLocalFixture = lib.recursiveUpdate workloadSchemaBase {
     users.users.bob = { isNormalUser = true; uid = 1001; };
     d2b.daemonExperimental.enable = true;
     d2b.realms.host = {
@@ -246,7 +253,7 @@ let
 
   workloadNames = prefix: count:
     map (n: "${prefix}-${toString n}") (lib.range 1 count);
-  unsafeBoundFixture = lib.recursiveUpdate hostBase {
+  unsafeBoundFixture = lib.recursiveUpdate workloadSchemaBase {
     d2b.daemonExperimental.enable = true;
     d2b.realms.host = {
       allowedUsers = [ "alice" ];
@@ -260,7 +267,7 @@ let
       });
     };
   };
-  localVmBoundFixture = lib.recursiveUpdate hostBase {
+  localVmBoundFixture = lib.recursiveUpdate workloadSchemaBase {
     d2b.realms.work = {
       allowedUsers = [ "alice" ];
       workloads = lib.genAttrs (workloadNames "local" 257) (_: {
@@ -281,6 +288,10 @@ let
     map (a: a.message)
       (lib.filter (a: !a.assertion) (mkEval modules).config.assertions);
 
+  failureMessagesFromConfig = cfg:
+    map (a: a.message)
+      (lib.filter (a: !a.assertion) cfg.assertions);
+
   hasMessage = needles: messages:
     lib.any
       (message: lib.all (needle: lib.hasInfix needle message) needles)
@@ -290,7 +301,7 @@ let
   # Use two envless VMs whose MD5-based CID formula produces the same value.
   # svc2532 and svc4319 both hash to md5-prefix 0x69b166 → CID 6930790.
   # Envless VMs use the hash-based CID formula (index is irrelevant).
-  cidCollisionFixture = lib.recursiveUpdate hostBase {
+  cidCollisionFixture = lib.recursiveUpdate workloadSchemaBase {
     d2b.vms.svc2532 = {
       # no env → hash-based CID derivation
       ssh.user = "alice";
@@ -321,7 +332,7 @@ let
   cidCollisionMessages = failureMessages [ cidCollisionFixture ];
 
   # ── same-VM cross-realm (no collision) fixture ──────────────────────────────
-  sameVmTwoRealmsFixture = lib.recursiveUpdate hostBase {
+  sameVmTwoRealmsFixture = lib.recursiveUpdate homeVmBase {
     d2b.realms.realm-a = {
       path = "realm-a";
       env = "home";
@@ -343,12 +354,12 @@ let
   };
 
   sameVmCfg = (mkEval [ sameVmTwoRealmsFixture ]).config;
-  sameVmMessages = failureMessages [ sameVmTwoRealmsFixture ];
+  sameVmMessages = failureMessagesFromConfig sameVmCfg;
 
   # ── external-network attachment conflict fixture ─────────────────────────────
   # Two realms both associate with the "work" env which has attachment enabled.
   # Only attachment is needed for conflict detection; no egress required.
-  extNetConflictFixture = lib.recursiveUpdate hostBase {
+  extNetConflictFixture = lib.recursiveUpdate workEnvBase {
     d2b.envs.work.externalNetwork.attachment = {
       enable = true;
       interface = "eth0";
@@ -366,7 +377,26 @@ let
   };
 
   extNetCfg = (mkEval [ extNetConflictFixture ]).config;
-  extNetMessages = failureMessages [ extNetConflictFixture ];
+  extNetMessages = failureMessagesFromConfig extNetCfg;
+
+  duplicateIconFixture = lib.recursiveUpdate workloadSchemaBase {
+    d2b.realms.realm-a = {
+      path = "realm-a";
+      workloads.browser = {
+        launcher.label = "Web Browser";
+        launcher.icon.id = "web-browser";
+      };
+    };
+    d2b.realms.realm-b = {
+      path = "realm-b";
+      workloads.browser = {
+        launcher.label = "Web Browser";
+        launcher.icon.id = "web-browser";
+      };
+    };
+  };
+  duplicateIconLauncherData =
+    (mkEval [ duplicateIconFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
 in
 {
   "realm-workloads/first-class-local-vm-private-launcher" = {
@@ -901,11 +931,10 @@ in
   "realm-workloads/launcher-json-icon-group-key-prefers-id-over-name" = {
     expr =
       let
-        bothIconFixture = lib.recursiveUpdate hostBase {
+        bothIconFixture = lib.recursiveUpdate workloadSchemaBase {
           d2b.realms.home = {
             name = "Home";
             path = "home";
-            network.envs = [ "home" ];
             workloads.notes = {
               launcher.label = "Notes";
               launcher.icon.id = "notes-app";
@@ -936,11 +965,10 @@ in
   "realm-workloads/launcher-json-icon-group-key-falls-back-to-name" = {
     expr =
       let
-        nameOnlyFixture = lib.recursiveUpdate hostBase {
+        nameOnlyFixture = lib.recursiveUpdate workloadSchemaBase {
           d2b.realms.home = {
             name = "Home";
             path = "home";
-            network.envs = [ "home" ];
             workloads.legacy-app = {
               launcher.label = "Legacy App";
               launcher.icon.name = "application-x-generic";
@@ -972,28 +1000,9 @@ in
   "realm-workloads/launcher-json-duplicate-icon-group-key-matches" = {
     expr =
       let
-        dupFixture = lib.recursiveUpdate hostBase {
-          d2b.realms.realm-a = {
-            path = "realm-a";
-            env = "home";
-            network.envs = [ "home" ];
-            workloads.browser = {
-              launcher.label = "Web Browser";
-              launcher.icon.id = "web-browser";
-            };
-          };
-          d2b.realms.realm-b = {
-            path = "realm-b";
-            env = "dev";
-            network.envs = [ "dev" ];
-            workloads.browser = {
-              launcher.label = "Web Browser";
-              launcher.icon.id = "web-browser";
-            };
-          };
-        };
-        data = (mkEval [ dupFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
-        browserRows = lib.filter (w: w.workloadName == "browser") data.workloads;
+        browserRows = lib.filter
+          (w: w.workloadName == "browser")
+          duplicateIconLauncherData.workloads;
         groupKeys = lib.unique (map (w: w.iconGroupKey) browserRows);
       in {
         bothPresent = builtins.length browserRows == 2;
@@ -1018,28 +1027,9 @@ in
   "realm-workloads/launcher-json-no-implicit-dedup" = {
     expr =
       let
-        dupFixture = lib.recursiveUpdate hostBase {
-          d2b.realms.realm-a = {
-            path = "realm-a";
-            env = "home";
-            network.envs = [ "home" ];
-            workloads.browser = {
-              launcher.label = "Web Browser";
-              launcher.icon.id = "web-browser";
-            };
-          };
-          d2b.realms.realm-b = {
-            path = "realm-b";
-            env = "dev";
-            network.envs = [ "dev" ];
-            workloads.browser = {
-              launcher.label = "Web Browser";
-              launcher.icon.id = "web-browser";
-            };
-          };
-        };
-        data = (mkEval [ dupFixture ]).config.d2b._bundle.realmWorkloadsLauncherJson.data;
-        browserRows = lib.filter (w: w.workloadName == "browser") data.workloads;
+        browserRows = lib.filter
+          (w: w.workloadName == "browser")
+          duplicateIconLauncherData.workloads;
       in {
         bothPresent = builtins.length browserRows == 2;
         distinctRealms = lib.sort lib.lessThan

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -369,7 +369,11 @@ let
     (mkEval [
       limitProbeBase
       ({ ... }: {
-        d2b._index.realms.workloads.enabled = lib.mkForce rows;
+        d2b._index = lib.mkForce (
+          lib.recursiveUpdate limitProbeBaseCfg.d2b._index {
+            realms.workloads.enabled = rows;
+          }
+        );
       })
     ]).config;
   limitProbeUnsafeCfg =

--- a/tests/unit/nix/cases/realm-workloads.nix
+++ b/tests/unit/nix/cases/realm-workloads.nix
@@ -21,7 +21,7 @@
 #     realmPath as array, canonicalTarget, providerId); kind and runtimeProviderId
 #     are absent at the workload root
 #   • launcher canonicalTarget override uses a valid .d2b target address
-{ mkEval, lib, ... }:
+{ mkEval, lib, d2bLib, ... }:
 
 let
   # ── shared schema base ─────────────────────────────────────────────────────
@@ -251,27 +251,80 @@ let
   unsafeCfg = (mkEval [ unsafeLocalFixture ]).config;
   unsafeRow = builtins.head unsafeCfg.d2b._index.realms.workloads.enabled;
 
-  workloadNames = prefix: count:
-    map (n: "${prefix}-${toString n}") (lib.range 1 count);
-  unsafeBoundFixture = lib.recursiveUpdate workloadSchemaBase {
+  privateAssertionAt = index: unsafeLocalCount: localVmConfiguredCount:
+    builtins.elemAt
+      (d2bLib.privateConfiguredWorkloadCountAssertions {
+        inherit unsafeLocalCount localVmConfiguredCount;
+      })
+      index;
+  expectedUnsafeLimitMessage = ''
+    d2b declares more than the supported maximum of 256 enabled
+    unsafe-local workloads.
+  '';
+  expectedLocalVmLimitMessage = ''
+    d2b declares more than the supported maximum of 256 enabled local-vm
+    workloads with configured launch.
+  '';
+  expectedTotalLimitMessage = ''
+    d2b declares more than the supported maximum of 512 private configured
+    workloads.
+  '';
+  privateAssertionMatches =
+    index: unsafeLocalCount: localVmConfiguredCount: expected: message:
+    let
+      record = privateAssertionAt index unsafeLocalCount localVmConfiguredCount;
+    in
+    record.assertion == expected && record.message == message;
+  privateLimitsExact =
+    d2bLib.privateConfiguredWorkloadLimits == {
+      unsafeLocal = 256;
+      localVmConfigured = 256;
+      total = 512;
+    };
+  privateUnsafeBoundaryChecks = lib.all
+    (probe: privateAssertionMatches
+      0
+      probe.count
+      0
+      probe.expected
+      expectedUnsafeLimitMessage)
+    [
+      { count = 255; expected = true; }
+      { count = 256; expected = true; }
+      { count = 257; expected = false; }
+    ];
+  privateLocalVmBoundaryChecks = lib.all
+    (probe: privateAssertionMatches
+      1
+      0
+      probe.count
+      probe.expected
+      expectedLocalVmLimitMessage)
+    [
+      { count = 255; expected = true; }
+      { count = 256; expected = true; }
+      { count = 257; expected = false; }
+    ];
+  privateTotalBoundaryChecks = lib.all
+    (probe: privateAssertionMatches
+      2
+      probe.unsafe
+      probe.localVm
+      probe.expected
+      expectedTotalLimitMessage)
+    [
+      { unsafe = 255; localVm = 256; expected = true; }
+      { unsafe = 256; localVm = 256; expected = true; }
+      { unsafe = 256; localVm = 257; expected = false; }
+    ];
+
+  limitProbeBase = lib.recursiveUpdate workloadBase {
     d2b.daemonExperimental.enable = true;
     d2b.realms.host = {
       allowedUsers = [ "alice" ];
       policy.allowUnsafeLocal = true;
-      workloads = lib.genAttrs (workloadNames "unsafe" 257) (_: {
+      workloads.tools = {
         kind = "unsafe-local";
-        launcher.items.run = {
-          type = "exec";
-          argv = [ "true" ];
-        };
-      });
-    };
-  };
-  localVmBoundFixture = lib.recursiveUpdate workloadSchemaBase {
-    d2b.realms.work = {
-      allowedUsers = [ "alice" ];
-      workloads = lib.genAttrs (workloadNames "local" 257) (_: {
-        kind = "local-vm";
         launcher = {
           enable = true;
           items.run = {
@@ -279,9 +332,85 @@ let
             argv = [ "true" ];
           };
         };
-      });
+      };
+    };
+    d2b.realms.work = {
+      path = "work";
+      env = "work";
+      network.envs = [ "work" ];
+      allowedUsers = [ "alice" ];
+      workloads.laptop = {
+        kind = "local-vm";
+        legacyVmName = "corpbox";
+        launcher = {
+          enable = true;
+          items.run = {
+            type = "exec";
+            argv = [ "true" ];
+          };
+        };
+      };
     };
   };
+  limitProbeBaseCfg = (mkEval [ limitProbeBase ]).config;
+  limitProbeRows = limitProbeBaseCfg.d2b._index.realms.workloads.enabled;
+  limitProbeUnsafeRow = lib.findFirst
+    (row: row.kind == "unsafe-local")
+    null
+    limitProbeRows;
+  limitProbeLocalVmRow = lib.findFirst
+    (row: row.kind == "local-vm")
+    null
+    limitProbeRows;
+
+  # Force compact copies of one real index row so the production assertion
+  # path sees boundary counts without expanding hundreds of workload modules.
+  limitProbeCfgWithRows = rows:
+    (mkEval [
+      limitProbeBase
+      ({ ... }: {
+        d2b._index.realms.workloads.enabled = lib.mkForce rows;
+      })
+    ]).config;
+  limitProbeUnsafeCfg =
+    limitProbeCfgWithRows (lib.replicate 257 limitProbeUnsafeRow);
+  limitProbeLocalVmCfg =
+    limitProbeCfgWithRows (lib.replicate 257 limitProbeLocalVmRow);
+  limitProbeTotalCfg =
+    limitProbeCfgWithRows (
+      (lib.replicate 257 limitProbeUnsafeRow)
+      ++ (lib.replicate 256 limitProbeLocalVmRow)
+    );
+  productionAssertionMatches = cfg: needles: expectedMessage:
+    let
+      record = lib.findFirst
+        (assertion:
+          assertion.assertion == false
+          && lib.all
+            (needle: lib.hasInfix needle assertion.message)
+            needles)
+        null
+        cfg.assertions;
+    in
+    record != null
+    && record.assertion == false
+    && record.message == expectedMessage;
+  productionUnsafeOverflow = productionAssertionMatches
+    limitProbeUnsafeCfg
+    [ "maximum of 256" "unsafe-local workloads" ]
+    expectedUnsafeLimitMessage;
+  productionLocalVmOverflow = productionAssertionMatches
+    limitProbeLocalVmCfg
+    [ "maximum of 256" "local-vm" "configured launch" ]
+    expectedLocalVmLimitMessage;
+  productionTotalUnsafeOverflow = productionAssertionMatches
+    limitProbeTotalCfg
+    [ "maximum of 256" "unsafe-local workloads" ]
+    expectedUnsafeLimitMessage;
+  productionTotalOverflow = productionAssertionMatches
+    limitProbeTotalCfg
+    [ "maximum of 512" "private configured" "workloads" ]
+    expectedTotalLimitMessage;
 
   # ── helpers ─────────────────────────────────────────────────────────────────
   failureMessages = modules:
@@ -491,12 +620,19 @@ in
 
   "realm-workloads/private-configured-workload-bounds" = {
     expr = {
-      unsafeOverflow = hasMessage
-        [ "maximum of 256" "unsafe-local workloads" ]
-        (failureMessages [ unsafeBoundFixture ]);
-      localVmOverflow = hasMessage
-        [ "maximum of 256" "local-vm" "configured launch" ]
-        (failureMessages [ localVmBoundFixture ]);
+      unsafeOverflow =
+        privateLimitsExact
+        && privateUnsafeBoundaryChecks
+        && privateTotalBoundaryChecks
+        && productionUnsafeOverflow
+        && productionTotalUnsafeOverflow
+        && productionTotalOverflow;
+      localVmOverflow =
+        privateLimitsExact
+        && privateLocalVmBoundaryChecks
+        && privateTotalBoundaryChecks
+        && productionLocalVmOverflow
+        && productionTotalOverflow;
     };
     expected = {
       unsafeOverflow = true;

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -2,7 +2,7 @@
 { mkEval, lib, flakeRoot, ... }:
 
 let
-  hostBase = {
+  realmSchemaBase = {
     boot.loader.grub.enable = false;
     boot.loader.systemd-boot.enable = false;
     boot.initrd.includeDefaultModules = false;
@@ -16,7 +16,9 @@ let
       waylandUser = "alice";
       launcherUsers = [ "alice" ];
     };
+  };
 
+  hostBase = lib.recursiveUpdate realmSchemaBase {
     d2b.envs.home = {
       lanSubnet = "10.10.0.0/24";
       uplinkSubnet = "192.0.2.0/30";
@@ -44,6 +46,22 @@ let
     };
     d2b.vms.corp = {
       env = "work";
+      index = 10;
+      ssh.user = "alice";
+      config.users.users.alice = { isNormalUser = true; uid = 1000; };
+    };
+  };
+
+  oneEnvBase = lib.recursiveUpdate realmSchemaBase {
+    d2b.envs.home = {
+      lanSubnet = "10.10.0.0/24";
+      uplinkSubnet = "192.0.2.0/30";
+    };
+  };
+
+  oneEnvOneVmBase = lib.recursiveUpdate oneEnvBase {
+    d2b.vms.homebox = {
+      env = "home";
       index = 10;
       ssh.user = "alice";
       config.users.users.alice = { isNormalUser = true; uid = 1000; };
@@ -129,7 +147,7 @@ let
       messages;
 
   missingParentMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.child = {
         parent = "missing";
         path = "child.missing";
@@ -138,7 +156,7 @@ let
   ];
 
   parentCycleMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.alpha = {
         path = "alpha";
         parent = "beta";
@@ -151,7 +169,7 @@ let
   ];
 
   duplicateIdPathMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.alpha = {
         id = "same";
         path = "same-path";
@@ -164,7 +182,7 @@ let
   ];
 
   duplicateRuntimePathMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.alpha = { };
       d2b.realms.beta.paths = {
         stateDir = "/var/lib/d2b/realms/alpha";
@@ -179,19 +197,19 @@ let
   longSocketPath = "/run/d2b/realms/${lib.concatStrings (lib.genList (_: "a") 96)}/public.sock";
 
   overlongPublicSocketMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.work.paths.publicSocket = longSocketPath;
     })
   ];
 
   overlongBrokerSocketMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.work.paths.brokerSocket = longSocketPath;
     })
   ];
 
   missingPlacementProviderMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.work = {
         placement = "provider-controller";
         providers.aca.kind = "aca";
@@ -200,7 +218,7 @@ let
   ];
 
   missingProviderSpecificPlacementProviderMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.work = {
         placement = "provider-specific";
         providerSpecificPlacement = "aca-managed-sandbox";
@@ -210,7 +228,7 @@ let
   ];
 
   unexpectedPlacementProviderMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.work = {
         placement = "gateway-vm";
         placementProvider = "aca";
@@ -220,7 +238,7 @@ let
   ];
 
   missingRealmAllowedUserMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.home = {
         allowedUsers = [ "missing-user" ];
       };
@@ -228,7 +246,7 @@ let
   ];
 
   secretIdentityRefMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.work.keys = {
         realmIdentityRef = "secret-identity";
         controllerKeyRef = "-----BEGIN PRIVATE KEY-----";
@@ -240,7 +258,7 @@ let
   ];
 
   validProviderPlacementCfg = (mkEval [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.work = {
         placement = "provider-agent";
         placementProvider = "aca";
@@ -252,7 +270,7 @@ let
     builtins.head validProviderPlacementCfg.d2b._bundle.realmControllersJson.data.controllers;
 
   legacyGatewayMessages = failureMessages [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.gateways.work = {
         env = "work";
         aca.endpoint = "https://example.azurecontainerapps.invalid";
@@ -270,7 +288,7 @@ let
   # should emit an advisory "inheritEnvNudge" warning pointing at the
   # v1.2→v2 migration guide.
   inheritEnvNudgeWarnings = (mkEval [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate oneEnvBase {
       d2b.realms.nudge-me = {
         env = "home";
         network.envs = [ "home" ];
@@ -283,7 +301,7 @@ let
   # Realm workload with legacyVmName pointing to a VM that does not exist in
   # d2b.vms should emit an advisory warning.
   orphanLegacyVmWarnings = (mkEval [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate oneEnvBase {
       d2b.realms.migrating = {
         env = "home";
         network.envs = [ "home" ];
@@ -298,7 +316,7 @@ let
   # Realm with matching legacyVmName that DOES exist in d2b.vms should NOT
   # emit the orphan warning.
   legacyVmPresentWarnings = (mkEval [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate oneEnvOneVmBase {
       d2b.realms.migrating = {
         env = "home";
         network.envs = [ "home" ];
@@ -313,7 +331,7 @@ let
   # Realm with workloads declared (even without env) does NOT emit the
   # inheritEnvNudge warning.
   withWorkloadsNoNudgeWarnings = (mkEval [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate oneEnvBase {
       d2b.realms.with-workloads = {
         env = "home";
         network.envs = [ "home" ];
@@ -331,7 +349,7 @@ let
   # failures for each supported kind (local-vm, qemu-media, provider-placeholder)
   # and that per-workload defaults are correctly materialized.
   acceptedWorkloadCfg = (mkEval [
-    (lib.recursiveUpdate hostBase {
+    (lib.recursiveUpdate realmSchemaBase {
       d2b.realms.corp = {
         parent = "home";
         path = "corp.home";


### PR DESCRIPTION
## Change

- Reduce repeated NixOS and guest graph evaluation in Nix-unit fixtures.
- Preserve full integration scenarios while using focused realm, workload,
  resource, gateway, niri, and warning fixtures.
- Share identical observability scenario evaluations.
- Replace production-sized workload-limit fixtures with a shared production
  counter, pure boundary checks, and a small real declaration-to-index wiring
  probe.

## Measured result

- `nix-unit-network` five-run mean RSS: 17,148,481 KiB to 9,461,756 KiB,
  44.8% lower.
- `nix-unit-network` five-run mean wall time: 351.6s to 237.3s.
- Full local `make test-nix-unit`: 136s with four workers.
- CI `nix-unit-network`: 5m42s on PR #378 to 2m38s on this PR.
- CI Nix-unit discovery-to-rollup: 7m47s on PR #378 to 5m01s on this PR.

## Validation

- `make check-tier0`
- `make check-inventory`
- `make test-lint`
- `make test-changelog`
- `D2B_SKIP_FIXTURE_BUILD=1 make test-rust`
- `make test-proofs`
- `D2B_FLAKE_LOCAL_SHARDS=1 make test-flake`
- `make test-policy`
- `make test-drift`
- `make test-runtime-ledger`
- `D2B_ENABLE_FIXTURE_BUILD=1 make test-fixture-contracts`
- `make test-integration`
- `make test-host-integration`
- selected Nix-unit network, daemon, runtime, and misc checks
- full `make test-nix-unit`

## Review

The ten-seat integrated work panel returned unanimous sign-off on
`acb05cb8970154deb296f113b4c139d648316301`.
