### PR TITLE
bind reviewer handoff artifacts

### DIFF
--- a/.github/agents/d2b-integrator.agent.md
+++ b/.github/agents/d2b-integrator.agent.md
@@ -22,7 +22,10 @@ sealed. You do not write feature code; you land it.
 2. **Run the wave's validation** and record the exact commands and results.
    That record becomes the evidence in every panel prompt, so it must be
    accurate about what was and was not covered.
-3. **Run a panel round** via the `d2b-panel-round` skill.
+3. **Run a panel round** via the `d2b-panel-round` skill. Never dispatch a
+   reviewer from a hand-written prompt: stage the round, edit its evidence and
+   seat notes, then use the generated `dispatch-prompt.txt` verbatim for every
+   seat.
 4. **If any reviewer returns findings**, dispatch fix agents scoped strictly
    to those findings, land the fixes, rerun the smallest relevant validation,
    and run another round.
@@ -52,7 +55,9 @@ unaffected.
 **Rounds after the first are delta reviews.** Record the tip commit each round
 reviewed so the next round can be scoped against it. Prompts carry two ranges:
 the delta since that reviewer last reviewed, which is what they review, and
-the full branch for context.
+the full branch for context. The staging helper must accept the recorded prior
+tip and prior verdict set before you dispatch; do not bypass that refusal by
+constructing diffs or prompts yourself.
 
 **A prose summary of what changed is intent, not evidence.** Instruct
 reviewers to read the delta themselves. A fix that silently touched something

--- a/.github/skills/d2b-panel-round/SKILL.md
+++ b/.github/skills/d2b-panel-round/SKILL.md
@@ -69,7 +69,13 @@ bash .github/skills/d2b-panel-round/scripts/stage-diffs.sh <base> <prev-tip> <RO
 `<base>` is the branch base, `<prev-tip>` is the commit the previous round
 reviewed, or the base again for round 1. This writes
 `.scratch/panel/<ROUND>/` containing `delta.diff`, `full.diff`,
-`evidence.md`, and `address.json`.
+`evidence.md`, `address.json`, `review-request.md`,
+`dispatch-prompt.txt`, and one file per seat under `reviewer-notes/`.
+
+For a later round, the script fails unless `<prev-tip>` is the tip recorded by
+the immediately previous round and every seat has a prior verdict. That check
+is what makes `delta.diff` incremental evidence rather than a caller-supplied
+claim about the range.
 
 The reviewers have no shell. Staging is what lets ten independent lanes see
 byte-identical evidence, and it is what keeps them off the shared Nix store,
@@ -81,28 +87,22 @@ dispatching: the exact commands run and their pass or fail results. State what
 was **not** covered too. A reviewer who cannot tell whether the change was
 validated is required to raise that as a finding.
 
+Edit `reviewer-notes/<seat>.md` only when that seat needs an integrator
+rebuttal or an explicit reviewer-specific validation request. Do not put a
+change summary there.
+
 ### 3. Dispatch all ten seats in one batch
 
 Dispatch every row of the table in a single response so the lanes run in
-parallel. Each lane's prompt carries:
+parallel. Use the exact contents of
+`.scratch/panel/<ROUND>/dispatch-prompt.txt` as every task prompt. Do not
+hand-author, summarize, shorten, or supplement reviewer prompts.
 
-- the paths `.scratch/panel/<ROUND>/delta.diff` and `full.diff`, and the
-  instruction to read them with `view`;
-- `.scratch/panel/<ROUND>/evidence.md`;
-- for a round after the first, the commit that reviewer last reviewed and the
-  instruction that **the delta is what they review**, with the full branch for
-  context only;
-- the phase deliverable, so findings stay confined to defects in the delta;
-- a restatement of the shared bar: a finding is a defect that would cause
-  incorrect behaviour, mask a regression, or weaken a stated invariant, and
-  everything else is a summary observation. Each seat carries this bar in its
-  own agent file, byte-identical and gate-enforced, but restating it in the
-  prompt costs one line and makes the threshold explicit for the round;
-- any integrator rebuttal of a prior finding, stated with its evidence, and an
-  explicit statement that the reviewer may withdraw an incorrect finding and is
-  not required to withdraw a correct one;
-- the instruction not to rerun tests, builds, evals, or long validations
-  unless this specific reviewer is explicitly asked to.
+The generated `review-request.md` is the complete shared instruction source.
+It names the exact delta and full ranges, the validation evidence, the phase
+deliverable, the seat-specific notes, the finding bar, the no-rerun rule, and,
+after the first round, the prior verdict each seat must verify. The task prompt
+has one job: direct the reviewer to that complete request.
 
 Do not summarise the change and ask reviewers to trust the summary. A prose
 summary is a statement of intent. A fix that silently touched something the

--- a/.github/skills/d2b-panel-round/scripts/stage-diffs.sh
+++ b/.github/skills/d2b-panel-round/scripts/stage-diffs.sh
@@ -23,6 +23,14 @@ case "$round" in
   */*|..*|"") echo "refusing round id with a path separator: $round" >&2; exit 2 ;;
 esac
 
+if [[ "$round" =~ ^([[:alnum:]]+)-r([1-9][0-9]*)$ ]]; then
+  wave="${BASH_REMATCH[1]}"
+  round_number=$((10#${BASH_REMATCH[2]}))
+else
+  echo "round id must end in -r<N>, for example spec001w1-r2: $round" >&2
+  exit 2
+fi
+
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
@@ -31,7 +39,110 @@ base_sha="$(git rev-parse "$base")"
 prev_sha="$(git rev-parse "$prev")"
 
 out="$root/.scratch/panel/$round"
-mkdir -p "$out/verdicts"
+
+read_address() {
+  node - "$1" <<'NODE'
+const fs = require("node:fs");
+const path = process.argv[2];
+let value;
+try {
+  value = JSON.parse(fs.readFileSync(path, "utf8"));
+} catch (error) {
+  console.error(`${path}: invalid address.json: ${error.message}`);
+  process.exit(1);
+}
+for (const key of ["round", "base", "previous_tip", "tip"]) {
+  if (typeof value[key] !== "string" || value[key].length === 0) {
+    console.error(`${path}: address.json is missing ${key}`);
+    process.exit(1);
+  }
+}
+process.stdout.write(
+  [value.round, value.base, value.previous_tip, value.tip].join("\t"),
+);
+NODE
+}
+
+previous_round=""
+previous_dir=""
+if [ "$round_number" -eq 1 ]; then
+  if [ "$prev_sha" != "$base_sha" ]; then
+    echo "round 1 must use the branch base as <prev-tip>" >&2
+    echo "  base      $base_sha" >&2
+    echo "  prev-tip  $prev_sha" >&2
+    exit 2
+  fi
+else
+  previous_round="$wave-r$((round_number - 1))"
+  previous_dir="$root/.scratch/panel/$previous_round"
+  previous_address="$previous_dir/address.json"
+  if [ ! -f "$previous_address" ]; then
+    echo "missing previous review address: $previous_address" >&2
+    echo "stage reviews sequentially so the incremental range is derived from recorded evidence" >&2
+    exit 2
+  fi
+  if ! previous_fields="$(read_address "$previous_address")"; then
+    exit 2
+  fi
+  IFS=$'\t' read -r recorded_round _ _ recorded_tip <<<"$previous_fields"
+  if [ "$recorded_round" != "$previous_round" ]; then
+    echo "$previous_address records round $recorded_round, expected $previous_round" >&2
+    exit 2
+  fi
+  if [ "$prev_sha" != "$recorded_tip" ]; then
+    echo "incremental range does not start at the previous recorded tip" >&2
+    echo "  previous round  $previous_round" >&2
+    echo "  recorded tip    $recorded_tip" >&2
+    echo "  supplied tip    $prev_sha" >&2
+    exit 2
+  fi
+fi
+
+mapfile -t panel_seats < <(
+  find "$root/.github/agents" -maxdepth 1 -type f -name 'panel-*.agent.md' \
+    -printf '%f\n' |
+    sed -e 's/^panel-//' -e 's/\.agent\.md$//' |
+    sort
+)
+if [ "${#panel_seats[@]}" -eq 0 ]; then
+  echo "no panel seat agents found under $root/.github/agents" >&2
+  exit 2
+fi
+
+if [ "$round_number" -gt 1 ]; then
+  for seat in "${panel_seats[@]}"; do
+    prior_verdict="$previous_dir/verdicts/$seat.json"
+    if [ ! -s "$prior_verdict" ]; then
+      echo "missing previous verdict for seat $seat: $prior_verdict" >&2
+      echo "later reviews must give every seat its own prior verdict to verify" >&2
+      exit 2
+    fi
+  done
+fi
+
+if [ -f "$out/address.json" ]; then
+  if ! existing_fields="$(read_address "$out/address.json")"; then
+    exit 2
+  fi
+  IFS=$'\t' read -r existing_round existing_base existing_prev existing_tip <<<"$existing_fields"
+  if [ "$existing_round" != "$round" ] ||
+     [ "$existing_base" != "$base_sha" ] ||
+     [ "$existing_prev" != "$prev_sha" ] ||
+     [ "$existing_tip" != "$tip" ]; then
+    echo "review address $round was already staged for different commits" >&2
+    echo "use the next review id instead of changing evidence beneath an existing address" >&2
+    exit 2
+  fi
+fi
+
+if [ -d "$out/verdicts" ] &&
+   find "$out/verdicts" -maxdepth 1 -type f -name '*.json' -print -quit |
+     grep -q .; then
+  echo "review $round already has verdicts; use the next review id" >&2
+  exit 2
+fi
+
+mkdir -p "$out/verdicts" "$out/reviewer-notes"
 
 # Write-then-rename every artifact. A diff truncated by a signal or a full
 # disk would otherwise sit at its final path, and a reviewer would read a
@@ -101,9 +212,100 @@ would break this deliverable or mask a regression.
 MD
 fi
 
+for seat in "${panel_seats[@]}"; do
+  note="$out/reviewer-notes/$seat.md"
+  if [ -f "$note" ]; then
+    continue
+  fi
+  cat > "$note" <<MD
+# Reviewer notes for $seat
+
+## Integrator rebuttals
+
+None.
+
+If a prior finding is disputed, replace "None." with the rebuttal and its
+evidence. The reviewer may withdraw an incorrect finding and is not required
+to withdraw a correct one.
+
+## Reviewer-specific validation request
+
+None. Reviewers do not rerun tests, builds, evals, exploits, or other long
+validations unless this section explicitly asks this seat to do so.
+MD
+done
+
+request_tmp="$out/review-request.md.$$.tmp"
+dispatch_tmp="$out/dispatch-prompt.txt.$$.tmp"
+trap 'rm -f -- "$addr_tmp" "$request_tmp" "$dispatch_tmp"' EXIT
+
+cat > "$request_tmp" <<MD
+# Panel review request
+
+This is the complete shared request for \`$round\`. Read the artifacts below
+with \`view\`; do not substitute a prose summary for them.
+
+## Review address
+
+- Delta to review: \`$out/delta.diff\`
+- Delta range: \`$prev_sha..$tip\`
+- Full branch context: \`$out/full.diff\`
+- Full range: \`$base_sha..$tip\`
+- Validation evidence and phase deliverable: \`$out/evidence.md\`
+- Seat-specific notes: \`$out/reviewer-notes/<your-seat>.md\`
+- Commit list: \`$out/commits.txt\`
+
+## Required review behaviour
+
+1. Read the delta in full. The delta is the review target; the full diff is
+   context only.
+2. Read the validation evidence and phase deliverable. Missing or insufficient
+   coverage is a finding. Do not rerun validation unless your seat-specific
+   notes explicitly ask you to.
+3. Read your seat-specific notes. Judge any rebuttal on its merits.
+4. Inspect the tree and the diff rather than trusting a summary of what was
+   intended to change.
+5. Confine findings to defects in the delta that would cause incorrect
+   behaviour, mask a regression, or weaken a stated invariant. Put other
+   observations in the summary.
+6. Return exactly the JSON verdict required by your panel agent and no other
+   text. \`signoff\` is true if and only if \`recommendations\` is empty.
+MD
+
+if [ "$round_number" -gt 1 ]; then
+  cat >> "$request_tmp" <<MD
+
+## Prior verdict obligation
+
+- Your previous verdict: \`$previous_dir/verdicts/<your-seat>.json\`
+- Previous reviewed tip: \`$prev_sha\`
+
+Read your own previous verdict and verify every prior recommendation against
+the current tree by inspection. Do not mark a finding resolved because the
+integrator says it was fixed. Any content change invalidated every prior
+sign-off, including a sign-off from a seat whose area appears unaffected.
+MD
+else
+  cat >> "$request_tmp" <<'MD'
+
+## Prior verdict obligation
+
+This is the first review. There is no prior verdict to verify.
+MD
+fi
+
+mv -f "$request_tmp" "$out/review-request.md"
+
+cat > "$dispatch_tmp" <<MD
+Read and follow the complete review request at $out/review-request.md. Use view to read every artifact it names, including the delta and your seat-specific notes. Review the delta rather than a prose summary, and return only your seat's required JSON verdict.
+MD
+mv -f "$dispatch_tmp" "$out/dispatch-prompt.txt"
+trap - EXIT
+
 echo "staged $out"
 echo "  tip          $tip"
 echo "  delta        $prev_sha..$tip  ($delta_sha)"
 echo "  full         $base_sha..$tip  ($full_sha)"
 echo
-echo "Edit $out/evidence.md before dispatching."
+echo "Edit $out/evidence.md and any seat-specific notes before dispatching."
+echo "Dispatch every seat with the exact contents of $out/dispatch-prompt.txt."

--- a/changelog.d/integrator-review-context.md
+++ b/changelog.d/integrator-review-context.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Generated one canonical reviewer request for every staged review, binding
+  the incremental and full diff ranges, validation evidence, prior verdicts,
+  finding threshold, and no-rerun instructions into the prompt integrators
+  dispatch verbatim.

--- a/docs/contributing/copilot-agents.md
+++ b/docs/contributing/copilot-agents.md
@@ -225,6 +225,14 @@ bash .github/skills/d2b-panel-round/scripts/stage-diffs.sh <base> <prev-tip> <ro
 node .github/skills/d2b-panel-round/scripts/make-records.mjs .scratch/panel/<round>
 ```
 
+Staging also writes `review-request.md`, `dispatch-prompt.txt`, and
+`reviewer-notes/<seat>.md`. The integrator edits the evidence and any
+seat-specific rebuttal, then dispatches every reviewer with the exact generated
+prompt. Later reviews fail closed unless `<prev-tip>` matches the previous
+recorded tip and every seat's prior verdict is available, so the incremental
+range and prior-finding instructions cannot be replaced by a free-form
+summary.
+
 Ten separate reviewers is a deliberate cost. This repository's own history is
 the argument: an early panel returned zero sign-offs with eleven high findings
 that the static gate caught none of, and the five-seat council is documented

--- a/docs/contributing/panel-review.md
+++ b/docs/contributing/panel-review.md
@@ -74,6 +74,15 @@ it. An unfounded finding drives a wrong change into the tree, so sustaining
 one to save face is worse than admitting the error; equally, a reviewer must
 not withdraw a valid finding merely because the integrator pushed back.
 
+The Copilot panel stages one canonical `review-request.md` for the whole
+roster and one `reviewer-notes/<seat>.md` file per reviewer. The request names
+the exact delta and full ranges, validation evidence, deliverable, finding
+threshold, no-rerun rule, and prior-verdict obligation. The integrator
+dispatches the exact generated `dispatch-prompt.txt` to every seat rather than
+reconstructing those instructions in ten free-form prompts. For a later
+review, staging fails unless the supplied previous tip matches the prior
+`address.json` and every seat's prior verdict is present.
+
 Any content change to the reviewed tree invalidates every prior sign-off in
 that phase, including sign-offs from reviewers whose focus the change did
 not touch. Those reviewers still re-report, but their prompt should scope

--- a/scripts/copilot/test-stage-diffs.mjs
+++ b/scripts/copilot/test-stage-diffs.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// Coverage for the staged panel review request. The integrator dispatches the
+// generated prompt verbatim, so this test proves that the prompt carries the
+// incremental range, full context, evidence, prior-verdict obligation, and
+// no-rerun rule instead of relying on a hand-written task prompt.
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const root = join(here, "..", "..");
+const script = join(
+  root,
+  ".github",
+  "skills",
+  "d2b-panel-round",
+  "scripts",
+  "stage-diffs.sh",
+);
+
+let failures = 0;
+const check = (name, ok, detail = "") => {
+  if (ok) {
+    console.log(`  ok   ${name}`);
+    return;
+  }
+  failures += 1;
+  console.error(`  FAIL ${name}${detail ? `: ${detail}` : ""}`);
+};
+
+function run(cwd, args) {
+  const result = spawnSync("bash", [script, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    text: `${result.stdout || ""}${result.stderr || ""}`,
+  };
+}
+
+function git(cwd, ...args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${result.stderr || result.stdout}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+const repo = mkdtempSync(join(tmpdir(), "d2b-stage-diffs-"));
+try {
+  git(repo, "init", "--quiet");
+  git(repo, "config", "user.name", "d2b test");
+  git(repo, "config", "user.email", "d2b-test@example.invalid");
+
+  const agents = join(repo, ".github", "agents");
+  mkdirSync(agents, { recursive: true });
+  for (const seat of ["software", "test"]) {
+    writeFileSync(join(agents, `panel-${seat}.agent.md`), `name: ${seat}\n`);
+  }
+
+  writeFileSync(join(repo, "base.txt"), "base\n");
+  git(repo, "add", "base.txt", ".github/agents");
+  git(repo, "commit", "--quiet", "-m", "base");
+  const base = git(repo, "rev-parse", "HEAD");
+
+  writeFileSync(join(repo, "first.txt"), "first change\n");
+  git(repo, "add", "first.txt");
+  git(repo, "commit", "--quiet", "-m", "first");
+  const firstTip = git(repo, "rev-parse", "HEAD");
+
+  console.log("stage-diffs: first review");
+  const first = run(repo, [base, base, "spec001w1-r1"]);
+  check("first review stages successfully", first.status === 0, first.text);
+
+  const firstDir = join(repo, ".scratch", "panel", "spec001w1-r1");
+  const firstRequest = readFileSync(join(firstDir, "review-request.md"), "utf8");
+  const firstDispatch = readFileSync(join(firstDir, "dispatch-prompt.txt"), "utf8");
+  check(
+    "request names the exact delta range",
+    firstRequest.includes(`Delta range: \`${base}..${firstTip}\``),
+  );
+  check(
+    "request names the full context range",
+    firstRequest.includes(`Full range: \`${base}..${firstTip}\``),
+  );
+  check(
+    "request binds evidence and no-rerun instructions",
+    firstRequest.includes("Validation evidence and phase deliverable") &&
+      firstRequest.includes(
+        "Do not rerun validation unless your seat-specific",
+      ),
+  );
+  check(
+    "dispatch prompt points at the complete request",
+    firstDispatch.includes(join(firstDir, "review-request.md")),
+  );
+  check(
+    "seat-specific note files are staged",
+    ["software", "test"].every((seat) =>
+      readFileSync(join(firstDir, "reviewer-notes", `${seat}.md`), "utf8")
+        .includes(`Reviewer notes for ${seat}`),
+    ),
+  );
+
+  for (const seat of ["software", "test"]) {
+    writeFileSync(
+      join(firstDir, "verdicts", `${seat}.json`),
+      `${JSON.stringify({
+        engineer: seat,
+        signoff: true,
+        summary: "Reviewed.",
+        recommendations: [],
+      })}\n`,
+    );
+  }
+
+  writeFileSync(join(repo, "second.txt"), "second change\n");
+  git(repo, "add", "second.txt");
+  git(repo, "commit", "--quiet", "-m", "second");
+  const secondTip = git(repo, "rev-parse", "HEAD");
+
+  console.log("stage-diffs: fail-closed continuity");
+  const wrongPreviousTip = run(repo, [base, base, "spec001w1-r2"]);
+  check(
+    "later review rejects a non-incremental previous tip",
+    wrongPreviousTip.status === 2 &&
+      wrongPreviousTip.text.includes(
+        "incremental range does not start at the previous recorded tip",
+      ),
+    wrongPreviousTip.text,
+  );
+
+  const missingVerdict = join(firstDir, "verdicts", "test.json");
+  const savedVerdict = readFileSync(missingVerdict);
+  rmSync(missingVerdict);
+  const incompletePreviousReview = run(repo, [base, firstTip, "spec001w1-r2"]);
+  check(
+    "later review rejects a missing prior seat verdict",
+    incompletePreviousReview.status === 2 &&
+      incompletePreviousReview.text.includes(
+        "missing previous verdict for seat test",
+      ),
+    incompletePreviousReview.text,
+  );
+  writeFileSync(missingVerdict, savedVerdict);
+
+  console.log("stage-diffs: incremental review");
+  const second = run(repo, [base, firstTip, "spec001w1-r2"]);
+  check("later review stages successfully", second.status === 0, second.text);
+
+  const secondDir = join(repo, ".scratch", "panel", "spec001w1-r2");
+  const delta = readFileSync(join(secondDir, "delta.diff"), "utf8");
+  const full = readFileSync(join(secondDir, "full.diff"), "utf8");
+  const secondRequest = readFileSync(join(secondDir, "review-request.md"), "utf8");
+  check(
+    "incremental diff excludes earlier changed paths",
+    delta.includes("second.txt") && !delta.includes("first.txt"),
+  );
+  check(
+    "full diff retains all branch changes",
+    full.includes("first.txt") && full.includes("second.txt"),
+  );
+  check(
+    "later request names the prior verdict and invalidated sign-off",
+    secondRequest.includes(
+      join(firstDir, "verdicts", "<your-seat>.json"),
+    ) &&
+      secondRequest.includes(
+        "Any content change invalidated every prior sign-off",
+      ),
+  );
+  check(
+    "later request names the exact incremental range",
+    secondRequest.includes(`Delta range: \`${firstTip}..${secondTip}\``),
+  );
+
+  writeFileSync(
+    join(secondDir, "verdicts", "software.json"),
+    "{}\n",
+  );
+  const reused = run(repo, [base, firstTip, "spec001w1-r2"]);
+  check(
+    "a review id with verdicts cannot be restaged",
+    reused.status === 2 &&
+      reused.text.includes("already has verdicts"),
+    reused.text,
+  );
+} finally {
+  rmSync(repo, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+  console.error(`\ntest-stage-diffs: ${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("\ntest-stage-diffs: all cases passed");

--- a/scripts/copilot/test-stage-diffs.mjs
+++ b/scripts/copilot/test-stage-diffs.mjs
@@ -177,8 +177,8 @@ try {
     secondRequest.includes(
       join(firstDir, "verdicts", "<your-seat>.json"),
     ) &&
-      secondRequest.includes(
-        "Any content change invalidated every prior sign-off",
+      /Any content change invalidated every prior\s+sign-off/.test(
+        secondRequest,
       ),
   );
   check(

--- a/tests/test-lint.sh
+++ b/tests/test-lint.sh
@@ -111,6 +111,25 @@ else
   exit 1
 fi
 
+# --- panel review request -------------------------------------------------
+# Reviewers have no shell and receive one generated request rather than a
+# hand-written summary. Exercise that request so incremental ranges, full
+# context, prior verdicts, evidence, and no-rerun instructions cannot silently
+# drop out of the integrator handoff.
+log "--> panel review request"
+if [ -f "$ROOT/scripts/copilot/test-stage-diffs.mjs" ]; then
+  if command -v node >/dev/null 2>&1; then
+    node "$ROOT/scripts/copilot/test-stage-diffs.mjs" >/dev/null
+    ok "panel review request"
+  else
+    fail "node not found; scripts/copilot/test-stage-diffs.mjs cannot run"
+    exit 1
+  fi
+else
+  fail "required gate is missing: scripts/copilot/test-stage-diffs.mjs"
+  exit 1
+fi
+
 # --- binding gate self-coverage -------------------------------------------
 # The seat-roster comparison inside check-bindings.mjs is enforced by parsing
 # source with a regex, and a regex guard can stop matching without anything


### PR DESCRIPTION
## Summary

- generate one canonical review request containing the incremental diff, full context, validation evidence, prior verdict obligations, and reviewer instructions
- reject later reviews unless they continue from the prior recorded tip and complete verdict set
- require the integrator to dispatch the generated prompt verbatim and cover the handoff with a regression test

## Validation

- `node scripts/copilot/test-stage-diffs.mjs`
- `make test-lint`
- `make check-tier0`