### PR TITLE
gascity: resolve rig-scoped worker roles

### DIFF
--- a/changelog.d/gascity-role-pack-import.md
+++ b/changelog.d/gascity-role-pack-import.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed the Gas City contributor graph to import its upstream role pack so
+  configured agent patches resolve and submitted work can start.

--- a/changelog.d/gascity-role-pack-import.md
+++ b/changelog.d/gascity-role-pack-import.md
@@ -1,4 +1,5 @@
 ### Fixed
 
-- Fixed the Gas City contributor graph to import its upstream role pack so
-  configured agent patches resolve and submitted work can start.
+- Fixed the Gas City contributor graph to register the d2b rig and import its
+  upstream role pack at rig scope so configured agent patches resolve and
+  submitted work can start.

--- a/nix/gas-city-contributor/city/city.toml
+++ b/nix/gas-city-contributor/city/city.toml
@@ -1,8 +1,9 @@
 # Immutable Gas City contributor city.
 #
-# The four imports are deliberate peer imports.  The Compound pack keeps its
-# own ../gascity dependency, so the Nix asset builder places the upstream
-# trees beside one another instead of copying one pack into another.
+# The four city imports are deliberate peers.  The Compound pack keeps its own
+# ../gascity dependency, so the Nix asset builder places the upstream trees
+# beside one another instead of copying one pack into another.  Gas City roles
+# are separately rig-scoped below, as required by the upstream pack contract.
 
 [workspace]
 name = "d2b-contributor"
@@ -16,7 +17,7 @@ global_fragments = ["d2b-managed-contributor"]
 provider = "subprocess"
 
 [imports.gc]
-source = "../packs/gascity/roles"
+source = "../packs/gascity"
 
 [imports.compound-engineering]
 source = "../packs/compound-engineering"
@@ -26,6 +27,13 @@ source = "../packs/discord"
 
 [imports.contributor]
 source = "../pack"
+
+[[rigs]]
+name = "d2b"
+path = "/var/lib/gascity-contributor/state/rigs/d2b"
+
+[rigs.imports.gc]
+source = "../packs/gascity/roles"
 
 # These provider presets are the only Copilot launch surface used by the
 # generated role bindings.  Model and context selection is supplied by the
@@ -90,241 +98,241 @@ env = { COPILOT_CUSTOM_INSTRUCTIONS_DIRS = "" }
 # provider with an implicit selector or add an implicit fallback.
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.requirements-planner"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.design-author"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.task-decomposer"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.design-implementation-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.design-test-risk-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.gap-analyst"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.implementation-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.issue-triager"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.review-synthesizer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "gc.implementation-worker"
 provider = "copilot-code-luna"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-adversarial-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-agent-native-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-api-contract-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-architecture-strategist"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-brainstorm"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-code-review-selector"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-code-review-synthesizer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-coherence-reviewer"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-compound"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-correctness-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-data-migration-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-deployment-verification-agent"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-feasibility-reviewer"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-julik-frontend-races-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-learnings-researcher"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-maintainability-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-performance-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-plan"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-plan-review-synthesizer"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-pr-comment-resolver"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-previous-comments-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-project-standards-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-reliability-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-scope-guardian-reviewer"
 provider = "copilot-planning-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-security-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-swift-ios-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-testing-reviewer"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "compound-engineering.ce-work"
 provider = "copilot-code-luna"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "contributor.d2b-pr-comment-judge"
 provider = "copilot-review-sol"
 session = "acp"
 
 [[patches.agent]]
-dir = ""
+dir = "d2b"
 name = "contributor.d2b-pr-comment-verifier"
 provider = "copilot-review-sol"
 session = "acp"

--- a/nix/gas-city-contributor/city/city.toml
+++ b/nix/gas-city-contributor/city/city.toml
@@ -16,7 +16,7 @@ global_fragments = ["d2b-managed-contributor"]
 provider = "subprocess"
 
 [imports.gc]
-source = "../packs/gascity"
+source = "../packs/gascity/roles"
 
 [imports.compound-engineering]
 source = "../packs/compound-engineering"

--- a/nixos-modules/gas-city-contributor/service.nix
+++ b/nixos-modules/gas-city-contributor/service.nix
@@ -53,12 +53,31 @@ let
   activeRunGCRootDirectory = "/nix/var/nix/gcroots/gascity-contributor";
   terminalStateRoot = "${stateRoot}/agent-state/terminal";
   packageAssetRoot = "${package}/share/gas-city-contributor";
-  cityPath = "${packageAssetRoot}/city";
-  packPath = "${packageAssetRoot}/pack";
-  profilesPath = "${packageAssetRoot}/copilot";
+  configuredAssetRoot = pkgs.runCommand "gas-city-contributor-configured-assets" { } ''
+    set -euo pipefail
+    mkdir -p "$out"
+    cp -R ${packageAssetRoot}/. "$out/"
+    chmod -R u+w "$out/city"
+
+    city="$out/city/city.toml"
+    test "$(grep -c '^name = "d2b"$' "$city")" -eq 1
+    test "$(grep -c '^path = "/var/lib/gascity-contributor/state/rigs/d2b"$' "$city")" -eq 1
+    test "$(grep -c '^dir = "d2b"$' "$city")" -eq 40
+    substituteInPlace "$city" \
+      --replace-fail 'name = "d2b"' \
+        'name = "${cfg.repository.rigName}"' \
+      --replace-fail \
+        'path = "/var/lib/gascity-contributor/state/rigs/d2b"' \
+        'path = "/var/lib/gascity-contributor/state/rigs/${cfg.repository.rigName}"' \
+      --replace-fail 'dir = "d2b"' \
+        'dir = "${cfg.repository.rigName}"'
+  '';
+  cityPath = "${configuredAssetRoot}/city";
+  packPath = "${configuredAssetRoot}/pack";
+  profilesPath = "${configuredAssetRoot}/copilot";
   instructionsPath = "${profilesPath}/instructions.md";
   runtimeClosure = pkgs.closureInfo {
-    rootPaths = [ package ];
+    rootPaths = [ package configuredAssetRoot ];
   };
   runtimeClosurePath = "${runtimeClosure}/store-paths";
   agentUid = lib.attrByPath [ "users" "users" "gascity-agent" "uid" ] 0 config;
@@ -66,7 +85,9 @@ let
   discordUid = config.users.users.gascity-discord.uid;
   publisherUid = config.users.users.gascity-publisher.uid;
   checkUid = lib.attrByPath [ "users" "users" "gascity-check" "uid" ] 0 config;
-  generation = builtins.substring 0 32 (builtins.hashString "sha256" (toString package));
+  generation = builtins.substring 0 32 (
+    builtins.hashString "sha256" (toString configuredAssetRoot)
+  );
   relayAuth = builtins.hashString "sha256"
     "gascity-fdproxy:${cfg.repository.githubSlug}:${cfg.repository.rigName}";
   checkAuth = builtins.hashString "sha256"
@@ -98,7 +119,7 @@ let
   materialize = "+${python} ${activation} materialize-assets"
     + " --uid 0"
     + " --group ${lib.escapeShellArg managedAssetGroup}"
-    + " --source ${lib.escapeShellArg "${package}/share/gas-city-contributor"}"
+    + " --source ${lib.escapeShellArg configuredAssetRoot}"
     + " --destination ${lib.escapeShellArg "${serviceRoot}/managed"}";
   decisionReconcile = pkgs.writeShellScript "gascity-decision-reconcile" ''
     set -euo pipefail
@@ -298,7 +319,7 @@ let
     ${python} ${launcher} \
       --server \
       --socket ${lib.escapeShellArg agentPrivateSocket} \
-      --settings-root ${lib.escapeShellArg "${package}/share/gas-city-contributor/copilot"} \
+      --settings-root ${lib.escapeShellArg profilesPath} \
       --copilot ${lib.escapeShellArg copilot} \
       --state-root ${lib.escapeShellArg "${stateRoot}/agent-state"} \
       --worktree ${lib.escapeShellArg "${stateRoot}/worktrees"} \
@@ -335,7 +356,7 @@ let
       --status-path ${lib.escapeShellArg readinessPath} \
       --generation ${lib.escapeShellArg generation} \
       --state-schema 1 \
-      --profile-script ${lib.escapeShellArg "${package}/share/gas-city-contributor/pack/scripts/copilot-profile.py"} \
+      --profile-script ${lib.escapeShellArg "${packPath}/scripts/copilot-profile.py"} \
       --run-id readiness \
       --bead-id readiness \
       --worktree ${lib.escapeShellArg "${stateRoot}/worktrees/readiness"} \
@@ -354,7 +375,7 @@ let
     ${python} ${launcher} \
       --server \
       --socket ${lib.escapeShellArg agentPrivateSocket} \
-      --settings-root ${lib.escapeShellArg "${package}/share/gas-city-contributor/copilot"} \
+      --settings-root ${lib.escapeShellArg profilesPath} \
       --copilot ${lib.escapeShellArg copilot} \
       --state-root ${lib.escapeShellArg "${stateRoot}/agent-state"} \
       --worktree ${lib.escapeShellArg "${stateRoot}/worktrees"} \
@@ -450,7 +471,7 @@ let
     "XDG_CACHE_HOME=${cacheRoot}"
     "XDG_RUNTIME_DIR=${runtimeRoot}"
     "GC_HOME=${gcRoot}"
-    "GC_CONTRIBUTOR_ROOT=${package}/share/gas-city-contributor"
+    "GC_CONTRIBUTOR_ROOT=${configuredAssetRoot}"
     "GC_RIG_NAME=${cfg.repository.rigName}"
     "GC_REPOSITORY=${cfg.repository.githubSlug}"
     "GC_BASE_BRANCH=${cfg.repository.baseBranch}"
@@ -570,7 +591,7 @@ in
               runtimeRoot
             ];
             ReadOnlyPaths = [
-              "${package}/share/gas-city-contributor"
+              configuredAssetRoot
               agentDirectory
               egressDirectory
               discordDirectory
@@ -670,7 +691,7 @@ in
                 "-${publisherDirectory}"
               ] ++ lib.optional cfg.check.enable "-${checkDirectory}";
             ReadOnlyPaths = [
-              "${package}/share/gas-city-contributor"
+              configuredAssetRoot
               egressDirectory
             ];
             LoadCredential = [

--- a/packages/d2b-contract-tests/tests/policy_gas_city.rs
+++ b/packages/d2b-contract-tests/tests/policy_gas_city.rs
@@ -391,7 +391,22 @@ fn validate_managed_graph(city: &str, instructions: &str, assets: &[&str]) -> Re
 fn gas_city_uses_four_immutable_sibling_imports() {
     let city = owned_asset(CITY);
     let local_pack = owned_asset(LOCAL_PACK);
+    let service = owned_asset(SERVICE_MODULE);
     validate_sibling_imports(&city, &local_pack).unwrap();
+    for required in [
+        "configuredAssetRoot = pkgs.runCommand",
+        "test \"$(grep -c '^dir = \"d2b\"$' \"$city\")\" -eq 40",
+        "'name = \"${cfg.repository.rigName}\"'",
+        "'path = \"/var/lib/gascity-contributor/state/rigs/${cfg.repository.rigName}\"'",
+        "'dir = \"${cfg.repository.rigName}\"'",
+        "rootPaths = [ package configuredAssetRoot ];",
+        "GC_CONTRIBUTOR_ROOT=${configuredAssetRoot}",
+    ] {
+        assert!(
+            service.contains(required),
+            "service module must derive the deployed city from repository.rigName: {required}"
+        );
+    }
     assert_eq!(
         owned_asset("nix/gas-city-contributor/city/packs.lock")
             .matches("schema = 1")

--- a/packages/d2b-contract-tests/tests/policy_gas_city.rs
+++ b/packages/d2b-contract-tests/tests/policy_gas_city.rs
@@ -155,6 +155,17 @@ fn validate_sibling_imports(city: &str, local_pack: &str) -> Result<(), String> 
     if city.matches("[imports.").count() != imports.len() {
         return Err("city imports must contain exactly four sibling tables".to_owned());
     }
+    for required in [
+        "[[rigs]]",
+        "name = \"d2b\"",
+        "path = \"/var/lib/gascity-contributor/state/rigs/d2b\"",
+        "[rigs.imports.gc]",
+        "source = \"../packs/gascity/roles\"",
+    ] {
+        if !city.contains(required) {
+            return Err(format!("missing canonical d2b rig role import: {required}"));
+        }
+    }
     if local_pack.contains("[imports.") {
         return Err("local contributor pack must not nest an upstream pack".to_owned());
     }
@@ -317,6 +328,9 @@ fn validate_role_routes(matrix: &str, city: &str, launcher: &str) -> Result<(), 
             ));
         }
         let block = matches[0];
+        if assignment_value(block, "dir").as_deref() != Some("d2b") {
+            return Err(format!("role {name} must be patched on the d2b rig"));
+        }
         let expected_provider = provider_for_class[class.as_str()];
         if assignment_value(block, "provider").as_deref() != Some(expected_provider) {
             return Err(format!(

--- a/tests/unit/smoke/gas-city-package-smoke.nix
+++ b/tests/unit/smoke/gas-city-package-smoke.nix
@@ -106,7 +106,7 @@ pkgs.runCommand "gas-city-package-smoke" {
   grep -F '/var/lib/gascity-contributor/state/rigs/d2b' \
     "$TMPDIR/resolved-city.toml"
   grep -F 'requirements-planner' "$TMPDIR/resolved-city.toml"
-  grep -F 'compound-engineering.ce-work' "$TMPDIR/resolved-city.toml"
+  grep -F 'name = "ce-work"' "$TMPDIR/resolved-city.toml"
   test ! -e "$root/packs/github"
   test -x "${gasCityContributor}/bin/gascity-discord-decision"
   test -x "${gasCityContributor}/bin/gascity-publish-pr"

--- a/tests/unit/smoke/gas-city-package-smoke.nix
+++ b/tests/unit/smoke/gas-city-package-smoke.nix
@@ -103,6 +103,8 @@ pkgs.runCommand "gas-city-package-smoke" {
   ${gasCityContributor}/bin/gc \
     --city "$root/city" \
     config show > "$TMPDIR/resolved-city.toml"
+  grep -F '/var/lib/gascity-contributor/state/rigs/d2b' \
+    "$TMPDIR/resolved-city.toml"
   grep -F 'requirements-planner' "$TMPDIR/resolved-city.toml"
   grep -F 'compound-engineering.ce-work' "$TMPDIR/resolved-city.toml"
   test ! -e "$root/packs/github"

--- a/tests/unit/smoke/gas-city-package-smoke.nix
+++ b/tests/unit/smoke/gas-city-package-smoke.nix
@@ -100,6 +100,11 @@ pkgs.runCommand "gas-city-package-smoke" {
     cd "$root/packs"
     ${gasCityContributor}/bin/gc lint .
   )
+  ${gasCityContributor}/bin/gc \
+    --city "$root/city" \
+    config show > "$TMPDIR/resolved-city.toml"
+  grep -F 'requirements-planner' "$TMPDIR/resolved-city.toml"
+  grep -F 'compound-engineering.ce-work' "$TMPDIR/resolved-city.toml"
   test ! -e "$root/packs/github"
   test -x "${gasCityContributor}/bin/gascity-discord-decision"
   test -x "${gasCityContributor}/bin/gascity-publish-pr"


### PR DESCRIPTION
## Summary

Gas City accepted operator requests but could not load its agent graph, so queued work never started. This follow-up to #410 registers the configured repository as a rig, imports upstream worker roles at rig scope while keeping workflow formulas at city scope, and binds provider patches to the resulting rig-qualified agents.

The NixOS module derives the deployed immutable graph from `repository.rigName`, so custom rig names remain consistent across service state, agent launch, and active-run roots.

## Validation

- Realized `gas-city-package-smoke`, including `gc config show` over the packaged city.
- Ran all 13 focused `policy_gas_city` tests.
- Ran the changelog gate.
- Evaluated the Gas City host-integration VM derivation.
