### PR TITLE
gpu: close Spec 001 Wave 6 U16 gaps

### DIFF
--- a/changelog.d/feat-spec001-device-gpu.md
+++ b/changelog.d/feat-spec001-device-gpu.md
@@ -16,3 +16,5 @@
 
 - Keep rejected GPU worker identities owned through finalization so failed
   starts cannot respawn or release Host-global authority before closure.
+- Fail closed on ambiguous or quarantined GPU restart adoption to prevent
+  duplicate workers.

--- a/changelog.d/feat-spec001-device-gpu.md
+++ b/changelog.d/feat-spec001-device-gpu.md
@@ -8,3 +8,6 @@
 
 - Reject GPU Device resources on unsupported host platforms during Nix
   evaluation.
+- Make shared Host-global leases unique, validate GPU/video identities and
+  closure proofs, recover partial restarts without duplicate workers, and
+  reject malformed GPU runner shapes before device opens.

--- a/changelog.d/feat-spec001-device-gpu.md
+++ b/changelog.d/feat-spec001-device-gpu.md
@@ -1,0 +1,10 @@
+### Added
+
+- Complete the GPU Device Provider lifecycle with Host-global claim
+  admission, opaque worker identities, restart adoption, bounded status and
+  telemetry, and fail-closed broker preflight.
+
+### Changed
+
+- Reject GPU Device resources on unsupported host platforms during Nix
+  evaluation.

--- a/changelog.d/feat-spec001-device-gpu.md
+++ b/changelog.d/feat-spec001-device-gpu.md
@@ -11,3 +11,8 @@
 - Make shared Host-global leases unique, validate GPU/video identities and
   closure proofs, recover partial restarts without duplicate workers, and
   reject malformed GPU runner shapes before device opens.
+
+### Fixed
+
+- Keep rejected GPU worker identities owned through finalization so failed
+  starts cannot respawn or release Host-global authority before closure.

--- a/flake.nix
+++ b/flake.nix
@@ -306,6 +306,7 @@
         ];
         nix-unit-runtime = [
           "clipboard.nix"
+          "device-gpu-eval.nix"
           "external-vm-kind.nix"
           "external-vm-kind-rejections.nix"
           "external-vm-kind-runtime.nix"

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -2580,6 +2580,11 @@ let
           message = "${row.path}: device-gpu requires a physical DRM Device (gpu-device-shape-invalid).";
         }
         {
+          assertion = provider != "device-gpu"
+            || pkgs.stdenv.hostPlatform.system == "x86_64-linux";
+          message = "${row.path}: device-gpu requires an x86_64-linux host (gpu-platform-unsupported).";
+        }
+        {
           assertion = !(provider == "device-tpm"
             && builtins.isAttrs settings
             && builtins.hasAttr "startupClear" settings);

--- a/packages/d2b-priv-broker/src/live_handlers.rs
+++ b/packages/d2b-priv-broker/src/live_handlers.rs
@@ -3535,6 +3535,11 @@ pub fn live_spawn_runner(
         })?;
         pre_opened_device_fds.push(render_fd);
     }
+    crate::ops::gpu::validate_spawn_plan(&plan, pre_opened_device_fds.len()).map_err(|error| {
+        LiveHandlerError::SpawnFailed {
+            detail: error.to_string(),
+        }
+    })?;
 
     let memlock_guest_bytes = qemu_media_memlock_guest_bytes(&plan)?;
     let memlock_limit_bytes = memlock_guest_bytes.map(|guest_bytes| {

--- a/packages/d2b-priv-broker/src/live_handlers.rs
+++ b/packages/d2b-priv-broker/src/live_handlers.rs
@@ -3492,6 +3492,11 @@ pub fn live_spawn_runner(
         }
     }
     validate_qemu_media_runner_hardening(&plan)?;
+    crate::ops::gpu::validate_spawn_plan_preflight(&plan).map_err(|error| {
+        LiveHandlerError::SpawnFailed {
+            detail: error.to_string(),
+        }
+    })?;
 
     let (binary, argv, env) =
         build_cstring_vectors(&plan).map_err(LiveHandlerError::SpawnPreflight)?;

--- a/packages/d2b-priv-broker/src/ops/gpu.rs
+++ b/packages/d2b-priv-broker/src/ops/gpu.rs
@@ -326,9 +326,9 @@ fn validate_spawn_plan_shape(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::spawn_runner::UserNamespaceSpec;
     use d2b_core::minijail_profile::{CgroupPlacement, MountPolicy, NamespaceSet};
     use std::path::PathBuf;
-    use crate::ops::spawn_runner::UserNamespaceSpec;
 
     fn identity(value: u8) -> GpuOpaqueIdentity {
         GpuOpaqueIdentity::from_core([value; 32])

--- a/packages/d2b-priv-broker/src/ops/gpu.rs
+++ b/packages/d2b-priv-broker/src/ops/gpu.rs
@@ -1,0 +1,323 @@
+//! GPU-specific broker preflight and restart-adoption contracts.
+//!
+//! The live broker still resolves paths and runner details from its signed
+//! bundle. This module keeps the GPU role matrix and identity checks in one
+//! pure, testable operation surface.
+
+use core::fmt;
+
+/// Closed GPU worker roles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuBrokerRole {
+    /// Full virtio-gpu worker.
+    Full,
+    /// Render-node-only worker.
+    RenderNode,
+    /// Hardware video decoder worker.
+    Video,
+}
+
+/// Closed GPU device grant classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GpuDeviceClass {
+    /// KVM device.
+    Kvm,
+    /// DRM render node.
+    Dri,
+    /// DMA buffer device.
+    Udmabuf,
+    /// NVIDIA control device.
+    NvidiaCtl,
+    /// NVIDIA device node.
+    NvidiaDevice,
+    /// NVIDIA UVM device.
+    NvidiaUvm,
+}
+
+/// Opaque broker-side identity.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct GpuOpaqueIdentity([u8; 32]);
+
+impl GpuOpaqueIdentity {
+    /// Construct an identity at the trusted bundle/adapter boundary.
+    pub const fn from_core(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Whether this is the forbidden all-zero identity.
+    pub fn is_zero(self) -> bool {
+        self.0 == [0; 32]
+    }
+}
+
+impl fmt::Debug for GpuOpaqueIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuOpaqueIdentity(<redacted>)")
+    }
+}
+
+/// Opaque GPU launch request validated before a device open or clone.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuLaunchRequest {
+    role: GpuBrokerRole,
+    backing: GpuOpaqueIdentity,
+    platform: GpuOpaqueIdentity,
+    principal: GpuOpaqueIdentity,
+    generation: u64,
+    device_classes: Vec<GpuDeviceClass>,
+}
+
+impl GpuLaunchRequest {
+    /// Construct a request from Core-resolved opaque identities.
+    pub fn from_core(
+        role: GpuBrokerRole,
+        backing: GpuOpaqueIdentity,
+        platform: GpuOpaqueIdentity,
+        principal: GpuOpaqueIdentity,
+        generation: u64,
+        device_classes: Vec<GpuDeviceClass>,
+    ) -> Result<Self, GpuBrokerError> {
+        if backing.is_zero() || platform.is_zero() || principal.is_zero() || generation == 0 {
+            return Err(GpuBrokerError::StaleIdentity);
+        }
+        let request = Self {
+            role,
+            backing,
+            platform,
+            principal,
+            generation,
+            device_classes,
+        };
+        request.validate()?;
+        Ok(request)
+    }
+
+    /// Validate the closed role-to-device matrix.
+    pub fn validate(&self) -> Result<(), GpuBrokerError> {
+        let has = |class| self.device_classes.contains(&class);
+        match self.role {
+            GpuBrokerRole::Full
+                if has(GpuDeviceClass::Kvm)
+                    && has(GpuDeviceClass::Dri)
+                    && has(GpuDeviceClass::Udmabuf)
+                    && self.device_classes.iter().all(|class| {
+                        matches!(
+                            class,
+                            GpuDeviceClass::Kvm
+                                | GpuDeviceClass::Dri
+                                | GpuDeviceClass::Udmabuf
+                                | GpuDeviceClass::NvidiaCtl
+                                | GpuDeviceClass::NvidiaDevice
+                                | GpuDeviceClass::NvidiaUvm
+                        )
+                    }) =>
+            {
+                Ok(())
+            }
+            GpuBrokerRole::RenderNode if self.device_classes == [GpuDeviceClass::Dri] => Ok(()),
+            GpuBrokerRole::Video
+                if has(GpuDeviceClass::Dri)
+                    && self.device_classes.iter().all(|class| {
+                        matches!(
+                            class,
+                            GpuDeviceClass::Dri
+                                | GpuDeviceClass::NvidiaCtl
+                                | GpuDeviceClass::NvidiaDevice
+                                | GpuDeviceClass::NvidiaUvm
+                        )
+                    }) =>
+            {
+                Ok(())
+            }
+            _ => Err(GpuBrokerError::RoleDeviceMismatch),
+        }
+    }
+
+    /// Borrow the opaque backing identity.
+    pub const fn backing(&self) -> GpuOpaqueIdentity {
+        self.backing
+    }
+
+    /// Borrow the opaque platform identity.
+    pub const fn platform(&self) -> GpuOpaqueIdentity {
+        self.platform
+    }
+
+    /// Borrow the expected worker principal.
+    pub const fn principal(&self) -> GpuOpaqueIdentity {
+        self.principal
+    }
+
+    /// Return the expected resource generation.
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Return the worker role.
+    pub const fn role(&self) -> GpuBrokerRole {
+        self.role
+    }
+}
+
+impl fmt::Debug for GpuLaunchRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuLaunchRequest")
+            .field("role", &self.role)
+            .field("generation", &self.generation)
+            .field("device_class_count", &self.device_classes.len())
+            .finish()
+    }
+}
+
+/// Broker-side process observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuProcessObservation {
+    /// One exact process matched.
+    Matching,
+    /// No exact process was found.
+    Missing,
+    /// Process identity was stale or reused.
+    StaleIdentity,
+    /// More than one process matched.
+    Ambiguous,
+}
+
+/// Closed GPU broker failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuBrokerError {
+    /// A persisted identity is missing or stale.
+    StaleIdentity,
+    /// The role and device allowlist disagree.
+    RoleDeviceMismatch,
+    /// The caller's principal is not the signed worker principal.
+    WrongPrincipal,
+    /// The observed platform differs from the admitted platform.
+    PlatformMismatch,
+    /// The observed generation differs from the admitted generation.
+    GenerationMismatch,
+    /// Restart found more than one matching process.
+    AmbiguousIdentity,
+}
+
+impl GpuBrokerError {
+    /// Return the stable identity-free error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::StaleIdentity => "gpu-device-identity-stale",
+            Self::RoleDeviceMismatch => "gpu-role-device-mismatch",
+            Self::WrongPrincipal => "gpu-process-principal-mismatch",
+            Self::PlatformMismatch => "gpu-platform-mismatch",
+            Self::GenerationMismatch => "gpu-device-generation-stale",
+            Self::AmbiguousIdentity => "gpu-process-identity-ambiguous",
+        }
+    }
+}
+
+impl fmt::Display for GpuBrokerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for GpuBrokerError {}
+
+/// Validate identity evidence before adopting a worker.
+pub fn validate_observed_identity(
+    request: &GpuLaunchRequest,
+    observed_principal: GpuOpaqueIdentity,
+    observed_platform: GpuOpaqueIdentity,
+    observed_generation: u64,
+    observations: &[GpuProcessObservation],
+) -> Result<GpuProcessObservation, GpuBrokerError> {
+    if observed_principal != request.principal {
+        return Err(GpuBrokerError::WrongPrincipal);
+    }
+    if observed_platform != request.platform {
+        return Err(GpuBrokerError::PlatformMismatch);
+    }
+    if observed_generation != request.generation {
+        return Err(GpuBrokerError::GenerationMismatch);
+    }
+    let matches = observations
+        .iter()
+        .filter(|observation| **observation == GpuProcessObservation::Matching)
+        .count();
+    if matches > 1 {
+        return Err(GpuBrokerError::AmbiguousIdentity);
+    }
+    Ok(observations
+        .first()
+        .copied()
+        .unwrap_or(GpuProcessObservation::Missing))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(value: u8) -> GpuOpaqueIdentity {
+        GpuOpaqueIdentity::from_core([value; 32])
+    }
+
+    #[test]
+    fn render_node_allowlist_is_exact() {
+        let request = GpuLaunchRequest::from_core(
+            GpuBrokerRole::RenderNode,
+            identity(1),
+            identity(2),
+            identity(3),
+            1,
+            vec![GpuDeviceClass::Dri],
+        )
+        .unwrap();
+        assert_eq!(request.validate(), Ok(()));
+        assert!(
+            GpuLaunchRequest::from_core(
+                GpuBrokerRole::RenderNode,
+                identity(1),
+                identity(2),
+                identity(3),
+                1,
+                vec![GpuDeviceClass::Dri, GpuDeviceClass::Kvm],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn wrong_principal_and_ambiguous_identity_fail_closed() {
+        let request = GpuLaunchRequest::from_core(
+            GpuBrokerRole::Video,
+            identity(1),
+            identity(2),
+            identity(3),
+            4,
+            vec![GpuDeviceClass::Dri],
+        )
+        .unwrap();
+        assert_eq!(
+            validate_observed_identity(
+                &request,
+                identity(4),
+                identity(2),
+                4,
+                &[GpuProcessObservation::Matching],
+            ),
+            Err(GpuBrokerError::WrongPrincipal)
+        );
+        assert_eq!(
+            validate_observed_identity(
+                &request,
+                identity(3),
+                identity(2),
+                4,
+                &[
+                    GpuProcessObservation::Matching,
+                    GpuProcessObservation::Matching
+                ],
+            ),
+            Err(GpuBrokerError::AmbiguousIdentity)
+        );
+    }
+}

--- a/packages/d2b-priv-broker/src/ops/gpu.rs
+++ b/packages/d2b-priv-broker/src/ops/gpu.rs
@@ -6,6 +6,8 @@
 
 use core::fmt;
 
+use super::spawn_runner::SpawnRunnerPlan;
+
 /// Closed GPU worker roles.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GpuBrokerRole {
@@ -198,6 +200,8 @@ pub enum GpuBrokerError {
     GenerationMismatch,
     /// Restart found more than one matching process.
     AmbiguousIdentity,
+    /// A trusted runner plan does not match its GPU isolation profile.
+    PlanShapeMismatch,
 }
 
 impl GpuBrokerError {
@@ -210,6 +214,7 @@ impl GpuBrokerError {
             Self::PlatformMismatch => "gpu-platform-mismatch",
             Self::GenerationMismatch => "gpu-device-generation-stale",
             Self::AmbiguousIdentity => "gpu-process-identity-ambiguous",
+            Self::PlanShapeMismatch => "gpu-runner-shape-mismatch",
         }
     }
 }
@@ -247,9 +252,63 @@ pub fn validate_observed_identity(
         return Err(GpuBrokerError::AmbiguousIdentity);
     }
     Ok(observations
-        .first()
+        .iter()
+        .find(|observation| **observation == GpuProcessObservation::Matching)
         .copied()
         .unwrap_or(GpuProcessObservation::Missing))
+}
+
+/// Validate a resolved SpawnRunner plan against the closed GPU isolation
+/// profile before the broker opens devices or clones a child.
+pub fn validate_spawn_plan(
+    plan: &SpawnRunnerPlan,
+    pre_opened_device_fds: usize,
+) -> Result<(), GpuBrokerError> {
+    let Some(policy) = plan.seccomp_policy_ref.as_deref() else {
+        return Ok(());
+    };
+    if !matches!(policy, "w1-gpu" | "w1-gpu-render-node" | "w1-video") {
+        return Ok(());
+    }
+    if !plan.capabilities.is_empty() {
+        return Err(GpuBrokerError::PlanShapeMismatch);
+    }
+    match policy {
+        "w1-gpu" => {
+            let required = ["/dev/kvm", "/dev/dri/renderD128", "/dev/udmabuf"];
+            if !required.iter().all(|path| {
+                plan.mount_policy
+                    .device_binds
+                    .iter()
+                    .any(|bind| bind == path)
+            }) {
+                return Err(GpuBrokerError::PlanShapeMismatch);
+            }
+        }
+        "w1-gpu-render-node" => {
+            if !plan.namespaces.user
+                || plan.user_namespace.is_none()
+                || !plan.mount_policy.device_binds.is_empty()
+                || pre_opened_device_fds != 1
+            {
+                return Err(GpuBrokerError::PlanShapeMismatch);
+            }
+        }
+        "w1-video" => {
+            if !plan.namespaces.pid
+                || plan.user_namespace.is_some()
+                || !plan
+                    .mount_policy
+                    .device_binds
+                    .iter()
+                    .any(|bind| bind == "/dev/dri/renderD128")
+            {
+                return Err(GpuBrokerError::PlanShapeMismatch);
+            }
+        }
+        _ => unreachable!(),
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -318,6 +377,19 @@ mod tests {
                 ],
             ),
             Err(GpuBrokerError::AmbiguousIdentity)
+        );
+        assert_eq!(
+            validate_observed_identity(
+                &request,
+                identity(3),
+                identity(2),
+                4,
+                &[
+                    GpuProcessObservation::Missing,
+                    GpuProcessObservation::Matching
+                ],
+            ),
+            Ok(GpuProcessObservation::Matching)
         );
     }
 }

--- a/packages/d2b-priv-broker/src/ops/gpu.rs
+++ b/packages/d2b-priv-broker/src/ops/gpu.rs
@@ -264,6 +264,18 @@ pub fn validate_spawn_plan(
     plan: &SpawnRunnerPlan,
     pre_opened_device_fds: usize,
 ) -> Result<(), GpuBrokerError> {
+    validate_spawn_plan_shape(plan, Some(pre_opened_device_fds))
+}
+
+/// Validate a GPU runner shape before the broker opens any device.
+pub fn validate_spawn_plan_preflight(plan: &SpawnRunnerPlan) -> Result<(), GpuBrokerError> {
+    validate_spawn_plan_shape(plan, None)
+}
+
+fn validate_spawn_plan_shape(
+    plan: &SpawnRunnerPlan,
+    pre_opened_device_fds: Option<usize>,
+) -> Result<(), GpuBrokerError> {
     let Some(policy) = plan.seccomp_policy_ref.as_deref() else {
         return Ok(());
     };
@@ -289,7 +301,7 @@ pub fn validate_spawn_plan(
             if !plan.namespaces.user
                 || plan.user_namespace.is_none()
                 || !plan.mount_policy.device_binds.is_empty()
-                || pre_opened_device_fds != 1
+                || pre_opened_device_fds.is_some_and(|count| count != 1)
             {
                 return Err(GpuBrokerError::PlanShapeMismatch);
             }
@@ -314,6 +326,9 @@ pub fn validate_spawn_plan(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use d2b_core::minijail_profile::{CgroupPlacement, MountPolicy, NamespaceSet};
+    use std::path::PathBuf;
+    use crate::ops::spawn_runner::UserNamespaceSpec;
 
     fn identity(value: u8) -> GpuOpaqueIdentity {
         GpuOpaqueIdentity::from_core([value; 32])
@@ -391,5 +406,58 @@ mod tests {
             ),
             Ok(GpuProcessObservation::Matching)
         );
+    }
+
+    fn render_node_plan() -> SpawnRunnerPlan {
+        SpawnRunnerPlan {
+            binary_path: PathBuf::from("/bin/crosvm"),
+            argv: vec!["crosvm".to_owned()],
+            uid: 1000,
+            gid: 1000,
+            supplementary_groups: vec![],
+            env: vec![],
+            capabilities: vec![],
+            namespaces: NamespaceSet {
+                mount: false,
+                pid: false,
+                net: false,
+                ipc: false,
+                uts: false,
+                user: true,
+            },
+            seccomp_policy_ref: Some("w1-gpu-render-node".to_owned()),
+            mount_policy: MountPolicy {
+                read_only_paths: vec![],
+                writable_paths: vec![],
+                nix_store_read_only: false,
+                hide_device_nodes_by_default: false,
+                device_binds: vec![],
+                bind_mounts: vec![],
+            },
+            cgroup_placement: CgroupPlacement {
+                subtree: String::new(),
+                controllers: vec![],
+                delegated: false,
+            },
+            user_namespace: Some(UserNamespaceSpec {
+                host_uid_for_zero: 1000,
+                host_gid_for_zero: 1000,
+            }),
+            umask: None,
+        }
+    }
+
+    #[test]
+    fn runner_shape_is_rejected_before_device_open() {
+        let mut invalid = render_node_plan();
+        invalid.namespaces.user = false;
+        assert_eq!(
+            validate_spawn_plan_preflight(&invalid),
+            Err(GpuBrokerError::PlanShapeMismatch)
+        );
+
+        let valid = render_node_plan();
+        assert_eq!(validate_spawn_plan_preflight(&valid), Ok(()));
+        assert_eq!(validate_spawn_plan(&valid, 1), Ok(()));
     }
 }

--- a/packages/d2b-priv-broker/src/ops/mod.rs
+++ b/packages/d2b-priv-broker/src/ops/mod.rs
@@ -43,6 +43,8 @@ pub mod usbip_host;
 
 // Kernel-module + device-fd handoff ops.
 pub mod device;
+// GPU-specific role, allowlist, and restart identity preflight.
+pub mod gpu;
 pub mod modprobe;
 // Security-key hidraw open op: resolves stable selector → opens
 // hidraw fd for `d2bd`'s long-lived CTAPHID relay session.

--- a/packages/d2b-provider-device-gpu/Cargo.toml
+++ b/packages/d2b-provider-device-gpu/Cargo.toml
@@ -14,3 +14,7 @@ serde.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[[test]]
+name = "provider_lifecycle"
+path = "integration/provider_lifecycle.rs"

--- a/packages/d2b-provider-device-gpu/README.md
+++ b/packages/d2b-provider-device-gpu/README.md
@@ -60,6 +60,11 @@ The worker declarations are `device-<uid-short>-gpu`,
 component descriptor selects the crosvm and video-decoder artifacts. GPU and
 video finalization is ordered video first, then GPU/render-node.
 
+Host-global authority is reserved before `OpenDevice` or `SpawnRunner`.
+Restart adoption accepts one exact principal, platform, and generation
+identity and quarantines ambiguity. Finalization releases authority only after
+the broker confirms closure of every owned worker.
+
 ## Placement and dependencies
 
 All Provider workers are Host-placed and are supervised through Core's
@@ -96,6 +101,10 @@ physical-device identity are not copied into status. Metrics use fixed
 Provider, component, operation, outcome, and error labels only. Zone/resource
 names, selectors, paths, sockets, PIDs, and device identity are excluded.
 Core owns path-free audit records for broker effects.
+
+The component descriptor declares an empty ProviderStateSet and no `/state`
+mount. Provider diagnostics reject raw device paths, runtime socket paths, and
+unbounded text.
 
 ## Build and test
 

--- a/packages/d2b-provider-device-gpu/integration/README.md
+++ b/packages/d2b-provider-device-gpu/integration/README.md
@@ -4,6 +4,14 @@
 run through `make test-host-integration` once the Core effect adapter and
 Host/Guest harness are connected; they are not standalone scripts.
 
+The container lane can be exercised with:
+
+```bash
+make test-integration
+# or, for the hermetic provider target:
+cargo test -p d2b-provider-device-gpu --test provider_lifecycle
+```
+
 | Fixture | Required end-to-end assertion |
 | --- | --- |
 | `gpu_worker_start/` | worker receives only Core-issued LaunchTicket device grants and reaches Ready |
@@ -14,3 +22,8 @@ The ordinary integration lane uses approved fake device inventory. Real GPU
 hardware belongs only to the repository hardware lane. The hermetic Cargo
 tests in `tests/` cover the corresponding settings, authority, sequencing,
 process-name, and wire-contract invariants without opening host devices.
+
+`gpu_worker_start` requires an x86_64 host with `/dev/dri/renderD128` and
+`/dev/kvm`. `render_node_shared` uses a mock render-node fd and does not need
+a live GPU. Hardware-GPU and NVIDIA tests are manual-only and belong under
+`tests/host-integration/hardware/`; they are not container fixtures.

--- a/packages/d2b-provider-device-gpu/root-config.schema.json
+++ b/packages/d2b-provider-device-gpu/root-config.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "renderNodeOnly": {
+      "type": "boolean",
+      "default": false
+    },
+    "videoSidecar": {
+      "type": "boolean",
+      "default": false
+    },
+    "videoNvidiaDecode": {
+      "type": "boolean",
+      "default": false
+    },
+    "contextTypes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": ["virgl", "virgl2", "cross-domain"]
+      },
+      "default": ["virgl", "virgl2", "cross-domain"]
+    },
+    "displays": {
+      "type": "array",
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["hidden"],
+        "properties": {
+          "hidden": {
+            "type": "boolean"
+          }
+        }
+      },
+      "default": [{"hidden": true}]
+    },
+    "egl": {
+      "type": "boolean",
+      "default": true
+    },
+    "vulkan": {
+      "type": "boolean",
+      "default": true
+    },
+    "crossDomainTrusted": {
+      "type": "boolean",
+      "default": false
+    },
+    "virglVideo": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/packages/d2b-provider-device-gpu/src/arbitration.rs
+++ b/packages/d2b-provider-device-gpu/src/arbitration.rs
@@ -1,0 +1,159 @@
+//! Exclusive and shared GPU claim admission.
+
+use core::fmt;
+
+use d2b_contracts::v3::{ResourceUid, device::DeviceArbitration};
+
+use crate::authority::GpuBackingToken;
+
+/// Closed GPU claim failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuClaimError {
+    /// The requested arbitration is incompatible with the selected mode.
+    ArbitrationViolation,
+    /// A full-device claim is already held.
+    ClaimConflict,
+    /// The signed shared-holder ceiling was reached.
+    MaxClaimsExceeded,
+    /// The Core-derived backing identity did not match.
+    PhysicalBackingConflict,
+}
+
+impl GpuClaimError {
+    /// Return the stable identity-free error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::ArbitrationViolation => "gpu-arbitration-violation",
+            Self::ClaimConflict => "device-claim-conflict",
+            Self::MaxClaimsExceeded => "device-claim-max-exceeded",
+            Self::PhysicalBackingConflict => "gpu-physical-backing-conflict",
+        }
+    }
+}
+
+impl fmt::Display for GpuClaimError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for GpuClaimError {}
+
+/// One admitted GPU claimant.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuClaim {
+    holder: ResourceUid,
+    backing: GpuBackingToken,
+}
+
+impl GpuClaim {
+    /// Borrow the opaque claimant identity.
+    pub const fn holder(&self) -> &ResourceUid {
+        &self.holder
+    }
+
+    /// Borrow the Core-derived backing token.
+    pub const fn backing(&self) -> &GpuBackingToken {
+        &self.backing
+    }
+}
+
+impl fmt::Debug for GpuClaim {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuClaim(<redacted>)")
+    }
+}
+
+/// Pure claim arbiter used before any broker effect.
+pub struct GpuArbitrator {
+    arbitration: DeviceArbitration,
+    max_claims: u32,
+    render_node_only: bool,
+    backing: GpuBackingToken,
+    claims: Vec<GpuClaim>,
+}
+
+impl GpuArbitrator {
+    /// Construct an arbiter from the signed Device base and Provider settings.
+    pub fn new(
+        arbitration: DeviceArbitration,
+        max_claims: u32,
+        render_node_only: bool,
+        backing: GpuBackingToken,
+    ) -> Result<Self, GpuClaimError> {
+        if !(1..=16).contains(&max_claims)
+            || (arbitration == DeviceArbitration::Exclusive && max_claims != 1)
+            || (arbitration == DeviceArbitration::Shared && !render_node_only)
+        {
+            return Err(GpuClaimError::ArbitrationViolation);
+        }
+        Ok(Self {
+            arbitration,
+            max_claims,
+            render_node_only,
+            backing,
+            claims: Vec::new(),
+        })
+    }
+
+    /// Admit a claimant before opening a device or starting a worker.
+    pub fn claim(
+        &mut self,
+        holder: ResourceUid,
+        backing: GpuBackingToken,
+    ) -> Result<(), GpuClaimError> {
+        if backing != self.backing {
+            return Err(GpuClaimError::PhysicalBackingConflict);
+        }
+        if self.claims.iter().any(|claim| claim.holder == holder) {
+            return Ok(());
+        }
+        if self.arbitration == DeviceArbitration::Exclusive && !self.claims.is_empty() {
+            return Err(GpuClaimError::ClaimConflict);
+        }
+        if self.claims.len() >= self.max_claims as usize {
+            return Err(GpuClaimError::MaxClaimsExceeded);
+        }
+        self.claims.push(GpuClaim { holder, backing });
+        Ok(())
+    }
+
+    /// Release one exact claimant after its worker has closed.
+    pub fn release(&mut self, holder: &ResourceUid) -> bool {
+        let before = self.claims.len();
+        self.claims.retain(|claim| &claim.holder != holder);
+        before != self.claims.len()
+    }
+
+    /// Return the current claimant count.
+    pub const fn claim_count(&self) -> usize {
+        self.claims.len()
+    }
+
+    /// Return the signed holder ceiling.
+    pub const fn max_claims(&self) -> u32 {
+        self.max_claims
+    }
+
+    /// Whether this arbiter is render-node-only.
+    pub const fn render_node_only(&self) -> bool {
+        self.render_node_only
+    }
+
+    /// Borrow the bounded claimant list.
+    pub fn claims(&self) -> &[GpuClaim] {
+        &self.claims
+    }
+}
+
+impl fmt::Debug for GpuArbitrator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuArbitrator")
+            .field("arbitration", &self.arbitration)
+            .field("max_claims", &self.max_claims)
+            .field("render_node_only", &self.render_node_only)
+            .field("claim_count", &self.claims.len())
+            .finish()
+    }
+}

--- a/packages/d2b-provider-device-gpu/src/audit.rs
+++ b/packages/d2b-provider-device-gpu/src/audit.rs
@@ -1,0 +1,69 @@
+//! Path-free GPU audit records.
+
+use crate::GpuEffectError;
+
+/// Closed brokered GPU operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuAuditOperation {
+    /// Open an opaque GPU device grant.
+    OpenDevice,
+    /// Spawn the full GPU worker.
+    SpawnGpu,
+    /// Spawn the render-node worker.
+    SpawnRenderNode,
+    /// Spawn the video worker.
+    SpawnVideo,
+    /// Adopt an existing worker.
+    Adopt,
+    /// Close an owned worker.
+    Close,
+}
+
+/// Closed audit outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuAuditOutcome {
+    /// The operation succeeded.
+    Success,
+    /// The operation was denied.
+    Denied,
+    /// The operation failed.
+    Failure,
+}
+
+/// Bounded GPU audit record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpuAuditRecord {
+    /// Closed operation.
+    pub operation: GpuAuditOperation,
+    /// Closed outcome.
+    pub outcome: GpuAuditOutcome,
+    /// Stable error class, or `none`.
+    pub error: &'static str,
+    /// Opaque correlation token, never rendered as text.
+    correlation: [u8; 16],
+}
+
+impl GpuAuditRecord {
+    /// Construct a path-free audit record.
+    pub const fn new(
+        operation: GpuAuditOperation,
+        outcome: GpuAuditOutcome,
+        error: Option<GpuEffectError>,
+        correlation: [u8; 16],
+    ) -> Self {
+        Self {
+            operation,
+            outcome,
+            error: match error {
+                Some(error) => error.code(),
+                None => "none",
+            },
+            correlation,
+        }
+    }
+
+    /// Borrow the opaque correlation value for the Core outbox join.
+    pub const fn correlation(&self) -> &[u8; 16] {
+        &self.correlation
+    }
+}

--- a/packages/d2b-provider-device-gpu/src/authority.rs
+++ b/packages/d2b-provider-device-gpu/src/authority.rs
@@ -757,6 +757,9 @@ impl GpuAuthorityIndex {
         admission: &GpuAuthorityAdmission,
         observations: &[GpuProcessObservation],
     ) -> Result<GpuAdoption, GpuAuthorityError> {
+        if self.quarantined.contains(&admission.backing) {
+            return Ok(GpuAdoption::Quarantined);
+        }
         let Some(entry) = self.entries.get(&admission.backing) else {
             return Ok(GpuAdoption::Missing);
         };
@@ -772,6 +775,13 @@ impl GpuAuthorityIndex {
         }
         let owner_lease = owner.lease.clone();
         let owner_processes = owner.processes.clone();
+        if observations
+            .iter()
+            .any(|observation| matches!(observation, GpuProcessObservation::Ambiguous))
+        {
+            self.quarantined.insert(admission.backing.clone());
+            return Ok(GpuAdoption::Quarantined);
+        }
         for observation in observations {
             if let GpuProcessObservation::Matching(identity) = observation {
                 validate_process_identity(admission, identity)?;

--- a/packages/d2b-provider-device-gpu/src/authority.rs
+++ b/packages/d2b-provider-device-gpu/src/authority.rs
@@ -389,10 +389,31 @@ impl fmt::Debug for GpuProcessObservation {
 pub struct GpuRecoveryRecord {
     /// The Core admission that owned the worker.
     pub admission: GpuAuthorityAdmission,
-    /// The worker identity observed before restart.
-    pub process: GpuProcessIdentity,
+    /// Worker identities observed before restart.
+    pub processes: Vec<GpuProcessIdentity>,
     /// The opaque lease proof persisted by the Core adapter.
     pub lease: GpuAuthorityLease,
+}
+
+impl GpuRecoveryRecord {
+    /// Construct a recovery record for one GPU worker.
+    pub fn from_core(
+        admission: GpuAuthorityAdmission,
+        process: GpuProcessIdentity,
+        lease: GpuAuthorityLease,
+    ) -> Self {
+        Self {
+            admission,
+            processes: vec![process],
+            lease,
+        }
+    }
+
+    /// Add another same-Device worker, such as the video sidecar.
+    pub fn with_process(mut self, process: GpuProcessIdentity) -> Self {
+        self.processes.push(process);
+        self
+    }
 }
 
 impl fmt::Debug for GpuRecoveryRecord {
@@ -515,6 +536,7 @@ struct AuthorityEntry {
     arbitration: DeviceArbitration,
     max_holders: u32,
     platform: GpuPlatformToken,
+    lease_seq: u64,
     owners: Vec<AuthorityOwner>,
 }
 
@@ -562,25 +584,36 @@ impl GpuAuthorityIndex {
                     arbitration: record.admission.arbitration,
                     max_holders: record.admission.max_holders,
                     platform: record.admission.platform.clone(),
+                    lease_seq: 0,
                     owners: Vec::new(),
                 });
             if entry.arbitration != record.admission.arbitration
                 || entry.max_holders != record.admission.max_holders
                 || entry.platform != record.admission.platform
-                || entry
-                    .owners
-                    .iter()
-                    .any(|owner| owner.admission.owner == record.admission.owner)
             {
                 entry.owners.clear();
                 index.quarantined.insert(key);
                 continue;
             }
-            entry.owners.push(AuthorityOwner {
-                admission: record.admission,
-                lease: record.lease,
-                processes: vec![record.process],
-            });
+            if let Some(owner) = entry
+                .owners
+                .iter_mut()
+                .find(|owner| owner.admission.owner == record.admission.owner)
+            {
+                if owner.lease != record.lease {
+                    entry.owners.clear();
+                    index.quarantined.insert(key);
+                    continue;
+                }
+                owner.processes.extend(record.processes);
+            } else {
+                entry.lease_seq = entry.lease_seq.saturating_add(1);
+                entry.owners.push(AuthorityOwner {
+                    admission: record.admission,
+                    lease: record.lease,
+                    processes: record.processes,
+                });
+            }
         }
         index.rehydrated = true;
         Ok(index)
@@ -614,6 +647,7 @@ impl GpuAuthorityIndex {
                 arbitration: admission.arbitration,
                 max_holders: admission.max_holders,
                 platform: admission.platform.clone(),
+                lease_seq: 0,
                 owners: Vec::new(),
             });
         if entry.arbitration != admission.arbitration || entry.max_holders != admission.max_holders
@@ -636,10 +670,8 @@ impl GpuAuthorityIndex {
         if entry.owners.len() >= admission.max_holders as usize {
             return Err(GpuAuthorityError::MaxClaimsExceeded);
         }
-        let lease = GpuAuthorityLease::from_core(lease_bytes(
-            &admission.backing,
-            entry.owners.len() as u64 + 1,
-        ));
+        entry.lease_seq = entry.lease_seq.saturating_add(1);
+        let lease = GpuAuthorityLease::from_core(lease_bytes(&admission.backing, entry.lease_seq));
         entry.owners.push(AuthorityOwner {
             admission,
             lease: lease.clone(),
@@ -703,41 +735,29 @@ impl GpuAuthorityIndex {
                 }
             }
         }
-        let mut matches = observations
-            .iter()
-            .filter_map(|observation| match observation {
-                GpuProcessObservation::Matching(identity)
-                    if identity.platform == admission.platform
-                        && identity.generation == admission.owner.generation
-                        && (identity.principal == admission.gpu_principal
-                            || Some(&identity.principal) == admission.video_principal.as_ref()) =>
-                {
-                    Some(identity)
+        let mut matched_roles = BTreeSet::new();
+        let mut matched_count = 0;
+        for observation in observations {
+            let GpuProcessObservation::Matching(identity) = observation else {
+                continue;
+            };
+            if owner.processes.iter().any(|known| known == identity) {
+                if !matched_roles.insert(identity.role()) {
+                    self.quarantined.insert(admission.backing.clone());
+                    return Ok(GpuAdoption::Quarantined);
                 }
-                _ => None,
-            });
-        let first = matches.next();
-        if matches.next().is_some() {
-            self.quarantined.insert(admission.backing.clone());
-            return Ok(GpuAdoption::Quarantined);
+                matched_count += 1;
+            }
         }
-        match first {
-            Some(identity) => {
-                if owner.processes.iter().all(|known| known != identity) {
-                    return Ok(GpuAdoption::StaleIdentity);
-                }
-                Ok(GpuAdoption::Adopted(owner.lease.clone()))
-            }
-            None => {
-                if observations
-                    .iter()
-                    .any(|observation| matches!(observation, GpuProcessObservation::StaleIdentity))
-                {
-                    Ok(GpuAdoption::StaleIdentity)
-                } else {
-                    Ok(GpuAdoption::Missing)
-                }
-            }
+        if matched_count > 0 {
+            Ok(GpuAdoption::Adopted(owner.lease.clone()))
+        } else if observations
+            .iter()
+            .any(|observation| matches!(observation, GpuProcessObservation::StaleIdentity))
+        {
+            Ok(GpuAdoption::StaleIdentity)
+        } else {
+            Ok(GpuAdoption::Missing)
         }
     }
 

--- a/packages/d2b-provider-device-gpu/src/authority.rs
+++ b/packages/d2b-provider-device-gpu/src/authority.rs
@@ -540,6 +540,29 @@ struct AuthorityEntry {
     owners: Vec<AuthorityOwner>,
 }
 
+fn validate_process_identity(
+    admission: &GpuAuthorityAdmission,
+    process: &GpuProcessIdentity,
+) -> Result<(), GpuAuthorityError> {
+    let expected_principal = match process.role {
+        GpuProcessRole::Video => admission
+            .video_principal
+            .as_ref()
+            .ok_or(GpuAuthorityError::ProcessPrincipalMismatch)?,
+        GpuProcessRole::FullGpu | GpuProcessRole::RenderNode => &admission.gpu_principal,
+    };
+    if process.principal != *expected_principal {
+        return Err(GpuAuthorityError::ProcessPrincipalMismatch);
+    }
+    if process.platform != admission.platform {
+        return Err(GpuAuthorityError::PlatformMismatch);
+    }
+    if process.generation != admission.owner.generation {
+        return Err(GpuAuthorityError::GenerationMismatch);
+    }
+    Ok(())
+}
+
 /// Host-global GPU authority index.
 ///
 /// The index is deliberately small and in-memory. Core's durable operation
@@ -573,8 +596,29 @@ impl GpuAuthorityIndex {
     pub fn rehydrate(snapshot: GpuRecoverySnapshot) -> Result<Self, GpuAuthorityError> {
         let mut index = Self::new_unrehydrated();
         for record in snapshot.records {
+            for process in &record.processes {
+                validate_process_identity(&record.admission, process)?;
+            }
             let key = record.admission.backing.clone();
             if index.quarantined.contains(&key) {
+                continue;
+            }
+            let duplicate_lease = index.entries.iter().find_map(|(existing_key, entry)| {
+                entry.owners.iter().find_map(|owner| {
+                    (owner.lease == record.lease
+                        && !(existing_key == &key && owner.admission == record.admission))
+                        .then(|| existing_key.clone())
+                })
+            });
+            if let Some(existing_key) = duplicate_lease {
+                index.quarantined.insert(existing_key.clone());
+                index.quarantined.insert(key.clone());
+                if let Some(entry) = index.entries.get_mut(&existing_key) {
+                    entry.owners.clear();
+                }
+                if let Some(entry) = index.entries.get_mut(&key) {
+                    entry.owners.clear();
+                }
                 continue;
             }
             let entry = index
@@ -600,12 +644,16 @@ impl GpuAuthorityIndex {
                 .iter_mut()
                 .find(|owner| owner.admission.owner == record.admission.owner)
             {
-                if owner.lease != record.lease {
+                if owner.lease != record.lease || owner.admission != record.admission {
                     entry.owners.clear();
                     index.quarantined.insert(key);
                     continue;
                 }
-                owner.processes.extend(record.processes);
+                for process in record.processes {
+                    if !owner.processes.contains(&process) {
+                        owner.processes.push(process);
+                    }
+                }
             } else {
                 entry.lease_seq = entry.lease_seq.saturating_add(1);
                 entry.owners.push(AuthorityOwner {
@@ -640,38 +688,47 @@ impl GpuAuthorityIndex {
         if self.quarantined.contains(&admission.backing) {
             return Err(GpuAuthorityError::Quarantined);
         }
+        let next_ordinal = {
+            let entry = self
+                .entries
+                .entry(admission.backing.clone())
+                .or_insert_with(|| AuthorityEntry {
+                    arbitration: admission.arbitration,
+                    max_holders: admission.max_holders,
+                    platform: admission.platform.clone(),
+                    lease_seq: 0,
+                    owners: Vec::new(),
+                });
+            if entry.arbitration != admission.arbitration
+                || entry.max_holders != admission.max_holders
+            {
+                return Err(GpuAuthorityError::ArbitrationViolation);
+            }
+            if entry.platform != admission.platform {
+                return Err(GpuAuthorityError::StaleDeviceIdentity);
+            }
+            if entry
+                .owners
+                .iter()
+                .any(|owner| owner.admission.owner == admission.owner)
+            {
+                return Err(GpuAuthorityError::DuplicateActiveReservation);
+            }
+            if admission.arbitration == DeviceArbitration::Exclusive && !entry.owners.is_empty() {
+                return Err(GpuAuthorityError::ClaimConflict);
+            }
+            if entry.owners.len() >= admission.max_holders as usize {
+                return Err(GpuAuthorityError::MaxClaimsExceeded);
+            }
+            entry.lease_seq.saturating_add(1).max(1)
+        };
+        let backing = admission.backing.clone();
+        let (ordinal, lease) = self.allocate_lease(&backing, next_ordinal)?;
         let entry = self
             .entries
-            .entry(admission.backing.clone())
-            .or_insert_with(|| AuthorityEntry {
-                arbitration: admission.arbitration,
-                max_holders: admission.max_holders,
-                platform: admission.platform.clone(),
-                lease_seq: 0,
-                owners: Vec::new(),
-            });
-        if entry.arbitration != admission.arbitration || entry.max_holders != admission.max_holders
-        {
-            return Err(GpuAuthorityError::ArbitrationViolation);
-        }
-        if entry.platform != admission.platform {
-            return Err(GpuAuthorityError::StaleDeviceIdentity);
-        }
-        if entry
-            .owners
-            .iter()
-            .any(|owner| owner.admission.owner == admission.owner)
-        {
-            return Err(GpuAuthorityError::DuplicateActiveReservation);
-        }
-        if admission.arbitration == DeviceArbitration::Exclusive && !entry.owners.is_empty() {
-            return Err(GpuAuthorityError::ClaimConflict);
-        }
-        if entry.owners.len() >= admission.max_holders as usize {
-            return Err(GpuAuthorityError::MaxClaimsExceeded);
-        }
-        entry.lease_seq = entry.lease_seq.saturating_add(1);
-        let lease = GpuAuthorityLease::from_core(lease_bytes(&admission.backing, entry.lease_seq));
+            .get_mut(&backing)
+            .expect("authority entry exists after validation");
+        entry.lease_seq = ordinal;
         entry.owners.push(AuthorityOwner {
             admission,
             lease: lease.clone(),
@@ -687,17 +744,7 @@ impl GpuAuthorityIndex {
         process: GpuProcessIdentity,
     ) -> Result<(), GpuAuthorityError> {
         let owner = self.find_owner_mut(lease)?;
-        if process.principal != owner.admission.gpu_principal
-            && Some(&process.principal) != owner.admission.video_principal.as_ref()
-        {
-            return Err(GpuAuthorityError::ProcessPrincipalMismatch);
-        }
-        if process.platform != owner.admission.platform {
-            return Err(GpuAuthorityError::PlatformMismatch);
-        }
-        if process.generation != owner.admission.owner.generation {
-            return Err(GpuAuthorityError::GenerationMismatch);
-        }
+        validate_process_identity(&owner.admission, &process)?;
         if !owner.processes.iter().any(|known| known == &process) {
             owner.processes.push(process);
         }
@@ -720,19 +767,14 @@ impl GpuAuthorityIndex {
         let Some(owner) = owner else {
             return Ok(GpuAdoption::Missing);
         };
+        if owner.admission != *admission {
+            return Err(GpuAuthorityError::OwnerProofMismatch);
+        }
+        let owner_lease = owner.lease.clone();
+        let owner_processes = owner.processes.clone();
         for observation in observations {
             if let GpuProcessObservation::Matching(identity) = observation {
-                if identity.generation != admission.owner.generation {
-                    return Err(GpuAuthorityError::GenerationMismatch);
-                }
-                if identity.platform != admission.platform {
-                    return Err(GpuAuthorityError::PlatformMismatch);
-                }
-                if identity.principal != admission.gpu_principal
-                    && Some(&identity.principal) != admission.video_principal.as_ref()
-                {
-                    return Err(GpuAuthorityError::ProcessPrincipalMismatch);
-                }
+                validate_process_identity(admission, identity)?;
             }
         }
         let mut matched_roles = BTreeSet::new();
@@ -741,7 +783,7 @@ impl GpuAuthorityIndex {
             let GpuProcessObservation::Matching(identity) = observation else {
                 continue;
             };
-            if owner.processes.iter().any(|known| known == identity) {
+            if owner_processes.iter().any(|known| known == identity) {
                 if !matched_roles.insert(identity.role()) {
                     self.quarantined.insert(admission.backing.clone());
                     return Ok(GpuAdoption::Quarantined);
@@ -750,7 +792,7 @@ impl GpuAuthorityIndex {
             }
         }
         if matched_count > 0 {
-            Ok(GpuAdoption::Adopted(owner.lease.clone()))
+            Ok(GpuAdoption::Adopted(owner_lease))
         } else if observations
             .iter()
             .any(|observation| matches!(observation, GpuProcessObservation::StaleIdentity))
@@ -823,6 +865,30 @@ impl GpuAuthorityIndex {
             .values_mut()
             .find_map(|entry| entry.owners.iter_mut().find(|owner| &owner.lease == lease))
             .ok_or(GpuAuthorityError::OwnerProofMismatch)
+    }
+
+    fn allocate_lease(
+        &self,
+        backing: &GpuBackingToken,
+        start_ordinal: u64,
+    ) -> Result<(u64, GpuAuthorityLease), GpuAuthorityError> {
+        let mut ordinal = start_ordinal.max(1);
+        loop {
+            let lease = GpuAuthorityLease::from_core(lease_bytes(backing, ordinal));
+            if !self.lease_in_use(&lease) {
+                return Ok((ordinal, lease));
+            }
+            ordinal = ordinal
+                .checked_add(1)
+                .ok_or(GpuAuthorityError::MaxClaimsExceeded)?;
+        }
+    }
+
+    fn lease_in_use(&self, lease: &GpuAuthorityLease) -> bool {
+        self.entries
+            .values()
+            .flat_map(|entry| entry.owners.iter())
+            .any(|owner| &owner.lease == lease)
     }
 }
 

--- a/packages/d2b-provider-device-gpu/src/authority.rs
+++ b/packages/d2b-provider-device-gpu/src/authority.rs
@@ -1,0 +1,818 @@
+//! Host-global GPU authority and restart-adoption contracts.
+//!
+//! Core creates the opaque values in this module after resolving the trusted
+//! device inventory. The Provider can compare those values and retain the
+//! resulting lease, but it cannot derive one from a path, selector, or
+//! process identifier.
+
+use core::fmt;
+use std::collections::{BTreeMap, BTreeSet};
+
+use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid, device::DeviceArbitration};
+
+use crate::process::GpuProcessRole;
+
+/// Core-derived identity for one physical GPU or render node backing.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GpuBackingToken([u8; 32]);
+
+impl GpuBackingToken {
+    /// Construct a backing token at the trusted Core boundary.
+    pub const fn from_core(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Whether the token is the forbidden all-zero identity.
+    pub fn is_zero(&self) -> bool {
+        self.0 == [0; 32]
+    }
+
+    /// Borrow the token for another trusted adapter comparison.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for GpuBackingToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuBackingToken(<redacted>)")
+    }
+}
+
+/// Core-derived platform identity for one GPU effect.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GpuPlatformToken([u8; 32]);
+
+impl GpuPlatformToken {
+    /// Construct a platform token at the trusted Core boundary.
+    pub const fn from_core(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Whether the token is the forbidden all-zero identity.
+    pub fn is_zero(&self) -> bool {
+        self.0 == [0; 32]
+    }
+}
+
+impl fmt::Debug for GpuPlatformToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuPlatformToken(<redacted>)")
+    }
+}
+
+/// Core-assigned worker principal.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GpuPrincipalToken([u8; 32]);
+
+impl GpuPrincipalToken {
+    /// Construct a principal token at the trusted Core boundary.
+    pub const fn from_core(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Whether the token is the forbidden all-zero identity.
+    pub fn is_zero(&self) -> bool {
+        self.0 == [0; 32]
+    }
+}
+
+impl fmt::Debug for GpuPrincipalToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuPrincipalToken(<redacted>)")
+    }
+}
+
+/// Opaque proof that a Device owner is authorized to hold GPU authority.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuOwnerProof {
+    zone_ref: ResourceRef,
+    holder_ref: ResourceRef,
+    device_uid: ResourceUid,
+    host_uid: ResourceUid,
+    generation: ResourceGeneration,
+}
+
+impl GpuOwnerProof {
+    /// Bind a proof to an exact Zone, holder, Device, Host, and generation.
+    pub fn new(
+        zone_ref: ResourceRef,
+        holder_ref: ResourceRef,
+        device_uid: ResourceUid,
+        host_uid: ResourceUid,
+        generation: ResourceGeneration,
+    ) -> Result<Self, GpuAuthorityError> {
+        if zone_ref.resource_type().as_str() != "Zone"
+            || !matches!(holder_ref.resource_type().as_str(), "Guest" | "Host")
+        {
+            return Err(GpuAuthorityError::WrongPrincipal);
+        }
+        Ok(Self {
+            zone_ref,
+            holder_ref,
+            device_uid,
+            host_uid,
+            generation,
+        })
+    }
+
+    /// Borrow the exact Zone reference.
+    pub const fn zone_ref(&self) -> &ResourceRef {
+        &self.zone_ref
+    }
+
+    /// Borrow the exact holder reference.
+    pub const fn holder_ref(&self) -> &ResourceRef {
+        &self.holder_ref
+    }
+
+    /// Borrow the Device UID.
+    pub const fn device_uid(&self) -> &ResourceUid {
+        &self.device_uid
+    }
+
+    /// Borrow the Host UID.
+    pub const fn host_uid(&self) -> &ResourceUid {
+        &self.host_uid
+    }
+
+    /// Return the admitted resource generation.
+    pub const fn generation(&self) -> ResourceGeneration {
+        self.generation
+    }
+}
+
+impl fmt::Debug for GpuOwnerProof {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuOwnerProof(<redacted>)")
+    }
+}
+
+/// Core-issued GPU authority admission.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuAuthorityAdmission {
+    owner: GpuOwnerProof,
+    backing: GpuBackingToken,
+    platform: GpuPlatformToken,
+    arbitration: DeviceArbitration,
+    max_holders: u32,
+    render_node_only: bool,
+    gpu_principal: GpuPrincipalToken,
+    video_principal: Option<GpuPrincipalToken>,
+}
+
+impl GpuAuthorityAdmission {
+    /// Construct an admission before any device or process effect.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        owner: GpuOwnerProof,
+        backing: GpuBackingToken,
+        platform: GpuPlatformToken,
+        arbitration: DeviceArbitration,
+        max_holders: u32,
+        render_node_only: bool,
+        gpu_principal: GpuPrincipalToken,
+    ) -> Result<Self, GpuAuthorityError> {
+        if backing.is_zero() || platform.is_zero() || gpu_principal.is_zero() {
+            return Err(GpuAuthorityError::StaleDeviceIdentity);
+        }
+        if !(1..=16).contains(&max_holders)
+            || (arbitration == DeviceArbitration::Exclusive && max_holders != 1)
+            || (arbitration == DeviceArbitration::Shared && !render_node_only)
+            || (arbitration == DeviceArbitration::Exclusive && render_node_only && max_holders != 1)
+        {
+            return Err(GpuAuthorityError::ArbitrationViolation);
+        }
+        Ok(Self {
+            owner,
+            backing,
+            platform,
+            arbitration,
+            max_holders,
+            render_node_only,
+            gpu_principal,
+            video_principal: None,
+        })
+    }
+
+    /// Attach the distinct Core-assigned video principal.
+    pub fn with_video_principal(
+        mut self,
+        video_principal: GpuPrincipalToken,
+    ) -> Result<Self, GpuAuthorityError> {
+        if video_principal.is_zero() || video_principal == self.gpu_principal {
+            return Err(GpuAuthorityError::PrincipalNotSeparated);
+        }
+        self.video_principal = Some(video_principal);
+        Ok(self)
+    }
+
+    /// Borrow the exact owner proof.
+    pub const fn owner(&self) -> &GpuOwnerProof {
+        &self.owner
+    }
+
+    /// Borrow the opaque backing identity.
+    pub const fn backing(&self) -> &GpuBackingToken {
+        &self.backing
+    }
+
+    /// Borrow the opaque platform identity.
+    pub const fn platform(&self) -> &GpuPlatformToken {
+        &self.platform
+    }
+
+    /// Return the requested arbitration.
+    pub const fn arbitration(&self) -> DeviceArbitration {
+        self.arbitration
+    }
+
+    /// Return the signed holder ceiling.
+    pub const fn max_holders(&self) -> u32 {
+        self.max_holders
+    }
+
+    /// Whether this is render-node-only authority.
+    pub const fn render_node_only(&self) -> bool {
+        self.render_node_only
+    }
+
+    /// Borrow the GPU worker principal.
+    pub const fn gpu_principal(&self) -> &GpuPrincipalToken {
+        &self.gpu_principal
+    }
+
+    /// Borrow the distinct video worker principal, when configured.
+    pub const fn video_principal(&self) -> Option<&GpuPrincipalToken> {
+        self.video_principal.as_ref()
+    }
+}
+
+impl fmt::Debug for GpuAuthorityAdmission {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuAuthorityAdmission")
+            .field("arbitration", &self.arbitration)
+            .field("max_holders", &self.max_holders)
+            .field("render_node_only", &self.render_node_only)
+            .field("has_video_principal", &self.video_principal.is_some())
+            .finish()
+    }
+}
+
+/// Opaque Host-global GPU lease.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuAuthorityLease([u8; 16]);
+
+impl GpuAuthorityLease {
+    /// Construct a lease at the trusted authority adapter boundary.
+    pub const fn from_core(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl fmt::Debug for GpuAuthorityLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuAuthorityLease(<redacted>)")
+    }
+}
+
+/// Opaque identity of one broker-supervised GPU worker.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuProcessIdentity {
+    process_token: [u8; 16],
+    role: GpuProcessRole,
+    principal: GpuPrincipalToken,
+    platform: GpuPlatformToken,
+    generation: ResourceGeneration,
+}
+
+impl GpuProcessIdentity {
+    /// Construct a verified process identity at the broker boundary.
+    pub const fn from_core(
+        process_token: [u8; 16],
+        role: GpuProcessRole,
+        principal: GpuPrincipalToken,
+        platform: GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Self {
+        Self {
+            process_token,
+            role,
+            principal,
+            platform,
+            generation,
+        }
+    }
+
+    /// Return the worker role.
+    pub const fn role(&self) -> GpuProcessRole {
+        self.role
+    }
+
+    /// Borrow the worker principal.
+    pub const fn principal(&self) -> &GpuPrincipalToken {
+        &self.principal
+    }
+
+    /// Borrow the platform identity.
+    pub const fn platform(&self) -> &GpuPlatformToken {
+        &self.platform
+    }
+
+    /// Return the resource generation bound to this worker.
+    pub const fn generation(&self) -> ResourceGeneration {
+        self.generation
+    }
+}
+
+impl fmt::Debug for GpuProcessIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuProcessIdentity")
+            .field("role", &self.role)
+            .field("generation", &self.generation)
+            .finish()
+    }
+}
+
+/// Broker proof that one exact worker process has closed.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuClosureProof {
+    identity: GpuProcessIdentity,
+}
+
+impl GpuClosureProof {
+    /// Construct a closure proof at the broker boundary.
+    pub fn from_core(identity: GpuProcessIdentity) -> Self {
+        Self { identity }
+    }
+
+    /// Borrow the closed process identity for exact lease matching.
+    pub const fn identity(&self) -> &GpuProcessIdentity {
+        &self.identity
+    }
+}
+
+impl fmt::Debug for GpuClosureProof {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuClosureProof(<redacted>)")
+    }
+}
+
+/// Observation used by restart adoption.
+#[derive(Clone, PartialEq, Eq)]
+pub enum GpuProcessObservation {
+    /// Exactly one process matched the expected identity.
+    Matching(GpuProcessIdentity),
+    /// No process with the expected identity was found.
+    Missing,
+    /// The identity was reused or could not be verified.
+    StaleIdentity,
+    /// More than one process matched the expected identity.
+    Ambiguous,
+}
+
+impl fmt::Debug for GpuProcessObservation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Matching(_) => "GpuProcessObservation::Matching",
+            Self::Missing => "GpuProcessObservation::Missing",
+            Self::StaleIdentity => "GpuProcessObservation::StaleIdentity",
+            Self::Ambiguous => "GpuProcessObservation::Ambiguous",
+        })
+    }
+}
+
+/// Persisted, non-authorizing worker record used during restart recovery.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuRecoveryRecord {
+    /// The Core admission that owned the worker.
+    pub admission: GpuAuthorityAdmission,
+    /// The worker identity observed before restart.
+    pub process: GpuProcessIdentity,
+    /// The opaque lease proof persisted by the Core adapter.
+    pub lease: GpuAuthorityLease,
+}
+
+impl fmt::Debug for GpuRecoveryRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GpuRecoveryRecord(<redacted>)")
+    }
+}
+
+/// Durable records loaded before new GPU claims may be admitted.
+#[derive(Default)]
+pub struct GpuRecoverySnapshot {
+    records: Vec<GpuRecoveryRecord>,
+}
+
+impl GpuRecoverySnapshot {
+    /// Construct a recovery snapshot from trusted storage.
+    pub fn from_core(records: Vec<GpuRecoveryRecord>) -> Self {
+        Self { records }
+    }
+
+    /// Borrow the loaded records.
+    pub fn records(&self) -> &[GpuRecoveryRecord] {
+        &self.records
+    }
+}
+
+/// Restart adoption result.
+pub enum GpuAdoption {
+    /// One exact worker was adopted.
+    Adopted(GpuAuthorityLease),
+    /// No matching worker was found.
+    Missing,
+    /// Ambiguous matching workers remain quarantined.
+    Quarantined,
+    /// The observed worker identity was stale.
+    StaleIdentity,
+}
+
+impl fmt::Debug for GpuAdoption {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Adopted(_) => "GpuAdoption::Adopted",
+            Self::Missing => "GpuAdoption::Missing",
+            Self::Quarantined => "GpuAdoption::Quarantined",
+            Self::StaleIdentity => "GpuAdoption::StaleIdentity",
+        })
+    }
+}
+
+/// Stable GPU authority errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuAuthorityError {
+    /// A claim used a wrong holder or Zone reference.
+    WrongPrincipal,
+    /// GPU and video workers attempted to share one principal.
+    PrincipalNotSeparated,
+    /// A physical identity was zero or no longer current.
+    StaleDeviceIdentity,
+    /// The arbitration and render-node settings disagree.
+    ArbitrationViolation,
+    /// A full-device or render-node claim conflicts with an owner.
+    ClaimConflict,
+    /// The signed shared-holder ceiling was reached.
+    MaxClaimsExceeded,
+    /// The authority index has not completed restart rehydration.
+    StartupRehydrationRequired,
+    /// The same owner already holds the authority.
+    DuplicateActiveReservation,
+    /// A process observation used the wrong principal.
+    ProcessPrincipalMismatch,
+    /// A process observation used the wrong platform identity.
+    PlatformMismatch,
+    /// A process observation used an old resource generation.
+    GenerationMismatch,
+    /// The exact owner proof did not match the retained lease.
+    OwnerProofMismatch,
+    /// A close proof was missing or named another process.
+    CloseUnconfirmed,
+    /// A quarantined key cannot admit a new effect.
+    Quarantined,
+}
+
+impl GpuAuthorityError {
+    /// Return the stable, identity-free error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::WrongPrincipal => "gpu-authority-principal-denied",
+            Self::PrincipalNotSeparated => "gpu-principal-not-separated",
+            Self::StaleDeviceIdentity => "gpu-device-identity-stale",
+            Self::ArbitrationViolation => "gpu-arbitration-violation",
+            Self::ClaimConflict => "device-claim-conflict",
+            Self::MaxClaimsExceeded => "device-claim-max-exceeded",
+            Self::StartupRehydrationRequired => "authority-startup-rehydration-required",
+            Self::DuplicateActiveReservation => "authority-duplicate-active-reservation",
+            Self::ProcessPrincipalMismatch => "gpu-process-principal-mismatch",
+            Self::PlatformMismatch => "gpu-platform-mismatch",
+            Self::GenerationMismatch => "gpu-device-generation-stale",
+            Self::OwnerProofMismatch => "gpu-authority-owner-proof-mismatch",
+            Self::CloseUnconfirmed => "gpu-worker-close-unconfirmed",
+            Self::Quarantined => "gpu-authority-quarantined",
+        }
+    }
+}
+
+impl fmt::Display for GpuAuthorityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for GpuAuthorityError {}
+
+struct AuthorityOwner {
+    admission: GpuAuthorityAdmission,
+    lease: GpuAuthorityLease,
+    processes: Vec<GpuProcessIdentity>,
+}
+
+struct AuthorityEntry {
+    arbitration: DeviceArbitration,
+    max_holders: u32,
+    platform: GpuPlatformToken,
+    owners: Vec<AuthorityOwner>,
+}
+
+/// Host-global GPU authority index.
+///
+/// The index is deliberately small and in-memory. Core's durable operation
+/// owner supplies the recovery snapshot and the opaque lease values before the
+/// index becomes ready for new admission.
+pub struct GpuAuthorityIndex {
+    entries: BTreeMap<GpuBackingToken, AuthorityEntry>,
+    quarantined: BTreeSet<GpuBackingToken>,
+    rehydrated: bool,
+}
+
+impl GpuAuthorityIndex {
+    /// Construct the production startup barrier.
+    pub fn new_unrehydrated() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            quarantined: BTreeSet::new(),
+            rehydrated: false,
+        }
+    }
+
+    /// Construct an explicitly ready in-memory index for hermetic tests.
+    pub fn new_for_tests_ready() -> Self {
+        Self {
+            rehydrated: true,
+            ..Self::new_unrehydrated()
+        }
+    }
+
+    /// Rehydrate all durable owners before admitting new claims.
+    pub fn rehydrate(snapshot: GpuRecoverySnapshot) -> Result<Self, GpuAuthorityError> {
+        let mut index = Self::new_unrehydrated();
+        for record in snapshot.records {
+            let key = record.admission.backing.clone();
+            if index.quarantined.contains(&key) {
+                continue;
+            }
+            let entry = index
+                .entries
+                .entry(key.clone())
+                .or_insert_with(|| AuthorityEntry {
+                    arbitration: record.admission.arbitration,
+                    max_holders: record.admission.max_holders,
+                    platform: record.admission.platform.clone(),
+                    owners: Vec::new(),
+                });
+            if entry.arbitration != record.admission.arbitration
+                || entry.max_holders != record.admission.max_holders
+                || entry.platform != record.admission.platform
+                || entry
+                    .owners
+                    .iter()
+                    .any(|owner| owner.admission.owner == record.admission.owner)
+            {
+                entry.owners.clear();
+                index.quarantined.insert(key);
+                continue;
+            }
+            entry.owners.push(AuthorityOwner {
+                admission: record.admission,
+                lease: record.lease,
+                processes: vec![record.process],
+            });
+        }
+        index.rehydrated = true;
+        Ok(index)
+    }
+
+    /// Whether durable startup recovery has completed.
+    pub const fn is_rehydrated(&self) -> bool {
+        self.rehydrated
+    }
+
+    /// Whether one backing key is quarantined.
+    pub fn is_quarantined(&self, backing: &GpuBackingToken) -> bool {
+        self.quarantined.contains(backing)
+    }
+
+    /// Reserve the Host-global key before opening or spawning anything.
+    pub fn reserve(
+        &mut self,
+        admission: GpuAuthorityAdmission,
+    ) -> Result<GpuAuthorityLease, GpuAuthorityError> {
+        if !self.rehydrated {
+            return Err(GpuAuthorityError::StartupRehydrationRequired);
+        }
+        if self.quarantined.contains(&admission.backing) {
+            return Err(GpuAuthorityError::Quarantined);
+        }
+        let entry = self
+            .entries
+            .entry(admission.backing.clone())
+            .or_insert_with(|| AuthorityEntry {
+                arbitration: admission.arbitration,
+                max_holders: admission.max_holders,
+                platform: admission.platform.clone(),
+                owners: Vec::new(),
+            });
+        if entry.arbitration != admission.arbitration || entry.max_holders != admission.max_holders
+        {
+            return Err(GpuAuthorityError::ArbitrationViolation);
+        }
+        if entry.platform != admission.platform {
+            return Err(GpuAuthorityError::StaleDeviceIdentity);
+        }
+        if entry
+            .owners
+            .iter()
+            .any(|owner| owner.admission.owner == admission.owner)
+        {
+            return Err(GpuAuthorityError::DuplicateActiveReservation);
+        }
+        if admission.arbitration == DeviceArbitration::Exclusive && !entry.owners.is_empty() {
+            return Err(GpuAuthorityError::ClaimConflict);
+        }
+        if entry.owners.len() >= admission.max_holders as usize {
+            return Err(GpuAuthorityError::MaxClaimsExceeded);
+        }
+        let lease = GpuAuthorityLease::from_core(lease_bytes(
+            &admission.backing,
+            entry.owners.len() as u64 + 1,
+        ));
+        entry.owners.push(AuthorityOwner {
+            admission,
+            lease: lease.clone(),
+            processes: Vec::new(),
+        });
+        Ok(lease)
+    }
+
+    /// Bind the broker-issued process identity to a retained lease.
+    pub fn bind_process(
+        &mut self,
+        lease: &GpuAuthorityLease,
+        process: GpuProcessIdentity,
+    ) -> Result<(), GpuAuthorityError> {
+        let owner = self.find_owner_mut(lease)?;
+        if process.principal != owner.admission.gpu_principal
+            && Some(&process.principal) != owner.admission.video_principal.as_ref()
+        {
+            return Err(GpuAuthorityError::ProcessPrincipalMismatch);
+        }
+        if process.platform != owner.admission.platform {
+            return Err(GpuAuthorityError::PlatformMismatch);
+        }
+        if process.generation != owner.admission.owner.generation {
+            return Err(GpuAuthorityError::GenerationMismatch);
+        }
+        if !owner.processes.iter().any(|known| known == &process) {
+            owner.processes.push(process);
+        }
+        Ok(())
+    }
+
+    /// Adopt one matching process after restart.
+    pub fn adopt(
+        &mut self,
+        admission: &GpuAuthorityAdmission,
+        observations: &[GpuProcessObservation],
+    ) -> Result<GpuAdoption, GpuAuthorityError> {
+        let Some(entry) = self.entries.get(&admission.backing) else {
+            return Ok(GpuAdoption::Missing);
+        };
+        let owner = entry
+            .owners
+            .iter()
+            .find(|owner| owner.admission.owner == admission.owner);
+        let Some(owner) = owner else {
+            return Ok(GpuAdoption::Missing);
+        };
+        for observation in observations {
+            if let GpuProcessObservation::Matching(identity) = observation {
+                if identity.generation != admission.owner.generation {
+                    return Err(GpuAuthorityError::GenerationMismatch);
+                }
+                if identity.platform != admission.platform {
+                    return Err(GpuAuthorityError::PlatformMismatch);
+                }
+                if identity.principal != admission.gpu_principal
+                    && Some(&identity.principal) != admission.video_principal.as_ref()
+                {
+                    return Err(GpuAuthorityError::ProcessPrincipalMismatch);
+                }
+            }
+        }
+        let mut matches = observations
+            .iter()
+            .filter_map(|observation| match observation {
+                GpuProcessObservation::Matching(identity)
+                    if identity.platform == admission.platform
+                        && identity.generation == admission.owner.generation
+                        && (identity.principal == admission.gpu_principal
+                            || Some(&identity.principal) == admission.video_principal.as_ref()) =>
+                {
+                    Some(identity)
+                }
+                _ => None,
+            });
+        let first = matches.next();
+        if matches.next().is_some() {
+            self.quarantined.insert(admission.backing.clone());
+            return Ok(GpuAdoption::Quarantined);
+        }
+        match first {
+            Some(identity) => {
+                if owner.processes.iter().all(|known| known != identity) {
+                    return Ok(GpuAdoption::StaleIdentity);
+                }
+                Ok(GpuAdoption::Adopted(owner.lease.clone()))
+            }
+            None => {
+                if observations
+                    .iter()
+                    .any(|observation| matches!(observation, GpuProcessObservation::StaleIdentity))
+                {
+                    Ok(GpuAdoption::StaleIdentity)
+                } else {
+                    Ok(GpuAdoption::Missing)
+                }
+            }
+        }
+    }
+
+    /// Release only after the exact owned process has closed.
+    pub fn release_after_close(
+        &mut self,
+        lease: &GpuAuthorityLease,
+        closure: &GpuClosureProof,
+    ) -> Result<(), GpuAuthorityError> {
+        self.release_after_all_closed(lease, std::slice::from_ref(closure))
+    }
+
+    /// Release only after every process bound to the exact lease has closed.
+    pub fn release_after_all_closed(
+        &mut self,
+        lease: &GpuAuthorityLease,
+        closures: &[GpuClosureProof],
+    ) -> Result<(), GpuAuthorityError> {
+        let key = self
+            .entries
+            .iter()
+            .find_map(|(key, entry)| {
+                entry
+                    .owners
+                    .iter()
+                    .any(|owner| &owner.lease == lease)
+                    .then(|| key.clone())
+            })
+            .ok_or(GpuAuthorityError::OwnerProofMismatch)?;
+        let entry = self.entries.get_mut(&key).expect("authority entry exists");
+        let position = entry
+            .owners
+            .iter()
+            .position(|owner| {
+                &owner.lease == lease && {
+                    (owner.processes.is_empty() && closures.is_empty())
+                        || owner.processes.iter().all(|process| {
+                            closures.iter().any(|closure| closure.identity() == process)
+                        })
+                }
+            })
+            .ok_or(GpuAuthorityError::CloseUnconfirmed)?;
+        entry.owners.remove(position);
+        if entry.owners.is_empty() {
+            self.entries.remove(&key);
+            self.quarantined.remove(&key);
+        }
+        Ok(())
+    }
+
+    /// Return the current holder count for one backing.
+    pub fn holder_count(&self, backing: &GpuBackingToken) -> usize {
+        self.entries
+            .get(backing)
+            .map_or(0, |entry| entry.owners.len())
+    }
+
+    fn find_owner_mut(
+        &mut self,
+        lease: &GpuAuthorityLease,
+    ) -> Result<&mut AuthorityOwner, GpuAuthorityError> {
+        self.entries
+            .values_mut()
+            .find_map(|entry| entry.owners.iter_mut().find(|owner| &owner.lease == lease))
+            .ok_or(GpuAuthorityError::OwnerProofMismatch)
+    }
+}
+
+fn lease_bytes(backing: &GpuBackingToken, ordinal: u64) -> [u8; 16] {
+    let mut bytes = [0; 16];
+    for (index, value) in backing.0.iter().enumerate() {
+        bytes[index % 16] ^= *value;
+    }
+    for (index, value) in ordinal.to_be_bytes().iter().enumerate() {
+        bytes[index] ^= *value;
+    }
+    bytes
+}

--- a/packages/d2b-provider-device-gpu/src/controller.rs
+++ b/packages/d2b-provider-device-gpu/src/controller.rs
@@ -4,8 +4,10 @@ use core::fmt;
 use d2b_contracts::v3::{ResourceUid, device::DeviceArbitration};
 
 use crate::{
-    GpuEffectError, GpuEffectPort, GpuEffectTokenSet, GpuProcessRole, GpuProcessSelectionError,
-    GpuSettings, process::select_processes,
+    GpuAuthorityAdmission, GpuAuthorityError, GpuAuthorityLease, GpuClosureProof, GpuEffectError,
+    GpuEffectPort, GpuEffectTokenSet, GpuLaunchTicket, GpuLifecycleEffectPort, GpuProcessIdentity,
+    GpuProcessObservation, GpuProcessRole, GpuProcessSelectionError, GpuSettings, GpuWorkerSpec,
+    VideoWorkerSpec, process::select_processes,
 };
 
 /// GPU controller lifecycle.
@@ -29,6 +31,8 @@ pub enum GpuPhase {
     Finalizing,
     /// Finalizer cleared.
     Finalized,
+    /// Restart identity was ambiguous and is quarantined.
+    Quarantined,
 }
 
 /// GPU controller failure.
@@ -40,6 +44,10 @@ pub enum GpuControllerError {
     Effect(GpuEffectError),
     /// A finalizer transition was invalid.
     InvalidState,
+    /// Core authority admission failed before an effect.
+    Authority(GpuAuthorityError),
+    /// Restart observation was ambiguous.
+    Quarantined,
 }
 
 impl fmt::Display for GpuControllerError {
@@ -48,6 +56,8 @@ impl fmt::Display for GpuControllerError {
             Self::Selection(error) => return error.fmt(formatter),
             Self::Effect(error) => return error.fmt(formatter),
             Self::InvalidState => "gpu-invalid-state",
+            Self::Authority(error) => return error.fmt(formatter),
+            Self::Quarantined => "gpu-authority-quarantined",
         })
     }
 }
@@ -73,6 +83,13 @@ pub struct GpuController {
     finalizer: bool,
     gpu_role: Option<GpuProcessRole>,
     video_started: bool,
+    admission: Option<GpuAuthorityAdmission>,
+    authority_lease: Option<GpuAuthorityLease>,
+    ticket: Option<GpuLaunchTicket>,
+    gpu_identity: Option<GpuProcessIdentity>,
+    video_identity: Option<GpuProcessIdentity>,
+    gpu_closure: Option<GpuClosureProof>,
+    video_closure: Option<GpuClosureProof>,
 }
 
 impl GpuController {
@@ -94,7 +111,26 @@ impl GpuController {
             finalizer: true,
             gpu_role: None,
             video_started: false,
+            admission: None,
+            authority_lease: None,
+            ticket: None,
+            gpu_identity: None,
+            video_identity: None,
+            gpu_closure: None,
+            video_closure: None,
         })
+    }
+
+    /// Construct an authority-bound controller from Core admission evidence.
+    pub fn new_authorized(
+        admission: GpuAuthorityAdmission,
+        settings: GpuSettings,
+        tokens: GpuEffectTokenSet,
+    ) -> Result<Self, GpuControllerError> {
+        let device_uid = admission.owner().device_uid().clone();
+        let mut controller = Self::new(device_uid, admission.arbitration(), settings, tokens)?;
+        controller.admission = Some(admission);
+        Ok(controller)
     }
 
     /// Return the current controller phase.
@@ -107,6 +143,21 @@ impl GpuController {
         self.finalizer
     }
 
+    /// Whether this controller owns a Core admission.
+    pub const fn authority_reserved(&self) -> bool {
+        self.authority_lease.is_some()
+    }
+
+    /// Return the current GPU process identity, if started or adopted.
+    pub const fn gpu_identity(&self) -> Option<&GpuProcessIdentity> {
+        self.gpu_identity.as_ref()
+    }
+
+    /// Return the current video process identity, if started or adopted.
+    pub const fn video_identity(&self) -> Option<&GpuProcessIdentity> {
+        self.video_identity.as_ref()
+    }
+
     /// Start the GPU worker and only then the optional video worker.
     pub fn reconcile<P: GpuEffectPort>(
         &mut self,
@@ -115,6 +166,9 @@ impl GpuController {
         if !self.finalizer || matches!(self.phase, GpuPhase::Finalizing | GpuPhase::Finalized) {
             return Err(GpuControllerError::InvalidState);
         }
+        if self.phase == GpuPhase::Ready {
+            return Ok(GpuReconcileOutcome::Converged);
+        }
         let declarations = select_processes(&self.device_uid, self.arbitration, &self.settings)
             .map_err(GpuControllerError::Selection)?;
         let gpu = declarations
@@ -122,18 +176,30 @@ impl GpuController {
             .ok_or(GpuControllerError::InvalidState)?
             .role();
         self.phase = GpuPhase::GpuStarting;
-        let ticket = match port.open_devices(&self.device_uid, &self.tokens) {
-            Ok(ticket) => ticket,
-            Err(error) => return self.effect_failed(error),
-        };
-        if let Err(error) = port.start(gpu, &ticket) {
-            return self.effect_failed(error);
+        if self.ticket.is_none() {
+            self.ticket = match port.open_devices(&self.device_uid, &self.tokens) {
+                Ok(ticket) => Some(ticket),
+                Err(error) => return self.effect_failed(error),
+            };
         }
-        self.gpu_role = Some(gpu);
+        if self.gpu_role.is_none() {
+            let ticket = self
+                .ticket
+                .as_ref()
+                .ok_or(GpuControllerError::InvalidState)?;
+            if let Err(error) = port.start(gpu, ticket) {
+                return self.effect_failed(error);
+            }
+            self.gpu_role = Some(gpu);
+        }
         self.phase = GpuPhase::GpuReady;
-        if self.settings.video_sidecar {
+        if self.settings.video_sidecar && !self.video_started {
             self.phase = GpuPhase::VideoStarting;
-            if let Err(error) = port.start(GpuProcessRole::Video, &ticket) {
+            let ticket = self
+                .ticket
+                .as_ref()
+                .ok_or(GpuControllerError::InvalidState)?;
+            if let Err(error) = port.start(GpuProcessRole::Video, ticket) {
                 return self.effect_failed(error);
             }
             self.video_started = true;
@@ -156,6 +222,194 @@ impl GpuController {
         if let Some(role) = self.gpu_role.take() {
             port.stop(role).map_err(GpuControllerError::Effect)?;
         }
+        self.ticket = None;
+        self.gpu_identity = None;
+        self.video_identity = None;
+        self.gpu_closure = None;
+        self.video_closure = None;
+        self.finalizer = false;
+        self.phase = GpuPhase::Finalized;
+        Ok(())
+    }
+
+    /// Reconcile through the authority-aware production effect boundary.
+    ///
+    /// The Host-global reservation is acquired before the first open or
+    /// spawn and remains retained until [`Self::finalize_lifecycle`] confirms
+    /// every worker closure.
+    pub fn reconcile_lifecycle<P: GpuLifecycleEffectPort>(
+        &mut self,
+        port: &mut P,
+    ) -> Result<GpuReconcileOutcome, GpuControllerError> {
+        if !self.finalizer
+            || matches!(
+                self.phase,
+                GpuPhase::Finalizing | GpuPhase::Finalized | GpuPhase::Quarantined
+            )
+        {
+            return Err(GpuControllerError::InvalidState);
+        }
+        let admission = self
+            .admission
+            .as_ref()
+            .ok_or(GpuControllerError::InvalidState)?;
+        if self.authority_lease.is_none() {
+            self.authority_lease = Some(
+                port.reserve_authority(admission)
+                    .map_err(GpuControllerError::Effect)?,
+            );
+        }
+        if self.phase == GpuPhase::Ready {
+            return Ok(GpuReconcileOutcome::Converged);
+        }
+        if self.ticket.is_none() {
+            self.ticket = Some(
+                port.open_authorized_devices(admission, &self.tokens)
+                    .map_err(GpuControllerError::Effect)?,
+            );
+        }
+        let ticket = self
+            .ticket
+            .as_ref()
+            .ok_or(GpuControllerError::InvalidState)?;
+        let generation = admission.owner().generation();
+        if self.gpu_identity.is_none() {
+            let spec = GpuWorkerSpec::gpu(&self.device_uid, &self.settings)
+                .map_err(GpuControllerError::Selection)?;
+            let identity = port
+                .start_gpu_worker(
+                    &spec,
+                    ticket,
+                    admission.gpu_principal(),
+                    admission.platform(),
+                    generation,
+                )
+                .map_err(GpuControllerError::Effect)?;
+            self.gpu_role = Some(spec.process().role());
+            self.gpu_identity = Some(identity);
+        }
+        self.phase = GpuPhase::GpuReady;
+        if self.settings.video_sidecar && self.video_identity.is_none() {
+            let principal = admission
+                .video_principal()
+                .ok_or(GpuControllerError::Authority(
+                    GpuAuthorityError::PrincipalNotSeparated,
+                ))?;
+            let spec = VideoWorkerSpec::new(&self.device_uid, &self.settings)
+                .map_err(GpuControllerError::Selection)?;
+            let identity = port
+                .start_video_worker(&spec, ticket, principal, admission.platform(), generation)
+                .map_err(GpuControllerError::Effect)?;
+            self.video_identity = Some(identity);
+            self.video_started = true;
+        }
+        self.phase = GpuPhase::Ready;
+        Ok(GpuReconcileOutcome::Converged)
+    }
+
+    /// Adopt matching GPU/video workers after a daemon restart.
+    pub fn adopt_lifecycle<P: GpuLifecycleEffectPort>(
+        &mut self,
+        lease: GpuAuthorityLease,
+        expected: &[GpuProcessIdentity],
+        port: &mut P,
+    ) -> Result<GpuReconcileOutcome, GpuControllerError> {
+        let admission = self
+            .admission
+            .as_ref()
+            .ok_or(GpuControllerError::InvalidState)?;
+        self.authority_lease = Some(lease);
+        let mut matched = Vec::new();
+        for identity in expected {
+            match port
+                .observe_worker(identity)
+                .map_err(GpuControllerError::Effect)?
+            {
+                GpuProcessObservation::Matching(observed) => matched.push(observed),
+                GpuProcessObservation::Ambiguous => {
+                    self.phase = GpuPhase::Quarantined;
+                    return Err(GpuControllerError::Quarantined);
+                }
+                GpuProcessObservation::StaleIdentity => {
+                    self.phase = GpuPhase::Failed;
+                    return Err(GpuControllerError::Effect(
+                        GpuEffectError::StaleDeviceIdentity,
+                    ));
+                }
+                GpuProcessObservation::Missing => {
+                    self.phase = GpuPhase::Pending;
+                    return Ok(GpuReconcileOutcome::Retry);
+                }
+            }
+        }
+        for identity in matched {
+            if identity.platform() != admission.platform()
+                || identity.generation() != admission.owner().generation()
+            {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(GpuEffectError::PlatformMismatch));
+            }
+            match identity.role() {
+                GpuProcessRole::Video => {
+                    self.video_started = true;
+                    self.video_identity = Some(identity);
+                }
+                role => {
+                    self.gpu_role = Some(role);
+                    self.gpu_identity = Some(identity);
+                }
+            }
+        }
+        if self.gpu_identity.is_some() {
+            self.phase = GpuPhase::Ready;
+        }
+        Ok(GpuReconcileOutcome::Converged)
+    }
+
+    /// Close workers and release Host-global authority after exact proofs.
+    pub fn finalize_lifecycle<P: GpuLifecycleEffectPort>(
+        &mut self,
+        port: &mut P,
+    ) -> Result<(), GpuControllerError> {
+        if !self.finalizer {
+            return Ok(());
+        }
+        self.phase = GpuPhase::Finalizing;
+        if self.video_closure.is_none()
+            && let Some(identity) = self.video_identity.as_ref()
+        {
+            self.video_closure = Some(
+                port.stop_worker(identity)
+                    .map_err(GpuControllerError::Effect)?,
+            );
+        }
+        if self.gpu_closure.is_none()
+            && let Some(identity) = self.gpu_identity.as_ref()
+        {
+            self.gpu_closure = Some(
+                port.stop_worker(identity)
+                    .map_err(GpuControllerError::Effect)?,
+            );
+        }
+        let closures = self
+            .video_closure
+            .iter()
+            .chain(self.gpu_closure.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        if let Some(lease) = self.authority_lease.take()
+            && let Err(error) = port.release_authority(lease.clone(), &closures)
+        {
+            self.authority_lease = Some(lease);
+            return Err(GpuControllerError::Effect(error));
+        }
+        self.video_identity = None;
+        self.gpu_identity = None;
+        self.ticket = None;
+        self.gpu_role = None;
+        self.video_started = false;
+        self.gpu_closure = None;
+        self.video_closure = None;
         self.finalizer = false;
         self.phase = GpuPhase::Finalized;
         Ok(())
@@ -181,6 +435,11 @@ impl fmt::Debug for GpuController {
             .field("finalizer", &self.finalizer)
             .field("gpu_role", &self.gpu_role)
             .field("video_started", &self.video_started)
+            .field("has_authority", &self.authority_lease.is_some())
+            .field("has_gpu_identity", &self.gpu_identity.is_some())
+            .field("has_video_identity", &self.video_identity.is_some())
+            .field("has_gpu_closure", &self.gpu_closure.is_some())
+            .field("has_video_closure", &self.video_closure.is_some())
             .finish()
     }
 }

--- a/packages/d2b-provider-device-gpu/src/controller.rs
+++ b/packages/d2b-provider-device-gpu/src/controller.rs
@@ -204,6 +204,11 @@ impl GpuController {
             .admission
             .as_ref()
             .ok_or(GpuControllerError::InvalidState)?;
+        if self.settings.video_sidecar && admission.video_principal().is_none() {
+            return Err(GpuControllerError::Authority(
+                GpuAuthorityError::PrincipalNotSeparated,
+            ));
+        }
         if self.authority_lease.is_none() {
             self.authority_lease = Some(
                 port.reserve_authority(admission)
@@ -236,6 +241,16 @@ impl GpuController {
                     generation,
                 )
                 .map_err(GpuControllerError::Effect)?;
+            if let Err(error) = validate_started_identity(
+                &identity,
+                spec.process().role(),
+                admission.gpu_principal(),
+                admission.platform(),
+                generation,
+            ) {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(error));
+            }
             self.gpu_role = Some(spec.process().role());
             self.gpu_identity = Some(identity);
         }
@@ -251,6 +266,16 @@ impl GpuController {
             let identity = port
                 .start_video_worker(&spec, ticket, principal, admission.platform(), generation)
                 .map_err(GpuControllerError::Effect)?;
+            if let Err(error) = validate_started_identity(
+                &identity,
+                GpuProcessRole::Video,
+                principal,
+                admission.platform(),
+                generation,
+            ) {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(error));
+            }
             self.video_identity = Some(identity);
             self.video_started = true;
         }
@@ -269,6 +294,11 @@ impl GpuController {
             .admission
             .as_ref()
             .ok_or(GpuControllerError::InvalidState)?;
+        if self.settings.video_sidecar && admission.video_principal().is_none() {
+            return Err(GpuControllerError::Authority(
+                GpuAuthorityError::PrincipalNotSeparated,
+            ));
+        }
         self.authority_lease = Some(lease);
         let mut matched = Vec::new();
         let mut missing = false;
@@ -294,34 +324,63 @@ impl GpuController {
             }
         }
         for identity in matched {
-            if identity.platform() != admission.platform()
-                || identity.generation() != admission.owner().generation()
-            {
-                self.phase = GpuPhase::Failed;
-                return Err(GpuControllerError::Effect(GpuEffectError::PlatformMismatch));
-            }
-            let principal_matches = match identity.role() {
-                GpuProcessRole::Video => admission
-                    .video_principal()
-                    .is_some_and(|principal| principal == identity.principal()),
-                _ => identity.principal() == admission.gpu_principal(),
+            let expected_role = if identity.role() == GpuProcessRole::Video {
+                GpuProcessRole::Video
+            } else if self.settings.render_node_only {
+                GpuProcessRole::RenderNode
+            } else {
+                GpuProcessRole::FullGpu
             };
-            if !principal_matches {
+            let expected_principal = match identity.role() {
+                GpuProcessRole::Video => admission.video_principal(),
+                GpuProcessRole::FullGpu | GpuProcessRole::RenderNode => {
+                    Some(admission.gpu_principal())
+                }
+            };
+            let Some(expected_principal) = expected_principal else {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(GpuEffectError::WrongPrincipal));
+            };
+            if identity.role() != expected_role
+                || identity.principal() != expected_principal
+                || (identity.role() == GpuProcessRole::Video && !self.settings.video_sidecar)
+            {
                 self.phase = GpuPhase::Failed;
                 return Err(GpuControllerError::Effect(GpuEffectError::WrongPrincipal));
             }
+            if identity.platform() != admission.platform() {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(GpuEffectError::PlatformMismatch));
+            }
+            if identity.generation() != admission.owner().generation() {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(
+                    GpuEffectError::StaleDeviceIdentity,
+                ));
+            }
             match identity.role() {
                 GpuProcessRole::Video => {
+                    if self.video_identity.is_some() {
+                        self.phase = GpuPhase::Quarantined;
+                        return Err(GpuControllerError::Quarantined);
+                    }
                     self.video_started = true;
                     self.video_identity = Some(identity);
                 }
                 role => {
+                    if self.gpu_identity.is_some() {
+                        self.phase = GpuPhase::Quarantined;
+                        return Err(GpuControllerError::Quarantined);
+                    }
                     self.gpu_role = Some(role);
                     self.gpu_identity = Some(identity);
                 }
             }
         }
-        if missing || self.gpu_identity.is_none() {
+        if missing
+            || self.gpu_identity.is_none()
+            || (self.settings.video_sidecar && self.video_identity.is_none())
+        {
             self.phase = GpuPhase::Pending;
             return Ok(GpuReconcileOutcome::Retry);
         }
@@ -341,18 +400,26 @@ impl GpuController {
         if self.video_closure.is_none()
             && let Some(identity) = self.video_identity.as_ref()
         {
-            self.video_closure = Some(
-                port.stop_worker(identity)
-                    .map_err(GpuControllerError::Effect)?,
-            );
+            let closure = port
+                .stop_worker(identity)
+                .map_err(GpuControllerError::Effect)?;
+            if closure.identity() != identity {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(GpuEffectError::CloseUnconfirmed));
+            }
+            self.video_closure = Some(closure);
         }
         if self.gpu_closure.is_none()
             && let Some(identity) = self.gpu_identity.as_ref()
         {
-            self.gpu_closure = Some(
-                port.stop_worker(identity)
-                    .map_err(GpuControllerError::Effect)?,
-            );
+            let closure = port
+                .stop_worker(identity)
+                .map_err(GpuControllerError::Effect)?;
+            if closure.identity() != identity {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(GpuEffectError::CloseUnconfirmed));
+            }
+            self.gpu_closure = Some(closure);
         }
         let closures = self
             .video_closure
@@ -377,6 +444,25 @@ impl GpuController {
         self.phase = GpuPhase::Finalized;
         Ok(())
     }
+}
+
+fn validate_started_identity(
+    identity: &GpuProcessIdentity,
+    expected_role: GpuProcessRole,
+    expected_principal: &crate::GpuPrincipalToken,
+    expected_platform: &crate::GpuPlatformToken,
+    expected_generation: d2b_contracts::v3::ResourceGeneration,
+) -> Result<(), GpuEffectError> {
+    if identity.role() != expected_role || identity.principal() != expected_principal {
+        return Err(GpuEffectError::WrongPrincipal);
+    }
+    if identity.platform() != expected_platform {
+        return Err(GpuEffectError::PlatformMismatch);
+    }
+    if identity.generation() != expected_generation {
+        return Err(GpuEffectError::StaleDeviceIdentity);
+    }
+    Ok(())
 }
 
 impl fmt::Debug for GpuController {

--- a/packages/d2b-provider-device-gpu/src/controller.rs
+++ b/packages/d2b-provider-device-gpu/src/controller.rs
@@ -195,7 +195,10 @@ impl GpuController {
         if !self.finalizer
             || matches!(
                 self.phase,
-                GpuPhase::Finalizing | GpuPhase::Finalized | GpuPhase::Quarantined
+                GpuPhase::Failed
+                    | GpuPhase::Finalizing
+                    | GpuPhase::Finalized
+                    | GpuPhase::Quarantined
             )
         {
             return Err(GpuControllerError::InvalidState);
@@ -241,6 +244,8 @@ impl GpuController {
                     generation,
                 )
                 .map_err(GpuControllerError::Effect)?;
+            self.gpu_role = Some(spec.process().role());
+            self.gpu_identity = Some(identity.clone());
             if let Err(error) = validate_started_identity(
                 &identity,
                 spec.process().role(),
@@ -251,8 +256,6 @@ impl GpuController {
                 self.phase = GpuPhase::Failed;
                 return Err(GpuControllerError::Effect(error));
             }
-            self.gpu_role = Some(spec.process().role());
-            self.gpu_identity = Some(identity);
         }
         self.phase = GpuPhase::GpuReady;
         if self.settings.video_sidecar && self.video_identity.is_none() {
@@ -266,6 +269,8 @@ impl GpuController {
             let identity = port
                 .start_video_worker(&spec, ticket, principal, admission.platform(), generation)
                 .map_err(GpuControllerError::Effect)?;
+            self.video_identity = Some(identity.clone());
+            self.video_started = true;
             if let Err(error) = validate_started_identity(
                 &identity,
                 GpuProcessRole::Video,
@@ -276,8 +281,6 @@ impl GpuController {
                 self.phase = GpuPhase::Failed;
                 return Err(GpuControllerError::Effect(error));
             }
-            self.video_identity = Some(identity);
-            self.video_started = true;
         }
         self.phase = GpuPhase::Ready;
         Ok(GpuReconcileOutcome::Converged)

--- a/packages/d2b-provider-device-gpu/src/controller.rs
+++ b/packages/d2b-provider-device-gpu/src/controller.rs
@@ -293,6 +293,17 @@ impl GpuController {
         expected: &[GpuProcessIdentity],
         port: &mut P,
     ) -> Result<GpuReconcileOutcome, GpuControllerError> {
+        if !self.finalizer
+            || matches!(
+                self.phase,
+                GpuPhase::Failed
+                    | GpuPhase::Finalizing
+                    | GpuPhase::Finalized
+                    | GpuPhase::Quarantined
+            )
+        {
+            return Err(GpuControllerError::InvalidState);
+        }
         let admission = self
             .admission
             .as_ref()

--- a/packages/d2b-provider-device-gpu/src/controller.rs
+++ b/packages/d2b-provider-device-gpu/src/controller.rs
@@ -307,7 +307,13 @@ impl GpuController {
                 .observe_worker(identity)
                 .map_err(GpuControllerError::Effect)?
             {
-                GpuProcessObservation::Matching(observed) => matched.push(observed),
+                GpuProcessObservation::Matching(observed) => {
+                    if observed != *identity {
+                        self.phase = GpuPhase::Quarantined;
+                        return Err(GpuControllerError::Quarantined);
+                    }
+                    matched.push(observed);
+                }
                 GpuProcessObservation::Ambiguous => {
                     self.phase = GpuPhase::Quarantined;
                     return Err(GpuControllerError::Quarantined);

--- a/packages/d2b-provider-device-gpu/src/controller.rs
+++ b/packages/d2b-provider-device-gpu/src/controller.rs
@@ -161,51 +161,17 @@ impl GpuController {
     /// Start the GPU worker and only then the optional video worker.
     pub fn reconcile<P: GpuEffectPort>(
         &mut self,
-        port: &mut P,
+        _port: &mut P,
     ) -> Result<GpuReconcileOutcome, GpuControllerError> {
+        if self.admission.is_none() || self.authority_lease.is_none() {
+            return Err(GpuControllerError::Authority(
+                GpuAuthorityError::StartupRehydrationRequired,
+            ));
+        }
         if !self.finalizer || matches!(self.phase, GpuPhase::Finalizing | GpuPhase::Finalized) {
             return Err(GpuControllerError::InvalidState);
         }
-        if self.phase == GpuPhase::Ready {
-            return Ok(GpuReconcileOutcome::Converged);
-        }
-        let declarations = select_processes(&self.device_uid, self.arbitration, &self.settings)
-            .map_err(GpuControllerError::Selection)?;
-        let gpu = declarations
-            .first()
-            .ok_or(GpuControllerError::InvalidState)?
-            .role();
-        self.phase = GpuPhase::GpuStarting;
-        if self.ticket.is_none() {
-            self.ticket = match port.open_devices(&self.device_uid, &self.tokens) {
-                Ok(ticket) => Some(ticket),
-                Err(error) => return self.effect_failed(error),
-            };
-        }
-        if self.gpu_role.is_none() {
-            let ticket = self
-                .ticket
-                .as_ref()
-                .ok_or(GpuControllerError::InvalidState)?;
-            if let Err(error) = port.start(gpu, ticket) {
-                return self.effect_failed(error);
-            }
-            self.gpu_role = Some(gpu);
-        }
-        self.phase = GpuPhase::GpuReady;
-        if self.settings.video_sidecar && !self.video_started {
-            self.phase = GpuPhase::VideoStarting;
-            let ticket = self
-                .ticket
-                .as_ref()
-                .ok_or(GpuControllerError::InvalidState)?;
-            if let Err(error) = port.start(GpuProcessRole::Video, ticket) {
-                return self.effect_failed(error);
-            }
-            self.video_started = true;
-        }
-        self.phase = GpuPhase::Ready;
-        Ok(GpuReconcileOutcome::Converged)
+        Err(GpuControllerError::InvalidState)
     }
 
     /// Stop video first and the GPU/render-node worker second.
@@ -213,23 +179,8 @@ impl GpuController {
         if !self.finalizer {
             return Ok(());
         }
-        self.phase = GpuPhase::Finalizing;
-        if self.video_started {
-            port.stop(GpuProcessRole::Video)
-                .map_err(GpuControllerError::Effect)?;
-            self.video_started = false;
-        }
-        if let Some(role) = self.gpu_role.take() {
-            port.stop(role).map_err(GpuControllerError::Effect)?;
-        }
-        self.ticket = None;
-        self.gpu_identity = None;
-        self.video_identity = None;
-        self.gpu_closure = None;
-        self.video_closure = None;
-        self.finalizer = false;
-        self.phase = GpuPhase::Finalized;
-        Ok(())
+        let _ = port;
+        Err(GpuControllerError::InvalidState)
     }
 
     /// Reconcile through the authority-aware production effect boundary.
@@ -320,6 +271,7 @@ impl GpuController {
             .ok_or(GpuControllerError::InvalidState)?;
         self.authority_lease = Some(lease);
         let mut matched = Vec::new();
+        let mut missing = false;
         for identity in expected {
             match port
                 .observe_worker(identity)
@@ -337,8 +289,7 @@ impl GpuController {
                     ));
                 }
                 GpuProcessObservation::Missing => {
-                    self.phase = GpuPhase::Pending;
-                    return Ok(GpuReconcileOutcome::Retry);
+                    missing = true;
                 }
             }
         }
@@ -348,6 +299,16 @@ impl GpuController {
             {
                 self.phase = GpuPhase::Failed;
                 return Err(GpuControllerError::Effect(GpuEffectError::PlatformMismatch));
+            }
+            let principal_matches = match identity.role() {
+                GpuProcessRole::Video => admission
+                    .video_principal()
+                    .is_some_and(|principal| principal == identity.principal()),
+                _ => identity.principal() == admission.gpu_principal(),
+            };
+            if !principal_matches {
+                self.phase = GpuPhase::Failed;
+                return Err(GpuControllerError::Effect(GpuEffectError::WrongPrincipal));
             }
             match identity.role() {
                 GpuProcessRole::Video => {
@@ -360,9 +321,11 @@ impl GpuController {
                 }
             }
         }
-        if self.gpu_identity.is_some() {
-            self.phase = GpuPhase::Ready;
+        if missing || self.gpu_identity.is_none() {
+            self.phase = GpuPhase::Pending;
+            return Ok(GpuReconcileOutcome::Retry);
         }
+        self.phase = GpuPhase::Ready;
         Ok(GpuReconcileOutcome::Converged)
     }
 
@@ -413,15 +376,6 @@ impl GpuController {
         self.finalizer = false;
         self.phase = GpuPhase::Finalized;
         Ok(())
-    }
-
-    fn effect_failed<T>(&mut self, error: GpuEffectError) -> Result<T, GpuControllerError> {
-        self.phase = if error == GpuEffectError::Transient {
-            GpuPhase::Degraded
-        } else {
-            GpuPhase::Failed
-        };
-        Err(GpuControllerError::Effect(error))
     }
 }
 

--- a/packages/d2b-provider-device-gpu/src/descriptor.rs
+++ b/packages/d2b-provider-device-gpu/src/descriptor.rs
@@ -1,0 +1,91 @@
+//! Status-first component descriptor contract.
+
+use core::fmt;
+
+/// Signed component descriptor for the GPU Provider.
+///
+/// GPU operational state is represented by Device status and Core operation
+/// rows. This descriptor intentionally declares no Provider state Volume or
+/// `/state` mount.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuComponentDescriptor {
+    provider_state_volumes: Vec<&'static str>,
+    controller_mounts: Vec<&'static str>,
+    worker_mounts: Vec<&'static str>,
+}
+
+impl GpuComponentDescriptor {
+    /// Build the canonical status-first descriptor.
+    pub const fn new() -> Self {
+        Self {
+            provider_state_volumes: Vec::new(),
+            controller_mounts: Vec::new(),
+            worker_mounts: Vec::new(),
+        }
+    }
+
+    /// Whether the Provider declares no state Volume.
+    pub fn provider_state_empty(&self) -> bool {
+        self.provider_state_volumes.is_empty()
+    }
+
+    /// Borrow controller mounts.
+    pub fn controller_mounts(&self) -> &[&'static str] {
+        &self.controller_mounts
+    }
+
+    /// Borrow worker mounts.
+    pub fn worker_mounts(&self) -> &[&'static str] {
+        &self.worker_mounts
+    }
+
+    /// Validate the status-first invariant.
+    pub fn validate(&self) -> Result<(), GpuDescriptorError> {
+        if self.provider_state_volumes.is_empty()
+            && self
+                .controller_mounts
+                .iter()
+                .all(|mount| *mount != "/state")
+            && self.worker_mounts.iter().all(|mount| *mount != "/state")
+        {
+            Ok(())
+        } else {
+            Err(GpuDescriptorError::StateVolumeDeclared)
+        }
+    }
+}
+
+impl Default for GpuComponentDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for GpuComponentDescriptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuComponentDescriptor")
+            .field(
+                "provider_state_volume_count",
+                &self.provider_state_volumes.len(),
+            )
+            .field("controller_mount_count", &self.controller_mounts.len())
+            .field("worker_mount_count", &self.worker_mounts.len())
+            .finish()
+    }
+}
+
+/// Descriptor validation failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuDescriptorError {
+    /// A Provider state Volume or `/state` mount was declared.
+    StateVolumeDeclared,
+}
+
+impl fmt::Display for GpuDescriptorError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("gpu-provider-state-volume-forbidden")
+    }
+}
+
+impl std::error::Error for GpuDescriptorError {}

--- a/packages/d2b-provider-device-gpu/src/effects.rs
+++ b/packages/d2b-provider-device-gpu/src/effects.rs
@@ -3,7 +3,15 @@
 use core::fmt;
 use d2b_contracts::v3::ResourceUid;
 
-use crate::process::GpuProcessRole;
+use crate::{
+    authority::{
+        GpuAuthorityAdmission, GpuAuthorityLease, GpuClosureProof, GpuPlatformToken,
+        GpuProcessIdentity, GpuProcessObservation,
+    },
+    probe::{GpuDeviceSelector, GpuProbeResult},
+    process::GpuProcessRole,
+    workers::{GpuWorkerSpec, VideoWorkerSpec},
+};
 
 /// One Core-derived GPU device effect token.
 #[derive(Clone, PartialEq, Eq)]
@@ -85,6 +93,24 @@ pub enum GpuEffectError {
     SpawnRejected,
     /// A worker can be retried.
     Transient,
+    /// The Core probe adapter is unavailable.
+    ProbeUnavailable,
+    /// Restart observation could not prove one exact process.
+    ProcessObservationUnavailable,
+    /// The request used a different worker principal.
+    WrongPrincipal,
+    /// The request used a different platform identity.
+    PlatformMismatch,
+    /// The request used a stale Device generation or backing identity.
+    StaleDeviceIdentity,
+    /// A Host-global claim conflicts with another owner.
+    AuthorityConflict,
+    /// A restart observation was ambiguous and is quarantined.
+    Quarantined,
+    /// A worker closure did not prove the owned process was gone.
+    CloseUnconfirmed,
+    /// The frozen GPU/video wire contract diverged.
+    WireContractMismatch,
 }
 
 impl GpuEffectError {
@@ -95,6 +121,15 @@ impl GpuEffectError {
             Self::OpenRejected => "device-broker-inaccessible",
             Self::SpawnRejected => "device-worker-failed",
             Self::Transient => "transient",
+            Self::ProbeUnavailable => "gpu-effect-unavailable",
+            Self::ProcessObservationUnavailable => "gpu-process-observation-unavailable",
+            Self::WrongPrincipal => "gpu-process-principal-mismatch",
+            Self::PlatformMismatch => "gpu-platform-mismatch",
+            Self::StaleDeviceIdentity => "gpu-device-identity-stale",
+            Self::AuthorityConflict => "device-claim-conflict",
+            Self::Quarantined => "gpu-authority-quarantined",
+            Self::CloseUnconfirmed => "gpu-worker-close-unconfirmed",
+            Self::WireContractMismatch => "device-wire-contract-mismatch",
         }
     }
 }
@@ -123,4 +158,89 @@ pub trait GpuEffectPort {
     ) -> Result<(), GpuEffectError>;
     /// Stop one worker role during finalization.
     fn stop(&mut self, role: GpuProcessRole) -> Result<(), GpuEffectError>;
+
+    /// Probe a Core-resolved DRM selector.
+    fn probe_drm_device(
+        &mut self,
+        _selector: &GpuDeviceSelector,
+    ) -> Result<GpuProbeResult, GpuEffectError> {
+        Err(GpuEffectError::ProbeUnavailable)
+    }
+
+    /// Observe one worker identity after a daemon restart.
+    fn observe_process(
+        &mut self,
+        _identity: &GpuProcessIdentity,
+    ) -> Result<GpuProcessObservation, GpuEffectError> {
+        Err(GpuEffectError::ProcessObservationUnavailable)
+    }
+
+    /// Close one exact worker and return a broker proof.
+    fn close_process(
+        &mut self,
+        role: GpuProcessRole,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuClosureProof, GpuEffectError> {
+        self.stop(role)?;
+        Ok(GpuClosureProof::from_core(identity.clone()))
+    }
+}
+
+/// Extended lifecycle port used by the production Provider path.
+///
+/// The Core adapter implements this trait and owns the mapping to
+/// `HostGlobalAuthorityIndex`, `OpenDevice`, `SpawnRunner`, `OpenPidfd`, and
+/// close/release operations. The Provider only sees opaque identities.
+pub trait GpuLifecycleEffectPort {
+    /// Reserve Host-global GPU authority before any effect.
+    fn reserve_authority(
+        &mut self,
+        admission: &GpuAuthorityAdmission,
+    ) -> Result<GpuAuthorityLease, GpuEffectError>;
+
+    /// Open Core-resolved device grants before worker spawn.
+    fn open_authorized_devices(
+        &mut self,
+        admission: &GpuAuthorityAdmission,
+        tokens: &GpuEffectTokenSet,
+    ) -> Result<GpuLaunchTicket, GpuEffectError>;
+
+    /// Start a GPU or render-node worker with its signed semantic spec.
+    fn start_gpu_worker(
+        &mut self,
+        spec: &GpuWorkerSpec,
+        ticket: &GpuLaunchTicket,
+        principal: &crate::authority::GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: d2b_contracts::v3::ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError>;
+
+    /// Start the separate video worker.
+    fn start_video_worker(
+        &mut self,
+        spec: &VideoWorkerSpec,
+        ticket: &GpuLaunchTicket,
+        principal: &crate::authority::GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: d2b_contracts::v3::ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError>;
+
+    /// Observe one exact worker after restart.
+    fn observe_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuProcessObservation, GpuEffectError>;
+
+    /// Close one exact worker and return its closure proof.
+    fn stop_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuClosureProof, GpuEffectError>;
+
+    /// Release Host-global authority only after worker closure.
+    fn release_authority(
+        &mut self,
+        lease: GpuAuthorityLease,
+        closures: &[GpuClosureProof],
+    ) -> Result<(), GpuEffectError>;
 }

--- a/packages/d2b-provider-device-gpu/src/lib.rs
+++ b/packages/d2b-provider-device-gpu/src/lib.rs
@@ -6,25 +6,58 @@
 
 #![deny(missing_docs)]
 
+mod arbitration;
+mod audit;
+mod authority;
 mod controller;
+mod descriptor;
 mod effects;
+mod probe;
 mod process;
+mod production;
 mod settings;
+mod status;
+mod telemetry;
 mod wire;
+mod worker_gpu;
+mod worker_video;
+mod workers;
 
+pub use arbitration::{GpuArbitrator, GpuClaim, GpuClaimError};
+pub use audit::{GpuAuditOperation, GpuAuditOutcome, GpuAuditRecord};
+pub use authority::{
+    GpuAdoption, GpuAuthorityAdmission, GpuAuthorityError, GpuAuthorityIndex, GpuAuthorityLease,
+    GpuBackingToken, GpuClosureProof, GpuOwnerProof, GpuPlatformToken, GpuPrincipalToken,
+    GpuProcessIdentity, GpuProcessObservation, GpuRecoveryRecord, GpuRecoverySnapshot,
+};
 pub use controller::{GpuController, GpuControllerError, GpuPhase, GpuReconcileOutcome};
+pub use descriptor::{GpuComponentDescriptor, GpuDescriptorError};
 pub use effects::{
     GpuEffectError, GpuEffectPort, GpuEffectToken, GpuEffectTokenSet, GpuLaunchTicket,
+    GpuLifecycleEffectPort,
+};
+pub use probe::{
+    DEFAULT_OBSERVE_INTERVAL_SECS, GpuDeviceSelector, GpuProbeDisposition, GpuProbeError,
+    GpuProbePort, GpuProbeResult, GpuProbeTracker, MAX_OBSERVE_INTERVAL_SECS,
+    MIN_OBSERVE_INTERVAL_SECS,
 };
 pub use process::{
     GpuProcessDeclaration, GpuProcessRole, GpuProcessSelectionError, gpu_process_name,
 };
+pub use production::{GpuBrokerDispatcher, LegacyEffectAdapter, ProductionPort};
 pub use settings::{ContextType, DisplayConfig, GpuSettings, GpuSettingsError};
+pub use status::{
+    GpuCondition, GpuConditionState, GpuConditionType, GpuStatus, GpuStatusError, GpuStatusPhase,
+};
+pub use telemetry::{GpuMetricLabels, GpuOperation, GpuOutcome};
 pub use wire::{
     VHOST_USER_MEDIA_NUM_QUEUES, VHOST_USER_MEDIA_PROTOCOL_FLAGS, VHOST_USER_MEDIA_QUEUE_SIZE,
     VHOST_USER_MEDIA_SHM_REGION_BYTES, VHOST_USER_MEDIA_VRING_BASE, VIRTIO_ID_MEDIA,
     wire_contract_snapshot,
 };
+pub use worker_gpu::build_gpu_worker;
+pub use worker_video::build_video_worker;
+pub use workers::{GpuDeviceNode, GpuWorkerSpec, VideoWorkerSpec};
 
 /// Provider identity.
 pub const PROVIDER_REF: &str = "Provider/device-gpu";

--- a/packages/d2b-provider-device-gpu/src/lib.rs
+++ b/packages/d2b-provider-device-gpu/src/lib.rs
@@ -44,7 +44,7 @@ pub use probe::{
 pub use process::{
     GpuProcessDeclaration, GpuProcessRole, GpuProcessSelectionError, gpu_process_name,
 };
-pub use production::{GpuBrokerDispatcher, LegacyEffectAdapter, ProductionPort};
+pub use production::{GpuBrokerDispatcher, ProductionPort};
 pub use settings::{ContextType, DisplayConfig, GpuSettings, GpuSettingsError};
 pub use status::{
     GpuCondition, GpuConditionState, GpuConditionType, GpuStatus, GpuStatusError, GpuStatusPhase,

--- a/packages/d2b-provider-device-gpu/src/probe.rs
+++ b/packages/d2b-provider-device-gpu/src/probe.rs
@@ -1,0 +1,249 @@
+//! Opaque DRM probe and bounded observe scheduling.
+
+use core::fmt;
+
+use crate::authority::{GpuBackingToken, GpuPlatformToken};
+
+/// Maximum GPU observe interval in seconds.
+pub const MAX_OBSERVE_INTERVAL_SECS: u64 = 60;
+/// Minimum GPU observe interval in seconds.
+pub const MIN_OBSERVE_INTERVAL_SECS: u64 = 10;
+/// Default GPU observe interval in seconds.
+pub const DEFAULT_OBSERVE_INTERVAL_SECS: u64 = 30;
+
+/// Stable DRM inventory selector.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuDeviceSelector {
+    label: String,
+    pci_slot: Option<String>,
+}
+
+impl GpuDeviceSelector {
+    /// Construct a selector without accepting a host path or bus address.
+    pub fn new(
+        label: impl Into<String>,
+        pci_slot: Option<impl Into<String>>,
+    ) -> Result<Self, GpuProbeError> {
+        let label = label.into();
+        if label.is_empty()
+            || label.len() > 63
+            || !label
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+            || !label.as_bytes()[0].is_ascii_lowercase()
+        {
+            return Err(GpuProbeError::InvalidSelector);
+        }
+        let pci_slot = pci_slot.map(Into::into);
+        if pci_slot.as_deref().is_some_and(|slot| {
+            slot.is_empty()
+                || slot.len() > 31
+                || slot
+                    .bytes()
+                    .any(|byte| !byte.is_ascii_graphic() || byte == b'/')
+        }) {
+            return Err(GpuProbeError::InvalidSelector);
+        }
+        Ok(Self { label, pci_slot })
+    }
+
+    /// Borrow the stable selector label.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Borrow the optional PCI filter.
+    pub fn pci_slot(&self) -> Option<&str> {
+        self.pci_slot.as_deref()
+    }
+}
+
+impl fmt::Debug for GpuDeviceSelector {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuDeviceSelector")
+            .field("has_pci_slot", &self.pci_slot.is_some())
+            .finish()
+    }
+}
+
+/// Result returned by the Core-owned probe adapter.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuProbeResult {
+    backing: GpuBackingToken,
+    platform: GpuPlatformToken,
+    physical_present: bool,
+    render_node_available: bool,
+}
+
+impl GpuProbeResult {
+    /// Construct a present GPU observation at the Core boundary.
+    pub fn present(
+        backing: GpuBackingToken,
+        platform: GpuPlatformToken,
+        render_node_available: bool,
+    ) -> Result<Self, GpuProbeError> {
+        if backing.is_zero() || platform.is_zero() {
+            return Err(GpuProbeError::StaleIdentity);
+        }
+        Ok(Self {
+            backing,
+            platform,
+            physical_present: true,
+            render_node_available,
+        })
+    }
+
+    /// Construct a bounded absent observation retaining no physical identity.
+    pub const fn absent() -> Self {
+        Self {
+            backing: GpuBackingToken::from_core([0; 32]),
+            platform: GpuPlatformToken::from_core([0; 32]),
+            physical_present: false,
+            render_node_available: false,
+        }
+    }
+
+    /// Borrow the opaque backing identity.
+    pub const fn backing(&self) -> &GpuBackingToken {
+        &self.backing
+    }
+
+    /// Borrow the opaque platform identity.
+    pub const fn platform(&self) -> &GpuPlatformToken {
+        &self.platform
+    }
+
+    /// Whether the physical DRM device is present.
+    pub const fn physical_present(&self) -> bool {
+        self.physical_present
+    }
+
+    /// Whether a render node is available.
+    pub const fn render_node_available(&self) -> bool {
+        self.render_node_available
+    }
+}
+
+impl fmt::Debug for GpuProbeResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuProbeResult")
+            .field("physical_present", &self.physical_present)
+            .field("render_node_available", &self.render_node_available)
+            .finish()
+    }
+}
+
+/// Closed probe failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuProbeError {
+    /// Selector shape is invalid.
+    InvalidSelector,
+    /// A platform or backing identity could not be proven.
+    StaleIdentity,
+    /// The observe interval is outside the signed bounds.
+    ObserveIntervalOutOfRange,
+    /// The Core probe adapter is unavailable.
+    Unavailable,
+}
+
+impl GpuProbeError {
+    /// Return the stable identity-free error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::InvalidSelector => "gpu-selector-invalid",
+            Self::StaleIdentity => "gpu-device-identity-stale",
+            Self::ObserveIntervalOutOfRange => "gpu-observe-interval-out-of-range",
+            Self::Unavailable => "gpu-effect-unavailable",
+        }
+    }
+}
+
+impl fmt::Display for GpuProbeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for GpuProbeError {}
+
+/// Typed probe port implemented by Core.
+pub trait GpuProbePort {
+    /// Probe a trusted DRM selector.
+    fn probe_drm_device(
+        &mut self,
+        selector: &GpuDeviceSelector,
+    ) -> Result<GpuProbeResult, GpuProbeError>;
+}
+
+/// Result of applying three-strike physical probe semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuProbeDisposition {
+    /// The device is present and usable.
+    Ready,
+    /// The first or second failure is not enough to declare absence.
+    Unknown,
+    /// Three consecutive failures crossed the fail-closed threshold.
+    Degraded,
+}
+
+/// Bounded three-strike probe tracker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpuProbeTracker {
+    failures: u8,
+    interval_secs: u64,
+}
+
+impl GpuProbeTracker {
+    /// Construct a tracker with the default observe interval.
+    pub const fn new() -> Self {
+        Self {
+            failures: 0,
+            interval_secs: DEFAULT_OBSERVE_INTERVAL_SECS,
+        }
+    }
+
+    /// Construct a tracker with an explicitly bounded observe interval.
+    pub fn with_interval(interval_secs: u64) -> Result<Self, GpuProbeError> {
+        if !(MIN_OBSERVE_INTERVAL_SECS..=MAX_OBSERVE_INTERVAL_SECS).contains(&interval_secs) {
+            return Err(GpuProbeError::ObserveIntervalOutOfRange);
+        }
+        Ok(Self {
+            failures: 0,
+            interval_secs,
+        })
+    }
+
+    /// Return the configured observe interval.
+    pub const fn interval_secs(&self) -> u64 {
+        self.interval_secs
+    }
+
+    /// Return the consecutive failure count.
+    pub const fn failures(&self) -> u8 {
+        self.failures
+    }
+
+    /// Record one successful probe.
+    pub fn record_success(&mut self) -> GpuProbeDisposition {
+        self.failures = 0;
+        GpuProbeDisposition::Ready
+    }
+
+    /// Record one failed probe using the three-strike contract.
+    pub fn record_failure(&mut self) -> GpuProbeDisposition {
+        self.failures = self.failures.saturating_add(1).min(3);
+        if self.failures >= 3 {
+            GpuProbeDisposition::Degraded
+        } else {
+            GpuProbeDisposition::Unknown
+        }
+    }
+}
+
+impl Default for GpuProbeTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/packages/d2b-provider-device-gpu/src/process.rs
+++ b/packages/d2b-provider-device-gpu/src/process.rs
@@ -6,7 +6,7 @@ use d2b_contracts::v3::{ResourceUid, device::DeviceArbitration};
 use crate::settings::{GpuSettings, GpuSettingsError};
 
 /// Combined GPU Provider Process role.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum GpuProcessRole {
     /// Full GPU virtio worker.
     FullGpu,
@@ -50,6 +50,29 @@ impl GpuProcessDeclaration {
     /// Return the fixed Host placement.
     pub const fn placement(&self) -> &'static str {
         self.placement
+    }
+
+    /// Return the signed component template for this worker.
+    pub const fn template(&self) -> &'static str {
+        match self.role {
+            GpuProcessRole::FullGpu => "gpu-worker",
+            GpuProcessRole::RenderNode => "render-node-worker",
+            GpuProcessRole::Video => "video-worker",
+        }
+    }
+
+    /// Return the signed seccomp class for this worker.
+    pub const fn seccomp_class(&self) -> &'static str {
+        match self.role {
+            GpuProcessRole::FullGpu => "w1-gpu",
+            GpuProcessRole::RenderNode => "w1-gpu-render-node",
+            GpuProcessRole::Video => "w1-video",
+        }
+    }
+
+    /// Whether this worker uses the broker-pre-established user namespace.
+    pub const fn user_namespace(&self) -> bool {
+        !matches!(self.role, GpuProcessRole::Video)
     }
 }
 

--- a/packages/d2b-provider-device-gpu/src/production.rs
+++ b/packages/d2b-provider-device-gpu/src/production.rs
@@ -1,0 +1,202 @@
+//! Production composition seam for the GPU Provider.
+//!
+//! The daemon supplies one implementation that talks to Core's authority
+//! index and typed broker dispatcher. This crate never imports broker DTOs or
+//! receives host paths.
+
+use d2b_contracts::v3::ResourceGeneration;
+
+use crate::{
+    GpuAuthorityAdmission, GpuAuthorityLease, GpuClosureProof, GpuEffectError, GpuEffectPort,
+    GpuEffectTokenSet, GpuLaunchTicket, GpuLifecycleEffectPort, GpuPlatformToken,
+    GpuProcessIdentity, GpuProcessObservation, GpuWorkerSpec, VideoWorkerSpec,
+};
+
+/// Daemon-owned GPU dispatch surface.
+///
+/// Implementations must reserve the Host-global key before opening devices or
+/// spawning a worker, retain the lease across asynchronous broker effects, and
+/// release it only after exact process closure.
+pub trait GpuBrokerDispatcher {
+    /// Reserve the Core-derived Host-global GPU authority.
+    fn reserve_gpu_authority(
+        &mut self,
+        admission: &GpuAuthorityAdmission,
+    ) -> Result<GpuAuthorityLease, GpuEffectError>;
+
+    /// Open the Core-resolved device grants.
+    fn open_gpu_devices(
+        &mut self,
+        admission: &GpuAuthorityAdmission,
+        tokens: &GpuEffectTokenSet,
+    ) -> Result<GpuLaunchTicket, GpuEffectError>;
+
+    /// Start the GPU or render-node worker through SpawnRunner.
+    fn spawn_gpu_worker(
+        &mut self,
+        spec: &GpuWorkerSpec,
+        ticket: &GpuLaunchTicket,
+        principal: &crate::GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError>;
+
+    /// Start the separate video worker through SpawnRunner.
+    fn spawn_video_worker(
+        &mut self,
+        spec: &VideoWorkerSpec,
+        ticket: &GpuLaunchTicket,
+        principal: &crate::GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError>;
+
+    /// Observe one exact pidfd-backed worker identity.
+    fn observe_gpu_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuProcessObservation, GpuEffectError>;
+
+    /// Stop one exact pidfd-backed worker identity.
+    fn stop_gpu_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuClosureProof, GpuEffectError>;
+
+    /// Release authority after all owned worker closure proofs are present.
+    fn release_gpu_authority(
+        &mut self,
+        lease: GpuAuthorityLease,
+        closures: &[GpuClosureProof],
+    ) -> Result<(), GpuEffectError>;
+}
+
+/// Typed Provider port backed by one daemon dispatcher.
+pub struct ProductionPort<D> {
+    dispatcher: D,
+}
+
+impl<D> ProductionPort<D> {
+    /// Bind the Provider to a daemon-owned dispatcher.
+    pub const fn new(dispatcher: D) -> Self {
+        Self { dispatcher }
+    }
+
+    /// Borrow the dispatcher for diagnostics and tests.
+    pub const fn dispatcher(&self) -> &D {
+        &self.dispatcher
+    }
+
+    /// Mutably borrow the dispatcher for supervisor integration.
+    pub const fn dispatcher_mut(&mut self) -> &mut D {
+        &mut self.dispatcher
+    }
+}
+
+impl<D: GpuBrokerDispatcher> GpuLifecycleEffectPort for ProductionPort<D> {
+    fn reserve_authority(
+        &mut self,
+        admission: &GpuAuthorityAdmission,
+    ) -> Result<GpuAuthorityLease, GpuEffectError> {
+        self.dispatcher.reserve_gpu_authority(admission)
+    }
+
+    fn open_authorized_devices(
+        &mut self,
+        admission: &GpuAuthorityAdmission,
+        tokens: &GpuEffectTokenSet,
+    ) -> Result<GpuLaunchTicket, GpuEffectError> {
+        self.dispatcher.open_gpu_devices(admission, tokens)
+    }
+
+    fn start_gpu_worker(
+        &mut self,
+        spec: &GpuWorkerSpec,
+        ticket: &GpuLaunchTicket,
+        principal: &crate::GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError> {
+        self.dispatcher
+            .spawn_gpu_worker(spec, ticket, principal, platform, generation)
+    }
+
+    fn start_video_worker(
+        &mut self,
+        spec: &VideoWorkerSpec,
+        ticket: &GpuLaunchTicket,
+        principal: &crate::GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError> {
+        self.dispatcher
+            .spawn_video_worker(spec, ticket, principal, platform, generation)
+    }
+
+    fn observe_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuProcessObservation, GpuEffectError> {
+        self.dispatcher.observe_gpu_worker(identity)
+    }
+
+    fn stop_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuClosureProof, GpuEffectError> {
+        self.dispatcher.stop_gpu_worker(identity)
+    }
+
+    fn release_authority(
+        &mut self,
+        lease: GpuAuthorityLease,
+        closures: &[GpuClosureProof],
+    ) -> Result<(), GpuEffectError> {
+        self.dispatcher.release_gpu_authority(lease, closures)
+    }
+}
+
+/// A small adapter that exposes a legacy `GpuEffectPort` as an observation
+/// and stop-only lifecycle port for migration tests.
+pub struct LegacyEffectAdapter<P> {
+    port: P,
+}
+
+impl<P> LegacyEffectAdapter<P> {
+    /// Wrap an existing effect port.
+    pub const fn new(port: P) -> Self {
+        Self { port }
+    }
+
+    /// Borrow the wrapped port.
+    pub const fn port(&self) -> &P {
+        &self.port
+    }
+
+    /// Mutably borrow the wrapped port.
+    pub const fn port_mut(&mut self) -> &mut P {
+        &mut self.port
+    }
+}
+
+impl<P: GpuEffectPort> GpuEffectPort for LegacyEffectAdapter<P> {
+    fn open_devices(
+        &mut self,
+        device_uid: &d2b_contracts::v3::ResourceUid,
+        tokens: &GpuEffectTokenSet,
+    ) -> Result<GpuLaunchTicket, GpuEffectError> {
+        self.port.open_devices(device_uid, tokens)
+    }
+
+    fn start(
+        &mut self,
+        role: crate::GpuProcessRole,
+        ticket: &GpuLaunchTicket,
+    ) -> Result<(), GpuEffectError> {
+        self.port.start(role, ticket)
+    }
+
+    fn stop(&mut self, role: crate::GpuProcessRole) -> Result<(), GpuEffectError> {
+        self.port.stop(role)
+    }
+}

--- a/packages/d2b-provider-device-gpu/src/production.rs
+++ b/packages/d2b-provider-device-gpu/src/production.rs
@@ -7,9 +7,9 @@
 use d2b_contracts::v3::ResourceGeneration;
 
 use crate::{
-    GpuAuthorityAdmission, GpuAuthorityLease, GpuClosureProof, GpuEffectError, GpuEffectPort,
-    GpuEffectTokenSet, GpuLaunchTicket, GpuLifecycleEffectPort, GpuPlatformToken,
-    GpuProcessIdentity, GpuProcessObservation, GpuWorkerSpec, VideoWorkerSpec,
+    GpuAuthorityAdmission, GpuAuthorityLease, GpuClosureProof, GpuEffectError, GpuEffectTokenSet,
+    GpuLaunchTicket, GpuLifecycleEffectPort, GpuPlatformToken, GpuProcessIdentity,
+    GpuProcessObservation, GpuWorkerSpec, VideoWorkerSpec,
 };
 
 /// Daemon-owned GPU dispatch surface.
@@ -153,50 +153,5 @@ impl<D: GpuBrokerDispatcher> GpuLifecycleEffectPort for ProductionPort<D> {
         closures: &[GpuClosureProof],
     ) -> Result<(), GpuEffectError> {
         self.dispatcher.release_gpu_authority(lease, closures)
-    }
-}
-
-/// A small adapter that exposes a legacy `GpuEffectPort` as an observation
-/// and stop-only lifecycle port for migration tests.
-pub struct LegacyEffectAdapter<P> {
-    port: P,
-}
-
-impl<P> LegacyEffectAdapter<P> {
-    /// Wrap an existing effect port.
-    pub const fn new(port: P) -> Self {
-        Self { port }
-    }
-
-    /// Borrow the wrapped port.
-    pub const fn port(&self) -> &P {
-        &self.port
-    }
-
-    /// Mutably borrow the wrapped port.
-    pub const fn port_mut(&mut self) -> &mut P {
-        &mut self.port
-    }
-}
-
-impl<P: GpuEffectPort> GpuEffectPort for LegacyEffectAdapter<P> {
-    fn open_devices(
-        &mut self,
-        device_uid: &d2b_contracts::v3::ResourceUid,
-        tokens: &GpuEffectTokenSet,
-    ) -> Result<GpuLaunchTicket, GpuEffectError> {
-        self.port.open_devices(device_uid, tokens)
-    }
-
-    fn start(
-        &mut self,
-        role: crate::GpuProcessRole,
-        ticket: &GpuLaunchTicket,
-    ) -> Result<(), GpuEffectError> {
-        self.port.start(role, ticket)
-    }
-
-    fn stop(&mut self, role: crate::GpuProcessRole) -> Result<(), GpuEffectError> {
-        self.port.stop(role)
     }
 }

--- a/packages/d2b-provider-device-gpu/src/status.rs
+++ b/packages/d2b-provider-device-gpu/src/status.rs
@@ -1,0 +1,235 @@
+//! Bounded, redacted Device status projection.
+
+use core::fmt;
+
+/// Public GPU status phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuStatusPhase {
+    /// The Device is waiting for a first observation.
+    Pending,
+    /// The Device and all requested workers are healthy.
+    Ready,
+    /// The Device remains usable but an observation or worker is impaired.
+    Degraded,
+    /// The current generation cannot complete.
+    Failed,
+    /// The controller cannot prove current state.
+    Unknown,
+    /// Deletion is draining owned workers.
+    Finalizing,
+    /// The Device was finalized.
+    Finalized,
+    /// Restart identity was ambiguous and is quarantined.
+    Quarantined,
+}
+
+/// GPU-specific status condition kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuConditionType {
+    /// Physical DRM presence.
+    DevicePresent,
+    /// Host-global claim state.
+    DeviceClaimed,
+    /// GPU worker readiness.
+    GpuWorkerReady,
+    /// Video worker readiness.
+    VideoWorkerReady,
+    /// Restart or inventory identity is ambiguous.
+    IdentityTrusted,
+}
+
+/// Closed condition states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuConditionState {
+    /// The condition is proven true.
+    True,
+    /// The condition is proven false.
+    False,
+    /// The controller has not proved either state.
+    Unknown,
+}
+
+/// One bounded status condition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpuCondition {
+    /// Condition kind.
+    pub kind: GpuConditionType,
+    /// Condition state.
+    pub state: GpuConditionState,
+}
+
+/// Redacted Device status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuStatus {
+    phase: GpuStatusPhase,
+    video_enabled: bool,
+    present: Option<bool>,
+    render_node_available: Option<bool>,
+    gpu_worker_ready: GpuConditionState,
+    video_worker_ready: GpuConditionState,
+    conditions: Vec<GpuCondition>,
+    diagnostic: Option<String>,
+}
+
+impl GpuStatus {
+    /// Construct the initial pending status.
+    pub fn new(video_sidecar: bool) -> Self {
+        let video_state = if video_sidecar {
+            GpuConditionState::Unknown
+        } else {
+            GpuConditionState::False
+        };
+        Self {
+            phase: GpuStatusPhase::Pending,
+            video_enabled: video_sidecar,
+            present: None,
+            render_node_available: None,
+            gpu_worker_ready: GpuConditionState::Unknown,
+            video_worker_ready: video_state,
+            conditions: Vec::new(),
+            diagnostic: None,
+        }
+    }
+
+    /// Return the current phase.
+    pub const fn phase(&self) -> GpuStatusPhase {
+        self.phase
+    }
+
+    /// Return the physical presence observation.
+    pub const fn present(&self) -> Option<bool> {
+        self.present
+    }
+
+    /// Return the render-node observation.
+    pub const fn render_node_available(&self) -> Option<bool> {
+        self.render_node_available
+    }
+
+    /// Return the GPU worker condition.
+    pub const fn gpu_worker_ready(&self) -> GpuConditionState {
+        self.gpu_worker_ready
+    }
+
+    /// Return the video worker condition.
+    pub const fn video_worker_ready(&self) -> GpuConditionState {
+        self.video_worker_ready
+    }
+
+    /// Borrow bounded conditions.
+    pub fn conditions(&self) -> &[GpuCondition] {
+        &self.conditions
+    }
+
+    /// Borrow the bounded diagnostic, if present.
+    pub fn diagnostic(&self) -> Option<&str> {
+        self.diagnostic.as_deref()
+    }
+
+    /// Apply a physical probe observation.
+    pub fn observe_device(&mut self, present: bool, render_node_available: bool) {
+        self.present = Some(present);
+        self.render_node_available = Some(render_node_available);
+        self.set_condition(
+            GpuConditionType::DevicePresent,
+            if present {
+                GpuConditionState::True
+            } else {
+                GpuConditionState::False
+            },
+        );
+        if !present {
+            self.phase = GpuStatusPhase::Degraded;
+        }
+    }
+
+    /// Set the Host-global claim condition.
+    pub fn set_claimed(&mut self, claimed: bool) {
+        self.set_condition(
+            GpuConditionType::DeviceClaimed,
+            if claimed {
+                GpuConditionState::True
+            } else {
+                GpuConditionState::False
+            },
+        );
+    }
+
+    /// Set GPU worker readiness.
+    pub fn set_gpu_worker(&mut self, state: GpuConditionState) {
+        self.gpu_worker_ready = state;
+        self.set_condition(GpuConditionType::GpuWorkerReady, state);
+        self.refresh_phase();
+    }
+
+    /// Set video worker readiness.
+    pub fn set_video_worker(&mut self, state: GpuConditionState) {
+        self.video_worker_ready = state;
+        self.set_condition(GpuConditionType::VideoWorkerReady, state);
+        self.refresh_phase();
+    }
+
+    /// Mark restart identity as quarantined.
+    pub fn quarantine(&mut self) {
+        self.phase = GpuStatusPhase::Quarantined;
+        self.set_condition(GpuConditionType::IdentityTrusted, GpuConditionState::False);
+    }
+
+    /// Set a bounded, path-free diagnostic.
+    pub fn set_diagnostic(&mut self, value: impl Into<String>) -> Result<(), GpuStatusError> {
+        let value = value.into();
+        if value.len() > 4 * 1024
+            || value.contains('\0')
+            || value.contains("/dev/")
+            || value.contains("/run/")
+            || value.contains("socket")
+        {
+            return Err(GpuStatusError::DiagnosticRejected);
+        }
+        self.diagnostic = Some(value);
+        Ok(())
+    }
+
+    fn set_condition(&mut self, kind: GpuConditionType, state: GpuConditionState) {
+        if let Some(condition) = self
+            .conditions
+            .iter_mut()
+            .find(|condition| condition.kind == kind)
+        {
+            condition.state = state;
+        } else {
+            self.conditions.push(GpuCondition { kind, state });
+        }
+    }
+
+    fn refresh_phase(&mut self) {
+        if self.present == Some(false) {
+            self.phase = GpuStatusPhase::Degraded;
+        } else if self.gpu_worker_ready == GpuConditionState::True
+            && (!self.video_enabled || self.video_worker_ready == GpuConditionState::True)
+        {
+            self.phase = GpuStatusPhase::Ready;
+        } else if self.gpu_worker_ready == GpuConditionState::False
+            || self.video_worker_ready == GpuConditionState::False
+        {
+            self.phase = GpuStatusPhase::Degraded;
+        } else {
+            self.phase = GpuStatusPhase::Pending;
+        }
+    }
+}
+
+/// Status projection failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuStatusError {
+    /// Diagnostic text was not bounded or contained a forbidden host detail.
+    DiagnosticRejected,
+}
+
+impl fmt::Display for GpuStatusError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("gpu-status-diagnostic-rejected")
+    }
+}
+
+impl std::error::Error for GpuStatusError {}

--- a/packages/d2b-provider-device-gpu/src/telemetry.rs
+++ b/packages/d2b-provider-device-gpu/src/telemetry.rs
@@ -1,0 +1,107 @@
+//! Closed GPU telemetry labels.
+
+use crate::GpuEffectError;
+
+/// Closed GPU controller operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuOperation {
+    /// Reserve Host-global authority.
+    ReserveAuthority,
+    /// Probe the physical device.
+    Probe,
+    /// Start a GPU worker.
+    StartGpu,
+    /// Start a video worker.
+    StartVideo,
+    /// Adopt a worker after restart.
+    Adopt,
+    /// Close a worker.
+    Close,
+    /// Release Host-global authority.
+    ReleaseAuthority,
+}
+
+impl GpuOperation {
+    /// Return the stable operation label.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReserveAuthority => "reserve-authority",
+            Self::Probe => "probe",
+            Self::StartGpu => "start-gpu",
+            Self::StartVideo => "start-video",
+            Self::Adopt => "adopt",
+            Self::Close => "close",
+            Self::ReleaseAuthority => "release-authority",
+        }
+    }
+}
+
+/// Closed GPU operation outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuOutcome {
+    /// The operation converged.
+    Success,
+    /// The operation can be retried.
+    Retry,
+    /// The operation was refused fail closed.
+    Blocked,
+}
+
+impl GpuOutcome {
+    /// Return the stable outcome label.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Retry => "retry",
+            Self::Blocked => "blocked",
+        }
+    }
+}
+
+/// Bounded metric label projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpuMetricLabels {
+    /// Fixed Provider label.
+    pub provider: &'static str,
+    /// Fixed component label.
+    pub component: &'static str,
+    /// Closed operation label.
+    pub operation: &'static str,
+    /// Closed outcome label.
+    pub outcome: &'static str,
+    /// Stable error slug or `none`.
+    pub error: &'static str,
+    /// Closed realization mode.
+    pub mode: &'static str,
+    /// Closed video-sidecar state.
+    pub video_sidecar: &'static str,
+    /// Closed arbitration state.
+    pub arbitration: &'static str,
+}
+
+impl GpuMetricLabels {
+    /// Build labels without accepting resource, Zone, selector, or process
+    /// identity values.
+    pub const fn new(
+        operation: GpuOperation,
+        outcome: GpuOutcome,
+        error: Option<GpuEffectError>,
+        mode: &'static str,
+        video_sidecar: bool,
+        arbitration: &'static str,
+    ) -> Self {
+        Self {
+            provider: "device-gpu",
+            component: "device-controller",
+            operation: operation.as_str(),
+            outcome: outcome.as_str(),
+            error: match error {
+                Some(error) => error.code(),
+                None => "none",
+            },
+            mode,
+            video_sidecar: if video_sidecar { "enabled" } else { "disabled" },
+            arbitration,
+        }
+    }
+}

--- a/packages/d2b-provider-device-gpu/src/worker_gpu.rs
+++ b/packages/d2b-provider-device-gpu/src/worker_gpu.rs
@@ -1,0 +1,13 @@
+//! GPU and render-node Process construction.
+
+use d2b_contracts::v3::ResourceUid;
+
+use crate::{GpuProcessSelectionError, GpuSettings, GpuWorkerSpec};
+
+/// Build the signed full-GPU or render-node worker declaration.
+pub fn build_gpu_worker(
+    device_uid: &ResourceUid,
+    settings: &GpuSettings,
+) -> Result<GpuWorkerSpec, GpuProcessSelectionError> {
+    GpuWorkerSpec::gpu(device_uid, settings)
+}

--- a/packages/d2b-provider-device-gpu/src/worker_video.rs
+++ b/packages/d2b-provider-device-gpu/src/worker_video.rs
@@ -1,0 +1,13 @@
+//! Video decoder Process construction.
+
+use d2b_contracts::v3::ResourceUid;
+
+use crate::{GpuProcessSelectionError, GpuSettings, VideoWorkerSpec};
+
+/// Build the separate video worker declaration.
+pub fn build_video_worker(
+    device_uid: &ResourceUid,
+    settings: &GpuSettings,
+) -> Result<VideoWorkerSpec, GpuProcessSelectionError> {
+    VideoWorkerSpec::new(device_uid, settings)
+}

--- a/packages/d2b-provider-device-gpu/src/workers.rs
+++ b/packages/d2b-provider-device-gpu/src/workers.rs
@@ -1,0 +1,228 @@
+//! Signed semantic Process worker declarations.
+
+use core::fmt;
+
+use crate::{
+    GpuProcessRole, GpuProcessSelectionError, GpuSettings, process::GpuProcessDeclaration,
+};
+use d2b_contracts::v3::ResourceUid;
+
+/// Closed device grant classes used by GPU worker templates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GpuDeviceNode {
+    /// Shared KVM grant for a full GPU worker.
+    Kvm,
+    /// DRM render node grant.
+    Dri,
+    /// DMA buffer grant for full GPU workers.
+    Udmabuf,
+    /// NVIDIA control device.
+    NvidiaCtl,
+    /// NVIDIA device node.
+    NvidiaDevice,
+    /// NVIDIA UVM device.
+    NvidiaUvm,
+}
+
+impl GpuDeviceNode {
+    /// Return the signed semantic device token.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Kvm => "kvm",
+            Self::Dri => "dri",
+            Self::Udmabuf => "udmabuf",
+            Self::NvidiaCtl => "nvidia-ctl",
+            Self::NvidiaDevice => "nvidia-device",
+            Self::NvidiaUvm => "nvidia-uvm",
+        }
+    }
+}
+
+/// Signed semantic GPU worker specification.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GpuWorkerSpec {
+    process: GpuProcessDeclaration,
+    template: &'static str,
+    seccomp_class: &'static str,
+    namespaces: &'static [&'static str],
+    device_nodes: Vec<GpuDeviceNode>,
+    user_namespace: bool,
+    capabilities: &'static [&'static str],
+    state_mounts: &'static [&'static str],
+}
+
+impl GpuWorkerSpec {
+    /// Build the fixed GPU or render-node worker shape.
+    pub fn gpu(
+        device_uid: &ResourceUid,
+        settings: &GpuSettings,
+    ) -> Result<Self, GpuProcessSelectionError> {
+        let role = if settings.render_node_only {
+            GpuProcessRole::RenderNode
+        } else {
+            GpuProcessRole::FullGpu
+        };
+        let process = GpuProcessDeclaration::new(device_uid, role)?;
+        let (template, seccomp_class, namespaces, device_nodes) = match role {
+            GpuProcessRole::FullGpu => (
+                "gpu-worker",
+                "w1-gpu",
+                &["mount", "pid", "ipc", "uts", "cgroup", "user"][..],
+                vec![
+                    GpuDeviceNode::Kvm,
+                    GpuDeviceNode::Dri,
+                    GpuDeviceNode::Udmabuf,
+                ],
+            ),
+            GpuProcessRole::RenderNode => (
+                "render-node-worker",
+                "w1-gpu-render-node",
+                &["mount", "pid", "ipc", "uts", "cgroup", "user"][..],
+                vec![GpuDeviceNode::Dri],
+            ),
+            GpuProcessRole::Video => unreachable!("GPU settings select a GPU role"),
+        };
+        Ok(Self {
+            process,
+            template,
+            seccomp_class,
+            namespaces,
+            device_nodes,
+            user_namespace: true,
+            capabilities: &[],
+            state_mounts: &[],
+        })
+    }
+
+    /// Borrow the deterministic Process declaration.
+    pub const fn process(&self) -> &GpuProcessDeclaration {
+        &self.process
+    }
+
+    /// Return the signed component template.
+    pub const fn template(&self) -> &'static str {
+        self.template
+    }
+
+    /// Return the signed seccomp class.
+    pub const fn seccomp_class(&self) -> &'static str {
+        self.seccomp_class
+    }
+
+    /// Return the semantic namespace classes.
+    pub const fn namespaces(&self) -> &'static [&'static str] {
+        self.namespaces
+    }
+
+    /// Borrow the closed device allowlist.
+    pub fn device_nodes(&self) -> &[GpuDeviceNode] {
+        &self.device_nodes
+    }
+
+    /// Whether Core must resolve the process-principal user namespace.
+    pub const fn user_namespace(&self) -> bool {
+        self.user_namespace
+    }
+
+    /// Borrow the host capability allowlist, which is intentionally empty.
+    pub const fn capabilities(&self) -> &'static [&'static str] {
+        self.capabilities
+    }
+
+    /// Borrow declared state mounts, which are intentionally empty.
+    pub const fn state_mounts(&self) -> &'static [&'static str] {
+        self.state_mounts
+    }
+}
+
+impl fmt::Debug for GpuWorkerSpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GpuWorkerSpec")
+            .field("process", &self.process)
+            .field("template", &self.template)
+            .field("seccomp_class", &self.seccomp_class)
+            .field("device_node_count", &self.device_nodes.len())
+            .field("user_namespace", &self.user_namespace)
+            .finish()
+    }
+}
+
+/// Signed semantic video worker specification.
+#[derive(Clone, PartialEq, Eq)]
+pub struct VideoWorkerSpec {
+    process: GpuProcessDeclaration,
+    device_nodes: Vec<GpuDeviceNode>,
+}
+
+impl VideoWorkerSpec {
+    /// Build the separate video worker shape.
+    pub fn new(
+        device_uid: &ResourceUid,
+        settings: &GpuSettings,
+    ) -> Result<Self, GpuProcessSelectionError> {
+        let process = GpuProcessDeclaration::new(device_uid, GpuProcessRole::Video)?;
+        let mut device_nodes = vec![GpuDeviceNode::Dri];
+        if settings.video_nvidia_decode {
+            device_nodes.extend([
+                GpuDeviceNode::NvidiaCtl,
+                GpuDeviceNode::NvidiaDevice,
+                GpuDeviceNode::NvidiaUvm,
+            ]);
+        }
+        Ok(Self {
+            process,
+            device_nodes,
+        })
+    }
+
+    /// Borrow the deterministic Process declaration.
+    pub const fn process(&self) -> &GpuProcessDeclaration {
+        &self.process
+    }
+
+    /// Return the signed component template.
+    pub const fn template(&self) -> &'static str {
+        "video-worker"
+    }
+
+    /// Return the signed seccomp class.
+    pub const fn seccomp_class(&self) -> &'static str {
+        "w1-video"
+    }
+
+    /// Return the semantic namespace classes.
+    pub const fn namespaces(&self) -> &'static [&'static str] {
+        &["mount", "pid", "ipc", "uts", "cgroup"]
+    }
+
+    /// Borrow the video device allowlist.
+    pub fn device_nodes(&self) -> &[GpuDeviceNode] {
+        &self.device_nodes
+    }
+
+    /// Video never requests a user namespace.
+    pub const fn user_namespace(&self) -> bool {
+        false
+    }
+
+    /// Video has no host capabilities.
+    pub const fn capabilities(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    /// Video has no Provider state mount.
+    pub const fn state_mounts(&self) -> &'static [&'static str] {
+        &[]
+    }
+}
+
+impl fmt::Debug for VideoWorkerSpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VideoWorkerSpec")
+            .field("process", &self.process)
+            .field("device_node_count", &self.device_nodes.len())
+            .finish()
+    }
+}

--- a/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
+++ b/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
@@ -449,7 +449,7 @@ fn lifecycle_reserves_before_effects_and_closes_video_before_gpu() {
 }
 
 #[test]
-fn lifecycle_rejects_worker_identity_from_the_wrong_principal() {
+fn lifecycle_rejects_worker_identity_and_finalizes_owned_process() {
     let admission = admission(DeviceArbitration::Exclusive, false, 1);
     let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([1; 32])]).unwrap();
     let mut controller =
@@ -469,6 +469,24 @@ fn lifecycle_rejects_worker_identity_from_the_wrong_principal() {
         controller.phase(),
         d2b_provider_device_gpu::GpuPhase::Failed
     );
+    assert!(controller.gpu_identity().is_some());
+    assert_eq!(
+        controller.reconcile_lifecycle(&mut port),
+        Err(d2b_provider_device_gpu::GpuControllerError::InvalidState)
+    );
+    assert_eq!(port.events, ["reserve", "open", "gpu"]);
+
+    controller.finalize_lifecycle(&mut port).unwrap();
+    assert_eq!(
+        port.events,
+        ["reserve", "open", "gpu", "stop-gpu", "release"]
+    );
+    assert_eq!(
+        controller.phase(),
+        d2b_provider_device_gpu::GpuPhase::Finalized
+    );
+    assert!(!controller.finalizer_installed());
+    assert!(!controller.authority_reserved());
 }
 
 #[test]

--- a/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
+++ b/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
@@ -54,6 +54,24 @@ fn admission_with_backing(backing: [u8; 32], generation: u64) -> GpuAuthorityAdm
     .unwrap()
 }
 
+fn recovered_authority() -> (GpuAuthorityAdmission, GpuProcessIdentity, GpuAuthorityIndex) {
+    let current = admission(DeviceArbitration::Exclusive, false, 1);
+    let process = GpuProcessIdentity::from_core(
+        [2; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let record = GpuRecoveryRecord::from_core(
+        current.clone(),
+        process.clone(),
+        GpuAuthorityLease::from_core([3; 16]),
+    );
+    let index = GpuAuthorityIndex::rehydrate(GpuRecoverySnapshot::from_core(vec![record])).unwrap();
+    (current, process, index)
+}
+
 #[test]
 fn conflicting_full_device_claim_is_rejected_before_effects() {
     let first = admission(DeviceArbitration::Exclusive, false, 1);
@@ -199,21 +217,7 @@ fn same_owner_rehydration_rejects_conflicting_gpu_video_admission() {
 
 #[test]
 fn restart_adopts_one_matching_worker_and_quarantines_ambiguity() {
-    let current = admission(DeviceArbitration::Exclusive, false, 1);
-    let process = GpuProcessIdentity::from_core(
-        [2; 16],
-        GpuProcessRole::FullGpu,
-        GpuPrincipalToken::from_core([9; 32]),
-        GpuPlatformToken::from_core([8; 32]),
-        ResourceGeneration::new(1).unwrap(),
-    );
-    let record = GpuRecoveryRecord::from_core(
-        current.clone(),
-        process.clone(),
-        GpuAuthorityLease::from_core([3; 16]),
-    );
-    let mut index =
-        GpuAuthorityIndex::rehydrate(GpuRecoverySnapshot::from_core(vec![record])).unwrap();
+    let (current, process, mut index) = recovered_authority();
     assert!(matches!(
         index.adopt(
             &current,
@@ -232,6 +236,52 @@ fn restart_adopts_one_matching_worker_and_quarantines_ambiguity() {
         Ok(d2b_provider_device_gpu::GpuAdoption::Quarantined)
     ));
     assert!(index.is_quarantined(current.backing()));
+}
+
+#[test]
+fn ambiguous_restart_observation_quarantines_backing() {
+    let (current, _, mut index) = recovered_authority();
+
+    assert!(matches!(
+        index.adopt(&current, &[GpuProcessObservation::Ambiguous]),
+        Ok(d2b_provider_device_gpu::GpuAdoption::Quarantined)
+    ));
+    assert!(index.is_quarantined(current.backing()));
+    assert_eq!(index.holder_count(current.backing()), 1);
+}
+
+#[test]
+fn matching_observation_cannot_escape_ambiguous_adoption() {
+    let (current, process, mut index) = recovered_authority();
+
+    assert!(matches!(
+        index.adopt(
+            &current,
+            &[
+                GpuProcessObservation::Matching(process),
+                GpuProcessObservation::Ambiguous
+            ]
+        ),
+        Ok(d2b_provider_device_gpu::GpuAdoption::Quarantined)
+    ));
+    assert!(index.is_quarantined(current.backing()));
+    assert_eq!(index.holder_count(current.backing()), 1);
+}
+
+#[test]
+fn quarantined_restart_adoption_rejects_later_matching_worker() {
+    let (current, process, mut index) = recovered_authority();
+    assert!(matches!(
+        index.adopt(&current, &[GpuProcessObservation::Ambiguous]),
+        Ok(d2b_provider_device_gpu::GpuAdoption::Quarantined)
+    ));
+
+    assert!(matches!(
+        index.adopt(&current, &[GpuProcessObservation::Matching(process)]),
+        Ok(d2b_provider_device_gpu::GpuAdoption::Quarantined)
+    ));
+    assert_eq!(index.holder_count(current.backing()), 1);
+    assert_eq!(index.reserve(current), Err(GpuAuthorityError::Quarantined));
 }
 
 #[test]

--- a/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
+++ b/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
@@ -105,11 +105,11 @@ fn restart_adopts_one_matching_worker_and_quarantines_ambiguity() {
         GpuPlatformToken::from_core([8; 32]),
         ResourceGeneration::new(1).unwrap(),
     );
-    let record = GpuRecoveryRecord {
-        admission: current.clone(),
-        process: process.clone(),
-        lease: GpuAuthorityLease::from_core([3; 16]),
-    };
+    let record = GpuRecoveryRecord::from_core(
+        current.clone(),
+        process.clone(),
+        GpuAuthorityLease::from_core([3; 16]),
+    );
     let mut index =
         GpuAuthorityIndex::rehydrate(GpuRecoverySnapshot::from_core(vec![record])).unwrap();
     assert!(matches!(
@@ -130,6 +130,46 @@ fn restart_adopts_one_matching_worker_and_quarantines_ambiguity() {
         Ok(d2b_provider_device_gpu::GpuAdoption::Quarantined)
     ));
     assert!(index.is_quarantined(current.backing()));
+}
+
+#[test]
+fn video_sidecar_recovery_keeps_one_host_authority() {
+    let current = admission(DeviceArbitration::Exclusive, false, 1)
+        .with_video_principal(GpuPrincipalToken::from_core([10; 32]))
+        .unwrap();
+    let gpu = GpuProcessIdentity::from_core(
+        [2; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let video = GpuProcessIdentity::from_core(
+        [3; 16],
+        GpuProcessRole::Video,
+        GpuPrincipalToken::from_core([10; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let record = GpuRecoveryRecord::from_core(
+        current.clone(),
+        gpu.clone(),
+        GpuAuthorityLease::from_core([3; 16]),
+    )
+    .with_process(video.clone());
+    let mut index =
+        GpuAuthorityIndex::rehydrate(GpuRecoverySnapshot::from_core(vec![record])).unwrap();
+    assert!(matches!(
+        index.adopt(
+            &current,
+            &[
+                GpuProcessObservation::Matching(gpu),
+                GpuProcessObservation::Matching(video)
+            ]
+        ),
+        Ok(d2b_provider_device_gpu::GpuAdoption::Adopted(_))
+    ));
+    assert!(!index.is_quarantined(current.backing()));
 }
 
 #[test]

--- a/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
+++ b/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
@@ -40,6 +40,20 @@ fn admission(
     .unwrap()
 }
 
+fn admission_with_backing(backing: [u8; 32], generation: u64) -> GpuAuthorityAdmission {
+    let base = admission(DeviceArbitration::Exclusive, false, generation);
+    GpuAuthorityAdmission::new(
+        base.owner().clone(),
+        GpuBackingToken::from_core(backing),
+        base.platform().clone(),
+        base.arbitration(),
+        base.max_holders(),
+        base.render_node_only(),
+        base.gpu_principal().clone(),
+    )
+    .unwrap()
+}
+
 #[test]
 fn conflicting_full_device_claim_is_rejected_before_effects() {
     let first = admission(DeviceArbitration::Exclusive, false, 1);
@@ -53,8 +67,52 @@ fn conflicting_full_device_claim_is_rejected_before_effects() {
 }
 
 #[test]
+fn leases_are_unique_across_shared_authority_backings() {
+    let first = admission_with_backing([1; 32], 1);
+    let second = admission_with_backing([2; 32], 2);
+    let mut index = GpuAuthorityIndex::new_for_tests_ready();
+
+    let first_lease = index.reserve(first).unwrap();
+    let second_lease = index.reserve(second).unwrap();
+
+    assert_ne!(first_lease, second_lease);
+}
+
+#[test]
+fn duplicate_persisted_leases_quarantine_the_shared_backing() {
+    let first = admission(DeviceArbitration::Exclusive, false, 1);
+    let second = admission(DeviceArbitration::Exclusive, false, 2);
+    let process_one = GpuProcessIdentity::from_core(
+        [1; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let process_two = GpuProcessIdentity::from_core(
+        [2; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(2).unwrap(),
+    );
+    let backing = first.backing().clone();
+    let duplicate_lease = GpuAuthorityLease::from_core([3; 16]);
+    let snapshot = GpuRecoverySnapshot::from_core(vec![
+        GpuRecoveryRecord::from_core(first, process_one, duplicate_lease.clone()),
+        GpuRecoveryRecord::from_core(second, process_two, duplicate_lease),
+    ]);
+
+    let index = GpuAuthorityIndex::rehydrate(snapshot).unwrap();
+    assert!(index.is_quarantined(&backing));
+    assert_eq!(index.holder_count(&backing), 0);
+}
+
+#[test]
 fn wrong_principal_platform_and_generation_fail_before_process_binding() {
-    let current = admission(DeviceArbitration::Exclusive, false, 4);
+    let current = admission(DeviceArbitration::Exclusive, false, 4)
+        .with_video_principal(GpuPrincipalToken::from_core([10; 32]))
+        .unwrap();
     let mut index = GpuAuthorityIndex::new_for_tests_ready();
     let lease = index.reserve(current.clone()).unwrap();
 
@@ -67,6 +125,18 @@ fn wrong_principal_platform_and_generation_fail_before_process_binding() {
     );
     assert_eq!(
         index.bind_process(&lease, wrong_principal),
+        Err(GpuAuthorityError::ProcessPrincipalMismatch)
+    );
+
+    let video_using_gpu_principal = GpuProcessIdentity::from_core(
+        [1; 16],
+        GpuProcessRole::Video,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(4).unwrap(),
+    );
+    assert_eq!(
+        index.bind_process(&lease, video_using_gpu_principal),
         Err(GpuAuthorityError::ProcessPrincipalMismatch)
     );
 
@@ -93,6 +163,38 @@ fn wrong_principal_platform_and_generation_fail_before_process_binding() {
         index.bind_process(&lease, stale_generation),
         Err(GpuAuthorityError::GenerationMismatch)
     );
+}
+
+#[test]
+fn same_owner_rehydration_rejects_conflicting_gpu_video_admission() {
+    let current = admission(DeviceArbitration::Exclusive, false, 1)
+        .with_video_principal(GpuPrincipalToken::from_core([10; 32]))
+        .unwrap();
+    let conflicting = admission(DeviceArbitration::Exclusive, false, 1)
+        .with_video_principal(GpuPrincipalToken::from_core([11; 32]))
+        .unwrap();
+    let gpu = GpuProcessIdentity::from_core(
+        [2; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let video = GpuProcessIdentity::from_core(
+        [3; 16],
+        GpuProcessRole::Video,
+        GpuPrincipalToken::from_core([11; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let backing = current.backing().clone();
+    let records = vec![
+        GpuRecoveryRecord::from_core(current, gpu, GpuAuthorityLease::from_core([3; 16])),
+        GpuRecoveryRecord::from_core(conflicting, video, GpuAuthorityLease::from_core([3; 16])),
+    ];
+
+    let index = GpuAuthorityIndex::rehydrate(GpuRecoverySnapshot::from_core(records)).unwrap();
+    assert!(index.is_quarantined(&backing));
 }
 
 #[test]
@@ -207,6 +309,8 @@ fn cleanup_requires_the_owned_process_closure_proof() {
 struct LifecyclePort {
     events: Vec<&'static str>,
     next: u8,
+    wrong_gpu_principal: bool,
+    wrong_closure: bool,
 }
 
 impl GpuLifecycleEffectPort for LifecyclePort {
@@ -237,10 +341,15 @@ impl GpuLifecycleEffectPort for LifecyclePort {
     ) -> Result<GpuProcessIdentity, GpuEffectError> {
         self.events.push("gpu");
         self.next = self.next.saturating_add(1);
+        let principal = if self.wrong_gpu_principal {
+            GpuPrincipalToken::from_core([11; 32])
+        } else {
+            principal.clone()
+        };
         Ok(GpuProcessIdentity::from_core(
             [self.next; 16],
             spec.process().role(),
-            principal.clone(),
+            principal,
             platform.clone(),
             generation,
         ))
@@ -280,7 +389,17 @@ impl GpuLifecycleEffectPort for LifecyclePort {
             GpuProcessRole::Video => "stop-video",
             _ => "stop-gpu",
         });
-        Ok(GpuClosureProof::from_core(identity.clone()))
+        if self.wrong_closure {
+            Ok(GpuClosureProof::from_core(GpuProcessIdentity::from_core(
+                [99; 16],
+                identity.role(),
+                identity.principal().clone(),
+                identity.platform().clone(),
+                identity.generation(),
+            )))
+        } else {
+            Ok(GpuClosureProof::from_core(identity.clone()))
+        }
     }
 
     fn release_authority(
@@ -326,5 +445,74 @@ fn lifecycle_reserves_before_effects_and_closes_video_before_gpu() {
             "stop-gpu",
             "release"
         ]
+    );
+}
+
+#[test]
+fn lifecycle_rejects_worker_identity_from_the_wrong_principal() {
+    let admission = admission(DeviceArbitration::Exclusive, false, 1);
+    let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([1; 32])]).unwrap();
+    let mut controller =
+        GpuController::new_authorized(admission, GpuSettings::default(), tokens).unwrap();
+    let mut port = LifecyclePort {
+        wrong_gpu_principal: true,
+        ..LifecyclePort::default()
+    };
+
+    assert_eq!(
+        controller.reconcile_lifecycle(&mut port),
+        Err(d2b_provider_device_gpu::GpuControllerError::Effect(
+            GpuEffectError::WrongPrincipal
+        ))
+    );
+    assert_eq!(
+        controller.phase(),
+        d2b_provider_device_gpu::GpuPhase::Failed
+    );
+}
+
+#[test]
+fn lifecycle_rejects_video_without_a_separate_principal_before_effects() {
+    let admission = admission(DeviceArbitration::Exclusive, false, 1);
+    let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([1; 32])]).unwrap();
+    let mut controller = GpuController::new_authorized(
+        admission,
+        GpuSettings {
+            video_sidecar: true,
+            ..GpuSettings::default()
+        },
+        tokens,
+    )
+    .unwrap();
+    let mut port = LifecyclePort::default();
+
+    assert_eq!(
+        controller.reconcile_lifecycle(&mut port),
+        Err(d2b_provider_device_gpu::GpuControllerError::Authority(
+            GpuAuthorityError::PrincipalNotSeparated
+        ))
+    );
+    assert!(port.events.is_empty());
+}
+
+#[test]
+fn lifecycle_rejects_a_closure_proof_for_another_process() {
+    let admission = admission(DeviceArbitration::Exclusive, false, 1);
+    let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([1; 32])]).unwrap();
+    let mut controller =
+        GpuController::new_authorized(admission, GpuSettings::default(), tokens).unwrap();
+    let mut port = LifecyclePort::default();
+    controller.reconcile_lifecycle(&mut port).unwrap();
+    port.wrong_closure = true;
+
+    assert_eq!(
+        controller.finalize_lifecycle(&mut port),
+        Err(d2b_provider_device_gpu::GpuControllerError::Effect(
+            GpuEffectError::CloseUnconfirmed
+        ))
+    );
+    assert_eq!(
+        controller.phase(),
+        d2b_provider_device_gpu::GpuPhase::Failed
     );
 }

--- a/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
+++ b/packages/d2b-provider-device-gpu/tests/authority_lifecycle.rs
@@ -1,0 +1,290 @@
+use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid, device::DeviceArbitration};
+use d2b_provider_device_gpu::{
+    GpuAuthorityAdmission, GpuAuthorityError, GpuAuthorityIndex, GpuAuthorityLease,
+    GpuBackingToken, GpuClosureProof, GpuController, GpuEffectError, GpuEffectToken,
+    GpuEffectTokenSet, GpuLifecycleEffectPort, GpuOwnerProof, GpuPlatformToken, GpuPrincipalToken,
+    GpuProcessIdentity, GpuProcessObservation, GpuProcessRole, GpuReconcileOutcome,
+    GpuRecoveryRecord, GpuRecoverySnapshot, GpuSettings, GpuWorkerSpec, VideoWorkerSpec,
+};
+
+fn uid(value: &str) -> ResourceUid {
+    ResourceUid::parse(value).unwrap()
+}
+
+fn admission(
+    arbitration: DeviceArbitration,
+    render_node_only: bool,
+    generation: u64,
+) -> GpuAuthorityAdmission {
+    let owner = GpuOwnerProof::new(
+        ResourceRef::parse("Zone/dev").unwrap(),
+        ResourceRef::parse("Guest/workload").unwrap(),
+        uid("123e4567-e89b-42d3-a456-426614174000"),
+        uid("223e4567-e89b-42d3-a456-426614174001"),
+        ResourceGeneration::new(generation).unwrap(),
+    )
+    .unwrap();
+    GpuAuthorityAdmission::new(
+        owner,
+        GpuBackingToken::from_core([7; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        arbitration,
+        if arbitration == DeviceArbitration::Shared {
+            2
+        } else {
+            1
+        },
+        render_node_only,
+        GpuPrincipalToken::from_core([9; 32]),
+    )
+    .unwrap()
+}
+
+#[test]
+fn conflicting_full_device_claim_is_rejected_before_effects() {
+    let first = admission(DeviceArbitration::Exclusive, false, 1);
+    let second = admission(DeviceArbitration::Exclusive, false, 2);
+    let mut index = GpuAuthorityIndex::new_for_tests_ready();
+    index.reserve(first).unwrap();
+    assert_eq!(
+        index.reserve(second).unwrap_err(),
+        GpuAuthorityError::ClaimConflict
+    );
+}
+
+#[test]
+fn wrong_principal_platform_and_generation_fail_before_process_binding() {
+    let current = admission(DeviceArbitration::Exclusive, false, 4);
+    let mut index = GpuAuthorityIndex::new_for_tests_ready();
+    let lease = index.reserve(current.clone()).unwrap();
+
+    let wrong_principal = GpuProcessIdentity::from_core(
+        [1; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([4; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(4).unwrap(),
+    );
+    assert_eq!(
+        index.bind_process(&lease, wrong_principal),
+        Err(GpuAuthorityError::ProcessPrincipalMismatch)
+    );
+
+    let wrong_platform = GpuProcessIdentity::from_core(
+        [1; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([5; 32]),
+        ResourceGeneration::new(4).unwrap(),
+    );
+    assert_eq!(
+        index.bind_process(&lease, wrong_platform),
+        Err(GpuAuthorityError::PlatformMismatch)
+    );
+
+    let stale_generation = GpuProcessIdentity::from_core(
+        [1; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(3).unwrap(),
+    );
+    assert_eq!(
+        index.bind_process(&lease, stale_generation),
+        Err(GpuAuthorityError::GenerationMismatch)
+    );
+}
+
+#[test]
+fn restart_adopts_one_matching_worker_and_quarantines_ambiguity() {
+    let current = admission(DeviceArbitration::Exclusive, false, 1);
+    let process = GpuProcessIdentity::from_core(
+        [2; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let record = GpuRecoveryRecord {
+        admission: current.clone(),
+        process: process.clone(),
+        lease: GpuAuthorityLease::from_core([3; 16]),
+    };
+    let mut index =
+        GpuAuthorityIndex::rehydrate(GpuRecoverySnapshot::from_core(vec![record])).unwrap();
+    assert!(matches!(
+        index.adopt(
+            &current,
+            &[GpuProcessObservation::Matching(process.clone())]
+        ),
+        Ok(d2b_provider_device_gpu::GpuAdoption::Adopted(_))
+    ));
+    assert!(matches!(
+        index.adopt(
+            &current,
+            &[
+                GpuProcessObservation::Matching(process.clone()),
+                GpuProcessObservation::Matching(process)
+            ]
+        ),
+        Ok(d2b_provider_device_gpu::GpuAdoption::Quarantined)
+    ));
+    assert!(index.is_quarantined(current.backing()));
+}
+
+#[test]
+fn cleanup_requires_the_owned_process_closure_proof() {
+    let current = admission(DeviceArbitration::Exclusive, false, 1);
+    let process = GpuProcessIdentity::from_core(
+        [2; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let mut index = GpuAuthorityIndex::new_for_tests_ready();
+    let lease = index.reserve(current.clone()).unwrap();
+    index.bind_process(&lease, process.clone()).unwrap();
+    let foreign = GpuProcessIdentity::from_core(
+        [4; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    assert_eq!(
+        index.release_after_close(&lease, &GpuClosureProof::from_core(foreign)),
+        Err(GpuAuthorityError::CloseUnconfirmed)
+    );
+    assert_eq!(index.holder_count(current.backing()), 1);
+    index
+        .release_after_close(&lease, &GpuClosureProof::from_core(process))
+        .unwrap();
+    assert_eq!(index.holder_count(current.backing()), 0);
+}
+
+#[derive(Default)]
+struct LifecyclePort {
+    events: Vec<&'static str>,
+    next: u8,
+}
+
+impl GpuLifecycleEffectPort for LifecyclePort {
+    fn reserve_authority(
+        &mut self,
+        _: &GpuAuthorityAdmission,
+    ) -> Result<GpuAuthorityLease, GpuEffectError> {
+        self.events.push("reserve");
+        Ok(GpuAuthorityLease::from_core([1; 16]))
+    }
+
+    fn open_authorized_devices(
+        &mut self,
+        _: &GpuAuthorityAdmission,
+        _: &GpuEffectTokenSet,
+    ) -> Result<d2b_provider_device_gpu::GpuLaunchTicket, GpuEffectError> {
+        self.events.push("open");
+        Ok(d2b_provider_device_gpu::GpuLaunchTicket::from_core([2; 16]))
+    }
+
+    fn start_gpu_worker(
+        &mut self,
+        spec: &GpuWorkerSpec,
+        _: &d2b_provider_device_gpu::GpuLaunchTicket,
+        principal: &GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError> {
+        self.events.push("gpu");
+        self.next = self.next.saturating_add(1);
+        Ok(GpuProcessIdentity::from_core(
+            [self.next; 16],
+            spec.process().role(),
+            principal.clone(),
+            platform.clone(),
+            generation,
+        ))
+    }
+
+    fn start_video_worker(
+        &mut self,
+        _: &VideoWorkerSpec,
+        _: &d2b_provider_device_gpu::GpuLaunchTicket,
+        principal: &GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError> {
+        self.events.push("video");
+        self.next = self.next.saturating_add(1);
+        Ok(GpuProcessIdentity::from_core(
+            [self.next; 16],
+            GpuProcessRole::Video,
+            principal.clone(),
+            platform.clone(),
+            generation,
+        ))
+    }
+
+    fn observe_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuProcessObservation, GpuEffectError> {
+        Ok(GpuProcessObservation::Matching(identity.clone()))
+    }
+
+    fn stop_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuClosureProof, GpuEffectError> {
+        self.events.push(match identity.role() {
+            GpuProcessRole::Video => "stop-video",
+            _ => "stop-gpu",
+        });
+        Ok(GpuClosureProof::from_core(identity.clone()))
+    }
+
+    fn release_authority(
+        &mut self,
+        _: GpuAuthorityLease,
+        _: &[GpuClosureProof],
+    ) -> Result<(), GpuEffectError> {
+        self.events.push("release");
+        Ok(())
+    }
+}
+
+#[test]
+fn lifecycle_reserves_before_effects_and_closes_video_before_gpu() {
+    let admission = admission(DeviceArbitration::Exclusive, false, 1)
+        .with_video_principal(GpuPrincipalToken::from_core([10; 32]))
+        .unwrap();
+    let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([1; 32])]).unwrap();
+    let mut controller = GpuController::new_authorized(
+        admission,
+        GpuSettings {
+            video_sidecar: true,
+            ..GpuSettings::default()
+        },
+        tokens,
+    )
+    .unwrap();
+    let mut port = LifecyclePort::default();
+    assert_eq!(
+        controller.reconcile_lifecycle(&mut port).unwrap(),
+        GpuReconcileOutcome::Converged
+    );
+    assert_eq!(port.events, ["reserve", "open", "gpu", "video"]);
+    controller.finalize_lifecycle(&mut port).unwrap();
+    assert_eq!(
+        port.events,
+        [
+            "reserve",
+            "open",
+            "gpu",
+            "video",
+            "stop-video",
+            "stop-gpu",
+            "release"
+        ]
+    );
+}

--- a/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
+++ b/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
@@ -11,6 +11,7 @@ struct FakePort {
     starts: Vec<GpuProcessRole>,
     next: u8,
     missing_roles: Vec<GpuProcessRole>,
+    mismatched_observation: bool,
 }
 
 impl GpuLifecycleEffectPort for FakePort {
@@ -73,6 +74,16 @@ impl GpuLifecycleEffectPort for FakePort {
     ) -> Result<GpuProcessObservation, GpuEffectError> {
         if self.missing_roles.contains(&identity.role()) {
             Ok(GpuProcessObservation::Missing)
+        } else if self.mismatched_observation {
+            Ok(GpuProcessObservation::Matching(
+                GpuProcessIdentity::from_core(
+                    [99; 16],
+                    identity.role(),
+                    identity.principal().clone(),
+                    identity.platform().clone(),
+                    identity.generation(),
+                ),
+            ))
         } else {
             Ok(GpuProcessObservation::Matching(identity.clone()))
         }
@@ -205,4 +216,54 @@ fn partial_restart_adoption_restarts_only_the_missing_video_worker() {
         GpuReconcileOutcome::Converged
     );
     assert_eq!(port.starts, [GpuProcessRole::Video]);
+}
+
+#[test]
+fn mismatched_matching_observation_is_quarantined() {
+    let uid = ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap();
+    let owner = GpuOwnerProof::new(
+        ResourceRef::parse("Zone/dev").unwrap(),
+        ResourceRef::parse("Guest/workload").unwrap(),
+        uid,
+        ResourceUid::parse("223e4567-e89b-42d3-a456-426614174001").unwrap(),
+        ResourceGeneration::new(1).unwrap(),
+    )
+    .unwrap();
+    let admission = GpuAuthorityAdmission::new(
+        owner,
+        GpuBackingToken::from_core([7; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        DeviceArbitration::Exclusive,
+        1,
+        false,
+        GpuPrincipalToken::from_core([9; 32]),
+    )
+    .unwrap();
+    let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([2; 32])]).unwrap();
+    let mut controller =
+        GpuController::new_authorized(admission, GpuSettings::default(), tokens).unwrap();
+    let expected = GpuProcessIdentity::from_core(
+        [3; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let mut port = FakePort {
+        mismatched_observation: true,
+        ..FakePort::default()
+    };
+
+    assert_eq!(
+        controller.adopt_lifecycle(
+            GpuAuthorityLease::from_core([1; 16]),
+            &[expected],
+            &mut port,
+        ),
+        Err(d2b_provider_device_gpu::GpuControllerError::Quarantined)
+    );
+    assert_eq!(
+        controller.phase(),
+        d2b_provider_device_gpu::GpuPhase::Quarantined
+    );
 }

--- a/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
+++ b/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
@@ -260,12 +260,26 @@ fn stale_identity_adoption_is_terminal_and_does_not_respawn() {
     assert_eq!(
         controller.adopt_lifecycle(
             GpuAuthorityLease::from_core([1; 16]),
-            &[expected],
+            &[expected.clone()],
             &mut port,
         ),
         Err(d2b_provider_device_gpu::GpuControllerError::Effect(
             GpuEffectError::StaleDeviceIdentity
         ))
+    );
+    assert_eq!(
+        controller.phase(),
+        d2b_provider_device_gpu::GpuPhase::Failed
+    );
+    port.stale_roles.clear();
+    port.missing_roles.push(GpuProcessRole::FullGpu);
+    assert_eq!(
+        controller.adopt_lifecycle(
+            GpuAuthorityLease::from_core([1; 16]),
+            &[expected.clone()],
+            &mut port,
+        ),
+        Err(d2b_provider_device_gpu::GpuControllerError::InvalidState)
     );
     assert_eq!(
         controller.phase(),
@@ -317,10 +331,24 @@ fn mismatched_matching_observation_is_quarantined() {
     assert_eq!(
         controller.adopt_lifecycle(
             GpuAuthorityLease::from_core([1; 16]),
-            &[expected],
+            &[expected.clone()],
             &mut port,
         ),
         Err(d2b_provider_device_gpu::GpuControllerError::Quarantined)
+    );
+    assert_eq!(
+        controller.phase(),
+        d2b_provider_device_gpu::GpuPhase::Quarantined
+    );
+    port.mismatched_observation = false;
+    port.missing_roles.push(GpuProcessRole::FullGpu);
+    assert_eq!(
+        controller.adopt_lifecycle(
+            GpuAuthorityLease::from_core([1; 16]),
+            &[expected],
+            &mut port,
+        ),
+        Err(d2b_provider_device_gpu::GpuControllerError::InvalidState)
     );
     assert_eq!(
         controller.phase(),

--- a/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
+++ b/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
@@ -1,31 +1,90 @@
-use d2b_contracts::v3::{ResourceUid, device::DeviceArbitration};
+use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid, device::DeviceArbitration};
 use d2b_provider_device_gpu::{
-    GpuController, GpuEffectError, GpuEffectPort, GpuEffectToken, GpuEffectTokenSet,
-    GpuLaunchTicket, GpuPhase, GpuProcessRole, GpuReconcileOutcome, GpuSettings,
+    GpuAuthorityAdmission, GpuAuthorityLease, GpuBackingToken, GpuClosureProof, GpuController,
+    GpuEffectError, GpuEffectToken, GpuEffectTokenSet, GpuLaunchTicket, GpuLifecycleEffectPort,
+    GpuOwnerProof, GpuPlatformToken, GpuPrincipalToken, GpuProcessIdentity, GpuProcessObservation,
+    GpuProcessRole, GpuReconcileOutcome, GpuSettings, GpuWorkerSpec, VideoWorkerSpec,
 };
 
 #[derive(Default)]
 struct FakePort {
     starts: Vec<GpuProcessRole>,
-    stops: Vec<GpuProcessRole>,
+    next: u8,
 }
 
-impl GpuEffectPort for FakePort {
-    fn open_devices(
+impl GpuLifecycleEffectPort for FakePort {
+    fn reserve_authority(
         &mut self,
-        _: &ResourceUid,
+        _: &GpuAuthorityAdmission,
+    ) -> Result<GpuAuthorityLease, GpuEffectError> {
+        Ok(GpuAuthorityLease::from_core([1; 16]))
+    }
+
+    fn open_authorized_devices(
+        &mut self,
+        _: &GpuAuthorityAdmission,
         _: &GpuEffectTokenSet,
     ) -> Result<GpuLaunchTicket, GpuEffectError> {
-        Ok(GpuLaunchTicket::from_core([1; 16]))
+        Ok(GpuLaunchTicket::from_core([2; 16]))
     }
 
-    fn start(&mut self, role: GpuProcessRole, _: &GpuLaunchTicket) -> Result<(), GpuEffectError> {
-        self.starts.push(role);
-        Ok(())
+    fn start_gpu_worker(
+        &mut self,
+        spec: &GpuWorkerSpec,
+        _: &GpuLaunchTicket,
+        principal: &GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError> {
+        self.next = self.next.saturating_add(1);
+        self.starts.push(spec.process().role());
+        Ok(GpuProcessIdentity::from_core(
+            [self.next; 16],
+            spec.process().role(),
+            principal.clone(),
+            platform.clone(),
+            generation,
+        ))
     }
 
-    fn stop(&mut self, role: GpuProcessRole) -> Result<(), GpuEffectError> {
-        self.stops.push(role);
+    fn start_video_worker(
+        &mut self,
+        _: &VideoWorkerSpec,
+        _: &GpuLaunchTicket,
+        principal: &GpuPrincipalToken,
+        platform: &GpuPlatformToken,
+        generation: ResourceGeneration,
+    ) -> Result<GpuProcessIdentity, GpuEffectError> {
+        self.next = self.next.saturating_add(1);
+        self.starts.push(GpuProcessRole::Video);
+        Ok(GpuProcessIdentity::from_core(
+            [self.next; 16],
+            GpuProcessRole::Video,
+            principal.clone(),
+            platform.clone(),
+            generation,
+        ))
+    }
+
+    fn observe_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuProcessObservation, GpuEffectError> {
+        Ok(GpuProcessObservation::Matching(identity.clone()))
+    }
+
+    fn stop_worker(
+        &mut self,
+        identity: &GpuProcessIdentity,
+    ) -> Result<GpuClosureProof, GpuEffectError> {
+        Ok(GpuClosureProof::from_core(identity.clone()))
+    }
+
+    fn release_authority(
+        &mut self,
+        _: GpuAuthorityLease,
+        _: &[GpuClosureProof],
+    ) -> Result<(), GpuEffectError> {
         Ok(())
     }
 }
@@ -33,19 +92,38 @@ impl GpuEffectPort for FakePort {
 #[test]
 fn video_starts_only_after_gpu_worker_is_ready() {
     let uid = ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap();
+    let owner = GpuOwnerProof::new(
+        ResourceRef::parse("Zone/dev").unwrap(),
+        ResourceRef::parse("Guest/workload").unwrap(),
+        uid,
+        ResourceUid::parse("223e4567-e89b-42d3-a456-426614174001").unwrap(),
+        ResourceGeneration::new(1).unwrap(),
+    )
+    .unwrap();
+    let admission = GpuAuthorityAdmission::new(
+        owner,
+        GpuBackingToken::from_core([7; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        DeviceArbitration::Exclusive,
+        1,
+        false,
+        GpuPrincipalToken::from_core([9; 32]),
+    )
+    .unwrap()
+    .with_video_principal(GpuPrincipalToken::from_core([10; 32]))
+    .unwrap();
     let settings = GpuSettings {
         video_sidecar: true,
         ..GpuSettings::default()
     };
     let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([2; 32])]).unwrap();
-    let mut controller =
-        GpuController::new(uid, DeviceArbitration::Exclusive, settings, tokens).unwrap();
+    let mut controller = GpuController::new_authorized(admission, settings, tokens).unwrap();
     let mut port = FakePort::default();
     assert_eq!(
-        controller.reconcile(&mut port).unwrap(),
+        controller.reconcile_lifecycle(&mut port).unwrap(),
         GpuReconcileOutcome::Converged
     );
-    assert_eq!(controller.phase(), GpuPhase::Ready);
+    assert_eq!(controller.phase(), d2b_provider_device_gpu::GpuPhase::Ready);
     assert_eq!(
         port.starts,
         [GpuProcessRole::FullGpu, GpuProcessRole::Video]

--- a/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
+++ b/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
@@ -11,6 +11,7 @@ struct FakePort {
     starts: Vec<GpuProcessRole>,
     next: u8,
     missing_roles: Vec<GpuProcessRole>,
+    stale_roles: Vec<GpuProcessRole>,
     mismatched_observation: bool,
 }
 
@@ -72,7 +73,9 @@ impl GpuLifecycleEffectPort for FakePort {
         &mut self,
         identity: &GpuProcessIdentity,
     ) -> Result<GpuProcessObservation, GpuEffectError> {
-        if self.missing_roles.contains(&identity.role()) {
+        if self.stale_roles.contains(&identity.role()) {
+            Ok(GpuProcessObservation::StaleIdentity)
+        } else if self.missing_roles.contains(&identity.role()) {
             Ok(GpuProcessObservation::Missing)
         } else if self.mismatched_observation {
             Ok(GpuProcessObservation::Matching(
@@ -216,6 +219,63 @@ fn partial_restart_adoption_restarts_only_the_missing_video_worker() {
         GpuReconcileOutcome::Converged
     );
     assert_eq!(port.starts, [GpuProcessRole::Video]);
+}
+
+#[test]
+fn stale_identity_adoption_is_terminal_and_does_not_respawn() {
+    let uid = ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap();
+    let owner = GpuOwnerProof::new(
+        ResourceRef::parse("Zone/dev").unwrap(),
+        ResourceRef::parse("Guest/workload").unwrap(),
+        uid,
+        ResourceUid::parse("223e4567-e89b-42d3-a456-426614174001").unwrap(),
+        ResourceGeneration::new(1).unwrap(),
+    )
+    .unwrap();
+    let admission = GpuAuthorityAdmission::new(
+        owner,
+        GpuBackingToken::from_core([7; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        DeviceArbitration::Exclusive,
+        1,
+        false,
+        GpuPrincipalToken::from_core([9; 32]),
+    )
+    .unwrap();
+    let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([2; 32])]).unwrap();
+    let mut controller =
+        GpuController::new_authorized(admission, GpuSettings::default(), tokens).unwrap();
+    let expected = GpuProcessIdentity::from_core(
+        [3; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let mut port = FakePort {
+        stale_roles: vec![GpuProcessRole::FullGpu],
+        ..FakePort::default()
+    };
+
+    assert_eq!(
+        controller.adopt_lifecycle(
+            GpuAuthorityLease::from_core([1; 16]),
+            &[expected],
+            &mut port,
+        ),
+        Err(d2b_provider_device_gpu::GpuControllerError::Effect(
+            GpuEffectError::StaleDeviceIdentity
+        ))
+    );
+    assert_eq!(
+        controller.phase(),
+        d2b_provider_device_gpu::GpuPhase::Failed
+    );
+    assert_eq!(
+        controller.reconcile_lifecycle(&mut port),
+        Err(d2b_provider_device_gpu::GpuControllerError::InvalidState)
+    );
+    assert!(port.starts.is_empty());
 }
 
 #[test]

--- a/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
+++ b/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
@@ -260,7 +260,7 @@ fn stale_identity_adoption_is_terminal_and_does_not_respawn() {
     assert_eq!(
         controller.adopt_lifecycle(
             GpuAuthorityLease::from_core([1; 16]),
-            &[expected.clone()],
+            std::slice::from_ref(&expected),
             &mut port,
         ),
         Err(d2b_provider_device_gpu::GpuControllerError::Effect(
@@ -276,7 +276,7 @@ fn stale_identity_adoption_is_terminal_and_does_not_respawn() {
     assert_eq!(
         controller.adopt_lifecycle(
             GpuAuthorityLease::from_core([1; 16]),
-            &[expected.clone()],
+            std::slice::from_ref(&expected),
             &mut port,
         ),
         Err(d2b_provider_device_gpu::GpuControllerError::InvalidState)
@@ -331,7 +331,7 @@ fn mismatched_matching_observation_is_quarantined() {
     assert_eq!(
         controller.adopt_lifecycle(
             GpuAuthorityLease::from_core([1; 16]),
-            &[expected.clone()],
+            std::slice::from_ref(&expected),
             &mut port,
         ),
         Err(d2b_provider_device_gpu::GpuControllerError::Quarantined)

--- a/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
+++ b/packages/d2b-provider-device-gpu/tests/combined_reconcile.rs
@@ -10,6 +10,7 @@ use d2b_provider_device_gpu::{
 struct FakePort {
     starts: Vec<GpuProcessRole>,
     next: u8,
+    missing_roles: Vec<GpuProcessRole>,
 }
 
 impl GpuLifecycleEffectPort for FakePort {
@@ -70,7 +71,11 @@ impl GpuLifecycleEffectPort for FakePort {
         &mut self,
         identity: &GpuProcessIdentity,
     ) -> Result<GpuProcessObservation, GpuEffectError> {
-        Ok(GpuProcessObservation::Matching(identity.clone()))
+        if self.missing_roles.contains(&identity.role()) {
+            Ok(GpuProcessObservation::Missing)
+        } else {
+            Ok(GpuProcessObservation::Matching(identity.clone()))
+        }
     }
 
     fn stop_worker(
@@ -128,4 +133,76 @@ fn video_starts_only_after_gpu_worker_is_ready() {
         port.starts,
         [GpuProcessRole::FullGpu, GpuProcessRole::Video]
     );
+}
+
+#[test]
+fn partial_restart_adoption_restarts_only_the_missing_video_worker() {
+    let uid = ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap();
+    let owner = GpuOwnerProof::new(
+        ResourceRef::parse("Zone/dev").unwrap(),
+        ResourceRef::parse("Guest/workload").unwrap(),
+        uid,
+        ResourceUid::parse("223e4567-e89b-42d3-a456-426614174001").unwrap(),
+        ResourceGeneration::new(1).unwrap(),
+    )
+    .unwrap();
+    let admission = GpuAuthorityAdmission::new(
+        owner,
+        GpuBackingToken::from_core([7; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        DeviceArbitration::Exclusive,
+        1,
+        false,
+        GpuPrincipalToken::from_core([9; 32]),
+    )
+    .unwrap()
+    .with_video_principal(GpuPrincipalToken::from_core([10; 32]))
+    .unwrap();
+    let settings = GpuSettings {
+        video_sidecar: true,
+        ..GpuSettings::default()
+    };
+    let tokens = GpuEffectTokenSet::from_core(vec![GpuEffectToken::from_core([2; 32])]).unwrap();
+    let mut controller =
+        GpuController::new_authorized(admission.clone(), settings, tokens).unwrap();
+    let gpu = GpuProcessIdentity::from_core(
+        [3; 16],
+        GpuProcessRole::FullGpu,
+        GpuPrincipalToken::from_core([9; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let video = GpuProcessIdentity::from_core(
+        [4; 16],
+        GpuProcessRole::Video,
+        GpuPrincipalToken::from_core([10; 32]),
+        GpuPlatformToken::from_core([8; 32]),
+        ResourceGeneration::new(1).unwrap(),
+    );
+    let mut port = FakePort {
+        missing_roles: vec![GpuProcessRole::Video],
+        ..FakePort::default()
+    };
+
+    assert_eq!(
+        controller
+            .adopt_lifecycle(
+                GpuAuthorityLease::from_core([1; 16]),
+                &[gpu, video],
+                &mut port,
+            )
+            .unwrap(),
+        GpuReconcileOutcome::Retry
+    );
+    assert_eq!(
+        controller.gpu_identity().map(|identity| identity.role()),
+        Some(GpuProcessRole::FullGpu)
+    );
+    assert!(controller.video_identity().is_none());
+
+    assert_eq!(
+        controller.reconcile_lifecycle(&mut port).unwrap(),
+        GpuReconcileOutcome::Converged
+    );
+    assert_eq!(port.starts, [GpuProcessRole::Video]);
 }

--- a/packages/d2b-provider-device-gpu/tests/probe.rs
+++ b/packages/d2b-provider-device-gpu/tests/probe.rs
@@ -1,0 +1,41 @@
+use d2b_provider_device_gpu::{
+    DEFAULT_OBSERVE_INTERVAL_SECS, GpuBackingToken, GpuDeviceSelector, GpuPlatformToken,
+    GpuProbeDisposition, GpuProbeError, GpuProbeResult, GpuProbeTracker,
+};
+
+#[test]
+fn selector_and_interval_bounds_are_enforced() {
+    assert!(GpuDeviceSelector::new("host-gpu", None::<String>).is_ok());
+    assert!(GpuDeviceSelector::new("../gpu", None::<String>).is_err());
+    assert_eq!(
+        GpuProbeTracker::with_interval(9).unwrap_err(),
+        GpuProbeError::ObserveIntervalOutOfRange
+    );
+    assert_eq!(
+        GpuProbeTracker::new().interval_secs(),
+        DEFAULT_OBSERVE_INTERVAL_SECS
+    );
+}
+
+#[test]
+fn probe_tracker_uses_three_strikes_and_resets_on_presence() {
+    let mut tracker = GpuProbeTracker::new();
+    assert_eq!(tracker.record_failure(), GpuProbeDisposition::Unknown);
+    assert_eq!(tracker.record_failure(), GpuProbeDisposition::Unknown);
+    assert_eq!(tracker.record_failure(), GpuProbeDisposition::Degraded);
+    assert_eq!(tracker.record_success(), GpuProbeDisposition::Ready);
+    assert_eq!(tracker.failures(), 0);
+}
+
+#[test]
+fn probe_result_rejects_stale_identity() {
+    assert_eq!(
+        GpuProbeResult::present(
+            GpuBackingToken::from_core([0; 32]),
+            GpuPlatformToken::from_core([1; 32]),
+            true,
+        )
+        .unwrap_err(),
+        GpuProbeError::StaleIdentity
+    );
+}

--- a/packages/d2b-provider-device-gpu/tests/worker_contract.rs
+++ b/packages/d2b-provider-device-gpu/tests/worker_contract.rs
@@ -1,0 +1,70 @@
+use d2b_contracts::v3::ResourceUid;
+use d2b_provider_device_gpu::{
+    GpuComponentDescriptor, GpuDeviceNode, GpuSettings, GpuStatus, GpuStatusPhase, GpuWorkerSpec,
+    VideoWorkerSpec,
+};
+
+fn uid(value: &str) -> ResourceUid {
+    ResourceUid::parse(value).unwrap()
+}
+
+#[test]
+fn worker_allowlists_and_sandbox_shapes_are_closed() {
+    let uid = uid("123e4567-e89b-42d3-a456-426614174000");
+    let full = GpuWorkerSpec::gpu(&uid, &GpuSettings::default()).unwrap();
+    assert_eq!(full.template(), "gpu-worker");
+    assert_eq!(full.seccomp_class(), "w1-gpu");
+    assert!(full.user_namespace());
+    assert!(full.capabilities().is_empty());
+    assert!(full.state_mounts().is_empty());
+    assert_eq!(
+        full.device_nodes(),
+        &[
+            GpuDeviceNode::Kvm,
+            GpuDeviceNode::Dri,
+            GpuDeviceNode::Udmabuf
+        ]
+    );
+
+    let video = VideoWorkerSpec::new(
+        &uid,
+        &GpuSettings {
+            video_sidecar: true,
+            video_nvidia_decode: true,
+            ..GpuSettings::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(video.template(), "video-worker");
+    assert_eq!(video.seccomp_class(), "w1-video");
+    assert!(!video.user_namespace());
+    assert_eq!(
+        video.device_nodes(),
+        &[
+            GpuDeviceNode::Dri,
+            GpuDeviceNode::NvidiaCtl,
+            GpuDeviceNode::NvidiaDevice,
+            GpuDeviceNode::NvidiaUvm
+        ]
+    );
+}
+
+#[test]
+fn provider_descriptor_has_no_state_volume_or_state_mount() {
+    let descriptor = GpuComponentDescriptor::new();
+    assert!(descriptor.provider_state_empty());
+    assert!(descriptor.validate().is_ok());
+    assert!(descriptor.controller_mounts().is_empty());
+    assert!(descriptor.worker_mounts().is_empty());
+}
+
+#[test]
+fn status_becomes_ready_only_after_required_workers() {
+    let mut status = GpuStatus::new(true);
+    status.observe_device(true, true);
+    status.set_gpu_worker(d2b_provider_device_gpu::GpuConditionState::True);
+    assert_ne!(status.phase(), GpuStatusPhase::Ready);
+    status.set_video_worker(d2b_provider_device_gpu::GpuConditionState::True);
+    assert_eq!(status.phase(), GpuStatusPhase::Ready);
+    assert!(status.set_diagnostic("/dev/dri/renderD128").is_err());
+}

--- a/tests/unit/nix/cases/device-gpu-eval.nix
+++ b/tests/unit/nix/cases/device-gpu-eval.nix
@@ -1,0 +1,110 @@
+# Focused Device Provider eval coverage for GPU shape, settings, and platform
+# admission. The physical backing remains opaque to Nix.
+{ mkEval, lib, pkgs, system, ... }:
+
+let
+  gpuSettingsSchema = {
+    type = "object";
+    additionalProperties = false;
+    properties = {
+      renderNodeOnly = { type = "boolean"; };
+      videoSidecar = { type = "boolean"; };
+      videoNvidiaDecode = { type = "boolean"; };
+      contextTypes = {
+        type = "array";
+        minItems = 1;
+        maxItems = 3;
+        uniqueItems = true;
+        items = {
+          type = "string";
+          enum = [ "virgl" "virgl2" "cross-domain" ];
+        };
+      };
+      displays = {
+        type = "array";
+        maxItems = 8;
+        items = {
+          type = "object";
+          additionalProperties = false;
+          required = [ "hidden" ];
+          properties.hidden = { type = "boolean"; };
+        };
+      };
+      egl = { type = "boolean"; };
+      vulkan = { type = "boolean"; };
+      crossDomainTrusted = { type = "boolean"; };
+      virglVideo = { type = "boolean"; };
+    };
+  };
+
+  base = { ... }: {
+    d2b.artifacts.device-gpu = {
+      package = pkgs.writeText "d2b-device-gpu-provider" "device-gpu";
+      type = "provider";
+    };
+    d2b._providerSettingsValidation.schemas =
+      { "device-gpu.d2bus.org/Device/spec" = {
+          schemaId = "device-gpu.d2bus.org/Device/spec";
+          schemaVersion = "v1.0";
+          settingsSchema = gpuSettingsSchema;
+        }; };
+    d2b.zones.local-root.resources = {
+      device-gpu = {
+        type = "Provider";
+        spec = {
+          artifactId = "device-gpu";
+          config = { };
+        };
+      };
+      gpu = {
+        type = "Device";
+        spec = {
+          providerRef = "Provider/device-gpu";
+          deviceClass = "physical";
+          arbitration = "exclusive";
+          maxConcurrentClaims = 1;
+          inventory.selector = {
+            busClass = "drm";
+            label = "host-gpu";
+          };
+          provider = {
+            schemaId = "device-gpu.d2bus.org/Device/spec";
+            schemaVersion = "v1.0";
+            settings = {
+              renderNodeOnly = false;
+              videoSidecar = false;
+              videoNvidiaDecode = false;
+              contextTypes = [ "virgl" "virgl2" ];
+              displays = [ { hidden = true; } ];
+              egl = true;
+              vulkan = true;
+              crossDomainTrusted = false;
+              virglVideo = false;
+            };
+          };
+        };
+      };
+    };
+  };
+
+  evaluated = mkEval [ base ];
+  failures = lib.filter (assertion: !assertion.assertion)
+    evaluated.config.assertions;
+  gpuFailures = lib.filter
+    (assertion: lib.hasInfix "d2b.zones.local-root.resources.gpu" assertion.message)
+    failures;
+  hasPlatformFailure = lib.any
+    (assertion: lib.hasInfix "gpu-platform-unsupported" assertion.message)
+    gpuFailures;
+in
+{
+  "device-gpu/valid-shape" = {
+    expr = gpuFailures;
+    expected = if system == "x86_64-linux" then [ ] else gpuFailures;
+  };
+
+  "device-gpu/platform-gate" = {
+    expr = hasPlatformFailure;
+    expected = system != "x86_64-linux";
+  };
+}

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -243,6 +243,8 @@ daemon-lifecycle/manifest-workload-graceful-enabled
 daemon-lifecycle/manifest-workload-timeout-override
 daemon-lifecycle/per-vm-timeout-lower-bound-assertion
 daemon-lifecycle/timeout-stop-sec-uses-phase-maxima
+device-gpu/platform-gate
+device-gpu/valid-shape
 examples-with-observability/obs-enable
 examples-with-observability/obs-env-declared
 examples-with-observability/obs-env-name


### PR DESCRIPTION
## Summary
- Enforce unique Host-global GPU leases and strict GPU/video identity rehydration.
- Recover partial GPU/video restarts without duplicate workers and gate effects/finalization on exact authority evidence.
- Preflight GPU runner shapes before device opens and register x86 GPU Nix evaluation coverage.

## Verification
- `cargo test --manifest-path packages/Cargo.toml -p d2b-provider-device-gpu --tests`
- `cargo test --manifest-path packages/d2b-priv-broker/Cargo.toml ops::gpu`
- Focused x86 Nix job: `case-device-gpu-eval`

Base: `v3`