### PR TITLE
gascity: dereference configured asset copies

### DIFF
--- a/changelog.d/gascity-role-pack-import.md
+++ b/changelog.d/gascity-role-pack-import.md
@@ -2,4 +2,5 @@
 
 - Fixed the Gas City contributor graph to register the d2b rig and import its
   upstream role pack at rig scope so configured agent patches resolve and
-  submitted work can start.
+  submitted work can start, while safely materializing writable configured
+  assets from the package's immutable symlink tree.

--- a/nixos-modules/gas-city-contributor/service.nix
+++ b/nixos-modules/gas-city-contributor/service.nix
@@ -56,7 +56,7 @@ let
   configuredAssetRoot = pkgs.runCommand "gas-city-contributor-configured-assets" { } ''
     set -euo pipefail
     mkdir -p "$out"
-    cp -R ${packageAssetRoot}/. "$out/"
+    cp -RL ${packageAssetRoot}/. "$out/"
     chmod -R u+w "$out/city"
 
     city="$out/city/city.toml"

--- a/packages/d2b-contract-tests/tests/policy_gas_city.rs
+++ b/packages/d2b-contract-tests/tests/policy_gas_city.rs
@@ -395,6 +395,7 @@ fn gas_city_uses_four_immutable_sibling_imports() {
     validate_sibling_imports(&city, &local_pack).unwrap();
     for required in [
         "configuredAssetRoot = pkgs.runCommand",
+        "cp -RL ${packageAssetRoot}/. \"$out/\"",
         "test \"$(grep -c '^dir = \"d2b\"$' \"$city\")\" -eq 40",
         "'name = \"${cfg.repository.rigName}\"'",
         "'path = \"/var/lib/gascity-contributor/state/rigs/${cfg.repository.rigName}\"'",


### PR DESCRIPTION
## Summary

The configured Gas City asset derivation from #412 failed during a real host build because the package exposes source-shaped assets through symlinks. The recursive copy preserved those links, so the subsequent permission change targeted immutable Nix store files.

This follow-up dereferences the trusted packaged asset tree while copying it. Rig-name substitution now operates on build-owned files without weakening the runtime boundary.

## Validation

- Built the complete ddbus NixOS toplevel with this branch overriding the `d2b` input.
- Realized `gas-city-package-smoke`.
- Ran all 13 focused `policy_gas_city` tests.
- Ran the changelog gate.
