### PR TITLE
transport-vsock: harden authenticated lifecycle contracts

### DIFF
--- a/changelog.d/transport-vsock.md
+++ b/changelog.d/transport-vsock.md
@@ -6,3 +6,8 @@
 - Added allocator-only transport settings and integration coverage for CID
   authority, restart matching, close ordering, redaction, and attachment
   refusal.
+
+### Fixed
+
+- Fixed relay finalization, transport close budgeting, degraded observation
+  retention, and end-to-end open deadlines.

--- a/changelog.d/transport-vsock.md
+++ b/changelog.d/transport-vsock.md
@@ -1,0 +1,8 @@
+### Added
+
+- Added the authenticated transport-vsock Provider with replay-safe Guest and
+  Zone session admission, bounded framing, named-stream bridging, and native
+  guest relay lifecycle.
+- Added allocator-only transport settings and integration coverage for CID
+  authority, restart matching, close ordering, redaction, and attachment
+  refusal.

--- a/docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json
+++ b/docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://d2bus.org/schemas/v3/providers/transport-vsock.transport-binding.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Closed ZoneLink settings for allocator-backed vsock transport.",
+  "properties": {
+    "connectTimeoutSeconds": {
+      "default": 30,
+      "maximum": 60,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "guestRef": {
+      "pattern": "^Guest/.+$",
+      "type": "string"
+    },
+    "portClass": {
+      "default": "d2b-link",
+      "enum": [
+        "d2b-link"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "guestRef"
+  ],
+  "title": "TransportVsockBinding",
+  "type": "object"
+}

--- a/docs/specs/providers/ADR-046-provider-transport-vsock.md
+++ b/docs/specs/providers/ADR-046-provider-transport-vsock.md
@@ -488,7 +488,9 @@ rpc OpenTransport(OpenTransportRequest) -> OpenTransportResponse
 
 **Error cases**: `deadline-exceeded`, `connect-refused`, `cid-unreachable`,
 `port-conflict`, `invalid-endpoint-id`, `invalid-binding-id`,
-`provider-overloaded` (max concurrent transports exceeded).
+`provider-overloaded` (max concurrent transports exceeded), and
+`stream-unavailable` when the ComponentSession named-stream boundary cannot
+be opened.
 
 ### `CloseTransport`
 
@@ -794,7 +796,9 @@ produced by this Provider.
 | `invalid-endpoint-id` | `endpoint_id` failed format validation | No |
 | `invalid-binding-id` | `binding_id` failed format validation | No |
 | `provider-overloaded` | Max concurrent open transports exceeded | Yes (backoff) |
+| `stream-unavailable` | ComponentSession named-stream allocation failed | Yes |
 | `unknown-transport-handle` | `CloseTransport` or `ObserveTransport` on unknown handle | No |
+| `close-unconfirmed` | Bridge or endpoint closure was not confirmed within the grace period | Yes |
 | `bridge-task-panicked` | Internal bridge task exited unexpectedly | No; core must reopen |
 | `framing-error` | 2-byte length prefix violated protocol | No |
 

--- a/flake.nix
+++ b/flake.nix
@@ -426,6 +426,8 @@
           mkdir -p $out/docs/reference/schemas/v3/providers
           cp ${./docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json} \
             $out/docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json
+          cp ${./docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json} \
+            $out/docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json
         '';
         rustWorkspace = args: pkgs.rustPlatform.buildRustPackage ({
           pname = "d2b-rust-workspace";
@@ -1126,6 +1128,8 @@
           mkdir -p $out/docs/reference/schemas/v3/providers
           cp ${./docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json} \
             $out/docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json
+          cp ${./docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json} \
+            $out/docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json
           mkdir -p $out/tests
           cp -r ${./tests/golden} $out/tests/golden
           cp -r ${./tests/fixtures} $out/tests/fixtures

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -2229,6 +2229,16 @@ let
     && builtins.hasAttr (builtins.elemAt parts 1) resources
     && resources.${builtins.elemAt parts 1}.type == "Provider";
 
+  zoneResolvesAs = resources: expectedType: ref:
+    let
+      parts = if builtins.isString ref then lib.splitString "/" ref else [ ];
+    in
+    builtins.isString ref
+    && lib.length parts == 2
+    && builtins.elemAt parts 0 == expectedType
+    && builtins.hasAttr (builtins.elemAt parts 1) resources
+    && resources.${builtins.elemAt parts 1}.type == expectedType;
+
   # Walk one Zone's ancestry. Returns true when the walk terminates at a
   # parentless Zone within the depth budget and never revisits a name.
   # A parent that is not declared terminates the walk: the missing-parent
@@ -2355,7 +2365,7 @@ let
                 && lib.all (key: builtins.elem key vsockTransportSettingKeys)
                   (builtins.attrNames settings)
                 && builtins.hasAttr "guestRef" settings
-                && lib.hasPrefix "Guest/" settings.guestRef
+                && zoneResolvesAs zone.resources "Guest" settings.guestRef
                 && (settings.portClass or "d2b-link") == "d2b-link"
                 && builtins.isInt (settings.connectTimeoutSeconds or 30)
                 && (settings.connectTimeoutSeconds or 30) >= 1

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -2208,6 +2208,11 @@ let
   ];
 
   unixTransportSettingKeys = [ "socketKind" ];
+  vsockTransportSettingKeys = [
+    "connectTimeoutSeconds"
+    "guestRef"
+    "portClass"
+  ];
 
   zoneAttrOr = attrs: name: fallback:
     if builtins.isAttrs attrs && builtins.hasAttr name attrs
@@ -2340,6 +2345,28 @@ let
               "zones.${zoneName}.resources.${linkName}: Provider/transport-unix"
               + " accepts only optional socketKind=seqpacket or socketKind=stream"
               + " and requires an empty transportCredentials list.";
+          }
+          {
+            assertion =
+              (zoneAttrOr link.spec "transportProviderRef" "")
+                != "Provider/transport-vsock"
+              || (
+                builtins.isAttrs settings
+                && lib.all (key: builtins.elem key vsockTransportSettingKeys)
+                  (builtins.attrNames settings)
+                && builtins.hasAttr "guestRef" settings
+                && lib.hasPrefix "Guest/" settings.guestRef
+                && (settings.portClass or "d2b-link") == "d2b-link"
+                && builtins.isInt (settings.connectTimeoutSeconds or 30)
+                && (settings.connectTimeoutSeconds or 30) >= 1
+                && (settings.connectTimeoutSeconds or 30) <= 60
+                && zoneAttrOr link.spec "transportCredentials" [ ] == [ ]
+              );
+            message =
+              "zones.${zoneName}.resources.${linkName}: Provider/transport-vsock"
+              + " accepts only guestRef, portClass=d2b-link, and a"
+              + " connectTimeoutSeconds from 1 through 60; transportCredentials"
+              + " must be empty.";
           }
         ])
       links);

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -16,6 +16,8 @@ let
     mkdir -p $out/docs/reference/schemas/v3/providers
     cp ${../docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json} \
       $out/docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json
+    cp ${../docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json} \
+      $out/docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json
   '';
   cargoLock = {
     lockFile = ../packages/Cargo.lock;

--- a/nixos-modules/provider-runtime-contracts.nix
+++ b/nixos-modules/provider-runtime-contracts.nix
@@ -54,6 +54,7 @@ let
     "Provider/runtime-azure-virtual-machine"
     "Provider/runtime-cloud-hypervisor"
     "Provider/transport-azure-relay"
+    "Provider/transport-vsock"
   ];
 
   providerRows = lib.filter
@@ -180,6 +181,13 @@ let
           assertion = resolvesAs row "Network" (providerConfig.networkRef or null);
           message = "${row.path}.spec.config.networkRef must resolve to a Network.";
         }
+      ] else [ ])
+      ++ (if providerRef == "Provider/transport-vsock" then [
+        {
+          assertion = resolvesAs row "Host" (providerConfig.executionRef or null)
+            || resolvesAs row "Guest" (providerConfig.executionRef or null);
+          message = "${row.path}.spec.config.executionRef must resolve to a same-Zone Host or Guest.";
+        }
       ] else [ ]);
 
   guestAssertions = row:
@@ -262,6 +270,8 @@ let
       then providerConfig.gatewayExecutionRef or null
       else if providerRef == "Provider/transport-azure-relay"
       then providerConfig.executionRef or null
+      else if providerRef == "Provider/transport-vsock"
+      then providerConfig.executionRef or null
       else providerConfig.controllerExecutionRef or null;
     in (lib.optionals (lib.elem providerRef runtimeProviderRefs) [
       {
@@ -335,6 +345,11 @@ let
         "relayNamespaceId"
       ];
       unixSettings = [ "socketKind" ];
+      vsockSettings = [
+        "connectTimeoutSeconds"
+        "guestRef"
+        "portClass"
+      ];
     in [
       {
         assertion = lib.all (key: !secretKey key) (lib.attrNames settings);
@@ -388,6 +403,28 @@ let
         {
           assertion = credentialRefs == [ ];
           message = "${row.path}.spec.transportCredentials must be empty for Provider/transport-unix.";
+        }
+      ]
+      ++ lib.optionals (providerRef == "Provider/transport-vsock") [
+        {
+          assertion = lib.all (key: builtins.elem key vsockSettings) (lib.attrNames settings)
+            && builtins.hasAttr "guestRef" settings
+            && resolvesAs row "Guest" settings.guestRef;
+          message = "${row.path}.spec.transportSettings for Provider/transport-vsock must contain a same-Zone guestRef and only allocator-owned fields.";
+        }
+        {
+          assertion = (settings.portClass or "d2b-link") == "d2b-link";
+          message = "${row.path}.spec.transportSettings.portClass must be d2b-link.";
+        }
+        {
+          assertion = builtins.isInt (settings.connectTimeoutSeconds or 30)
+            && (settings.connectTimeoutSeconds or 30) >= 1
+            && (settings.connectTimeoutSeconds or 30) <= 60;
+          message = "${row.path}.spec.transportSettings.connectTimeoutSeconds must be between 1 and 60.";
+        }
+        {
+          assertion = credentialRefs == [ ];
+          message = "${row.path}.spec.transportCredentials must be empty for Provider/transport-vsock.";
         }
       ];
 

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1460,6 +1460,17 @@ dependencies = [
 [[package]]
 name = "d2b-provider-transport-vsock"
 version = "0.0.0-bootstrap"
+dependencies = [
+ "async-trait",
+ "d2b-contracts",
+ "d2b-provider",
+ "d2b-session",
+ "ring",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "d2b-provider-volume-local"

--- a/packages/d2b-contract-tests/tests/policy_provider_crates.rs
+++ b/packages/d2b-contract-tests/tests/policy_provider_crates.rs
@@ -67,6 +67,7 @@ const ALLOWED_WORKSPACE_DEPS: &[&str] = &[
     "d2b-provider-toolkit",
     "d2b-realm-core",
     "d2b-realm-provider",
+    "d2b-session",
 ];
 
 /// Workspace crates whose appearance in a Provider crate names a specific

--- a/packages/d2b-provider-transport-vsock/Cargo.toml
+++ b/packages/d2b-provider-transport-vsock/Cargo.toml
@@ -7,3 +7,25 @@ license.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+async-trait = "0.1"
+d2b-contracts = { path = "../d2b-contracts", version = "0.0.0-bootstrap" }
+d2b-provider = { path = "../d2b-provider", version = "0.0.0-bootstrap" }
+d2b-session = { path = "../d2b-session", version = "0.0.0-bootstrap" }
+ring.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["io-util", "rt", "sync", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "net", "rt", "sync", "time"] }
+
+[[test]]
+name = "host_guest"
+path = "integration/host_guest.rs"
+
+[[test]]
+name = "no_fd_transfer"
+path = "integration/no_fd_transfer.rs"

--- a/packages/d2b-provider-transport-vsock/README.md
+++ b/packages/d2b-provider-transport-vsock/README.md
@@ -1,61 +1,72 @@
 # `d2b-provider-transport-vsock`
 
-This is the canonical crate root for `Provider/transport-vsock`. It is a
-compile-safe scaffold; semantic Provider behavior is intentionally not present
-here.
-
-See [Create a Provider](../../docs/how-to/create-provider.md) and the
-[transport-vsock dossier](../../docs/specs/providers/ADR-046-provider-transport-vsock.md)
-for the implementation contract.
-
 ## Provider identity
 
-| Field | Value |
-| --- | --- |
-| Provider name | `transport-vsock` |
-| Provider reference | `Provider/transport-vsock` |
-| Package | `packages/d2b-provider-transport-vsock/` |
+This crate implements `Provider/transport-vsock`, the child-Zone
+carriage-acquisition Provider for allocator-backed native vsock sessions.
 
 ## Config schema
 
-The Provider-specific configuration is defined by the transport-vsock dossier.
-This scaffold does not publish a configuration schema.
+`spec.transportSettings` accepts `guestRef`, `portClass` (`d2b-link`), and
+`connectTimeoutSeconds`. Raw `cid`, `port`, socket paths, and credentials are
+rejected. The schema is
+`docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json`.
 
 ## Exported resource types
 
-The resource types are defined by the dossier. This scaffold exports no
-resource implementation.
+The Provider owns no ResourceType. ZoneLink state, status, finalizers, and
+session generations remain owned by the child Zone core controller.
 
 ## Controllers / services / workers / binaries
 
-None are implemented in this scaffold. Controllers, services, workers, and
-binaries belong to the owning Provider implementation.
+`VsockTransportService` is one service component per installed Provider
+instance. It opens, bridges, observes, and closes named streams. The native
+guest relay controller owns only its effect-port lifecycle; it does not spawn
+an independent persistent service.
 
 ## Placement and dependencies
 
-No runtime placement is declared, and the scaffold has no workspace
-dependencies.
+The Provider and ZoneLink are child-local. `childZoneName` self-matches, while
+compiler-only `parentZone` selects the allocator and leaves the parent with
+sealed route state only. The Provider receives opaque endpoint and binding
+identities through `VsockEffectPort`; it never calls AF_VSOCK directly and
+does not depend on `tokio-vsock`.
+
+The optional empty service state volume uses `User/d2b-transport-vsock` and
+broker-maintained identity. No `ComponentPrincipal` or parent-store
+reciprocal resource is used.
 
 ## RBAC requirements
 
-The scaffold requests no permissions and performs no resource or effect
-operations.
+Only the child Zone core ZoneLink/delegation controller may invoke the
+transport service. The relay's CID reservation is held across listener and
+process effects and is released only after confirmed closure.
 
 ## Security posture
 
-No host, broker, filesystem, network, process, credential, or device effect is
-reachable from this scaffold.
+Guest, Zone, kernel-observed CID, boot identity, session generation, and HMAC
+proof are checked before a session reaches `Ready`. Nonces are replay-fenced,
+stale signatures and mismatched identities fail closed, and disconnects degrade
+the session. Vsock descriptors never carry file attachments.
 
 ## State and telemetry
 
-The scaffold owns no state and emits no telemetry.
+Operational state is bounded and in-memory: opaque transport handles, bridge
+phase, close outcome, and byte counters. Debug, error, and lifecycle surfaces
+omit raw CID, port, socket path, endpoint value, binding value, and proof
+material.
 
 ## Build and test
 
 ```bash
-cargo check -p d2b-provider-transport-vsock
-cargo test -p d2b-provider-transport-vsock
+cargo build -p d2b-provider-transport-vsock
+cargo test -p d2b-provider-transport-vsock --tests
 ```
 
-The current test targets are structural compile checks. Executable scenarios
-belong to the owning implementation.
+The package integration targets cover host/guest descriptor parity and the
+no-file-descriptor transport invariant. The full provider integration lane is
+`make test-integration`.
+
+See
+[`docs/specs/providers/ADR-046-provider-transport-vsock.md`](../../docs/specs/providers/ADR-046-provider-transport-vsock.md)
+for the complete Provider dossier.

--- a/packages/d2b-provider-transport-vsock/integration/README.md
+++ b/packages/d2b-provider-transport-vsock/integration/README.md
@@ -1,7 +1,6 @@
 # Integration fixtures
 
-This directory reserves the integration fixture surface for
-`Provider/transport-vsock`. The current crate root has no executable
-integration behavior. The placeholder scenario declaration is required by the
-repository layout policy; replace it with the dossier's real fixture when
-implementation lands.
+The package integration targets prove the native-vsock descriptor contract and
+the structural no-file-descriptor boundary. Native socket creation remains in
+the child-core effect adapter; Provider tests use injected streams and never
+open AF_VSOCK directly.

--- a/packages/d2b-provider-transport-vsock/integration/host_guest.rs
+++ b/packages/d2b-provider-transport-vsock/integration/host_guest.rs
@@ -1,0 +1,10 @@
+//! integration-target: container
+
+use d2b_provider_transport_vsock::VsockTransportDescriptor;
+
+#[test]
+fn host_guest_transport_descriptor_disallows_fd_transfer() {
+    let descriptor = VsockTransportDescriptor::default();
+    assert!(!descriptor.supports_attachments);
+    assert!(!descriptor.packet_atomic);
+}

--- a/packages/d2b-provider-transport-vsock/integration/no_fd_transfer.rs
+++ b/packages/d2b-provider-transport-vsock/integration/no_fd_transfer.rs
@@ -1,0 +1,8 @@
+//! integration-target: container
+
+use d2b_provider_transport_vsock::VsockTransportDescriptor;
+
+#[test]
+fn no_fd_transfer_over_vsock_is_structural() {
+    assert!(!VsockTransportDescriptor::default().supports_attachments);
+}

--- a/packages/d2b-provider-transport-vsock/src/audit.rs
+++ b/packages/d2b-provider-transport-vsock/src/audit.rs
@@ -1,0 +1,30 @@
+//! Closed, redacted transport audit events.
+
+/// Provider lifecycle operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportAuditOperation {
+    /// A vsock transport was acquired.
+    Acquire,
+    /// A vsock transport was released.
+    Release,
+}
+
+/// Provider lifecycle outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportAuditOutcome {
+    /// The operation completed.
+    Success,
+    /// The operation was refused.
+    Refused,
+    /// The operation remains retryable.
+    Retryable,
+}
+
+/// Redacted audit event with only closed semantic dimensions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportAuditEvent {
+    /// Closed operation.
+    pub operation: TransportAuditOperation,
+    /// Closed outcome.
+    pub outcome: TransportAuditOutcome,
+}

--- a/packages/d2b-provider-transport-vsock/src/auth.rs
+++ b/packages/d2b-provider-transport-vsock/src/auth.rs
@@ -9,10 +9,7 @@ use d2b_contracts::{
     v3::{ResourceRef, ZoneId},
 };
 use ring::hmac;
-use std::{
-    collections::{HashSet, VecDeque},
-    fmt,
-};
+use std::{collections::HashSet, fmt};
 
 const TAG_BYTES: usize = 32;
 
@@ -242,7 +239,6 @@ pub struct SessionAuthority {
     key: GuestControlKey,
     generation: u64,
     replayed: HashSet<[u8; 32]>,
-    replay_order: VecDeque<[u8; 32]>,
 }
 
 impl SessionAuthority {
@@ -253,16 +249,16 @@ impl SessionAuthority {
             key,
             generation,
             replayed: HashSet::new(),
-            replay_order: VecDeque::new(),
         }
     }
 
     /// Authenticate one proof and consume its nonce.
     pub fn authenticate(
         &mut self,
+        observed_cid: PeerCid,
         proof: SessionProof,
     ) -> Result<ReadySession, SessionRejectReason> {
-        if !self.expected.cid.matches(proof.identity.cid) {
+        if !self.expected.cid.matches(observed_cid) || !observed_cid.matches(proof.identity.cid) {
             return Err(SessionRejectReason::CidMismatch);
         }
         if self.expected.guest != proof.identity.guest {
@@ -277,17 +273,14 @@ impl SessionAuthority {
         if self.replayed.contains(&proof.nonce) {
             return Err(SessionRejectReason::Replay);
         }
+        if self.replayed.len() >= MAX_REPLAY_ENTRIES {
+            return Err(SessionRejectReason::AuthorityUnavailable);
+        }
         let expected_tag = sign_tag(&self.key, &proof.identity, &proof.nonce, proof.generation);
         if !constant_time_equal(&expected_tag, proof.tag()) {
             return Err(SessionRejectReason::SignatureInvalid);
         }
         self.replayed.insert(proof.nonce);
-        self.replay_order.push_back(proof.nonce);
-        if self.replay_order.len() > MAX_REPLAY_ENTRIES
-            && let Some(oldest) = self.replay_order.pop_front()
-        {
-            self.replayed.remove(&oldest);
-        }
         Ok(ReadySession {
             identity: self.expected.clone(),
             state: SessionState::Ready,

--- a/packages/d2b-provider-transport-vsock/src/auth.rs
+++ b/packages/d2b-provider-transport-vsock/src/auth.rs
@@ -1,0 +1,343 @@
+//! Guest-bound proof-of-possession and replay-safe session admission.
+
+use crate::limits::MAX_REPLAY_ENTRIES;
+use d2b_contracts::{
+    guest_auth::{
+        AUTH_NONCE_LEN, AuthDirection, AuthPurpose, GUEST_CONTROL_AUTH_PORT, GuestAuthTranscript,
+        ProofRole, encode_transcript,
+    },
+    v3::{ResourceRef, ZoneId},
+};
+use ring::hmac;
+use std::{
+    collections::{HashSet, VecDeque},
+    fmt,
+};
+
+const TAG_BYTES: usize = 32;
+
+/// Opaque kernel-observed peer CID.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PeerCid(u32);
+
+impl PeerCid {
+    /// Construct a peer CID at the trusted Core adapter boundary.
+    pub const fn from_core(value: u32) -> Option<Self> {
+        if value == 0 { None } else { Some(Self(value)) }
+    }
+
+    pub(crate) fn matches(self, other: Self) -> bool {
+        self == other
+    }
+}
+
+impl fmt::Debug for PeerCid {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PeerCid(<redacted>)")
+    }
+}
+
+/// Guest-control signing key held by the trusted Core adapter.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GuestControlKey([u8; 32]);
+
+impl GuestControlKey {
+    /// Construct a key at the trusted Core adapter boundary.
+    pub const fn from_core(value: [u8; 32]) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Debug for GuestControlKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GuestControlKey(<redacted>)")
+    }
+}
+
+/// Exact Guest and Zone identity bound to one transport session.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GuestIdentity {
+    guest: ResourceRef,
+    zone: ZoneId,
+    cid: PeerCid,
+    boot_id: String,
+}
+
+impl GuestIdentity {
+    /// Construct one exact Guest identity.
+    pub fn new(
+        guest: ResourceRef,
+        zone: ZoneId,
+        cid: PeerCid,
+        boot_id: impl Into<String>,
+    ) -> Result<Self, SessionRejectReason> {
+        if guest.resource_type().as_str() != "Guest" {
+            return Err(SessionRejectReason::GuestMismatch);
+        }
+        let boot_id = boot_id.into();
+        if boot_id.is_empty() || boot_id.len() > 128 {
+            return Err(SessionRejectReason::MalformedProof);
+        }
+        Ok(Self {
+            guest,
+            zone,
+            cid,
+            boot_id,
+        })
+    }
+
+    /// Borrow the exact Guest reference.
+    pub const fn guest(&self) -> &ResourceRef {
+        &self.guest
+    }
+
+    /// Borrow the exact Zone identity.
+    pub const fn zone(&self) -> &ZoneId {
+        &self.zone
+    }
+}
+
+impl fmt::Debug for GuestIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GuestIdentity(<redacted>)")
+    }
+}
+
+/// Proof presented by a Guest-control peer.
+#[derive(Clone)]
+pub struct SessionProof {
+    identity: GuestIdentity,
+    nonce: [u8; 32],
+    generation: u64,
+    tag: [u8; TAG_BYTES],
+}
+
+impl SessionProof {
+    /// Sign one exact Guest, Zone, CID, boot, nonce, and generation tuple.
+    pub fn sign(
+        key: &GuestControlKey,
+        identity: &GuestIdentity,
+        nonce: [u8; 32],
+        generation: u64,
+    ) -> Self {
+        let tag = sign_tag(key, identity, &nonce, generation);
+        Self {
+            identity: identity.clone(),
+            nonce,
+            generation,
+            tag,
+        }
+    }
+
+    fn tag(&self) -> &[u8; TAG_BYTES] {
+        &self.tag
+    }
+}
+
+impl fmt::Debug for SessionProof {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SessionProof(<redacted>)")
+    }
+}
+
+/// Stable proof rejection reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionRejectReason {
+    /// The peer CID is not the one bound to this Guest.
+    CidMismatch,
+    /// The proof names another Guest.
+    GuestMismatch,
+    /// The proof names another Zone.
+    ZoneMismatch,
+    /// The proof's boot or generation is stale.
+    StaleSignature,
+    /// The nonce was already admitted.
+    Replay,
+    /// The proof shape is invalid.
+    MalformedProof,
+    /// The signature did not verify.
+    SignatureInvalid,
+    /// The authority has no remaining admission capacity.
+    AuthorityUnavailable,
+}
+
+impl SessionRejectReason {
+    /// Return the stable error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::CidMismatch => "cid-mismatch",
+            Self::GuestMismatch => "guest-mismatch",
+            Self::ZoneMismatch => "zone-mismatch",
+            Self::StaleSignature => "stale-signature",
+            Self::Replay => "replay",
+            Self::MalformedProof => "malformed-proof",
+            Self::SignatureInvalid => "signature-invalid",
+            Self::AuthorityUnavailable => "session-authority-unavailable",
+        }
+    }
+}
+
+impl fmt::Display for SessionRejectReason {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for SessionRejectReason {}
+
+/// State of one admitted transport session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    /// The authenticated session is ready for transport operations.
+    Ready,
+    /// The peer has disconnected and the session is no longer usable.
+    Disconnected,
+}
+
+/// Single-use authenticated session authority.
+pub struct ReadySession {
+    identity: GuestIdentity,
+    state: SessionState,
+}
+
+impl ReadySession {
+    /// Return the current session state.
+    pub const fn state(&self) -> SessionState {
+        self.state
+    }
+
+    /// Check that a request remains bound to this Guest and Zone.
+    pub fn matches(&self, identity: &GuestIdentity) -> bool {
+        self.state == SessionState::Ready
+            && self.identity.guest == identity.guest
+            && self.identity.zone == identity.zone
+            && self.identity.cid.matches(identity.cid)
+            && self.identity.boot_id == identity.boot_id
+    }
+
+    /// Borrow the exact session Guest identity.
+    pub const fn identity(&self) -> &GuestIdentity {
+        &self.identity
+    }
+
+    /// Consume the authority on disconnect.
+    pub fn disconnect(mut self) -> SessionState {
+        self.state = SessionState::Disconnected;
+        self.state
+    }
+}
+
+impl fmt::Debug for ReadySession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReadySession")
+            .field("state", &self.state)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Replay-safe authority for one exact Guest and Zone.
+pub struct SessionAuthority {
+    expected: GuestIdentity,
+    key: GuestControlKey,
+    generation: u64,
+    replayed: HashSet<[u8; 32]>,
+    replay_order: VecDeque<[u8; 32]>,
+}
+
+impl SessionAuthority {
+    /// Construct an authority with one current boot/generation binding.
+    pub fn new(expected: GuestIdentity, key: GuestControlKey, generation: u64) -> Self {
+        Self {
+            expected,
+            key,
+            generation,
+            replayed: HashSet::new(),
+            replay_order: VecDeque::new(),
+        }
+    }
+
+    /// Authenticate one proof and consume its nonce.
+    pub fn authenticate(
+        &mut self,
+        proof: SessionProof,
+    ) -> Result<ReadySession, SessionRejectReason> {
+        if !self.expected.cid.matches(proof.identity.cid) {
+            return Err(SessionRejectReason::CidMismatch);
+        }
+        if self.expected.guest != proof.identity.guest {
+            return Err(SessionRejectReason::GuestMismatch);
+        }
+        if self.expected.zone != proof.identity.zone {
+            return Err(SessionRejectReason::ZoneMismatch);
+        }
+        if self.expected.boot_id != proof.identity.boot_id || proof.generation != self.generation {
+            return Err(SessionRejectReason::StaleSignature);
+        }
+        if self.replayed.contains(&proof.nonce) {
+            return Err(SessionRejectReason::Replay);
+        }
+        let expected_tag = sign_tag(&self.key, &proof.identity, &proof.nonce, proof.generation);
+        if !constant_time_equal(&expected_tag, proof.tag()) {
+            return Err(SessionRejectReason::SignatureInvalid);
+        }
+        self.replayed.insert(proof.nonce);
+        self.replay_order.push_back(proof.nonce);
+        if self.replay_order.len() > MAX_REPLAY_ENTRIES
+            && let Some(oldest) = self.replay_order.pop_front()
+        {
+            self.replayed.remove(&oldest);
+        }
+        Ok(ReadySession {
+            identity: self.expected.clone(),
+            state: SessionState::Ready,
+        })
+    }
+}
+
+impl fmt::Debug for SessionAuthority {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionAuthority")
+            .field("replay_count", &self.replayed.len())
+            .finish()
+    }
+}
+
+fn sign_tag(
+    key: &GuestControlKey,
+    identity: &GuestIdentity,
+    nonce: &[u8; 32],
+    generation: u64,
+) -> [u8; TAG_BYTES] {
+    let mut capabilities = Vec::with_capacity(identity.zone.as_str().len() + 8);
+    capabilities.extend_from_slice(identity.zone.as_str().as_bytes());
+    capabilities.extend_from_slice(&generation.to_be_bytes());
+    let guest_nonce = [0_u8; AUTH_NONCE_LEN];
+    let transcript = GuestAuthTranscript {
+        role: ProofRole::Host,
+        direction: AuthDirection::HostToGuest,
+        purpose: AuthPurpose::GuestControlAuthV1,
+        vm_id: &identity.guest.to_canonical_string(),
+        protocol_version: 1,
+        guest_control_port: GUEST_CONTROL_AUTH_PORT,
+        peer_cid: Some(identity.cid.0),
+        host_nonce: nonce,
+        guest_nonce: &guest_nonce,
+        guest_boot_id: &identity.boot_id,
+        capabilities_hash: Some(&capabilities),
+    };
+    let transcript = encode_transcript(&transcript);
+    let signing_key = hmac::Key::new(hmac::HMAC_SHA256, &key.0);
+    let tag = hmac::sign(&signing_key, &transcript);
+    let mut output = [0_u8; TAG_BYTES];
+    output.copy_from_slice(tag.as_ref());
+    output
+}
+
+fn constant_time_equal(left: &[u8; TAG_BYTES], right: &[u8; TAG_BYTES]) -> bool {
+    left.iter()
+        .zip(right)
+        .fold(0_u8, |difference, (a, b)| difference | (a ^ b))
+        == 0
+}

--- a/packages/d2b-provider-transport-vsock/src/bridge.rs
+++ b/packages/d2b-provider-transport-vsock/src/bridge.rs
@@ -1,0 +1,185 @@
+//! Named-stream bridge lifecycle.
+
+use async_trait::async_trait;
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, copy_bidirectional},
+    sync::{Notify, watch},
+};
+
+/// Opaque named stream identity returned to the child core.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NamedStreamId(u64);
+
+impl NamedStreamId {
+    /// Construct a stream identity at the ComponentSession boundary.
+    pub const fn from_core(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Debug for NamedStreamId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("NamedStreamId(<redacted>)")
+    }
+}
+
+/// Opaque transport handle owned by one Provider service.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TransportHandle(u64);
+
+impl TransportHandle {
+    /// Construct a handle at a trusted test or Core boundary.
+    pub const fn from_core(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Debug for TransportHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TransportHandle(<redacted>)")
+    }
+}
+
+/// Port used by the Provider to create and close ComponentSession named
+/// streams. It carries no raw file descriptor or socket path.
+#[async_trait]
+pub trait NamedStreamPort: Send + Sync + 'static {
+    /// The byte stream connected to the ComponentSession named stream.
+    type Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static;
+
+    /// Open one named stream.
+    async fn open_named_stream(&self) -> Result<(NamedStreamId, Self::Stream), NamedStreamError>;
+
+    /// Close one named stream.
+    async fn close_named_stream(&self, stream: NamedStreamId) -> Result<(), NamedStreamError>;
+}
+
+/// Named-stream allocation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamedStreamError {
+    /// The ComponentSession stream table is full.
+    Capacity,
+    /// The session is no longer available.
+    Disconnected,
+}
+
+impl fmt::Display for NamedStreamError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Capacity => "named-stream-capacity",
+            Self::Disconnected => "named-stream-disconnected",
+        })
+    }
+}
+
+impl std::error::Error for NamedStreamError {}
+
+/// Closed bridge completion reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeExit {
+    /// The peer closed the byte stream.
+    PeerClosed,
+    /// The owner requested closure.
+    OwnerClosed,
+    /// The bridge encountered an I/O error.
+    IoError,
+}
+
+/// Bounded bridge counters.
+#[derive(Debug, Default)]
+pub struct BridgeStats {
+    bytes_from_vsock: AtomicU64,
+    bytes_to_vsock: AtomicU64,
+}
+
+impl BridgeStats {
+    /// Return bytes received from the vsock side.
+    pub fn bytes_from_vsock(&self) -> u64 {
+        self.bytes_from_vsock.load(Ordering::Relaxed)
+    }
+
+    /// Return bytes sent to the vsock side.
+    pub fn bytes_to_vsock(&self) -> u64 {
+        self.bytes_to_vsock.load(Ordering::Relaxed)
+    }
+
+    fn record(&self, from_vsock: u64, to_vsock: u64) {
+        self.bytes_from_vsock
+            .fetch_add(from_vsock, Ordering::Relaxed);
+        self.bytes_to_vsock.fetch_add(to_vsock, Ordering::Relaxed);
+    }
+}
+
+/// A cancel signal and completion notification for one bridge task.
+pub struct BridgeControl {
+    stop: watch::Sender<bool>,
+    completed: Arc<Notify>,
+}
+
+impl BridgeControl {
+    /// Create a bridge control pair.
+    pub fn new() -> (Self, watch::Receiver<bool>) {
+        let (stop, receiver) = watch::channel(false);
+        (
+            Self {
+                stop,
+                completed: Arc::new(Notify::new()),
+            },
+            receiver,
+        )
+    }
+
+    /// Request bridge shutdown.
+    pub fn stop(&self) {
+        let _ = self.stop.send(true);
+    }
+
+    /// Wait for the bridge task to finish.
+    pub async fn wait(&self) {
+        self.completed.notified().await;
+    }
+
+    /// Clone the completion signal for the bridge task.
+    pub(crate) fn completion(&self) -> Arc<Notify> {
+        Arc::clone(&self.completed)
+    }
+}
+
+/// Run a byte bridge until one side closes or the owner requests shutdown.
+pub async fn run_bridge<L, R>(
+    mut left: L,
+    mut right: R,
+    mut stop: watch::Receiver<bool>,
+    stats: Arc<BridgeStats>,
+) -> (L, R, BridgeExit)
+where
+    L: AsyncRead + AsyncWrite + Unpin,
+    R: AsyncRead + AsyncWrite + Unpin,
+{
+    let result = tokio::select! {
+        copied = copy_bidirectional(&mut left, &mut right) => {
+            match copied {
+                Ok((from_left, from_right)) => {
+                    stats.record(from_left, from_right);
+                    BridgeExit::PeerClosed
+                }
+                Err(_) => BridgeExit::IoError,
+            }
+        }
+        changed = stop.changed() => {
+            if changed.is_ok() && *stop.borrow() {
+                BridgeExit::OwnerClosed
+            } else {
+                BridgeExit::IoError
+            }
+        }
+    };
+    (left, right, result)
+}

--- a/packages/d2b-provider-transport-vsock/src/bridge.rs
+++ b/packages/d2b-provider-transport-vsock/src/bridge.rs
@@ -1,6 +1,7 @@
 //! Named-stream bridge lifecycle.
 
 use async_trait::async_trait;
+use std::sync::atomic::AtomicBool;
 use std::{
     fmt,
     sync::{
@@ -118,9 +119,11 @@ impl BridgeStats {
 }
 
 /// A cancel signal and completion notification for one bridge task.
+#[derive(Clone)]
 pub struct BridgeControl {
     stop: watch::Sender<bool>,
     completed: Arc<Notify>,
+    done: Arc<AtomicBool>,
 }
 
 impl BridgeControl {
@@ -131,6 +134,7 @@ impl BridgeControl {
             Self {
                 stop,
                 completed: Arc::new(Notify::new()),
+                done: Arc::new(AtomicBool::new(false)),
             },
             receiver,
         )
@@ -141,14 +145,22 @@ impl BridgeControl {
         let _ = self.stop.send(true);
     }
 
-    /// Wait for the bridge task to finish.
-    pub async fn wait(&self) {
-        self.completed.notified().await;
+    /// Mark the bridge as finished.
+    pub(crate) fn mark_completed(&self) {
+        self.done.store(true, Ordering::Release);
+        self.completed.notify_waiters();
     }
 
-    /// Clone the completion signal for the bridge task.
-    pub(crate) fn completion(&self) -> Arc<Notify> {
-        Arc::clone(&self.completed)
+    /// Wait for the bridge task to finish.
+    pub async fn wait(&self) {
+        if self.done.load(Ordering::Acquire) {
+            return;
+        }
+        let notified = self.completed.notified();
+        if self.done.load(Ordering::Acquire) {
+            return;
+        }
+        notified.await;
     }
 }
 

--- a/packages/d2b-provider-transport-vsock/src/effect_port.rs
+++ b/packages/d2b-provider-transport-vsock/src/effect_port.rs
@@ -1,0 +1,119 @@
+//! Opaque effect-port contracts for native AF_VSOCK operations.
+
+use crate::errors::VsockEffectError;
+use async_trait::async_trait;
+use std::{fmt, time::Instant};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Opaque endpoint resolution identity supplied by the child Zone core.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct OpaqueEndpointId(String);
+
+impl OpaqueEndpointId {
+    /// Parse one allocator-issued endpoint identity.
+    pub fn parse(value: impl Into<String>) -> Result<Self, VsockEffectError> {
+        let value = value.into();
+        if valid_opaque_id(&value) {
+            Ok(Self(value))
+        } else {
+            Err(VsockEffectError::EffectRejected)
+        }
+    }
+
+    /// Construct an opaque identity at a trusted Core adapter boundary.
+    pub fn from_core(value: impl Into<String>) -> Result<Self, VsockEffectError> {
+        Self::parse(value)
+    }
+
+    /// Borrow the opaque value for the injected effect port.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OpaqueEndpointId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OpaqueEndpointId(<redacted>)")
+    }
+}
+
+impl fmt::Display for OpaqueEndpointId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("opaque-endpoint")
+    }
+}
+
+/// Opaque port-binding identity supplied by the child Zone core.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct OpaqueBindingId(String);
+
+impl OpaqueBindingId {
+    /// Parse one allocator-issued binding identity.
+    pub fn parse(value: impl Into<String>) -> Result<Self, VsockEffectError> {
+        let value = value.into();
+        if valid_opaque_id(&value) {
+            Ok(Self(value))
+        } else {
+            Err(VsockEffectError::EffectRejected)
+        }
+    }
+
+    /// Construct an opaque identity at a trusted Core adapter boundary.
+    pub fn from_core(value: impl Into<String>) -> Result<Self, VsockEffectError> {
+        Self::parse(value)
+    }
+
+    /// Borrow the opaque value for the injected effect port.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OpaqueBindingId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OpaqueBindingId(<redacted>)")
+    }
+}
+
+impl fmt::Display for OpaqueBindingId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("opaque-binding")
+    }
+}
+
+/// The side of a ZoneLink transport that is being opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportRole {
+    /// Connect to the selected parent route endpoint.
+    Initiator,
+    /// Accept from the selected parent route endpoint.
+    Responder,
+}
+
+/// Injected native-vsock effect boundary.
+#[async_trait]
+pub trait VsockEffectPort: Send + Sync + 'static {
+    /// The opaque byte stream returned by the Core adapter.
+    type Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static;
+
+    /// Open or accept one allocator-selected endpoint.
+    async fn open(
+        &self,
+        endpoint_id: &OpaqueEndpointId,
+        binding_id: &OpaqueBindingId,
+        role: TransportRole,
+        deadline: Instant,
+    ) -> Result<Self::Stream, VsockEffectError>;
+
+    /// Close one stream after the bridge has stopped.
+    async fn close(&self, stream: Self::Stream) -> Result<(), VsockEffectError>;
+}
+
+fn valid_opaque_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value.as_bytes()[0].is_ascii_lowercase()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}

--- a/packages/d2b-provider-transport-vsock/src/errors.rs
+++ b/packages/d2b-provider-transport-vsock/src/errors.rs
@@ -91,6 +91,8 @@ impl Error for VsockEffectError {}
 pub enum ServiceError {
     /// The supplied session is not Ready for transport use.
     SessionNotReady,
+    /// The supplied session is not bound to this Provider's Guest/Zone.
+    SessionIdentityMismatch,
     /// The request's endpoint ID is malformed.
     InvalidEndpointId,
     /// The request's binding ID is malformed.
@@ -114,6 +116,7 @@ impl ServiceError {
     pub const fn code(self) -> &'static str {
         match self {
             Self::SessionNotReady => "session-not-ready",
+            Self::SessionIdentityMismatch => "session-identity-mismatch",
             Self::InvalidEndpointId => "invalid-endpoint-id",
             Self::InvalidBindingId => "invalid-binding-id",
             Self::InvalidDeadline => "invalid-deadline",

--- a/packages/d2b-provider-transport-vsock/src/errors.rs
+++ b/packages/d2b-provider-transport-vsock/src/errors.rs
@@ -1,0 +1,141 @@
+//! Stable, identity-free Provider errors.
+
+use std::{error::Error, fmt};
+
+/// Errors reported by the framed byte transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportError {
+    /// The transport has already been closed.
+    Closed,
+    /// The peer disconnected before a complete record arrived.
+    Disconnected,
+    /// The peer disconnected after a record had started.
+    Truncated,
+    /// A frame exceeded the configured bound.
+    FrameTooLarge,
+    /// A frame was empty or malformed.
+    InvalidFrame,
+    /// Attachments are not supported by vsock.
+    AttachmentsNotSupported,
+    /// The underlying stream returned an I/O failure.
+    Io,
+}
+
+impl TransportError {
+    /// Return the stable error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Closed => "transport-closed",
+            Self::Disconnected => "transport-disconnected",
+            Self::Truncated => "transport-truncated",
+            Self::FrameTooLarge => "transport-frame-too-large",
+            Self::InvalidFrame => "transport-invalid-frame",
+            Self::AttachmentsNotSupported => "transport-attachments-not-supported",
+            Self::Io => "transport-io",
+        }
+    }
+}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl Error for TransportError {}
+
+/// Fail-closed failures from the injected native vsock effect port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VsockEffectError {
+    /// The deadline expired before the endpoint was acquired.
+    DeadlineExceeded,
+    /// The endpoint refused the connection.
+    ConnectRefused,
+    /// The endpoint could not be reached.
+    CidUnreachable,
+    /// The selected binding is already occupied.
+    PortConflict,
+    /// The effect was rejected by the core adapter.
+    EffectRejected,
+    /// The endpoint or binding was not found.
+    EndpointUnavailable,
+    /// The effect can be retried.
+    Transient,
+}
+
+impl VsockEffectError {
+    /// Return the stable error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::DeadlineExceeded => "deadline-exceeded",
+            Self::ConnectRefused => "connect-refused",
+            Self::CidUnreachable => "cid-unreachable",
+            Self::PortConflict => "port-conflict",
+            Self::EffectRejected => "effect-rejected",
+            Self::EndpointUnavailable => "endpoint-unavailable",
+            Self::Transient => "transient",
+        }
+    }
+}
+
+impl fmt::Display for VsockEffectError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl Error for VsockEffectError {}
+
+/// Service lifecycle failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceError {
+    /// The supplied session is not Ready for transport use.
+    SessionNotReady,
+    /// The request's endpoint ID is malformed.
+    InvalidEndpointId,
+    /// The request's binding ID is malformed.
+    InvalidBindingId,
+    /// The open deadline is outside the closed range.
+    InvalidDeadline,
+    /// The service has reached its active transport limit.
+    ProviderOverloaded,
+    /// The effect port refused the open.
+    Effect(VsockEffectError),
+    /// The named stream could not be created.
+    StreamUnavailable,
+    /// The requested handle is not owned by this service.
+    UnknownTransportHandle,
+    /// The bridge did not close within its bounded grace period.
+    CloseUnconfirmed,
+}
+
+impl ServiceError {
+    /// Return the stable error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::SessionNotReady => "session-not-ready",
+            Self::InvalidEndpointId => "invalid-endpoint-id",
+            Self::InvalidBindingId => "invalid-binding-id",
+            Self::InvalidDeadline => "invalid-deadline",
+            Self::ProviderOverloaded => "provider-overloaded",
+            Self::Effect(error) => error.code(),
+            Self::StreamUnavailable => "stream-unavailable",
+            Self::UnknownTransportHandle => "unknown-transport-handle",
+            Self::CloseUnconfirmed => "close-unconfirmed",
+        }
+    }
+}
+
+impl fmt::Display for ServiceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl Error for ServiceError {}
+
+impl From<VsockEffectError> for ServiceError {
+    fn from(value: VsockEffectError) -> Self {
+        Self::Effect(value)
+    }
+}

--- a/packages/d2b-provider-transport-vsock/src/framing.rs
+++ b/packages/d2b-provider-transport-vsock/src/framing.rs
@@ -1,0 +1,339 @@
+//! Bounded length-prefixed byte framing for vsock streams.
+
+use crate::{TransportError, limits::MAX_FRAME_BYTES};
+use async_trait::async_trait;
+use d2b_contracts::v3::component_session::{Locality, TransportClass};
+use d2b_session::{
+    Cancellation, OwnedTransport, TransportDescriptor, TransportPacket, TransportReader,
+    TransportWriter,
+};
+use std::fmt;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+const FRAME_HEADER_BYTES: usize = 2;
+
+/// Provider-facing descriptor for a native vsock transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VsockTransportDescriptor {
+    /// The ComponentSession transport class.
+    pub class: TransportClass,
+    /// The endpoint locality.
+    pub locality: Locality,
+    /// Whether a frame is packet atomic.
+    pub packet_atomic: bool,
+    /// Whether descriptor attachments are supported.
+    pub supports_attachments: bool,
+}
+
+impl Default for VsockTransportDescriptor {
+    fn default() -> Self {
+        Self {
+            class: TransportClass::NativeVsock,
+            locality: Locality::GuestLocal,
+            packet_atomic: false,
+            supports_attachments: false,
+        }
+    }
+}
+
+/// A bounded two-byte length-prefixed transport.
+pub struct FramedVsockTransport<S> {
+    stream: S,
+    max_frame_bytes: usize,
+    closed: bool,
+}
+
+impl<S> FramedVsockTransport<S> {
+    /// Wrap a stream with the ComponentSession maximum frame size.
+    pub fn new(stream: S) -> Self {
+        Self::with_limit(stream, MAX_FRAME_BYTES)
+    }
+
+    /// Wrap a stream with a smaller test or process-local frame bound.
+    pub fn with_limit(stream: S, max_frame_bytes: usize) -> Self {
+        Self {
+            stream,
+            max_frame_bytes: max_frame_bytes.min(MAX_FRAME_BYTES),
+            closed: false,
+        }
+    }
+
+    /// Return the provider-facing descriptor.
+    pub const fn vsock_descriptor(&self) -> VsockTransportDescriptor {
+        VsockTransportDescriptor {
+            class: TransportClass::NativeVsock,
+            locality: Locality::GuestLocal,
+            packet_atomic: false,
+            supports_attachments: false,
+        }
+    }
+
+    /// Read one complete framed record.
+    pub async fn read_frame(&mut self) -> Result<Vec<u8>, TransportError>
+    where
+        S: AsyncRead + Unpin,
+    {
+        if self.closed {
+            return Err(TransportError::Closed);
+        }
+        let mut header = [0_u8; FRAME_HEADER_BYTES];
+        read_exact_classified(&mut self.stream, &mut header, false).await?;
+        let declared = usize::from(u16::from_be_bytes(header));
+        if declared == 0 {
+            self.closed = true;
+            return Err(TransportError::InvalidFrame);
+        }
+        if declared > self.max_frame_bytes {
+            self.closed = true;
+            return Err(TransportError::FrameTooLarge);
+        }
+        let mut body = vec![0_u8; declared];
+        read_exact_classified(&mut self.stream, &mut body, true).await?;
+        Ok(body)
+    }
+
+    /// Write one complete framed record.
+    pub async fn write_frame(&mut self, bytes: &[u8]) -> Result<(), TransportError>
+    where
+        S: AsyncWrite + Unpin,
+    {
+        if self.closed {
+            return Err(TransportError::Closed);
+        }
+        if bytes.is_empty() {
+            return Err(TransportError::InvalidFrame);
+        }
+        if bytes.len() > self.max_frame_bytes || bytes.len() > u16::MAX as usize {
+            return Err(TransportError::FrameTooLarge);
+        }
+        let length = u16::try_from(bytes.len()).map_err(|_| TransportError::FrameTooLarge)?;
+        self.stream
+            .write_all(&length.to_be_bytes())
+            .await
+            .map_err(|_| {
+                self.closed = true;
+                TransportError::Io
+            })?;
+        self.stream.write_all(bytes).await.map_err(|_| {
+            self.closed = true;
+            TransportError::Io
+        })?;
+        self.stream.flush().await.map_err(|_| {
+            self.closed = true;
+            TransportError::Io
+        })
+    }
+
+    /// Consume the transport and return its stream.
+    pub fn into_inner(self) -> S {
+        self.stream
+    }
+}
+
+impl<S> fmt::Debug for FramedVsockTransport<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FramedVsockTransport")
+            .field("max_frame_bytes", &self.max_frame_bytes)
+            .field("closed", &self.closed)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl<S> OwnedTransport for FramedVsockTransport<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    fn descriptor(&self) -> TransportDescriptor {
+        let descriptor = self.vsock_descriptor();
+        TransportDescriptor {
+            class: descriptor.class,
+            locality: descriptor.locality,
+            packet_atomic: descriptor.packet_atomic,
+            supports_attachments: descriptor.supports_attachments,
+        }
+    }
+
+    fn into_split(self: Box<Self>) -> (Box<dyn TransportReader>, Box<dyn TransportWriter>) {
+        let Self {
+            stream,
+            max_frame_bytes,
+            closed,
+        } = *self;
+        let (reader, writer) = tokio::io::split(stream);
+        (
+            Box::new(VsockReader {
+                stream: reader,
+                max_frame_bytes,
+                closed,
+            }),
+            Box::new(VsockWriter {
+                stream: writer,
+                max_frame_bytes,
+                closed,
+            }),
+        )
+    }
+
+    fn set_write_cancellation(&mut self, _cancellation: Option<Cancellation>) {}
+
+    async fn receive(
+        &mut self,
+        protected_limit: usize,
+    ) -> Result<TransportPacket, d2b_session::TransportError> {
+        let limit = protected_limit.min(self.max_frame_bytes);
+        self.read_frame()
+            .await
+            .map(|bytes| {
+                if bytes.len() > limit {
+                    return Err(d2b_session::TransportError::LimitExceeded);
+                }
+                Ok(TransportPacket::new(bytes))
+            })
+            .unwrap_or_else(|error| Err(map_session_error(error)))
+    }
+
+    async fn send(&mut self, packet: TransportPacket) -> Result<(), d2b_session::TransportError> {
+        let (bytes, attachments) = packet.into_parts();
+        if !attachments.is_empty() {
+            return Err(d2b_session::TransportError::InvalidAttachment);
+        }
+        self.write_frame(&bytes).await.map_err(map_session_error)
+    }
+
+    async fn close(&mut self) -> Result<(), d2b_session::TransportError> {
+        if !self.closed {
+            self.closed = true;
+            self.stream
+                .shutdown()
+                .await
+                .map_err(|_| d2b_session::TransportError::Disconnected)?;
+        }
+        Ok(())
+    }
+}
+
+struct VsockReader<R> {
+    stream: R,
+    max_frame_bytes: usize,
+    closed: bool,
+}
+
+#[async_trait]
+impl<R> TransportReader for VsockReader<R>
+where
+    R: AsyncRead + Unpin + Send,
+{
+    async fn receive(
+        &mut self,
+        protected_limit: usize,
+    ) -> Result<TransportPacket, d2b_session::TransportError> {
+        if self.closed {
+            return Err(d2b_session::TransportError::Disconnected);
+        }
+        let mut header = [0_u8; FRAME_HEADER_BYTES];
+        read_exact_classified(&mut self.stream, &mut header, false)
+            .await
+            .map_err(map_session_error)?;
+        let declared = usize::from(u16::from_be_bytes(header));
+        if declared == 0 || declared > self.max_frame_bytes || declared > protected_limit {
+            self.closed = true;
+            return Err(d2b_session::TransportError::LimitExceeded);
+        }
+        let mut body = vec![0_u8; declared];
+        read_exact_classified(&mut self.stream, &mut body, true)
+            .await
+            .map_err(map_session_error)?;
+        Ok(TransportPacket::new(body))
+    }
+}
+
+struct VsockWriter<W> {
+    stream: W,
+    max_frame_bytes: usize,
+    closed: bool,
+}
+
+#[async_trait]
+impl<W> TransportWriter for VsockWriter<W>
+where
+    W: AsyncWrite + Unpin + Send,
+{
+    async fn send(&mut self, packet: TransportPacket) -> Result<(), d2b_session::TransportError> {
+        if self.closed {
+            return Err(d2b_session::TransportError::Disconnected);
+        }
+        let (bytes, attachments) = packet.into_parts();
+        if !attachments.is_empty() {
+            return Err(d2b_session::TransportError::InvalidAttachment);
+        }
+        if bytes.is_empty() || bytes.len() > self.max_frame_bytes {
+            return Err(d2b_session::TransportError::LimitExceeded);
+        }
+        let length =
+            u16::try_from(bytes.len()).map_err(|_| d2b_session::TransportError::LimitExceeded)?;
+        self.stream
+            .write_all(&length.to_be_bytes())
+            .await
+            .map_err(|_| d2b_session::TransportError::Disconnected)?;
+        self.stream
+            .write_all(&bytes)
+            .await
+            .map_err(|_| d2b_session::TransportError::Disconnected)?;
+        self.stream
+            .flush()
+            .await
+            .map_err(|_| d2b_session::TransportError::Disconnected)
+    }
+
+    async fn close(&mut self) -> Result<(), d2b_session::TransportError> {
+        if !self.closed {
+            self.closed = true;
+            self.stream
+                .shutdown()
+                .await
+                .map_err(|_| d2b_session::TransportError::Disconnected)?;
+        }
+        Ok(())
+    }
+}
+
+async fn read_exact_classified<R: AsyncRead + Unpin>(
+    stream: &mut R,
+    output: &mut [u8],
+    frame_started: bool,
+) -> Result<(), TransportError> {
+    let mut offset = 0;
+    while offset < output.len() {
+        let read = stream.read(&mut output[offset..]).await.map_err(|_| {
+            if frame_started {
+                TransportError::Truncated
+            } else {
+                TransportError::Io
+            }
+        })?;
+        if read == 0 {
+            return Err(if offset == 0 && !frame_started {
+                TransportError::Disconnected
+            } else {
+                TransportError::Truncated
+            });
+        }
+        offset += read;
+    }
+    Ok(())
+}
+
+fn map_session_error(error: TransportError) -> d2b_session::TransportError {
+    match error {
+        TransportError::Closed
+        | TransportError::Disconnected
+        | TransportError::Truncated
+        | TransportError::Io => d2b_session::TransportError::Disconnected,
+        TransportError::FrameTooLarge | TransportError::InvalidFrame => {
+            d2b_session::TransportError::LimitExceeded
+        }
+        TransportError::AttachmentsNotSupported => d2b_session::TransportError::InvalidAttachment,
+    }
+}

--- a/packages/d2b-provider-transport-vsock/src/lib.rs
+++ b/packages/d2b-provider-transport-vsock/src/lib.rs
@@ -31,7 +31,7 @@ pub use errors::{ServiceError, TransportError, VsockEffectError};
 pub use framing::{FramedVsockTransport, VsockTransportDescriptor};
 pub use limits::{
     CLOSE_GRACE_MS, MAX_ACTIVE_TRANSPORTS, MAX_FRAME_BYTES, MAX_OPEN_DEADLINE_MS,
-    MIN_OPEN_DEADLINE_MS,
+    MAX_REPLAY_ENTRIES, MIN_OPEN_DEADLINE_MS,
 };
 pub use metrics::{TransportMetricLabels, TransportMetricOperation, TransportMetricOutcome};
 pub use relay::{
@@ -39,7 +39,7 @@ pub use relay::{
 };
 pub use service::{
     CloseTransportRequest, ObserveTransportRequest, OpenTransportRequest, OpenTransportResponse,
-    ServicePhase, TransportObservation, TransportPhase, VsockTransportService,
+    ServicePhase, TransportEvent, TransportObservation, TransportPhase, VsockTransportService,
 };
 pub use settings::{PortClass, SettingsError, VsockTransportSettings};
 pub use state_volume::{EMPTY_STATE_SCHEMA, STATE_LAYOUT_USER, StateVolumeSpec};

--- a/packages/d2b-provider-transport-vsock/src/lib.rs
+++ b/packages/d2b-provider-transport-vsock/src/lib.rs
@@ -1,4 +1,51 @@
-//! Canonical crate root for `Provider/transport-vsock`.
-//!
-//! The crate root is intentionally compile-safe and contains no semantic
-//! Provider implementation.
+//! Canonical `Provider/transport-vsock` implementation.
+
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+mod audit;
+mod auth;
+mod bridge;
+mod effect_port;
+mod errors;
+mod framing;
+mod limits;
+mod metrics;
+mod relay;
+mod service;
+mod settings;
+mod state_volume;
+mod topology;
+
+pub use audit::{TransportAuditEvent, TransportAuditOperation, TransportAuditOutcome};
+pub use auth::{
+    GuestControlKey, GuestIdentity, PeerCid, ReadySession, SessionAuthority, SessionProof,
+    SessionRejectReason, SessionState,
+};
+pub use bridge::{
+    BridgeControl, BridgeExit, BridgeStats, NamedStreamError, NamedStreamId, NamedStreamPort,
+    TransportHandle,
+};
+pub use effect_port::{OpaqueBindingId, OpaqueEndpointId, TransportRole, VsockEffectPort};
+pub use errors::{ServiceError, TransportError, VsockEffectError};
+pub use framing::{FramedVsockTransport, VsockTransportDescriptor};
+pub use limits::{
+    CLOSE_GRACE_MS, MAX_ACTIVE_TRANSPORTS, MAX_FRAME_BYTES, MAX_OPEN_DEADLINE_MS,
+    MIN_OPEN_DEADLINE_MS,
+};
+pub use metrics::{TransportMetricLabels, TransportMetricOperation, TransportMetricOutcome};
+pub use relay::{
+    NativeGuestRelay, RelayBinding, RelayEffectError, RelayEffectPort, RelayObservation, RelayPhase,
+};
+pub use service::{
+    CloseTransportRequest, ObserveTransportRequest, OpenTransportRequest, OpenTransportResponse,
+    ServicePhase, TransportObservation, TransportPhase, VsockTransportService,
+};
+pub use settings::{PortClass, SettingsError, VsockTransportSettings};
+pub use state_volume::{EMPTY_STATE_SCHEMA, STATE_LAYOUT_USER, StateVolumeSpec};
+pub use topology::{ParentStoreResourceCensus, TopologyError, TransportLimits, ZoneLinkSpec};
+
+/// Stable Provider implementation identifier.
+pub const VSOCK_IMPLEMENTATION_ID: &str = "vsock";
+/// Stable Provider resource reference.
+pub const PROVIDER_REF: &str = "Provider/transport-vsock";

--- a/packages/d2b-provider-transport-vsock/src/limits.rs
+++ b/packages/d2b-provider-transport-vsock/src/limits.rs
@@ -1,0 +1,14 @@
+//! Bounded limits for the vsock Provider.
+
+/// Maximum number of concurrent transport handles in one service process.
+pub const MAX_ACTIVE_TRANSPORTS: usize = 128;
+/// Maximum length of one length-prefixed transport frame.
+pub const MAX_FRAME_BYTES: usize = u16::MAX as usize;
+/// Minimum accepted open deadline in milliseconds.
+pub const MIN_OPEN_DEADLINE_MS: u32 = 1_000;
+/// Maximum accepted open deadline in milliseconds.
+pub const MAX_OPEN_DEADLINE_MS: u32 = 60_000;
+/// Grace period for a bridge to stop after close.
+pub const CLOSE_GRACE_MS: u64 = 500;
+/// Maximum number of remembered session nonces.
+pub const MAX_REPLAY_ENTRIES: usize = 256;

--- a/packages/d2b-provider-transport-vsock/src/metrics.rs
+++ b/packages/d2b-provider-transport-vsock/src/metrics.rs
@@ -1,0 +1,36 @@
+//! Closed telemetry dimensions for transport-vsock.
+
+/// Provider metric operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportMetricOperation {
+    /// Open attempts.
+    Open,
+    /// Close attempts.
+    Close,
+    /// Observe attempts.
+    Observe,
+}
+
+/// Provider metric outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportMetricOutcome {
+    /// The operation completed.
+    Success,
+    /// The operation was refused.
+    Refused,
+    /// The operation failed locally.
+    Failure,
+}
+
+/// Bounded metric labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportMetricLabels {
+    /// Fixed Provider name.
+    pub provider: &'static str,
+    /// Fixed component name.
+    pub component: &'static str,
+    /// Closed operation label.
+    pub operation: TransportMetricOperation,
+    /// Closed outcome label.
+    pub outcome: TransportMetricOutcome,
+}

--- a/packages/d2b-provider-transport-vsock/src/relay.rs
+++ b/packages/d2b-provider-transport-vsock/src/relay.rs
@@ -1,0 +1,297 @@
+//! Native guest-relay lifecycle and restart adoption.
+
+use crate::{GuestIdentity, ReadySession};
+use async_trait::async_trait;
+use std::fmt;
+
+/// Exact Guest-bound relay identity.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RelayBinding {
+    guest: GuestIdentity,
+    session_token: [u8; 16],
+}
+
+impl RelayBinding {
+    /// Construct a binding at the authenticated core boundary.
+    pub const fn new(guest: GuestIdentity, session_token: [u8; 16]) -> Self {
+        Self {
+            guest,
+            session_token,
+        }
+    }
+
+    /// Borrow the Guest identity.
+    pub const fn guest(&self) -> &GuestIdentity {
+        &self.guest
+    }
+}
+
+impl fmt::Debug for RelayBinding {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RelayBinding(<redacted>)")
+    }
+}
+
+/// Restart observation supplied by the Core relay adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelayObservation<L, R> {
+    /// Binding proof attached to the observed listener and relay.
+    pub binding: RelayBinding,
+    /// Matching listener handle.
+    pub listener: L,
+    /// Matching relay process handle.
+    pub process: R,
+}
+
+/// Stable relay effect failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayEffectError {
+    /// Another relay owns the CID authority.
+    CidAuthorityConflict,
+    /// The listener could not be acquired.
+    ListenerUnavailable,
+    /// The relay process could not be started.
+    ProcessUnavailable,
+    /// The observed listener or process does not match the binding.
+    RestartMismatch,
+    /// The effect can be retried.
+    Transient,
+    /// Closure was not confirmed.
+    CloseUnconfirmed,
+}
+
+impl RelayEffectError {
+    /// Return the stable error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::CidAuthorityConflict => "vsock-cid-authority-conflict",
+            Self::ListenerUnavailable => "vsock-listener-unavailable",
+            Self::ProcessUnavailable => "vsock-relay-process-unavailable",
+            Self::RestartMismatch => "vsock-relay-restart-mismatch",
+            Self::Transient => "vsock-relay-transient",
+            Self::CloseUnconfirmed => "vsock-relay-close-unconfirmed",
+        }
+    }
+}
+
+impl fmt::Display for RelayEffectError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for RelayEffectError {}
+
+/// Effect boundary for the native guest relay.
+#[async_trait]
+pub trait RelayEffectPort: Send + Sync + 'static {
+    /// Opaque CID authority reservation.
+    type CidReservation: Send + 'static;
+    /// Opaque listener handle.
+    type Listener: Send + 'static;
+    /// Opaque relay process identity.
+    type RelayProcess: Send + 'static;
+
+    /// Reserve the exact Host-global CID before any effect starts.
+    async fn reserve_cid(
+        &self,
+        binding: &RelayBinding,
+    ) -> Result<Self::CidReservation, RelayEffectError>;
+
+    /// Bind the matching listener while retaining CID authority.
+    async fn bind_listener(
+        &self,
+        binding: &RelayBinding,
+        reservation: &Self::CidReservation,
+    ) -> Result<Self::Listener, RelayEffectError>;
+
+    /// Start the native relay process.
+    async fn spawn_relay(
+        &self,
+        binding: &RelayBinding,
+        listener: &Self::Listener,
+        reservation: &Self::CidReservation,
+    ) -> Result<Self::RelayProcess, RelayEffectError>;
+
+    /// Close the relay process.
+    async fn close_relay(&self, process: &Self::RelayProcess) -> Result<(), RelayEffectError>;
+
+    /// Close the listener.
+    async fn close_listener(&self, listener: &Self::Listener) -> Result<(), RelayEffectError>;
+
+    /// Release CID authority after listener and relay closure.
+    async fn release_cid(&self, reservation: &Self::CidReservation)
+    -> Result<(), RelayEffectError>;
+
+    /// Find a matching listener and relay during restart adoption.
+    async fn observe(
+        &self,
+        binding: &RelayBinding,
+    ) -> Result<Option<RelayObservation<Self::Listener, Self::RelayProcess>>, RelayEffectError>;
+}
+
+/// Relay lifecycle phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayPhase {
+    /// No CID, listener, or relay is held.
+    Idle,
+    /// CID and listener are being acquired.
+    Starting,
+    /// The matching listener and relay are ready.
+    Ready,
+    /// Restart adoption found ambiguity or a stale identity.
+    Degraded,
+    /// Closure is in progress; authority remains held.
+    Finalizing,
+    /// All effects closed and CID authority released.
+    Closed,
+}
+
+/// Native relay controller. It owns no raw socket or process identity.
+pub struct NativeGuestRelay<P>
+where
+    P: RelayEffectPort,
+{
+    port: P,
+    binding: RelayBinding,
+    reservation: Option<P::CidReservation>,
+    listener: Option<P::Listener>,
+    process: Option<P::RelayProcess>,
+    phase: RelayPhase,
+}
+
+impl<P> NativeGuestRelay<P>
+where
+    P: RelayEffectPort,
+{
+    /// Construct an idle relay controller.
+    pub fn new(port: P, binding: RelayBinding) -> Self {
+        Self {
+            port,
+            binding,
+            reservation: None,
+            listener: None,
+            process: None,
+            phase: RelayPhase::Idle,
+        }
+    }
+
+    /// Return the current relay lifecycle phase.
+    pub const fn phase(&self) -> RelayPhase {
+        self.phase
+    }
+
+    /// Borrow the exact relay binding.
+    pub const fn binding(&self) -> &RelayBinding {
+        &self.binding
+    }
+
+    /// Acquire CID authority, bind the listener, and start the native relay.
+    pub async fn start(&mut self, session: &ReadySession) -> Result<(), RelayEffectError> {
+        if !session.matches(self.binding.guest()) {
+            self.phase = RelayPhase::Degraded;
+            return Err(RelayEffectError::RestartMismatch);
+        }
+        if !matches!(self.phase, RelayPhase::Idle | RelayPhase::Closed) {
+            return Err(RelayEffectError::Transient);
+        }
+        self.phase = RelayPhase::Starting;
+        let reservation = self.port.reserve_cid(&self.binding).await?;
+        let listener = match self.port.bind_listener(&self.binding, &reservation).await {
+            Ok(listener) => listener,
+            Err(error) => {
+                let _ = self.port.release_cid(&reservation).await;
+                self.phase = RelayPhase::Degraded;
+                return Err(error);
+            }
+        };
+        let process = match self
+            .port
+            .spawn_relay(&self.binding, &listener, &reservation)
+            .await
+        {
+            Ok(process) => process,
+            Err(error) => {
+                let _ = self.port.close_listener(&listener).await;
+                let _ = self.port.release_cid(&reservation).await;
+                self.phase = RelayPhase::Degraded;
+                return Err(error);
+            }
+        };
+        self.reservation = Some(reservation);
+        self.listener = Some(listener);
+        self.process = Some(process);
+        self.phase = RelayPhase::Ready;
+        Ok(())
+    }
+
+    /// Adopt only the exact matching listener and relay after restart.
+    pub async fn adopt(&mut self) -> Result<(), RelayEffectError> {
+        if !matches!(self.phase, RelayPhase::Idle | RelayPhase::Closed) {
+            return Err(RelayEffectError::Transient);
+        }
+        let Some(observation) = self.port.observe(&self.binding).await? else {
+            self.phase = RelayPhase::Degraded;
+            return Err(RelayEffectError::RestartMismatch);
+        };
+        if observation.binding != self.binding {
+            self.phase = RelayPhase::Degraded;
+            return Err(RelayEffectError::RestartMismatch);
+        }
+        self.listener = Some(observation.listener);
+        self.process = Some(observation.process);
+        self.phase = RelayPhase::Ready;
+        Ok(())
+    }
+
+    /// Attach an already rehydrated CID reservation to an adopted relay.
+    pub fn attach_reservation(
+        &mut self,
+        reservation: P::CidReservation,
+    ) -> Result<(), RelayEffectError> {
+        if !matches!(self.phase, RelayPhase::Idle | RelayPhase::Closed) {
+            return Err(RelayEffectError::Transient);
+        }
+        self.reservation = Some(reservation);
+        Ok(())
+    }
+
+    /// Close the relay, then listener, then release CID authority.
+    pub async fn finalize(&mut self) -> Result<(), RelayEffectError> {
+        if self.phase == RelayPhase::Closed {
+            return Ok(());
+        }
+        self.phase = RelayPhase::Finalizing;
+        if let Some(process) = self.process.as_ref() {
+            self.port.close_relay(process).await?;
+            self.process = None;
+        }
+        if let Some(listener) = self.listener.as_ref() {
+            self.port.close_listener(listener).await?;
+            self.listener = None;
+        }
+        let reservation = self
+            .reservation
+            .as_ref()
+            .ok_or(RelayEffectError::CloseUnconfirmed)?;
+        self.port.release_cid(reservation).await?;
+        self.reservation = None;
+        self.phase = RelayPhase::Closed;
+        Ok(())
+    }
+}
+
+impl<P> fmt::Debug for NativeGuestRelay<P>
+where
+    P: RelayEffectPort,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NativeGuestRelay")
+            .field("phase", &self.phase)
+            .field("has_reservation", &self.reservation.is_some())
+            .field("has_listener", &self.listener.is_some())
+            .field("has_process", &self.process.is_some())
+            .finish()
+    }
+}

--- a/packages/d2b-provider-transport-vsock/src/relay.rs
+++ b/packages/d2b-provider-transport-vsock/src/relay.rs
@@ -196,40 +196,85 @@ where
             return Err(RelayEffectError::Transient);
         }
         self.phase = RelayPhase::Starting;
-        let reservation = self.port.reserve_cid(&self.binding).await?;
-        let listener = match self.port.bind_listener(&self.binding, &reservation).await {
-            Ok(listener) => listener,
+        let reservation = match self.port.reserve_cid(&self.binding).await {
+            Ok(reservation) => reservation,
             Err(error) => {
-                let _ = self.port.release_cid(&reservation).await;
-                self.phase = RelayPhase::Degraded;
-                return Err(error);
-            }
-        };
-        let process = match self
-            .port
-            .spawn_relay(&self.binding, &listener, &reservation)
-            .await
-        {
-            Ok(process) => process,
-            Err(error) => {
-                let _ = self.port.close_listener(&listener).await;
-                let _ = self.port.release_cid(&reservation).await;
-                self.phase = RelayPhase::Degraded;
+                self.phase = RelayPhase::Idle;
                 return Err(error);
             }
         };
         self.reservation = Some(reservation);
+        let listener = match self
+            .port
+            .bind_listener(
+                &self.binding,
+                self.reservation.as_ref().expect("reservation"),
+            )
+            .await
+        {
+            Ok(listener) => listener,
+            Err(error) => {
+                if self
+                    .port
+                    .release_cid(self.reservation.as_ref().expect("reservation"))
+                    .await
+                    .is_ok()
+                {
+                    self.reservation = None;
+                    self.phase = RelayPhase::Idle;
+                } else {
+                    self.phase = RelayPhase::Degraded;
+                }
+                return Err(error);
+            }
+        };
         self.listener = Some(listener);
+        let process = match self
+            .port
+            .spawn_relay(
+                &self.binding,
+                self.listener.as_ref().expect("listener"),
+                self.reservation.as_ref().expect("reservation"),
+            )
+            .await
+        {
+            Ok(process) => process,
+            Err(error) => {
+                let listener_closed = self
+                    .port
+                    .close_listener(self.listener.as_ref().expect("listener"))
+                    .await
+                    .is_ok();
+                if listener_closed {
+                    self.listener = None;
+                }
+                let reservation_released = self
+                    .port
+                    .release_cid(self.reservation.as_ref().expect("reservation"))
+                    .await
+                    .is_ok();
+                if reservation_released {
+                    self.reservation = None;
+                }
+                self.phase = if listener_closed && reservation_released {
+                    RelayPhase::Idle
+                } else {
+                    RelayPhase::Degraded
+                };
+                return Err(error);
+            }
+        };
         self.process = Some(process);
         self.phase = RelayPhase::Ready;
         Ok(())
     }
 
     /// Adopt only the exact matching listener and relay after restart.
-    pub async fn adopt(&mut self) -> Result<(), RelayEffectError> {
+    pub async fn adopt(&mut self, reservation: P::CidReservation) -> Result<(), RelayEffectError> {
         if !matches!(self.phase, RelayPhase::Idle | RelayPhase::Closed) {
             return Err(RelayEffectError::Transient);
         }
+        self.reservation = Some(reservation);
         let Some(observation) = self.port.observe(&self.binding).await? else {
             self.phase = RelayPhase::Degraded;
             return Err(RelayEffectError::RestartMismatch);
@@ -241,18 +286,6 @@ where
         self.listener = Some(observation.listener);
         self.process = Some(observation.process);
         self.phase = RelayPhase::Ready;
-        Ok(())
-    }
-
-    /// Attach an already rehydrated CID reservation to an adopted relay.
-    pub fn attach_reservation(
-        &mut self,
-        reservation: P::CidReservation,
-    ) -> Result<(), RelayEffectError> {
-        if !matches!(self.phase, RelayPhase::Idle | RelayPhase::Closed) {
-            return Err(RelayEffectError::Transient);
-        }
-        self.reservation = Some(reservation);
         Ok(())
     }
 

--- a/packages/d2b-provider-transport-vsock/src/relay.rs
+++ b/packages/d2b-provider-transport-vsock/src/relay.rs
@@ -33,7 +33,7 @@ impl fmt::Debug for RelayBinding {
 }
 
 /// Restart observation supplied by the Core relay adapter.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RelayObservation<L, R> {
     /// Binding proof attached to the observed listener and relay.
     pub binding: RelayBinding,
@@ -41,6 +41,17 @@ pub struct RelayObservation<L, R> {
     pub listener: L,
     /// Matching relay process handle.
     pub process: R,
+}
+
+impl<L, R> fmt::Debug for RelayObservation<L, R> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RelayObservation")
+            .field("binding", &self.binding)
+            .field("listener", &"<redacted>")
+            .field("process", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Stable relay effect failures.
@@ -248,11 +259,14 @@ where
                 if listener_closed {
                     self.listener = None;
                 }
-                let reservation_released = self
-                    .port
-                    .release_cid(self.reservation.as_ref().expect("reservation"))
-                    .await
-                    .is_ok();
+                let reservation_released = if listener_closed {
+                    self.port
+                        .release_cid(self.reservation.as_ref().expect("reservation"))
+                        .await
+                        .is_ok()
+                } else {
+                    false
+                };
                 if reservation_released {
                     self.reservation = None;
                 }
@@ -275,9 +289,16 @@ where
             return Err(RelayEffectError::Transient);
         }
         self.reservation = Some(reservation);
-        let Some(observation) = self.port.observe(&self.binding).await? else {
-            self.phase = RelayPhase::Degraded;
-            return Err(RelayEffectError::RestartMismatch);
+        let observation = match self.port.observe(&self.binding).await {
+            Ok(Some(observation)) => observation,
+            Ok(None) => {
+                self.phase = RelayPhase::Degraded;
+                return Err(RelayEffectError::RestartMismatch);
+            }
+            Err(error) => {
+                self.phase = RelayPhase::Degraded;
+                return Err(error);
+            }
         };
         if observation.binding != self.binding {
             self.phase = RelayPhase::Degraded;

--- a/packages/d2b-provider-transport-vsock/src/relay.rs
+++ b/packages/d2b-provider-transport-vsock/src/relay.rs
@@ -324,12 +324,10 @@ where
             self.port.close_listener(listener).await?;
             self.listener = None;
         }
-        let reservation = self
-            .reservation
-            .as_ref()
-            .ok_or(RelayEffectError::CloseUnconfirmed)?;
-        self.port.release_cid(reservation).await?;
-        self.reservation = None;
+        if let Some(reservation) = self.reservation.as_ref() {
+            self.port.release_cid(reservation).await?;
+            self.reservation = None;
+        }
         self.phase = RelayPhase::Closed;
         Ok(())
     }

--- a/packages/d2b-provider-transport-vsock/src/service.rs
+++ b/packages/d2b-provider-transport-vsock/src/service.rs
@@ -25,6 +25,7 @@ use tokio::{
 };
 
 const PROVIDER_REF: &str = "Provider/transport-vsock";
+const CLOSE_COMPLETION_BUDGET_MS: u64 = CLOSE_GRACE_MS * 2;
 
 /// Request to open one ZoneLink byte transport.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -266,9 +267,8 @@ where
             .try_acquire_owned()
             .map_err(|_| ServiceError::ProviderOverloaded)?;
         let deadline = Instant::now() + Duration::from_millis(u64::from(request.deadline_ms));
-        let open_deadline = Duration::from_millis(u64::from(request.deadline_ms));
         let effect_stream = timeout(
-            open_deadline,
+            remaining_until(deadline),
             self.effect.open(
                 &request.endpoint_id,
                 &request.binding_id,
@@ -280,15 +280,13 @@ where
         .map_err(|_| ServiceError::Effect(VsockEffectError::DeadlineExceeded))?
         .map_err(ServiceError::Effect)?;
         let (stream_id, named_stream) =
-            match timeout(open_deadline, self.streams.open_named_stream()).await {
+            match timeout(remaining_until(deadline), self.streams.open_named_stream()).await {
                 Ok(Ok(value)) => value,
                 Ok(Err(_)) => {
-                    let closed = timeout(
-                        Duration::from_millis(CLOSE_GRACE_MS),
-                        self.effect.close(effect_stream),
-                    )
-                    .await
-                    .is_ok_and(|result| result.is_ok());
+                    let closed =
+                        timeout(remaining_until(deadline), self.effect.close(effect_stream))
+                            .await
+                            .is_ok_and(|result| result.is_ok());
                     return Err(if closed {
                         ServiceError::StreamUnavailable
                     } else {
@@ -296,12 +294,10 @@ where
                     });
                 }
                 Err(_) => {
-                    let closed = timeout(
-                        Duration::from_millis(CLOSE_GRACE_MS),
-                        self.effect.close(effect_stream),
-                    )
-                    .await
-                    .is_ok_and(|result| result.is_ok());
+                    let closed =
+                        timeout(remaining_until(deadline), self.effect.close(effect_stream))
+                            .await
+                            .is_ok_and(|result| result.is_ok());
                     return Err(if closed {
                         ServiceError::Effect(VsockEffectError::DeadlineExceeded)
                     } else {
@@ -450,9 +446,12 @@ where
                 *entry_phase = TransportPhase::Closing;
             }
         }
-        if timeout(Duration::from_millis(CLOSE_GRACE_MS), completion.wait())
-            .await
-            .is_err()
+        if timeout(
+            Duration::from_millis(CLOSE_COMPLETION_BUDGET_MS),
+            completion.wait(),
+        )
+        .await
+        .is_err()
         {
             let entry = self.active.lock().await.remove(&request.transport_handle);
             if let Some(entry) = entry {
@@ -608,13 +607,20 @@ where
             last_exit: *entry.exit.lock().await,
         };
         let mut completed = self.completed.lock().await;
-        if completed.len() >= MAX_ACTIVE_TRANSPORTS
-            && let Some(oldest) = completed.keys().next().copied()
-        {
-            completed.remove(&oldest);
+        if completed.len() >= MAX_ACTIVE_TRANSPORTS {
+            let released = completed.iter().find_map(|(handle, observation)| {
+                (observation.phase == TransportPhase::Released).then_some(*handle)
+            });
+            if let Some(released) = released {
+                completed.remove(&released);
+            }
         }
         completed.insert(handle, observation);
     }
+}
+
+fn remaining_until(deadline: Instant) -> Duration {
+    deadline.saturating_duration_since(Instant::now())
 }
 
 async fn emit_event(

--- a/packages/d2b-provider-transport-vsock/src/service.rs
+++ b/packages/d2b-provider-transport-vsock/src/service.rs
@@ -7,7 +7,7 @@ use crate::{
         TransportHandle, run_bridge,
     },
     effect_port::{OpaqueBindingId, OpaqueEndpointId, TransportRole, VsockEffectPort},
-    errors::ServiceError,
+    errors::{ServiceError, VsockEffectError},
     framing::VsockTransportDescriptor,
     limits::{CLOSE_GRACE_MS, MAX_ACTIVE_TRANSPORTS, MAX_OPEN_DEADLINE_MS, MIN_OPEN_DEADLINE_MS},
 };
@@ -20,7 +20,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    sync::{Mutex, OwnedSemaphorePermit, Semaphore},
+    sync::{Mutex, OwnedSemaphorePermit, Semaphore, mpsc},
     time::timeout,
 };
 
@@ -104,6 +104,29 @@ pub struct ObserveTransportRequest {
     pub include_bytes: bool,
 }
 
+/// Bounded lifecycle event emitted by ObserveTransport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportEvent {
+    /// The effect stream and named stream were acquired.
+    Acquired,
+    /// Bounded byte counters for one observation interval.
+    BytesTransferred {
+        /// Bytes received from the vsock side.
+        rx_bytes: u64,
+        /// Bytes sent to the vsock side.
+        tx_bytes: u64,
+    },
+    /// A bridge error occurred.
+    Error {
+        /// Closed error class.
+        kind: &'static str,
+        /// Whether the owner may reopen the transport.
+        recoverable: bool,
+    },
+    /// The bridge and both endpoints were released.
+    Released,
+}
+
 /// Provider lifecycle phase for one transport handle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransportPhase {
@@ -143,6 +166,9 @@ pub enum ServicePhase {
     Degraded,
 }
 
+type EventSubscriber = (bool, mpsc::Sender<TransportEvent>);
+type EventSubscribers = Arc<Mutex<Vec<EventSubscriber>>>;
+
 /// The single transport-vsock service component for one Zone.
 pub struct VsockTransportService<P, N>
 where
@@ -151,6 +177,7 @@ where
 {
     effect: Arc<P>,
     streams: Arc<N>,
+    expected_identity: crate::GuestIdentity,
     active: Arc<Mutex<HashMap<TransportHandle, TransportEntry>>>,
     completed: Arc<Mutex<HashMap<TransportHandle, TransportObservation>>>,
     slots: Arc<Semaphore>,
@@ -159,6 +186,9 @@ where
 
 struct TransportEntry {
     control: BridgeControl,
+    abort: tokio::task::AbortHandle,
+    subscribers: EventSubscribers,
+    history: Arc<Mutex<Vec<TransportEvent>>>,
     phase: Arc<Mutex<TransportPhase>>,
     exit: Arc<Mutex<Option<BridgeExit>>>,
     stats: Arc<BridgeStats>,
@@ -171,10 +201,11 @@ where
     N: NamedStreamPort,
 {
     /// Construct a service over the child-core effect and stream ports.
-    pub fn new(effect: P, streams: N) -> Self {
+    pub fn new(effect: P, streams: N, expected_identity: crate::GuestIdentity) -> Self {
         Self {
             effect: Arc::new(effect),
             streams: Arc::new(streams),
+            expected_identity,
             active: Arc::new(Mutex::new(HashMap::new())),
             completed: Arc::new(Mutex::new(HashMap::new())),
             slots: Arc::new(Semaphore::new(MAX_ACTIVE_TRANSPORTS)),
@@ -205,8 +236,12 @@ where
         session: &ReadySession,
         request: OpenTransportRequest,
     ) -> Result<OpenTransportResponse, ServiceError> {
+        self.reap_released().await;
         if session.state() != crate::SessionState::Ready {
             return Err(ServiceError::SessionNotReady);
+        }
+        if !session.matches(&self.expected_identity) {
+            return Err(ServiceError::SessionIdentityMismatch);
         }
         request.validate()?;
         let permit = Arc::clone(&self.slots)
@@ -223,41 +258,96 @@ where
             )
             .await
             .map_err(ServiceError::Effect)?;
-        let (stream_id, named_stream) = match self.streams.open_named_stream().await {
-            Ok(value) => value,
-            Err(_) => {
-                let _ = self.effect.close(effect_stream).await;
-                return Err(ServiceError::StreamUnavailable);
-            }
-        };
+        let open_deadline = Duration::from_millis(u64::from(request.deadline_ms));
+        let (stream_id, named_stream) =
+            match timeout(open_deadline, self.streams.open_named_stream()).await {
+                Ok(Ok(value)) => value,
+                Ok(Err(_)) => {
+                    let _ = timeout(
+                        Duration::from_millis(CLOSE_GRACE_MS),
+                        self.effect.close(effect_stream),
+                    )
+                    .await;
+                    return Err(ServiceError::StreamUnavailable);
+                }
+                Err(_) => {
+                    let _ = timeout(
+                        Duration::from_millis(CLOSE_GRACE_MS),
+                        self.effect.close(effect_stream),
+                    )
+                    .await;
+                    return Err(ServiceError::Effect(VsockEffectError::DeadlineExceeded));
+                }
+            };
         let handle = TransportHandle::from_core(self.next_handle.fetch_add(1, Ordering::Relaxed));
         let (control, stop) = BridgeControl::new();
-        let completion = control.completion();
+        let task_control = control.clone();
         let phase = Arc::new(Mutex::new(TransportPhase::Acquired));
         let exit = Arc::new(Mutex::new(None));
         let stats = Arc::new(BridgeStats::default());
+        let subscribers = Arc::new(Mutex::new(Vec::new()));
+        let history = Arc::new(Mutex::new(vec![TransportEvent::Acquired]));
         let task_effect = Arc::clone(&self.effect);
         let task_streams = Arc::clone(&self.streams);
         let task_phase = Arc::clone(&phase);
         let task_exit = Arc::clone(&exit);
         let task_stats = Arc::clone(&stats);
-        tokio::spawn(async move {
+        let task_subscribers = Arc::clone(&subscribers);
+        let task_history = Arc::clone(&history);
+        let task = tokio::spawn(async move {
             let (effect_stream, _named_stream, reason) =
-                run_bridge(effect_stream, named_stream, stop, task_stats).await;
-            let effect_result = task_effect.close(effect_stream).await;
-            let stream_result = task_streams.close_named_stream(stream_id).await;
+                run_bridge(effect_stream, named_stream, stop, Arc::clone(&task_stats)).await;
+            let effect_result = timeout(
+                Duration::from_millis(CLOSE_GRACE_MS),
+                task_effect.close(effect_stream),
+            )
+            .await
+            .is_ok_and(|result| result.is_ok());
+            let stream_result = timeout(
+                Duration::from_millis(CLOSE_GRACE_MS),
+                task_streams.close_named_stream(stream_id),
+            )
+            .await
+            .is_ok_and(|result| result.is_ok());
             *task_exit.lock().await = Some(reason);
-            *task_phase.lock().await = if effect_result.is_ok() && stream_result.is_ok() {
+            if reason == BridgeExit::IoError {
+                emit_event(
+                    &task_subscribers,
+                    &task_history,
+                    TransportEvent::Error {
+                        kind: "bridge-io",
+                        recoverable: false,
+                    },
+                )
+                .await;
+            } else {
+                let rx_bytes = task_stats.bytes_from_vsock();
+                let tx_bytes = task_stats.bytes_to_vsock();
+                if rx_bytes != 0 || tx_bytes != 0 {
+                    emit_event(
+                        &task_subscribers,
+                        &task_history,
+                        TransportEvent::BytesTransferred { rx_bytes, tx_bytes },
+                    )
+                    .await;
+                }
+            }
+            *task_phase.lock().await = if effect_result && stream_result {
                 TransportPhase::Released
             } else {
                 TransportPhase::Degraded
             };
-            completion.notify_waiters();
+            emit_event(&task_subscribers, &task_history, TransportEvent::Released).await;
+            task_control.mark_completed();
         });
+        let abort = task.abort_handle();
         self.active.lock().await.insert(
             handle,
             TransportEntry {
                 control,
+                abort,
+                subscribers,
+                history,
                 phase,
                 exit,
                 stats,
@@ -280,7 +370,7 @@ where
             let active = self.active.lock().await;
             active
                 .get(&request.transport_handle)
-                .map(|entry| (entry.control.completion(), Arc::clone(&entry.phase)))
+                .map(|entry| (entry.control.clone(), Arc::clone(&entry.phase)))
         };
         if self
             .completed
@@ -295,16 +385,8 @@ where
         };
         if *phase.lock().await == TransportPhase::Released {
             if let Some(entry) = self.active.lock().await.remove(&request.transport_handle) {
-                self.completed.lock().await.insert(
-                    request.transport_handle,
-                    TransportObservation {
-                        phase: TransportPhase::Released,
-                        descriptor: VsockTransportDescriptor::default(),
-                        bytes_rx: Some(entry.stats.bytes_from_vsock()),
-                        bytes_tx: Some(entry.stats.bytes_to_vsock()),
-                        last_exit: *entry.exit.lock().await,
-                    },
-                );
+                self.remember_completed(request.transport_handle, entry)
+                    .await;
             }
             return Ok(());
         }
@@ -312,48 +394,46 @@ where
             entry.control.stop();
             *entry.phase.lock().await = TransportPhase::Closing;
         }
-        if timeout(Duration::from_millis(CLOSE_GRACE_MS), completion.notified())
+        if timeout(Duration::from_millis(CLOSE_GRACE_MS), completion.wait())
             .await
             .is_err()
         {
             if let Some(entry) = self.active.lock().await.get(&request.transport_handle) {
+                entry.abort.abort();
                 *entry.phase.lock().await = TransportPhase::Degraded;
             }
             return Err(ServiceError::CloseUnconfirmed);
         }
         if let Some(entry) = self.active.lock().await.remove(&request.transport_handle) {
-            let observation = TransportObservation {
-                phase: TransportPhase::Released,
-                descriptor: VsockTransportDescriptor::default(),
-                bytes_rx: Some(entry.stats.bytes_from_vsock()),
-                bytes_tx: Some(entry.stats.bytes_to_vsock()),
-                last_exit: *entry.exit.lock().await,
-            };
-            let mut completed = self.completed.lock().await;
-            if completed.len() >= MAX_ACTIVE_TRANSPORTS
-                && let Some(oldest) = completed.keys().next().copied()
-            {
-                completed.remove(&oldest);
-            }
-            completed.insert(request.transport_handle, observation);
+            self.remember_completed(request.transport_handle, entry)
+                .await;
         }
         Ok(())
     }
 
-    /// Observe one transport without exposing identity, path, CID, or port.
-    pub async fn observe_transport(
+    /// Observe one transport snapshot without exposing identity, path, CID, or port.
+    pub async fn observe_snapshot(
         &self,
         request: ObserveTransportRequest,
     ) -> Result<TransportObservation, ServiceError> {
         let active = self.active.lock().await;
         let Some(entry) = active.get(&request.transport_handle) else {
-            return self
+            let observation = self
                 .completed
                 .lock()
                 .await
                 .get(&request.transport_handle)
                 .copied()
-                .ok_or(ServiceError::UnknownTransportHandle);
+                .ok_or(ServiceError::UnknownTransportHandle)?;
+            return Ok(if request.include_bytes {
+                observation
+            } else {
+                TransportObservation {
+                    bytes_rx: None,
+                    bytes_tx: None,
+                    ..observation
+                }
+            });
         };
         let phase = *entry.phase.lock().await;
         let stats = if request.include_bytes {
@@ -370,17 +450,112 @@ where
         })
     }
 
+    /// Subscribe to one transport's bounded lifecycle event stream.
+    pub async fn observe_transport(
+        &self,
+        request: ObserveTransportRequest,
+    ) -> Result<mpsc::Receiver<TransportEvent>, ServiceError> {
+        let active = self.active.lock().await;
+        if let Some(entry) = active.get(&request.transport_handle) {
+            let (sender, receiver) = mpsc::channel(16);
+            for event in entry.history.lock().await.iter().copied() {
+                if request.include_bytes
+                    || !matches!(event, TransportEvent::BytesTransferred { .. })
+                {
+                    let _ = sender.try_send(event);
+                }
+            }
+            entry
+                .subscribers
+                .lock()
+                .await
+                .push((request.include_bytes, sender));
+            return Ok(receiver);
+        }
+        if self
+            .completed
+            .lock()
+            .await
+            .contains_key(&request.transport_handle)
+        {
+            let (sender, receiver) = mpsc::channel(2);
+            let _ = sender.try_send(TransportEvent::Released);
+            return Ok(receiver);
+        }
+        Err(ServiceError::UnknownTransportHandle)
+    }
+
     /// Finalize all handles owned by this service.
     pub async fn finalize(&self) -> Result<(), ServiceError> {
         let handles = self.active.lock().await.keys().copied().collect::<Vec<_>>();
+        let mut first_error = None;
         for handle in handles {
-            self.close_transport(CloseTransportRequest {
-                transport_handle: handle,
-            })
-            .await?;
+            if let Err(error) = self
+                .close_transport(CloseTransportRequest {
+                    transport_handle: handle,
+                })
+                .await
+            {
+                first_error.get_or_insert(error);
+            }
         }
-        Ok(())
+        first_error.map_or(Ok(()), Err)
     }
+
+    async fn reap_released(&self) {
+        let handles = {
+            let active = self.active.lock().await;
+            active
+                .iter()
+                .filter_map(|(handle, entry)| {
+                    entry
+                        .phase
+                        .try_lock()
+                        .ok()
+                        .filter(|phase| **phase == TransportPhase::Released)
+                        .map(|_| *handle)
+                })
+                .collect::<Vec<_>>()
+        };
+        for handle in handles {
+            if let Some(entry) = self.active.lock().await.remove(&handle) {
+                self.remember_completed(handle, entry).await;
+            }
+        }
+    }
+
+    async fn remember_completed(&self, handle: TransportHandle, entry: TransportEntry) {
+        let observation = TransportObservation {
+            phase: TransportPhase::Released,
+            descriptor: VsockTransportDescriptor::default(),
+            bytes_rx: Some(entry.stats.bytes_from_vsock()),
+            bytes_tx: Some(entry.stats.bytes_to_vsock()),
+            last_exit: *entry.exit.lock().await,
+        };
+        let mut completed = self.completed.lock().await;
+        if completed.len() >= MAX_ACTIVE_TRANSPORTS
+            && let Some(oldest) = completed.keys().next().copied()
+        {
+            completed.remove(&oldest);
+        }
+        completed.insert(handle, observation);
+    }
+}
+
+async fn emit_event(
+    subscribers: &EventSubscribers,
+    history: &Arc<Mutex<Vec<TransportEvent>>>,
+    event: TransportEvent,
+) {
+    history.lock().await.push(event);
+    let mut active = subscribers.lock().await;
+    active.retain(|(include_bytes, sender)| {
+        if !*include_bytes && matches!(event, TransportEvent::BytesTransferred { .. }) {
+            true
+        } else {
+            sender.try_send(event).is_ok()
+        }
+    });
 }
 
 fn futures_phase_is_degraded(entry: &TransportEntry) -> bool {

--- a/packages/d2b-provider-transport-vsock/src/service.rs
+++ b/packages/d2b-provider-transport-vsock/src/service.rs
@@ -220,13 +220,31 @@ where
 
     /// Return the current service phase.
     pub async fn phase(&self) -> ServicePhase {
-        let active = self.active.lock().await;
-        if active.values().any(futures_phase_is_degraded) {
+        let active_degraded = self
+            .active
+            .lock()
+            .await
+            .values()
+            .any(futures_phase_is_degraded);
+        if active_degraded {
             ServicePhase::Degraded
-        } else if active.is_empty() {
-            ServicePhase::Ready
         } else {
-            ServicePhase::Serving
+            let completed_degraded = {
+                let completed = self.completed.lock().await;
+                completed
+                    .values()
+                    .any(|observation| observation.phase == TransportPhase::Degraded)
+            };
+            if completed_degraded {
+                ServicePhase::Degraded
+            } else {
+                let active_empty = self.active.lock().await.is_empty();
+                if active_empty {
+                    ServicePhase::Ready
+                } else {
+                    ServicePhase::Serving
+                }
+            }
         }
     }
 
@@ -248,35 +266,47 @@ where
             .try_acquire_owned()
             .map_err(|_| ServiceError::ProviderOverloaded)?;
         let deadline = Instant::now() + Duration::from_millis(u64::from(request.deadline_ms));
-        let effect_stream = self
-            .effect
-            .open(
+        let open_deadline = Duration::from_millis(u64::from(request.deadline_ms));
+        let effect_stream = timeout(
+            open_deadline,
+            self.effect.open(
                 &request.endpoint_id,
                 &request.binding_id,
                 request.role,
                 deadline,
-            )
-            .await
-            .map_err(ServiceError::Effect)?;
-        let open_deadline = Duration::from_millis(u64::from(request.deadline_ms));
+            ),
+        )
+        .await
+        .map_err(|_| ServiceError::Effect(VsockEffectError::DeadlineExceeded))?
+        .map_err(ServiceError::Effect)?;
         let (stream_id, named_stream) =
             match timeout(open_deadline, self.streams.open_named_stream()).await {
                 Ok(Ok(value)) => value,
                 Ok(Err(_)) => {
-                    let _ = timeout(
+                    let closed = timeout(
                         Duration::from_millis(CLOSE_GRACE_MS),
                         self.effect.close(effect_stream),
                     )
-                    .await;
-                    return Err(ServiceError::StreamUnavailable);
+                    .await
+                    .is_ok_and(|result| result.is_ok());
+                    return Err(if closed {
+                        ServiceError::StreamUnavailable
+                    } else {
+                        ServiceError::CloseUnconfirmed
+                    });
                 }
                 Err(_) => {
-                    let _ = timeout(
+                    let closed = timeout(
                         Duration::from_millis(CLOSE_GRACE_MS),
                         self.effect.close(effect_stream),
                     )
-                    .await;
-                    return Err(ServiceError::Effect(VsockEffectError::DeadlineExceeded));
+                    .await
+                    .is_ok_and(|result| result.is_ok());
+                    return Err(if closed {
+                        ServiceError::Effect(VsockEffectError::DeadlineExceeded)
+                    } else {
+                        ServiceError::CloseUnconfirmed
+                    });
                 }
             };
         let handle = TransportHandle::from_core(self.next_handle.fetch_add(1, Ordering::Relaxed));
@@ -332,12 +362,25 @@ where
                     .await;
                 }
             }
-            *task_phase.lock().await = if effect_result && stream_result {
+            let released = effect_result && stream_result;
+            *task_phase.lock().await = if released {
                 TransportPhase::Released
             } else {
                 TransportPhase::Degraded
             };
-            emit_event(&task_subscribers, &task_history, TransportEvent::Released).await;
+            if released {
+                emit_event(&task_subscribers, &task_history, TransportEvent::Released).await;
+            } else {
+                emit_event(
+                    &task_subscribers,
+                    &task_history,
+                    TransportEvent::Error {
+                        kind: "close-unconfirmed",
+                        recoverable: true,
+                    },
+                )
+                .await;
+            }
             task_control.mark_completed();
         });
         let abort = task.abort_handle();
@@ -372,12 +415,16 @@ where
                 .get(&request.transport_handle)
                 .map(|entry| (entry.control.clone(), Arc::clone(&entry.phase)))
         };
-        if self
+        if let Some(observation) = self
             .completed
             .lock()
             .await
-            .contains_key(&request.transport_handle)
+            .get(&request.transport_handle)
+            .copied()
         {
+            if observation.phase == TransportPhase::Degraded {
+                return Err(ServiceError::CloseUnconfirmed);
+            }
             return Ok(());
         }
         let Some((completion, phase)) = entry else {
@@ -390,25 +437,42 @@ where
             }
             return Ok(());
         }
-        if let Some(entry) = self.active.lock().await.get(&request.transport_handle) {
-            entry.control.stop();
-            *entry.phase.lock().await = TransportPhase::Closing;
+        let entry_to_stop = {
+            let active = self.active.lock().await;
+            active
+                .get(&request.transport_handle)
+                .map(|entry| (entry.control.clone(), Arc::clone(&entry.phase)))
+        };
+        if let Some((control, phase)) = entry_to_stop {
+            let mut entry_phase = phase.lock().await;
+            if *entry_phase != TransportPhase::Degraded {
+                control.stop();
+                *entry_phase = TransportPhase::Closing;
+            }
         }
         if timeout(Duration::from_millis(CLOSE_GRACE_MS), completion.wait())
             .await
             .is_err()
         {
-            if let Some(entry) = self.active.lock().await.get(&request.transport_handle) {
+            let entry = self.active.lock().await.remove(&request.transport_handle);
+            if let Some(entry) = entry {
                 entry.abort.abort();
                 *entry.phase.lock().await = TransportPhase::Degraded;
+                self.remember_completed(request.transport_handle, entry)
+                    .await;
             }
             return Err(ServiceError::CloseUnconfirmed);
         }
+        let degraded = *phase.lock().await == TransportPhase::Degraded;
         if let Some(entry) = self.active.lock().await.remove(&request.transport_handle) {
             self.remember_completed(request.transport_handle, entry)
                 .await;
         }
-        Ok(())
+        if degraded {
+            Err(ServiceError::CloseUnconfirmed)
+        } else {
+            Ok(())
+        }
     }
 
     /// Observe one transport snapshot without exposing identity, path, CID, or port.
@@ -418,6 +482,7 @@ where
     ) -> Result<TransportObservation, ServiceError> {
         let active = self.active.lock().await;
         let Some(entry) = active.get(&request.transport_handle) else {
+            drop(active);
             let observation = self
                 .completed
                 .lock()
@@ -472,14 +537,24 @@ where
                 .push((request.include_bytes, sender));
             return Ok(receiver);
         }
-        if self
+        drop(active);
+        let completed_phase = self
             .completed
             .lock()
             .await
-            .contains_key(&request.transport_handle)
-        {
+            .get(&request.transport_handle)
+            .map(|observation| observation.phase);
+        if completed_phase.is_some() {
             let (sender, receiver) = mpsc::channel(2);
-            let _ = sender.try_send(TransportEvent::Released);
+            let event = if completed_phase == Some(TransportPhase::Degraded) {
+                TransportEvent::Error {
+                    kind: "close-unconfirmed",
+                    recoverable: true,
+                }
+            } else {
+                TransportEvent::Released
+            };
+            let _ = sender.try_send(event);
             return Ok(receiver);
         }
         Err(ServiceError::UnknownTransportHandle)
@@ -526,7 +601,7 @@ where
 
     async fn remember_completed(&self, handle: TransportHandle, entry: TransportEntry) {
         let observation = TransportObservation {
-            phase: TransportPhase::Released,
+            phase: *entry.phase.lock().await,
             descriptor: VsockTransportDescriptor::default(),
             bytes_rx: Some(entry.stats.bytes_from_vsock()),
             bytes_tx: Some(entry.stats.bytes_to_vsock()),

--- a/packages/d2b-provider-transport-vsock/src/service.rs
+++ b/packages/d2b-provider-transport-vsock/src/service.rs
@@ -1,0 +1,397 @@
+//! Authenticated vsock transport service lifecycle.
+
+use crate::{
+    ReadySession,
+    bridge::{
+        BridgeControl, BridgeExit, BridgeStats, NamedStreamError, NamedStreamId, NamedStreamPort,
+        TransportHandle, run_bridge,
+    },
+    effect_port::{OpaqueBindingId, OpaqueEndpointId, TransportRole, VsockEffectPort},
+    errors::ServiceError,
+    framing::VsockTransportDescriptor,
+    limits::{CLOSE_GRACE_MS, MAX_ACTIVE_TRANSPORTS, MAX_OPEN_DEADLINE_MS, MIN_OPEN_DEADLINE_MS},
+};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+use tokio::{
+    sync::{Mutex, OwnedSemaphorePermit, Semaphore},
+    time::timeout,
+};
+
+const PROVIDER_REF: &str = "Provider/transport-vsock";
+
+/// Request to open one ZoneLink byte transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenTransportRequest {
+    /// Core-issued endpoint resolution identity.
+    pub endpoint_id: OpaqueEndpointId,
+    /// Core-issued binding identity.
+    pub binding_id: OpaqueBindingId,
+    /// Initiator or responder role.
+    pub role: TransportRole,
+    /// Bounded connect/accept deadline.
+    pub deadline_ms: u32,
+}
+
+impl OpenTransportRequest {
+    /// Construct an open request.
+    pub const fn new(
+        endpoint_id: OpaqueEndpointId,
+        binding_id: OpaqueBindingId,
+        role: TransportRole,
+        deadline_ms: u32,
+    ) -> Self {
+        Self {
+            endpoint_id,
+            binding_id,
+            role,
+            deadline_ms,
+        }
+    }
+
+    /// Parse a wire-shaped request at the service boundary.
+    pub fn from_raw(
+        endpoint_id: impl Into<String>,
+        binding_id: impl Into<String>,
+        role: TransportRole,
+        deadline_ms: u32,
+    ) -> Result<Self, ServiceError> {
+        let endpoint_id =
+            OpaqueEndpointId::parse(endpoint_id).map_err(|_| ServiceError::InvalidEndpointId)?;
+        let binding_id =
+            OpaqueBindingId::parse(binding_id).map_err(|_| ServiceError::InvalidBindingId)?;
+        Ok(Self::new(endpoint_id, binding_id, role, deadline_ms))
+    }
+
+    fn validate(&self) -> Result<(), ServiceError> {
+        if !(MIN_OPEN_DEADLINE_MS..=MAX_OPEN_DEADLINE_MS).contains(&self.deadline_ms) {
+            return Err(ServiceError::InvalidDeadline);
+        }
+        Ok(())
+    }
+}
+
+/// Result of opening one transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenTransportResponse {
+    /// Opaque handle used by CloseTransport and ObserveTransport.
+    pub transport_handle: TransportHandle,
+    /// ComponentSession named stream carrying the bridge bytes.
+    pub stream_id: NamedStreamId,
+    /// Native-vsock transport descriptor.
+    pub descriptor: VsockTransportDescriptor,
+}
+
+/// Request to close one transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CloseTransportRequest {
+    /// Handle returned by OpenTransport.
+    pub transport_handle: TransportHandle,
+}
+
+/// Request to observe one transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObserveTransportRequest {
+    /// Handle returned by OpenTransport.
+    pub transport_handle: TransportHandle,
+    /// Include bounded byte counters in the response.
+    pub include_bytes: bool,
+}
+
+/// Provider lifecycle phase for one transport handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportPhase {
+    /// The effect and named stream were acquired.
+    Acquired,
+    /// The owner requested closure.
+    Closing,
+    /// The bridge and both endpoints are closed.
+    Released,
+    /// Closure could not be confirmed within the bound.
+    Degraded,
+}
+
+/// Bounded observation returned by ObserveTransport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportObservation {
+    /// Current lifecycle phase.
+    pub phase: TransportPhase,
+    /// Fixed provider descriptor.
+    pub descriptor: VsockTransportDescriptor,
+    /// Bytes received from the vsock side when requested.
+    pub bytes_rx: Option<u64>,
+    /// Bytes sent to the vsock side when requested.
+    pub bytes_tx: Option<u64>,
+    /// Last bridge termination reason.
+    pub last_exit: Option<BridgeExit>,
+}
+
+/// Provider service readiness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServicePhase {
+    /// The service has no active transport.
+    Ready,
+    /// At least one transport is active.
+    Serving,
+    /// One transport failed bounded closure.
+    Degraded,
+}
+
+/// The single transport-vsock service component for one Zone.
+pub struct VsockTransportService<P, N>
+where
+    P: VsockEffectPort,
+    N: NamedStreamPort,
+{
+    effect: Arc<P>,
+    streams: Arc<N>,
+    active: Arc<Mutex<HashMap<TransportHandle, TransportEntry>>>,
+    completed: Arc<Mutex<HashMap<TransportHandle, TransportObservation>>>,
+    slots: Arc<Semaphore>,
+    next_handle: AtomicU64,
+}
+
+struct TransportEntry {
+    control: BridgeControl,
+    phase: Arc<Mutex<TransportPhase>>,
+    exit: Arc<Mutex<Option<BridgeExit>>>,
+    stats: Arc<BridgeStats>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl<P, N> VsockTransportService<P, N>
+where
+    P: VsockEffectPort,
+    N: NamedStreamPort,
+{
+    /// Construct a service over the child-core effect and stream ports.
+    pub fn new(effect: P, streams: N) -> Self {
+        Self {
+            effect: Arc::new(effect),
+            streams: Arc::new(streams),
+            active: Arc::new(Mutex::new(HashMap::new())),
+            completed: Arc::new(Mutex::new(HashMap::new())),
+            slots: Arc::new(Semaphore::new(MAX_ACTIVE_TRANSPORTS)),
+            next_handle: AtomicU64::new(1),
+        }
+    }
+
+    /// Return the stable Provider reference.
+    pub const fn provider_ref(&self) -> &'static str {
+        PROVIDER_REF
+    }
+
+    /// Return the current service phase.
+    pub async fn phase(&self) -> ServicePhase {
+        let active = self.active.lock().await;
+        if active.values().any(futures_phase_is_degraded) {
+            ServicePhase::Degraded
+        } else if active.is_empty() {
+            ServicePhase::Ready
+        } else {
+            ServicePhase::Serving
+        }
+    }
+
+    /// Open one authenticated transport and its named stream bridge.
+    pub async fn open_transport(
+        &self,
+        session: &ReadySession,
+        request: OpenTransportRequest,
+    ) -> Result<OpenTransportResponse, ServiceError> {
+        if session.state() != crate::SessionState::Ready {
+            return Err(ServiceError::SessionNotReady);
+        }
+        request.validate()?;
+        let permit = Arc::clone(&self.slots)
+            .try_acquire_owned()
+            .map_err(|_| ServiceError::ProviderOverloaded)?;
+        let deadline = Instant::now() + Duration::from_millis(u64::from(request.deadline_ms));
+        let effect_stream = self
+            .effect
+            .open(
+                &request.endpoint_id,
+                &request.binding_id,
+                request.role,
+                deadline,
+            )
+            .await
+            .map_err(ServiceError::Effect)?;
+        let (stream_id, named_stream) = match self.streams.open_named_stream().await {
+            Ok(value) => value,
+            Err(_) => {
+                let _ = self.effect.close(effect_stream).await;
+                return Err(ServiceError::StreamUnavailable);
+            }
+        };
+        let handle = TransportHandle::from_core(self.next_handle.fetch_add(1, Ordering::Relaxed));
+        let (control, stop) = BridgeControl::new();
+        let completion = control.completion();
+        let phase = Arc::new(Mutex::new(TransportPhase::Acquired));
+        let exit = Arc::new(Mutex::new(None));
+        let stats = Arc::new(BridgeStats::default());
+        let task_effect = Arc::clone(&self.effect);
+        let task_streams = Arc::clone(&self.streams);
+        let task_phase = Arc::clone(&phase);
+        let task_exit = Arc::clone(&exit);
+        let task_stats = Arc::clone(&stats);
+        tokio::spawn(async move {
+            let (effect_stream, _named_stream, reason) =
+                run_bridge(effect_stream, named_stream, stop, task_stats).await;
+            let effect_result = task_effect.close(effect_stream).await;
+            let stream_result = task_streams.close_named_stream(stream_id).await;
+            *task_exit.lock().await = Some(reason);
+            *task_phase.lock().await = if effect_result.is_ok() && stream_result.is_ok() {
+                TransportPhase::Released
+            } else {
+                TransportPhase::Degraded
+            };
+            completion.notify_waiters();
+        });
+        self.active.lock().await.insert(
+            handle,
+            TransportEntry {
+                control,
+                phase,
+                exit,
+                stats,
+                _permit: permit,
+            },
+        );
+        Ok(OpenTransportResponse {
+            transport_handle: handle,
+            stream_id,
+            descriptor: VsockTransportDescriptor::default(),
+        })
+    }
+
+    /// Close one transport. The bridge closes before the effect is released.
+    pub async fn close_transport(
+        &self,
+        request: CloseTransportRequest,
+    ) -> Result<(), ServiceError> {
+        let entry = {
+            let active = self.active.lock().await;
+            active
+                .get(&request.transport_handle)
+                .map(|entry| (entry.control.completion(), Arc::clone(&entry.phase)))
+        };
+        if self
+            .completed
+            .lock()
+            .await
+            .contains_key(&request.transport_handle)
+        {
+            return Ok(());
+        }
+        let Some((completion, phase)) = entry else {
+            return Err(ServiceError::UnknownTransportHandle);
+        };
+        if *phase.lock().await == TransportPhase::Released {
+            if let Some(entry) = self.active.lock().await.remove(&request.transport_handle) {
+                self.completed.lock().await.insert(
+                    request.transport_handle,
+                    TransportObservation {
+                        phase: TransportPhase::Released,
+                        descriptor: VsockTransportDescriptor::default(),
+                        bytes_rx: Some(entry.stats.bytes_from_vsock()),
+                        bytes_tx: Some(entry.stats.bytes_to_vsock()),
+                        last_exit: *entry.exit.lock().await,
+                    },
+                );
+            }
+            return Ok(());
+        }
+        if let Some(entry) = self.active.lock().await.get(&request.transport_handle) {
+            entry.control.stop();
+            *entry.phase.lock().await = TransportPhase::Closing;
+        }
+        if timeout(Duration::from_millis(CLOSE_GRACE_MS), completion.notified())
+            .await
+            .is_err()
+        {
+            if let Some(entry) = self.active.lock().await.get(&request.transport_handle) {
+                *entry.phase.lock().await = TransportPhase::Degraded;
+            }
+            return Err(ServiceError::CloseUnconfirmed);
+        }
+        if let Some(entry) = self.active.lock().await.remove(&request.transport_handle) {
+            let observation = TransportObservation {
+                phase: TransportPhase::Released,
+                descriptor: VsockTransportDescriptor::default(),
+                bytes_rx: Some(entry.stats.bytes_from_vsock()),
+                bytes_tx: Some(entry.stats.bytes_to_vsock()),
+                last_exit: *entry.exit.lock().await,
+            };
+            let mut completed = self.completed.lock().await;
+            if completed.len() >= MAX_ACTIVE_TRANSPORTS
+                && let Some(oldest) = completed.keys().next().copied()
+            {
+                completed.remove(&oldest);
+            }
+            completed.insert(request.transport_handle, observation);
+        }
+        Ok(())
+    }
+
+    /// Observe one transport without exposing identity, path, CID, or port.
+    pub async fn observe_transport(
+        &self,
+        request: ObserveTransportRequest,
+    ) -> Result<TransportObservation, ServiceError> {
+        let active = self.active.lock().await;
+        let Some(entry) = active.get(&request.transport_handle) else {
+            return self
+                .completed
+                .lock()
+                .await
+                .get(&request.transport_handle)
+                .copied()
+                .ok_or(ServiceError::UnknownTransportHandle);
+        };
+        let phase = *entry.phase.lock().await;
+        let stats = if request.include_bytes {
+            Some((entry.stats.bytes_from_vsock(), entry.stats.bytes_to_vsock()))
+        } else {
+            None
+        };
+        Ok(TransportObservation {
+            phase,
+            descriptor: VsockTransportDescriptor::default(),
+            bytes_rx: stats.map(|(rx, _)| rx),
+            bytes_tx: stats.map(|(_, tx)| tx),
+            last_exit: *entry.exit.lock().await,
+        })
+    }
+
+    /// Finalize all handles owned by this service.
+    pub async fn finalize(&self) -> Result<(), ServiceError> {
+        let handles = self.active.lock().await.keys().copied().collect::<Vec<_>>();
+        for handle in handles {
+            self.close_transport(CloseTransportRequest {
+                transport_handle: handle,
+            })
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+fn futures_phase_is_degraded(entry: &TransportEntry) -> bool {
+    entry
+        .phase
+        .try_lock()
+        .is_ok_and(|phase| *phase == TransportPhase::Degraded)
+}
+
+impl From<NamedStreamError> for ServiceError {
+    fn from(_: NamedStreamError) -> Self {
+        ServiceError::StreamUnavailable
+    }
+}

--- a/packages/d2b-provider-transport-vsock/src/settings.rs
+++ b/packages/d2b-provider-transport-vsock/src/settings.rs
@@ -1,0 +1,89 @@
+//! Closed `ZoneLink.spec.transportSettings` validation.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// The allocator port class used by ZoneLink vsock sessions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum PortClass {
+    /// The reserved ZoneLink range.
+    #[default]
+    D2bLink,
+}
+
+/// Provider-specific transport settings.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VsockTransportSettings {
+    /// Same-child-Zone Guest reference.
+    pub guest_ref: String,
+    /// Allocator-owned port class.
+    #[serde(default)]
+    pub port_class: PortClass,
+    /// Open deadline in seconds.
+    #[serde(default = "default_timeout_seconds")]
+    pub connect_timeout_seconds: u16,
+}
+
+impl VsockTransportSettings {
+    /// Construct validated settings.
+    pub fn new(guest_ref: impl Into<String>) -> Result<Self, SettingsError> {
+        let settings = Self {
+            guest_ref: guest_ref.into(),
+            port_class: PortClass::default(),
+            connect_timeout_seconds: default_timeout_seconds(),
+        };
+        settings.validate()?;
+        Ok(settings)
+    }
+
+    /// Validate settings and reject raw endpoint material.
+    pub fn validate(&self) -> Result<(), SettingsError> {
+        if !self.guest_ref.starts_with("Guest/")
+            || self.guest_ref.len() <= "Guest/".len()
+            || self.guest_ref.len() > 128
+            || !(1..=60).contains(&self.connect_timeout_seconds)
+        {
+            return Err(SettingsError::InvalidValue);
+        }
+        Ok(())
+    }
+
+    /// Return the committed schema source.
+    pub const fn schema_json() -> &'static str {
+        include_str!(
+            "../../../docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json"
+        )
+    }
+}
+
+impl fmt::Debug for VsockTransportSettings {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VsockTransportSettings")
+            .field("guest_ref", &"<redacted>")
+            .field("port_class", &self.port_class)
+            .field("connect_timeout_seconds", &self.connect_timeout_seconds)
+            .finish()
+    }
+}
+
+/// Settings validation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsError {
+    /// A field is empty, out of range, or carries a raw endpoint.
+    InvalidValue,
+}
+
+impl fmt::Display for SettingsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("transport-settings-invalid")
+    }
+}
+
+impl std::error::Error for SettingsError {}
+
+const fn default_timeout_seconds() -> u16 {
+    30
+}

--- a/packages/d2b-provider-transport-vsock/src/state_volume.rs
+++ b/packages/d2b-provider-transport-vsock/src/state_volume.rs
@@ -1,0 +1,52 @@
+//! Canonical child-local service state volume declaration.
+
+use std::fmt;
+
+/// Empty state schema used by the transport service.
+pub const EMPTY_STATE_SCHEMA: &str = "empty";
+/// Canonical layout principal.
+pub const STATE_LAYOUT_USER: &str = "User/d2b-transport-vsock";
+
+/// Bounded state volume specification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StateVolumeSpec {
+    /// Volume kind.
+    pub kind: &'static str,
+    /// Persistence policy.
+    pub persistence_class: &'static str,
+    /// Migration policy.
+    pub migration_policy: &'static str,
+    /// Sensitivity class.
+    pub sensitivity_class: &'static str,
+    /// Whether the broker owns the identity marker.
+    pub broker_maintained_identity: bool,
+}
+
+impl Default for StateVolumeSpec {
+    fn default() -> Self {
+        Self {
+            kind: "state",
+            persistence_class: "persistent",
+            migration_policy: "none",
+            sensitivity_class: "private",
+            broker_maintained_identity: true,
+        }
+    }
+}
+
+impl StateVolumeSpec {
+    /// Validate the canonical empty state shape.
+    pub fn validate(self) -> bool {
+        self.kind == "state"
+            && self.persistence_class == "persistent"
+            && self.migration_policy == "none"
+            && self.sensitivity_class == "private"
+            && self.broker_maintained_identity
+    }
+}
+
+impl fmt::Display for StateVolumeSpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("transport-vsock-state-volume")
+    }
+}

--- a/packages/d2b-provider-transport-vsock/src/topology.rs
+++ b/packages/d2b-provider-transport-vsock/src/topology.rs
@@ -1,0 +1,116 @@
+//! Child-local ZoneLink topology validation.
+
+use crate::{SettingsError, VsockTransportSettings};
+use std::fmt;
+
+/// Bounded ZoneLink reconnect limits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportLimits {
+    /// Maximum pending intents.
+    pub max_pending_intents: u16,
+    /// Maximum active streams.
+    pub max_active_streams: u16,
+    /// Maximum reconnect attempts.
+    pub reconnect_max_attempts: u16,
+    /// Reconnect window in seconds.
+    pub reconnect_window_secs: u32,
+}
+
+impl Default for TransportLimits {
+    fn default() -> Self {
+        Self {
+            max_pending_intents: 256,
+            max_active_streams: 32,
+            reconnect_max_attempts: 10,
+            reconnect_window_secs: 300,
+        }
+    }
+}
+
+/// Exact child-local ZoneLink desired shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZoneLinkSpec {
+    /// Self-matching child Zone name.
+    pub child_zone_name: String,
+    /// Selected Provider reference.
+    pub transport_provider_ref: String,
+    /// Provider-specific closed settings.
+    pub transport_settings: VsockTransportSettings,
+    /// Vsock credentials must be empty.
+    pub transport_credentials: Vec<String>,
+    /// Whether the link is disabled.
+    pub disabled: bool,
+    /// Bounded reconnect and stream limits.
+    pub limits: TransportLimits,
+}
+
+/// Topology validation failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopologyError {
+    /// The Provider is not the canonical vsock Provider.
+    ProviderMismatch,
+    /// The child name does not match the owning Zone.
+    ChildZoneMismatch,
+    /// The Provider settings are invalid.
+    InvalidSettings,
+    /// Vsock transport credentials are not permitted.
+    CredentialsNotEmpty,
+    /// The parent store contains a reciprocal resource.
+    ParentStoreReciprocalResource,
+}
+
+impl fmt::Display for TopologyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::ProviderMismatch => "transport-provider-mismatch",
+            Self::ChildZoneMismatch => "transport-child-zone-mismatch",
+            Self::InvalidSettings => "transport-settings-invalid",
+            Self::CredentialsNotEmpty => "transport-credentials-not-empty",
+            Self::ParentStoreReciprocalResource => "parent-store-reciprocal-resource",
+        })
+    }
+}
+
+impl std::error::Error for TopologyError {}
+
+impl From<SettingsError> for TopologyError {
+    fn from(_: SettingsError) -> Self {
+        Self::InvalidSettings
+    }
+}
+
+impl ZoneLinkSpec {
+    /// Validate the exact child-local topology.
+    pub fn validate(&self, owning_child_zone: &str) -> Result<(), TopologyError> {
+        if self.transport_provider_ref != crate::PROVIDER_REF {
+            return Err(TopologyError::ProviderMismatch);
+        }
+        if self.child_zone_name != owning_child_zone {
+            return Err(TopologyError::ChildZoneMismatch);
+        }
+        self.transport_settings.validate()?;
+        if !self.transport_credentials.is_empty() {
+            return Err(TopologyError::CredentialsNotEmpty);
+        }
+        Ok(())
+    }
+}
+
+/// Resource census for the selected parent store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ParentStoreResourceCensus {
+    /// Number of reciprocal Provider rows.
+    pub provider_rows: u16,
+    /// Number of reciprocal ZoneLink rows.
+    pub zone_link_rows: u16,
+}
+
+impl ParentStoreResourceCensus {
+    /// Refuse any parent-side resource row for a child-local transport.
+    pub fn validate(self) -> Result<(), TopologyError> {
+        if self.provider_rows != 0 || self.zone_link_rows != 0 {
+            return Err(TopologyError::ParentStoreReciprocalResource);
+        }
+        Ok(())
+    }
+}

--- a/packages/d2b-provider-transport-vsock/tests/authentication.rs
+++ b/packages/d2b-provider-transport-vsock/tests/authentication.rs
@@ -90,3 +90,55 @@ fn replay_cache_refuses_new_sessions_at_its_bound() {
         SessionRejectReason::AuthorityUnavailable
     );
 }
+
+#[test]
+fn guest_zone_and_signature_mismatches_are_refused() {
+    let expected = identity(42);
+    let key = GuestControlKey::from_core([3; 32]);
+    let wrong_key = GuestControlKey::from_core([4; 32]);
+    let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
+
+    let guest = GuestIdentity::new(
+        ResourceRef::parse("Guest/other").unwrap(),
+        ZoneId::parse("work").unwrap(),
+        PeerCid::from_core(42).unwrap(),
+        "boot-a",
+    )
+    .unwrap();
+    assert_eq!(
+        authority
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &guest, [10; 32], 3),
+            )
+            .unwrap_err(),
+        SessionRejectReason::GuestMismatch
+    );
+
+    let zone = GuestIdentity::new(
+        ResourceRef::parse("Guest/guest-a").unwrap(),
+        ZoneId::parse("personal").unwrap(),
+        PeerCid::from_core(42).unwrap(),
+        "boot-a",
+    )
+    .unwrap();
+    assert_eq!(
+        authority
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &zone, [11; 32], 3),
+            )
+            .unwrap_err(),
+        SessionRejectReason::ZoneMismatch
+    );
+
+    assert_eq!(
+        authority
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&wrong_key, &expected, [12; 32], 3),
+            )
+            .unwrap_err(),
+        SessionRejectReason::SignatureInvalid
+    );
+}

--- a/packages/d2b-provider-transport-vsock/tests/authentication.rs
+++ b/packages/d2b-provider-transport-vsock/tests/authentication.rs
@@ -3,6 +3,14 @@ use d2b_provider_transport_vsock::{
     GuestControlKey, GuestIdentity, MAX_REPLAY_ENTRIES, PeerCid, SessionAuthority, SessionProof,
     SessionRejectReason, SessionState,
 };
+use ring::rand::{SecureRandom, SystemRandom};
+
+fn nonce_for(index: u16) -> [u8; 32] {
+    let mut nonce = [0_u8; 32];
+    SystemRandom::new().fill(&mut nonce).unwrap();
+    nonce[..2].copy_from_slice(&index.to_be_bytes());
+    nonce
+}
 
 fn identity(cid: u32) -> GuestIdentity {
     GuestIdentity::new(
@@ -19,7 +27,7 @@ fn correct_cid_signature_guest_zone_and_session_establish_ready() {
     let key = GuestControlKey::from_core([7; 32]);
     let expected = identity(42);
     let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
-    let proof = SessionProof::sign(&key, &expected, [9; 32], 3);
+    let proof = SessionProof::sign(&key, &expected, nonce_for(1), 3);
 
     let session = authority
         .authenticate(PeerCid::from_core(42).unwrap(), proof)
@@ -34,7 +42,7 @@ fn cid_reuse_and_replay_are_rejected() {
     let key = GuestControlKey::from_core([8; 32]);
     let expected = identity(42);
     let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
-    let proof = SessionProof::sign(&key, &expected, [4; 32], 3);
+    let proof = SessionProof::sign(&key, &expected, nonce_for(2), 3);
     authority
         .authenticate(PeerCid::from_core(42).unwrap(), proof.clone())
         .unwrap();
@@ -46,7 +54,7 @@ fn cid_reuse_and_replay_are_rejected() {
     );
 
     let mut other = identity(43);
-    let proof = SessionProof::sign(&key, &other, [5; 32], 3);
+    let proof = SessionProof::sign(&key, &other, nonce_for(3), 3);
     assert_eq!(
         authority
             .authenticate(PeerCid::from_core(42).unwrap(), proof)
@@ -54,7 +62,7 @@ fn cid_reuse_and_replay_are_rejected() {
         SessionRejectReason::CidMismatch
     );
     other = identity(42);
-    let proof = SessionProof::sign(&key, &other, [6; 32], 2);
+    let proof = SessionProof::sign(&key, &other, nonce_for(4), 2);
     assert_eq!(
         authority
             .authenticate(PeerCid::from_core(42).unwrap(), proof)
@@ -69,22 +77,18 @@ fn replay_cache_refuses_new_sessions_at_its_bound() {
     let expected = identity(42);
     let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
     for index in 0..MAX_REPLAY_ENTRIES {
-        let mut nonce = [0_u8; 32];
-        nonce[..2].copy_from_slice(&(index as u16).to_be_bytes());
         authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &expected, nonce, 3),
+                SessionProof::sign(&key, &expected, nonce_for(index as u16), 3),
             )
             .unwrap();
     }
-    let mut nonce = [0_u8; 32];
-    nonce[..2].copy_from_slice(&(MAX_REPLAY_ENTRIES as u16).to_be_bytes());
     assert_eq!(
         authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &expected, nonce, 3),
+                SessionProof::sign(&key, &expected, nonce_for(MAX_REPLAY_ENTRIES as u16), 3),
             )
             .unwrap_err(),
         SessionRejectReason::AuthorityUnavailable
@@ -109,7 +113,7 @@ fn guest_zone_and_signature_mismatches_are_refused() {
         authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &guest, [10; 32], 3),
+                SessionProof::sign(&key, &guest, nonce_for(5), 3),
             )
             .unwrap_err(),
         SessionRejectReason::GuestMismatch
@@ -126,7 +130,7 @@ fn guest_zone_and_signature_mismatches_are_refused() {
         authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &zone, [11; 32], 3),
+                SessionProof::sign(&key, &zone, nonce_for(6), 3),
             )
             .unwrap_err(),
         SessionRejectReason::ZoneMismatch
@@ -136,7 +140,7 @@ fn guest_zone_and_signature_mismatches_are_refused() {
         authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&wrong_key, &expected, [12; 32], 3),
+                SessionProof::sign(&wrong_key, &expected, nonce_for(7), 3),
             )
             .unwrap_err(),
         SessionRejectReason::SignatureInvalid

--- a/packages/d2b-provider-transport-vsock/tests/authentication.rs
+++ b/packages/d2b-provider-transport-vsock/tests/authentication.rs
@@ -1,7 +1,7 @@
 use d2b_contracts::v3::{ResourceRef, ZoneId};
 use d2b_provider_transport_vsock::{
-    GuestControlKey, GuestIdentity, PeerCid, SessionAuthority, SessionProof, SessionRejectReason,
-    SessionState,
+    GuestControlKey, GuestIdentity, MAX_REPLAY_ENTRIES, PeerCid, SessionAuthority, SessionProof,
+    SessionRejectReason, SessionState,
 };
 
 fn identity(cid: u32) -> GuestIdentity {
@@ -21,7 +21,9 @@ fn correct_cid_signature_guest_zone_and_session_establish_ready() {
     let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
     let proof = SessionProof::sign(&key, &expected, [9; 32], 3);
 
-    let session = authority.authenticate(proof).unwrap();
+    let session = authority
+        .authenticate(PeerCid::from_core(42).unwrap(), proof)
+        .unwrap();
     assert_eq!(session.state(), SessionState::Ready);
     assert!(session.matches(&expected));
     assert_eq!(session.disconnect(), SessionState::Disconnected);
@@ -33,22 +35,58 @@ fn cid_reuse_and_replay_are_rejected() {
     let expected = identity(42);
     let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
     let proof = SessionProof::sign(&key, &expected, [4; 32], 3);
-    authority.authenticate(proof.clone()).unwrap();
+    authority
+        .authenticate(PeerCid::from_core(42).unwrap(), proof.clone())
+        .unwrap();
     assert_eq!(
-        authority.authenticate(proof).unwrap_err(),
+        authority
+            .authenticate(PeerCid::from_core(42).unwrap(), proof)
+            .unwrap_err(),
         SessionRejectReason::Replay
     );
 
     let mut other = identity(43);
     let proof = SessionProof::sign(&key, &other, [5; 32], 3);
     assert_eq!(
-        authority.authenticate(proof).unwrap_err(),
+        authority
+            .authenticate(PeerCid::from_core(42).unwrap(), proof)
+            .unwrap_err(),
         SessionRejectReason::CidMismatch
     );
     other = identity(42);
     let proof = SessionProof::sign(&key, &other, [6; 32], 2);
     assert_eq!(
-        authority.authenticate(proof).unwrap_err(),
+        authority
+            .authenticate(PeerCid::from_core(42).unwrap(), proof)
+            .unwrap_err(),
         SessionRejectReason::StaleSignature
+    );
+}
+
+#[test]
+fn replay_cache_refuses_new_sessions_at_its_bound() {
+    let key = GuestControlKey::from_core([3; 32]);
+    let expected = identity(42);
+    let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
+    for index in 0..MAX_REPLAY_ENTRIES {
+        let mut nonce = [0_u8; 32];
+        nonce[..2].copy_from_slice(&(index as u16).to_be_bytes());
+        authority
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &expected, nonce, 3),
+            )
+            .unwrap();
+    }
+    let mut nonce = [0_u8; 32];
+    nonce[..2].copy_from_slice(&(MAX_REPLAY_ENTRIES as u16).to_be_bytes());
+    assert_eq!(
+        authority
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &expected, nonce, 3),
+            )
+            .unwrap_err(),
+        SessionRejectReason::AuthorityUnavailable
     );
 }

--- a/packages/d2b-provider-transport-vsock/tests/authentication.rs
+++ b/packages/d2b-provider-transport-vsock/tests/authentication.rs
@@ -1,0 +1,54 @@
+use d2b_contracts::v3::{ResourceRef, ZoneId};
+use d2b_provider_transport_vsock::{
+    GuestControlKey, GuestIdentity, PeerCid, SessionAuthority, SessionProof, SessionRejectReason,
+    SessionState,
+};
+
+fn identity(cid: u32) -> GuestIdentity {
+    GuestIdentity::new(
+        ResourceRef::parse("Guest/guest-a").unwrap(),
+        ZoneId::parse("work").unwrap(),
+        PeerCid::from_core(cid).unwrap(),
+        "boot-a",
+    )
+    .unwrap()
+}
+
+#[test]
+fn correct_cid_signature_guest_zone_and_session_establish_ready() {
+    let key = GuestControlKey::from_core([7; 32]);
+    let expected = identity(42);
+    let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
+    let proof = SessionProof::sign(&key, &expected, [9; 32], 3);
+
+    let session = authority.authenticate(proof).unwrap();
+    assert_eq!(session.state(), SessionState::Ready);
+    assert!(session.matches(&expected));
+    assert_eq!(session.disconnect(), SessionState::Disconnected);
+}
+
+#[test]
+fn cid_reuse_and_replay_are_rejected() {
+    let key = GuestControlKey::from_core([8; 32]);
+    let expected = identity(42);
+    let mut authority = SessionAuthority::new(expected.clone(), key.clone(), 3);
+    let proof = SessionProof::sign(&key, &expected, [4; 32], 3);
+    authority.authenticate(proof.clone()).unwrap();
+    assert_eq!(
+        authority.authenticate(proof).unwrap_err(),
+        SessionRejectReason::Replay
+    );
+
+    let mut other = identity(43);
+    let proof = SessionProof::sign(&key, &other, [5; 32], 3);
+    assert_eq!(
+        authority.authenticate(proof).unwrap_err(),
+        SessionRejectReason::CidMismatch
+    );
+    other = identity(42);
+    let proof = SessionProof::sign(&key, &other, [6; 32], 2);
+    assert_eq!(
+        authority.authenticate(proof).unwrap_err(),
+        SessionRejectReason::StaleSignature
+    );
+}

--- a/packages/d2b-provider-transport-vsock/tests/authentication.rs
+++ b/packages/d2b-provider-transport-vsock/tests/authentication.rs
@@ -3,11 +3,10 @@ use d2b_provider_transport_vsock::{
     GuestControlKey, GuestIdentity, MAX_REPLAY_ENTRIES, PeerCid, SessionAuthority, SessionProof,
     SessionRejectReason, SessionState,
 };
-use ring::rand::{SecureRandom, SystemRandom};
+use ring::rand::{SystemRandom, generate};
 
 fn nonce_for(index: u16) -> [u8; 32] {
-    let mut nonce = [0_u8; 32];
-    SystemRandom::new().fill(&mut nonce).unwrap();
+    let mut nonce = generate::<[u8; 32]>(&SystemRandom::new()).unwrap().expose();
     nonce[..2].copy_from_slice(&index.to_be_bytes());
     nonce
 }

--- a/packages/d2b-provider-transport-vsock/tests/effect_port_mock.rs
+++ b/packages/d2b-provider-transport-vsock/tests/effect_port_mock.rs
@@ -1,0 +1,19 @@
+use d2b_provider_transport_vsock::{OpaqueBindingId, OpaqueEndpointId, VsockEffectError};
+
+#[test]
+fn opaque_effect_ids_are_bounded_and_redacted() {
+    assert!(OpaqueEndpointId::parse("endpoint-a").is_ok());
+    assert!(OpaqueBindingId::parse("binding-a").is_ok());
+    assert_eq!(
+        OpaqueEndpointId::parse("Endpoint-a").unwrap_err(),
+        VsockEffectError::EffectRejected
+    );
+    assert_eq!(
+        OpaqueBindingId::parse("binding/path").unwrap_err(),
+        VsockEffectError::EffectRejected
+    );
+    assert_eq!(
+        format!("{:?}", OpaqueEndpointId::parse("endpoint-a").unwrap()),
+        "OpaqueEndpointId(<redacted>)"
+    );
+}

--- a/packages/d2b-provider-transport-vsock/tests/framing.rs
+++ b/packages/d2b-provider-transport-vsock/tests/framing.rs
@@ -1,0 +1,61 @@
+use d2b_provider_transport_vsock::{FramedVsockTransport, TransportError};
+use d2b_session::{OwnedTransport, TransportPacket};
+use tokio::{
+    io::{AsyncWriteExt, duplex},
+    runtime::Builder,
+};
+
+#[test]
+fn framed_transport_handles_partial_and_coalesced_records() {
+    let runtime = Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .expect("runtime");
+    runtime.block_on(async {
+        let (mut sender, receiver) = duplex(128);
+        let writer = tokio::spawn(async move {
+            sender.write_all(&[0, 5, b'h', b'e']).await.unwrap();
+            sender.write_all(b"llo\0\x05world").await.unwrap();
+        });
+
+        let mut transport = FramedVsockTransport::new(receiver);
+        assert_eq!(
+            transport.vsock_descriptor(),
+            d2b_provider_transport_vsock::VsockTransportDescriptor::default()
+        );
+        assert_eq!(transport.receive(64).await.unwrap().as_bytes(), b"hello");
+        assert_eq!(transport.receive(64).await.unwrap().as_bytes(), b"world");
+        writer.await.unwrap();
+    });
+}
+
+#[test]
+fn framed_transport_rejects_oversized_records_before_allocation() {
+    let runtime = Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .expect("runtime");
+    runtime.block_on(async {
+        let (mut sender, receiver) = duplex(16);
+        sender.write_all(&[0, 8, 1, 2]).await.unwrap();
+        let mut transport = FramedVsockTransport::with_limit(receiver, 4);
+        assert_eq!(
+            transport.read_frame().await,
+            Err(TransportError::FrameTooLarge)
+        );
+    });
+}
+
+#[test]
+fn framed_transport_rejects_attachments() {
+    let runtime = Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .expect("runtime");
+    runtime.block_on(async {
+        let (_sender, receiver) = duplex(64);
+        let mut transport = FramedVsockTransport::new(receiver);
+        let packet = TransportPacket::with_attachments(b"payload".to_vec(), Vec::new());
+        transport.send(packet).await.unwrap();
+    });
+}

--- a/packages/d2b-provider-transport-vsock/tests/observe.rs
+++ b/packages/d2b-provider-transport-vsock/tests/observe.rs
@@ -1,0 +1,16 @@
+use d2b_provider_transport_vsock::{
+    ServicePhase, TransportObservation, TransportPhase, VsockTransportDescriptor,
+};
+
+#[test]
+fn released_observation_is_identity_free_and_bounded() {
+    let observation = TransportObservation {
+        phase: TransportPhase::Released,
+        descriptor: VsockTransportDescriptor::default(),
+        bytes_rx: Some(4),
+        bytes_tx: Some(5),
+        last_exit: Some(d2b_provider_transport_vsock::BridgeExit::OwnerClosed),
+    };
+    assert_eq!(observation.phase, TransportPhase::Released);
+    assert_eq!(ServicePhase::Ready, ServicePhase::Ready);
+}

--- a/packages/d2b-provider-transport-vsock/tests/open_close.rs
+++ b/packages/d2b-provider-transport-vsock/tests/open_close.rs
@@ -1,0 +1,28 @@
+use d2b_provider_transport_vsock::{
+    OpaqueBindingId, OpaqueEndpointId, OpenTransportRequest, ServiceError, TransportRole,
+};
+
+#[test]
+fn open_request_deadline_is_bounded() {
+    let request = OpenTransportRequest::new(
+        OpaqueEndpointId::parse("endpoint-a").unwrap(),
+        OpaqueBindingId::parse("binding-a").unwrap(),
+        TransportRole::Initiator,
+        999,
+    );
+    assert_eq!(
+        request.deadline_ms, 999,
+        "the service performs the final range check"
+    );
+    assert_eq!(ServiceError::InvalidDeadline.code(), "invalid-deadline");
+    assert_eq!(
+        OpenTransportRequest::from_raw("bad/path", "binding-a", TransportRole::Initiator, 1_000)
+            .unwrap_err(),
+        ServiceError::InvalidEndpointId
+    );
+    assert_eq!(
+        OpenTransportRequest::from_raw("endpoint-a", "bad/path", TransportRole::Initiator, 1_000)
+            .unwrap_err(),
+        ServiceError::InvalidBindingId
+    );
+}

--- a/packages/d2b-provider-transport-vsock/tests/redaction.rs
+++ b/packages/d2b-provider-transport-vsock/tests/redaction.rs
@@ -1,0 +1,41 @@
+use d2b_contracts::v3::{ResourceRef, ZoneId};
+use d2b_provider_transport_vsock::{
+    GuestControlKey, GuestIdentity, OpaqueBindingId, OpaqueEndpointId, PeerCid, SessionAuthority,
+    SessionProof, VsockTransportSettings,
+};
+
+#[test]
+fn diagnostics_do_not_expose_endpoint_binding_cid_or_signature_material() {
+    let endpoint = OpaqueEndpointId::parse("endpoint-secret").unwrap();
+    let binding = OpaqueBindingId::parse("binding-secret").unwrap();
+    let identity = GuestIdentity::new(
+        ResourceRef::parse("Guest/secret-guest").unwrap(),
+        ZoneId::parse("secret-zone").unwrap(),
+        PeerCid::from_core(77).unwrap(),
+        "secret-boot",
+    )
+    .unwrap();
+    let key = GuestControlKey::from_core([9; 32]);
+    let authority = SessionAuthority::new(identity.clone(), key.clone(), 1);
+    let proof = SessionProof::sign(&key, &identity, [8; 32], 1);
+    let rendered = format!("{endpoint:?} {binding:?} {identity:?} {proof:?} {authority:?}");
+    for canary in [
+        "endpoint-secret",
+        "binding-secret",
+        "secret-guest",
+        "secret-zone",
+        "77",
+    ] {
+        assert!(!rendered.contains(canary), "diagnostics leaked {canary}");
+    }
+}
+
+#[test]
+fn transport_settings_reject_raw_endpoint_fields() {
+    let settings: Result<VsockTransportSettings, _> =
+        serde_json::from_str(r#"{"guestRef":"Guest/guest-a","cid":42}"#);
+    assert!(settings.is_err());
+    let settings: Result<VsockTransportSettings, _> =
+        serde_json::from_str(r#"{"guestRef":"Guest/guest-a","port":14420}"#);
+    assert!(settings.is_err());
+}

--- a/packages/d2b-provider-transport-vsock/tests/redaction.rs
+++ b/packages/d2b-provider-transport-vsock/tests/redaction.rs
@@ -3,12 +3,10 @@ use d2b_provider_transport_vsock::{
     GuestControlKey, GuestIdentity, OpaqueBindingId, OpaqueEndpointId, PeerCid, SessionAuthority,
     SessionProof, VsockTransportSettings,
 };
-use ring::rand::{SecureRandom, SystemRandom};
+use ring::rand::{SystemRandom, generate};
 
 fn nonce() -> [u8; 32] {
-    let mut nonce = [0_u8; 32];
-    SystemRandom::new().fill(&mut nonce).unwrap();
-    nonce
+    generate::<[u8; 32]>(&SystemRandom::new()).unwrap().expose()
 }
 
 #[test]

--- a/packages/d2b-provider-transport-vsock/tests/redaction.rs
+++ b/packages/d2b-provider-transport-vsock/tests/redaction.rs
@@ -3,6 +3,13 @@ use d2b_provider_transport_vsock::{
     GuestControlKey, GuestIdentity, OpaqueBindingId, OpaqueEndpointId, PeerCid, SessionAuthority,
     SessionProof, VsockTransportSettings,
 };
+use ring::rand::{SecureRandom, SystemRandom};
+
+fn nonce() -> [u8; 32] {
+    let mut nonce = [0_u8; 32];
+    SystemRandom::new().fill(&mut nonce).unwrap();
+    nonce
+}
 
 #[test]
 fn diagnostics_do_not_expose_endpoint_binding_cid_or_signature_material() {
@@ -17,7 +24,7 @@ fn diagnostics_do_not_expose_endpoint_binding_cid_or_signature_material() {
     .unwrap();
     let key = GuestControlKey::from_core([9; 32]);
     let authority = SessionAuthority::new(identity.clone(), key.clone(), 1);
-    let proof = SessionProof::sign(&key, &identity, [8; 32], 1);
+    let proof = SessionProof::sign(&key, &identity, nonce(), 1);
     let rendered = format!("{endpoint:?} {binding:?} {identity:?} {proof:?} {authority:?}");
     for canary in [
         "endpoint-secret",

--- a/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
+++ b/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
@@ -4,13 +4,11 @@ use d2b_provider_transport_vsock::{
     GuestControlKey, GuestIdentity, NativeGuestRelay, PeerCid, RelayBinding, RelayEffectError,
     RelayEffectPort, RelayObservation, RelayPhase, SessionAuthority, SessionProof,
 };
-use ring::rand::{SecureRandom, SystemRandom};
+use ring::rand::{SystemRandom, generate};
 use std::sync::{Arc, Mutex};
 
 fn nonce() -> [u8; 32] {
-    let mut nonce = [0_u8; 32];
-    SystemRandom::new().fill(&mut nonce).unwrap();
-    nonce
+    generate::<[u8; 32]>(&SystemRandom::new()).unwrap().expose()
 }
 
 #[derive(Default)]

--- a/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
+++ b/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
@@ -4,7 +4,14 @@ use d2b_provider_transport_vsock::{
     GuestControlKey, GuestIdentity, NativeGuestRelay, PeerCid, RelayBinding, RelayEffectError,
     RelayEffectPort, RelayObservation, RelayPhase, SessionAuthority, SessionProof,
 };
+use ring::rand::{SecureRandom, SystemRandom};
 use std::sync::{Arc, Mutex};
+
+fn nonce() -> [u8; 32] {
+    let mut nonce = [0_u8; 32];
+    SystemRandom::new().fill(&mut nonce).unwrap();
+    nonce
+}
 
 #[derive(Default)]
 struct FakeRelayPort {
@@ -121,7 +128,7 @@ fn finalization_closes_relay_before_releasing_cid_authority() {
         let session = authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &guest, [1; 32], 1),
+                SessionProof::sign(&key, &guest, nonce(), 1),
             )
             .unwrap();
         let mut relay = NativeGuestRelay::new(port, binding());
@@ -193,6 +200,7 @@ fn reserve_failure_leaves_relay_retryable() {
         .unwrap();
     runtime.block_on(async {
         let port = FakeRelayPort::default();
+        let fail_reserve = Arc::clone(&port.fail_reserve);
         *port.fail_reserve.lock().unwrap() = true;
         let key = GuestControlKey::from_core([7; 32]);
         let guest = binding().guest().clone();
@@ -200,7 +208,7 @@ fn reserve_failure_leaves_relay_retryable() {
         let session = authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &guest, [4; 32], 1),
+                SessionProof::sign(&key, &guest, nonce(), 1),
             )
             .unwrap();
         let mut relay = NativeGuestRelay::new(port, binding());
@@ -209,6 +217,15 @@ fn reserve_failure_leaves_relay_retryable() {
             RelayEffectError::CidAuthorityConflict
         );
         assert_eq!(relay.phase(), RelayPhase::Idle);
+
+        relay.finalize().await.unwrap();
+        assert_eq!(relay.phase(), RelayPhase::Closed);
+
+        *fail_reserve.lock().unwrap() = false;
+        relay.start(&session).await.unwrap();
+        assert_eq!(relay.phase(), RelayPhase::Ready);
+        relay.finalize().await.unwrap();
+        assert_eq!(relay.phase(), RelayPhase::Closed);
     });
 }
 
@@ -227,7 +244,7 @@ fn failed_cid_release_retains_authority_for_retry() {
         let session = authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &guest, [3; 32], 1),
+                SessionProof::sign(&key, &guest, nonce(), 1),
             )
             .unwrap();
         let mut relay = NativeGuestRelay::new(port, binding());
@@ -262,7 +279,7 @@ fn listener_close_failure_keeps_cid_authority_for_retry() {
         let session = authority
             .authenticate(
                 PeerCid::from_core(42).unwrap(),
-                SessionProof::sign(&key, &guest, [13; 32], 1),
+                SessionProof::sign(&key, &guest, nonce(), 1),
             )
             .unwrap();
         let mut relay = NativeGuestRelay::new(port, binding());

--- a/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
+++ b/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 #[derive(Default)]
 struct FakeRelayPort {
     calls: Arc<Mutex<Vec<&'static str>>>,
+    fail_reserve: Arc<Mutex<bool>>,
     fail_release: Arc<Mutex<bool>>,
     observed: Arc<Mutex<Option<RelayObservation<u64, u64>>>>,
 }
@@ -24,7 +25,11 @@ impl RelayEffectPort for FakeRelayPort {
         _: &RelayBinding,
     ) -> Result<Self::CidReservation, RelayEffectError> {
         self.calls.lock().unwrap().push("reserve-cid");
-        Ok(1)
+        if *self.fail_reserve.lock().unwrap() {
+            Err(RelayEffectError::CidAuthorityConflict)
+        } else {
+            Ok(1)
+        }
     }
 
     async fn bind_listener(
@@ -100,7 +105,10 @@ fn finalization_closes_relay_before_releasing_cid_authority() {
         let guest = binding().guest().clone();
         let mut authority = SessionAuthority::new(guest.clone(), key.clone(), 1);
         let session = authority
-            .authenticate(SessionProof::sign(&key, &guest, [1; 32], 1))
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &guest, [1; 32], 1),
+            )
             .unwrap();
         let mut relay = NativeGuestRelay::new(port, binding());
         relay.start(&session).await.unwrap();
@@ -135,8 +143,9 @@ fn restart_adopts_only_the_matching_listener_and_process() {
             process: 3,
         });
         let mut relay = NativeGuestRelay::new(port, binding.clone());
-        relay.adopt().await.unwrap();
+        relay.adopt(1).await.unwrap();
         assert_eq!(relay.phase(), RelayPhase::Ready);
+        relay.finalize().await.unwrap();
 
         let port = FakeRelayPort::default();
         *port.observed.lock().unwrap() = Some(RelayObservation {
@@ -155,10 +164,37 @@ fn restart_adopts_only_the_matching_listener_and_process() {
         });
         let mut relay = NativeGuestRelay::new(port, binding);
         assert_eq!(
-            relay.adopt().await.unwrap_err(),
+            relay.adopt(1).await.unwrap_err(),
             RelayEffectError::RestartMismatch
         );
         assert_eq!(relay.phase(), RelayPhase::Degraded);
+    });
+}
+
+#[test]
+fn reserve_failure_leaves_relay_retryable() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let port = FakeRelayPort::default();
+        *port.fail_reserve.lock().unwrap() = true;
+        let key = GuestControlKey::from_core([7; 32]);
+        let guest = binding().guest().clone();
+        let mut authority = SessionAuthority::new(guest.clone(), key.clone(), 1);
+        let session = authority
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &guest, [4; 32], 1),
+            )
+            .unwrap();
+        let mut relay = NativeGuestRelay::new(port, binding());
+        assert_eq!(
+            relay.start(&session).await.unwrap_err(),
+            RelayEffectError::CidAuthorityConflict
+        );
+        assert_eq!(relay.phase(), RelayPhase::Idle);
     });
 }
 
@@ -175,7 +211,10 @@ fn failed_cid_release_retains_authority_for_retry() {
         let guest = binding().guest().clone();
         let mut authority = SessionAuthority::new(guest.clone(), key.clone(), 1);
         let session = authority
-            .authenticate(SessionProof::sign(&key, &guest, [3; 32], 1))
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &guest, [3; 32], 1),
+            )
             .unwrap();
         let mut relay = NativeGuestRelay::new(port, binding());
         relay.start(&session).await.unwrap();

--- a/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
+++ b/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
@@ -1,0 +1,192 @@
+use async_trait::async_trait;
+use d2b_contracts::v3::{ResourceRef, ZoneId};
+use d2b_provider_transport_vsock::{
+    GuestControlKey, GuestIdentity, NativeGuestRelay, PeerCid, RelayBinding, RelayEffectError,
+    RelayEffectPort, RelayObservation, RelayPhase, SessionAuthority, SessionProof,
+};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct FakeRelayPort {
+    calls: Arc<Mutex<Vec<&'static str>>>,
+    fail_release: Arc<Mutex<bool>>,
+    observed: Arc<Mutex<Option<RelayObservation<u64, u64>>>>,
+}
+
+#[async_trait]
+impl RelayEffectPort for FakeRelayPort {
+    type CidReservation = u64;
+    type Listener = u64;
+    type RelayProcess = u64;
+
+    async fn reserve_cid(
+        &self,
+        _: &RelayBinding,
+    ) -> Result<Self::CidReservation, RelayEffectError> {
+        self.calls.lock().unwrap().push("reserve-cid");
+        Ok(1)
+    }
+
+    async fn bind_listener(
+        &self,
+        _: &RelayBinding,
+        _: &Self::CidReservation,
+    ) -> Result<Self::Listener, RelayEffectError> {
+        self.calls.lock().unwrap().push("bind-listener");
+        Ok(2)
+    }
+
+    async fn spawn_relay(
+        &self,
+        _: &RelayBinding,
+        _: &Self::Listener,
+        _: &Self::CidReservation,
+    ) -> Result<Self::RelayProcess, RelayEffectError> {
+        self.calls.lock().unwrap().push("spawn-relay");
+        Ok(3)
+    }
+
+    async fn close_relay(&self, _: &Self::RelayProcess) -> Result<(), RelayEffectError> {
+        self.calls.lock().unwrap().push("close-relay");
+        Ok(())
+    }
+
+    async fn close_listener(&self, _: &Self::Listener) -> Result<(), RelayEffectError> {
+        self.calls.lock().unwrap().push("close-listener");
+        Ok(())
+    }
+
+    async fn release_cid(&self, _: &Self::CidReservation) -> Result<(), RelayEffectError> {
+        self.calls.lock().unwrap().push("release-cid");
+        if *self.fail_release.lock().unwrap() {
+            Err(RelayEffectError::CloseUnconfirmed)
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn observe(
+        &self,
+        _: &RelayBinding,
+    ) -> Result<Option<RelayObservation<Self::Listener, Self::RelayProcess>>, RelayEffectError>
+    {
+        Ok(self.observed.lock().unwrap().clone())
+    }
+}
+
+fn binding() -> RelayBinding {
+    RelayBinding::new(
+        GuestIdentity::new(
+            ResourceRef::parse("Guest/guest-a").unwrap(),
+            ZoneId::parse("work").unwrap(),
+            PeerCid::from_core(42).unwrap(),
+            "boot-a",
+        )
+        .unwrap(),
+        [11; 16],
+    )
+}
+
+#[test]
+fn finalization_closes_relay_before_releasing_cid_authority() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let port = FakeRelayPort::default();
+        let calls = Arc::clone(&port.calls);
+        let key = GuestControlKey::from_core([7; 32]);
+        let guest = binding().guest().clone();
+        let mut authority = SessionAuthority::new(guest.clone(), key.clone(), 1);
+        let session = authority
+            .authenticate(SessionProof::sign(&key, &guest, [1; 32], 1))
+            .unwrap();
+        let mut relay = NativeGuestRelay::new(port, binding());
+        relay.start(&session).await.unwrap();
+        relay.finalize().await.unwrap();
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![
+                "reserve-cid",
+                "bind-listener",
+                "spawn-relay",
+                "close-relay",
+                "close-listener",
+                "release-cid",
+            ]
+        );
+        assert_eq!(relay.phase(), RelayPhase::Closed);
+    });
+}
+
+#[test]
+fn restart_adopts_only_the_matching_listener_and_process() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let binding = binding();
+        let port = FakeRelayPort::default();
+        *port.observed.lock().unwrap() = Some(RelayObservation {
+            binding: binding.clone(),
+            listener: 2,
+            process: 3,
+        });
+        let mut relay = NativeGuestRelay::new(port, binding.clone());
+        relay.adopt().await.unwrap();
+        assert_eq!(relay.phase(), RelayPhase::Ready);
+
+        let port = FakeRelayPort::default();
+        *port.observed.lock().unwrap() = Some(RelayObservation {
+            binding: RelayBinding::new(
+                GuestIdentity::new(
+                    ResourceRef::parse("Guest/other").unwrap(),
+                    ZoneId::parse("work").unwrap(),
+                    PeerCid::from_core(42).unwrap(),
+                    "boot-a",
+                )
+                .unwrap(),
+                [12; 16],
+            ),
+            listener: 2,
+            process: 3,
+        });
+        let mut relay = NativeGuestRelay::new(port, binding);
+        assert_eq!(
+            relay.adopt().await.unwrap_err(),
+            RelayEffectError::RestartMismatch
+        );
+        assert_eq!(relay.phase(), RelayPhase::Degraded);
+    });
+}
+
+#[test]
+fn failed_cid_release_retains_authority_for_retry() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let port = FakeRelayPort::default();
+        let fail_release = Arc::clone(&port.fail_release);
+        let key = GuestControlKey::from_core([7; 32]);
+        let guest = binding().guest().clone();
+        let mut authority = SessionAuthority::new(guest.clone(), key.clone(), 1);
+        let session = authority
+            .authenticate(SessionProof::sign(&key, &guest, [3; 32], 1))
+            .unwrap();
+        let mut relay = NativeGuestRelay::new(port, binding());
+        relay.start(&session).await.unwrap();
+        *fail_release.lock().unwrap() = true;
+        assert_eq!(
+            relay.finalize().await.unwrap_err(),
+            RelayEffectError::CloseUnconfirmed
+        );
+        assert_eq!(relay.phase(), RelayPhase::Finalizing);
+        *fail_release.lock().unwrap() = false;
+        relay.finalize().await.unwrap();
+        assert_eq!(relay.phase(), RelayPhase::Closed);
+    });
+}

--- a/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
+++ b/packages/d2b-provider-transport-vsock/tests/relay_lifecycle.rs
@@ -10,8 +10,11 @@ use std::sync::{Arc, Mutex};
 struct FakeRelayPort {
     calls: Arc<Mutex<Vec<&'static str>>>,
     fail_reserve: Arc<Mutex<bool>>,
+    fail_spawn: Arc<Mutex<bool>>,
+    fail_close_listener: Arc<Mutex<bool>>,
     fail_release: Arc<Mutex<bool>>,
     observed: Arc<Mutex<Option<RelayObservation<u64, u64>>>>,
+    observe_error: Arc<Mutex<Option<RelayEffectError>>>,
 }
 
 #[async_trait]
@@ -48,7 +51,11 @@ impl RelayEffectPort for FakeRelayPort {
         _: &Self::CidReservation,
     ) -> Result<Self::RelayProcess, RelayEffectError> {
         self.calls.lock().unwrap().push("spawn-relay");
-        Ok(3)
+        if *self.fail_spawn.lock().unwrap() {
+            Err(RelayEffectError::ProcessUnavailable)
+        } else {
+            Ok(3)
+        }
     }
 
     async fn close_relay(&self, _: &Self::RelayProcess) -> Result<(), RelayEffectError> {
@@ -58,7 +65,11 @@ impl RelayEffectPort for FakeRelayPort {
 
     async fn close_listener(&self, _: &Self::Listener) -> Result<(), RelayEffectError> {
         self.calls.lock().unwrap().push("close-listener");
-        Ok(())
+        if *self.fail_close_listener.lock().unwrap() {
+            Err(RelayEffectError::CloseUnconfirmed)
+        } else {
+            Ok(())
+        }
     }
 
     async fn release_cid(&self, _: &Self::CidReservation) -> Result<(), RelayEffectError> {
@@ -75,6 +86,9 @@ impl RelayEffectPort for FakeRelayPort {
         _: &RelayBinding,
     ) -> Result<Option<RelayObservation<Self::Listener, Self::RelayProcess>>, RelayEffectError>
     {
+        if let Some(error) = *self.observe_error.lock().unwrap() {
+            return Err(error);
+        }
         Ok(self.observed.lock().unwrap().clone())
     }
 }
@@ -228,4 +242,91 @@ fn failed_cid_release_retains_authority_for_retry() {
         relay.finalize().await.unwrap();
         assert_eq!(relay.phase(), RelayPhase::Closed);
     });
+}
+
+#[test]
+fn listener_close_failure_keeps_cid_authority_for_retry() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let port = FakeRelayPort::default();
+        *port.fail_spawn.lock().unwrap() = true;
+        *port.fail_close_listener.lock().unwrap() = true;
+        let calls = Arc::clone(&port.calls);
+        let fail_close_listener = Arc::clone(&port.fail_close_listener);
+        let key = GuestControlKey::from_core([7; 32]);
+        let guest = binding().guest().clone();
+        let mut authority = SessionAuthority::new(guest.clone(), key.clone(), 1);
+        let session = authority
+            .authenticate(
+                PeerCid::from_core(42).unwrap(),
+                SessionProof::sign(&key, &guest, [13; 32], 1),
+            )
+            .unwrap();
+        let mut relay = NativeGuestRelay::new(port, binding());
+
+        assert_eq!(
+            relay.start(&session).await.unwrap_err(),
+            RelayEffectError::ProcessUnavailable
+        );
+        assert_eq!(relay.phase(), RelayPhase::Degraded);
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![
+                "reserve-cid",
+                "bind-listener",
+                "spawn-relay",
+                "close-listener",
+            ]
+        );
+
+        *fail_close_listener.lock().unwrap() = false;
+        relay.finalize().await.unwrap();
+        assert_eq!(relay.phase(), RelayPhase::Closed);
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![
+                "reserve-cid",
+                "bind-listener",
+                "spawn-relay",
+                "close-listener",
+                "close-listener",
+                "release-cid",
+            ]
+        );
+    });
+}
+
+#[test]
+fn restart_observation_error_degrades_without_adoption() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let port = FakeRelayPort::default();
+        *port.observe_error.lock().unwrap() = Some(RelayEffectError::Transient);
+        let mut relay = NativeGuestRelay::new(port, binding());
+
+        assert_eq!(
+            relay.adopt(1).await.unwrap_err(),
+            RelayEffectError::Transient
+        );
+        assert_eq!(relay.phase(), RelayPhase::Degraded);
+    });
+}
+
+#[test]
+fn relay_observation_debug_is_redacted() {
+    let observation = RelayObservation {
+        binding: binding(),
+        listener: 1234_u64,
+        process: 5678_u64,
+    };
+    let rendered = format!("{observation:?}");
+    assert!(!rendered.contains("1234"));
+    assert!(!rendered.contains("5678"));
+    assert!(!rendered.contains("guest-a"));
 }

--- a/packages/d2b-provider-transport-vsock/tests/schema.rs
+++ b/packages/d2b-provider-transport-vsock/tests/schema.rs
@@ -1,0 +1,19 @@
+use d2b_provider_transport_vsock::{PortClass, VsockTransportSettings};
+
+#[test]
+fn transport_settings_schema_rejects_cid_and_port_fields() {
+    let schema: serde_json::Value =
+        serde_json::from_str(VsockTransportSettings::schema_json()).unwrap();
+    assert_eq!(schema["additionalProperties"], false);
+    assert!(schema["properties"].get("cid").is_none());
+    assert!(schema["properties"].get("port").is_none());
+}
+
+#[test]
+fn transport_settings_round_trip_keeps_the_closed_port_class() {
+    let settings: VsockTransportSettings =
+        serde_json::from_str(r#"{"guestRef":"Guest/guest-a"}"#).unwrap();
+    assert_eq!(settings.port_class, PortClass::D2bLink);
+    assert_eq!(settings.connect_timeout_seconds, 30);
+    settings.validate().unwrap();
+}

--- a/packages/d2b-provider-transport-vsock/tests/service.rs
+++ b/packages/d2b-provider-transport-vsock/tests/service.rs
@@ -8,7 +8,7 @@ use d2b_provider_transport_vsock::{
 };
 use std::{
     sync::{Arc, Mutex},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
 
@@ -16,6 +16,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
 struct FakeEffect {
     peers: Arc<Mutex<Vec<DuplexStream>>>,
     closes: Arc<Mutex<usize>>,
+    open_delay: Option<Duration>,
+    fail_close: Arc<Mutex<bool>>,
 }
 
 #[async_trait]
@@ -29,6 +31,9 @@ impl VsockEffectPort for FakeEffect {
         _: TransportRole,
         _: Instant,
     ) -> Result<Self::Stream, VsockEffectError> {
+        if let Some(delay) = self.open_delay {
+            tokio::time::sleep(delay).await;
+        }
         let (local, peer) = duplex(1024);
         self.peers.lock().unwrap().push(peer);
         Ok(local)
@@ -36,7 +41,11 @@ impl VsockEffectPort for FakeEffect {
 
     async fn close(&self, _: Self::Stream) -> Result<(), VsockEffectError> {
         *self.closes.lock().unwrap() += 1;
-        Ok(())
+        if *self.fail_close.lock().unwrap() {
+            Err(VsockEffectError::Transient)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -106,6 +115,8 @@ fn open_observe_and_close_release_the_bridge() {
         let effect = FakeEffect {
             peers: Arc::new(Mutex::new(Vec::new())),
             closes: Arc::new(Mutex::new(0)),
+            open_delay: None,
+            fail_close: Arc::new(Mutex::new(false)),
         };
         let effect_closes = Arc::clone(&effect.closes);
         let effect_peers = Arc::clone(&effect.peers);
@@ -169,6 +180,10 @@ fn open_observe_and_close_release_the_bridge() {
         assert_eq!(*effect_closes.lock().unwrap(), 1);
         assert_eq!(*stream_closes.lock().unwrap(), 1);
         assert_eq!(
+            service.phase().await,
+            d2b_provider_transport_vsock::ServicePhase::Ready
+        );
+        assert_eq!(
             service
                 .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
                     transport_handle: opened.transport_handle,
@@ -188,6 +203,111 @@ fn open_observe_and_close_release_the_bridge() {
                 .await
                 .unwrap_err(),
             ServiceError::UnknownTransportHandle
+        );
+    });
+}
+
+#[test]
+fn open_effect_is_bounded_by_the_request_deadline() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let effect = FakeEffect {
+            peers: Arc::new(Mutex::new(Vec::new())),
+            closes: Arc::new(Mutex::new(0)),
+            open_delay: Some(Duration::from_millis(1_100)),
+            fail_close: Arc::new(Mutex::new(false)),
+        };
+        let service = VsockTransportService::new(
+            effect,
+            FakeStreams {
+                next: Arc::new(Mutex::new(0)),
+                closes: Arc::new(Mutex::new(0)),
+                peers: Arc::new(Mutex::new(Vec::new())),
+            },
+            identity(),
+        );
+        assert_eq!(
+            service
+                .open_transport(&session(), request())
+                .await
+                .unwrap_err(),
+            ServiceError::Effect(VsockEffectError::DeadlineExceeded)
+        );
+    });
+}
+
+#[test]
+fn failed_endpoint_close_is_reported_as_degraded() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let effect = FakeEffect {
+            peers: Arc::new(Mutex::new(Vec::new())),
+            closes: Arc::new(Mutex::new(0)),
+            open_delay: None,
+            fail_close: Arc::new(Mutex::new(true)),
+        };
+        let service = VsockTransportService::new(
+            effect,
+            FakeStreams {
+                next: Arc::new(Mutex::new(0)),
+                closes: Arc::new(Mutex::new(0)),
+                peers: Arc::new(Mutex::new(Vec::new())),
+            },
+            identity(),
+        );
+        let opened = service.open_transport(&session(), request()).await.unwrap();
+        assert_eq!(
+            service
+                .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                    transport_handle: opened.transport_handle,
+                })
+                .await
+                .unwrap_err(),
+            ServiceError::CloseUnconfirmed
+        );
+        assert_eq!(
+            service
+                .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
+                    transport_handle: opened.transport_handle,
+                    include_bytes: false,
+                })
+                .await
+                .unwrap()
+                .phase,
+            TransportPhase::Degraded
+        );
+        assert_eq!(
+            service.phase().await,
+            d2b_provider_transport_vsock::ServicePhase::Degraded
+        );
+        assert_eq!(
+            service
+                .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                    transport_handle: opened.transport_handle,
+                })
+                .await
+                .unwrap_err(),
+            ServiceError::CloseUnconfirmed
+        );
+        let mut events = service
+            .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+                transport_handle: opened.transport_handle,
+                include_bytes: false,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            events.recv().await,
+            Some(d2b_provider_transport_vsock::TransportEvent::Error {
+                kind: "close-unconfirmed",
+                recoverable: true,
+            })
         );
     });
 }

--- a/packages/d2b-provider-transport-vsock/tests/service.rs
+++ b/packages/d2b-provider-transport-vsock/tests/service.rs
@@ -6,7 +6,7 @@ use d2b_provider_transport_vsock::{
     PeerCid, ReadySession, ServiceError, SessionAuthority, SessionProof, TransportPhase,
     TransportRole, VsockEffectError, VsockEffectPort, VsockTransportService,
 };
-use ring::rand::{SecureRandom, SystemRandom};
+use ring::rand::{SystemRandom, generate};
 use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -14,9 +14,7 @@ use std::{
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
 
 fn nonce() -> [u8; 32] {
-    let mut nonce = [0_u8; 32];
-    SystemRandom::new().fill(&mut nonce).unwrap();
-    nonce
+    generate::<[u8; 32]>(&SystemRandom::new()).unwrap().expose()
 }
 
 #[derive(Clone)]

--- a/packages/d2b-provider-transport-vsock/tests/service.rs
+++ b/packages/d2b-provider-transport-vsock/tests/service.rs
@@ -65,18 +65,25 @@ impl NamedStreamPort for FakeStreams {
     }
 }
 
-fn session() -> ReadySession {
-    let identity = GuestIdentity::new(
+fn identity() -> GuestIdentity {
+    GuestIdentity::new(
         ResourceRef::parse("Guest/guest-a").unwrap(),
         ZoneId::parse("work").unwrap(),
         PeerCid::from_core(42).unwrap(),
         "boot-a",
     )
-    .unwrap();
+    .unwrap()
+}
+
+fn session() -> ReadySession {
+    let identity = identity();
     let key = GuestControlKey::from_core([1; 32]);
     let mut authority = SessionAuthority::new(identity.clone(), key.clone(), 1);
     authority
-        .authenticate(SessionProof::sign(&key, &identity, [2; 32], 1))
+        .authenticate(
+            PeerCid::from_core(42).unwrap(),
+            SessionProof::sign(&key, &identity, [2; 32], 1),
+        )
         .unwrap()
 }
 
@@ -109,7 +116,7 @@ fn open_observe_and_close_release_the_bridge() {
         };
         let stream_closes = Arc::clone(&streams.closes);
         let stream_peers = Arc::clone(&streams.peers);
-        let service = VsockTransportService::new(effect, streams);
+        let service = VsockTransportService::new(effect, streams, identity());
         let opened = service.open_transport(&session(), request()).await.unwrap();
         let mut effect_peer = effect_peers.lock().unwrap().pop().unwrap();
         let mut stream_peer = stream_peers.lock().unwrap().pop().unwrap();
@@ -122,24 +129,48 @@ fn open_observe_and_close_release_the_bridge() {
         effect_peer.read_exact(&mut received).await.unwrap();
         assert_eq!(&received, b"core-to-guest");
         let observed = service
-            .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+            .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
                 transport_handle: opened.transport_handle,
                 include_bytes: true,
             })
             .await
             .unwrap();
         assert_eq!(observed.phase, TransportPhase::Acquired);
+        let mut events = service
+            .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+                transport_handle: opened.transport_handle,
+                include_bytes: true,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            events.recv().await,
+            Some(d2b_provider_transport_vsock::TransportEvent::Acquired)
+        );
         service
             .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
                 transport_handle: opened.transport_handle,
             })
             .await
             .unwrap();
+        loop {
+            match events.recv().await {
+                Some(d2b_provider_transport_vsock::TransportEvent::BytesTransferred {
+                    rx_bytes,
+                    tx_bytes,
+                }) => {
+                    assert_eq!((rx_bytes, tx_bytes), (13, 13));
+                }
+                Some(d2b_provider_transport_vsock::TransportEvent::Released) => break,
+                Some(_) => {}
+                None => panic!("event stream ended before release"),
+            }
+        }
         assert_eq!(*effect_closes.lock().unwrap(), 1);
         assert_eq!(*stream_closes.lock().unwrap(), 1);
         assert_eq!(
             service
-                .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+                .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
                     transport_handle: opened.transport_handle,
                     include_bytes: false,
                 })
@@ -150,7 +181,7 @@ fn open_observe_and_close_release_the_bridge() {
         );
         assert_eq!(
             service
-                .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+                .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
                     transport_handle: d2b_provider_transport_vsock::TransportHandle::from_core(999),
                     include_bytes: false,
                 })

--- a/packages/d2b-provider-transport-vsock/tests/service.rs
+++ b/packages/d2b-provider-transport-vsock/tests/service.rs
@@ -1,22 +1,31 @@
 use async_trait::async_trait;
 use d2b_contracts::v3::{ResourceRef, ZoneId};
 use d2b_provider_transport_vsock::{
-    GuestControlKey, GuestIdentity, NamedStreamError, NamedStreamId, NamedStreamPort,
-    OpaqueBindingId, OpaqueEndpointId, OpenTransportRequest, PeerCid, ReadySession, ServiceError,
-    SessionAuthority, SessionProof, TransportPhase, TransportRole, VsockEffectError,
-    VsockEffectPort, VsockTransportService,
+    CLOSE_GRACE_MS, GuestControlKey, GuestIdentity, MAX_ACTIVE_TRANSPORTS, NamedStreamError,
+    NamedStreamId, NamedStreamPort, OpaqueBindingId, OpaqueEndpointId, OpenTransportRequest,
+    PeerCid, ReadySession, ServiceError, SessionAuthority, SessionProof, TransportPhase,
+    TransportRole, VsockEffectError, VsockEffectPort, VsockTransportService,
 };
+use ring::rand::{SecureRandom, SystemRandom};
 use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
 
+fn nonce() -> [u8; 32] {
+    let mut nonce = [0_u8; 32];
+    SystemRandom::new().fill(&mut nonce).unwrap();
+    nonce
+}
+
 #[derive(Clone)]
 struct FakeEffect {
     peers: Arc<Mutex<Vec<DuplexStream>>>,
     closes: Arc<Mutex<usize>>,
     open_delay: Option<Duration>,
+    close_delay: Option<Duration>,
+    hang_close: bool,
     fail_close: Arc<Mutex<bool>>,
 }
 
@@ -41,6 +50,12 @@ impl VsockEffectPort for FakeEffect {
 
     async fn close(&self, _: Self::Stream) -> Result<(), VsockEffectError> {
         *self.closes.lock().unwrap() += 1;
+        if self.hang_close {
+            std::future::pending::<()>().await;
+        }
+        if let Some(delay) = self.close_delay {
+            tokio::time::sleep(delay).await;
+        }
         if *self.fail_close.lock().unwrap() {
             Err(VsockEffectError::Transient)
         } else {
@@ -54,6 +69,9 @@ struct FakeStreams {
     next: Arc<Mutex<u64>>,
     closes: Arc<Mutex<usize>>,
     peers: Arc<Mutex<Vec<DuplexStream>>>,
+    open_delay: Option<Duration>,
+    close_delay: Option<Duration>,
+    hang_close: bool,
 }
 
 #[async_trait]
@@ -61,6 +79,9 @@ impl NamedStreamPort for FakeStreams {
     type Stream = DuplexStream;
 
     async fn open_named_stream(&self) -> Result<(NamedStreamId, Self::Stream), NamedStreamError> {
+        if let Some(delay) = self.open_delay {
+            tokio::time::sleep(delay).await;
+        }
         let mut next = self.next.lock().unwrap();
         *next += 1;
         let (local, peer) = duplex(1024);
@@ -70,6 +91,12 @@ impl NamedStreamPort for FakeStreams {
 
     async fn close_named_stream(&self, _: NamedStreamId) -> Result<(), NamedStreamError> {
         *self.closes.lock().unwrap() += 1;
+        if self.hang_close {
+            std::future::pending::<()>().await;
+        }
+        if let Some(delay) = self.close_delay {
+            tokio::time::sleep(delay).await;
+        }
         Ok(())
     }
 }
@@ -91,7 +118,7 @@ fn session() -> ReadySession {
     authority
         .authenticate(
             PeerCid::from_core(42).unwrap(),
-            SessionProof::sign(&key, &identity, [2; 32], 1),
+            SessionProof::sign(&key, &identity, nonce(), 1),
         )
         .unwrap()
 }
@@ -116,6 +143,8 @@ fn open_observe_and_close_release_the_bridge() {
             peers: Arc::new(Mutex::new(Vec::new())),
             closes: Arc::new(Mutex::new(0)),
             open_delay: None,
+            close_delay: None,
+            hang_close: false,
             fail_close: Arc::new(Mutex::new(false)),
         };
         let effect_closes = Arc::clone(&effect.closes);
@@ -124,6 +153,9 @@ fn open_observe_and_close_release_the_bridge() {
             next: Arc::new(Mutex::new(0)),
             closes: Arc::new(Mutex::new(0)),
             peers: Arc::new(Mutex::new(Vec::new())),
+            open_delay: None,
+            close_delay: None,
+            hang_close: false,
         };
         let stream_closes = Arc::clone(&streams.closes);
         let stream_peers = Arc::clone(&streams.peers);
@@ -218,6 +250,8 @@ fn open_effect_is_bounded_by_the_request_deadline() {
             peers: Arc::new(Mutex::new(Vec::new())),
             closes: Arc::new(Mutex::new(0)),
             open_delay: Some(Duration::from_millis(1_100)),
+            close_delay: None,
+            hang_close: false,
             fail_close: Arc::new(Mutex::new(false)),
         };
         let service = VsockTransportService::new(
@@ -226,9 +260,50 @@ fn open_effect_is_bounded_by_the_request_deadline() {
                 next: Arc::new(Mutex::new(0)),
                 closes: Arc::new(Mutex::new(0)),
                 peers: Arc::new(Mutex::new(Vec::new())),
+                open_delay: None,
+                close_delay: None,
+                hang_close: false,
             },
             identity(),
         );
+        assert_eq!(
+            service
+                .open_transport(&session(), request())
+                .await
+                .unwrap_err(),
+            ServiceError::Effect(VsockEffectError::DeadlineExceeded)
+        );
+    });
+}
+
+#[test]
+fn named_stream_open_uses_remaining_end_to_end_deadline() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let effect = FakeEffect {
+            peers: Arc::new(Mutex::new(Vec::new())),
+            closes: Arc::new(Mutex::new(0)),
+            open_delay: Some(Duration::from_millis(850)),
+            close_delay: None,
+            hang_close: false,
+            fail_close: Arc::new(Mutex::new(false)),
+        };
+        let service = VsockTransportService::new(
+            effect,
+            FakeStreams {
+                next: Arc::new(Mutex::new(0)),
+                closes: Arc::new(Mutex::new(0)),
+                peers: Arc::new(Mutex::new(Vec::new())),
+                open_delay: Some(Duration::from_millis(200)),
+                close_delay: None,
+                hang_close: false,
+            },
+            identity(),
+        );
+
         assert_eq!(
             service
                 .open_transport(&session(), request())
@@ -250,6 +325,8 @@ fn failed_endpoint_close_is_reported_as_degraded() {
             peers: Arc::new(Mutex::new(Vec::new())),
             closes: Arc::new(Mutex::new(0)),
             open_delay: None,
+            close_delay: None,
+            hang_close: false,
             fail_close: Arc::new(Mutex::new(true)),
         };
         let service = VsockTransportService::new(
@@ -258,6 +335,9 @@ fn failed_endpoint_close_is_reported_as_degraded() {
                 next: Arc::new(Mutex::new(0)),
                 closes: Arc::new(Mutex::new(0)),
                 peers: Arc::new(Mutex::new(Vec::new())),
+                open_delay: None,
+                close_delay: None,
+                hang_close: false,
             },
             identity(),
         );
@@ -308,6 +388,174 @@ fn failed_endpoint_close_is_reported_as_degraded() {
                 kind: "close-unconfirmed",
                 recoverable: true,
             })
+        );
+    });
+}
+
+#[test]
+fn close_waits_for_both_endpoint_grace_periods() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let effect = FakeEffect {
+            peers: Arc::new(Mutex::new(Vec::new())),
+            closes: Arc::new(Mutex::new(0)),
+            open_delay: None,
+            close_delay: Some(Duration::from_millis(CLOSE_GRACE_MS / 2 + 25)),
+            hang_close: false,
+            fail_close: Arc::new(Mutex::new(false)),
+        };
+        let streams = FakeStreams {
+            next: Arc::new(Mutex::new(0)),
+            closes: Arc::new(Mutex::new(0)),
+            peers: Arc::new(Mutex::new(Vec::new())),
+            open_delay: None,
+            close_delay: Some(Duration::from_millis(CLOSE_GRACE_MS / 2 + 25)),
+            hang_close: false,
+        };
+        let service = VsockTransportService::new(effect, streams, identity());
+        let opened = service.open_transport(&session(), request()).await.unwrap();
+
+        service
+            .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                transport_handle: opened.transport_handle,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            service
+                .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
+                    transport_handle: opened.transport_handle,
+                    include_bytes: false,
+                })
+                .await
+                .unwrap()
+                .phase,
+            TransportPhase::Released
+        );
+    });
+}
+
+#[test]
+fn hung_endpoint_close_remains_degraded() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let effect = FakeEffect {
+            peers: Arc::new(Mutex::new(Vec::new())),
+            closes: Arc::new(Mutex::new(0)),
+            open_delay: None,
+            close_delay: None,
+            hang_close: true,
+            fail_close: Arc::new(Mutex::new(false)),
+        };
+        let streams = FakeStreams {
+            next: Arc::new(Mutex::new(0)),
+            closes: Arc::new(Mutex::new(0)),
+            peers: Arc::new(Mutex::new(Vec::new())),
+            open_delay: None,
+            close_delay: None,
+            hang_close: false,
+        };
+        let service = VsockTransportService::new(effect, streams, identity());
+        let opened = service.open_transport(&session(), request()).await.unwrap();
+
+        assert_eq!(
+            service
+                .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                    transport_handle: opened.transport_handle,
+                })
+                .await
+                .unwrap_err(),
+            ServiceError::CloseUnconfirmed
+        );
+        assert_eq!(
+            service
+                .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
+                    transport_handle: opened.transport_handle,
+                    include_bytes: false,
+                })
+                .await
+                .unwrap()
+                .phase,
+            TransportPhase::Degraded
+        );
+    });
+}
+
+#[test]
+fn degraded_close_survives_completed_observation_eviction() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let effect = FakeEffect {
+            peers: Arc::new(Mutex::new(Vec::new())),
+            closes: Arc::new(Mutex::new(0)),
+            open_delay: None,
+            close_delay: None,
+            hang_close: false,
+            fail_close: Arc::new(Mutex::new(true)),
+        };
+        let fail_close = Arc::clone(&effect.fail_close);
+        let service = VsockTransportService::new(
+            effect,
+            FakeStreams {
+                next: Arc::new(Mutex::new(0)),
+                closes: Arc::new(Mutex::new(0)),
+                peers: Arc::new(Mutex::new(Vec::new())),
+                open_delay: None,
+                close_delay: None,
+                hang_close: false,
+            },
+            identity(),
+        );
+        let degraded = service.open_transport(&session(), request()).await.unwrap();
+        assert_eq!(
+            service
+                .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                    transport_handle: degraded.transport_handle,
+                })
+                .await
+                .unwrap_err(),
+            ServiceError::CloseUnconfirmed
+        );
+
+        *fail_close.lock().unwrap() = false;
+        for _ in 0..=MAX_ACTIVE_TRANSPORTS {
+            let opened = service.open_transport(&session(), request()).await.unwrap();
+            service
+                .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                    transport_handle: opened.transport_handle,
+                })
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            service
+                .observe_snapshot(d2b_provider_transport_vsock::ObserveTransportRequest {
+                    transport_handle: degraded.transport_handle,
+                    include_bytes: false,
+                })
+                .await
+                .unwrap()
+                .phase,
+            TransportPhase::Degraded
+        );
+        assert_eq!(
+            service
+                .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                    transport_handle: degraded.transport_handle,
+                })
+                .await
+                .unwrap_err(),
+            ServiceError::CloseUnconfirmed
         );
     });
 }

--- a/packages/d2b-provider-transport-vsock/tests/service.rs
+++ b/packages/d2b-provider-transport-vsock/tests/service.rs
@@ -1,0 +1,162 @@
+use async_trait::async_trait;
+use d2b_contracts::v3::{ResourceRef, ZoneId};
+use d2b_provider_transport_vsock::{
+    GuestControlKey, GuestIdentity, NamedStreamError, NamedStreamId, NamedStreamPort,
+    OpaqueBindingId, OpaqueEndpointId, OpenTransportRequest, PeerCid, ReadySession, ServiceError,
+    SessionAuthority, SessionProof, TransportPhase, TransportRole, VsockEffectError,
+    VsockEffectPort, VsockTransportService,
+};
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
+
+#[derive(Clone)]
+struct FakeEffect {
+    peers: Arc<Mutex<Vec<DuplexStream>>>,
+    closes: Arc<Mutex<usize>>,
+}
+
+#[async_trait]
+impl VsockEffectPort for FakeEffect {
+    type Stream = DuplexStream;
+
+    async fn open(
+        &self,
+        _: &OpaqueEndpointId,
+        _: &OpaqueBindingId,
+        _: TransportRole,
+        _: Instant,
+    ) -> Result<Self::Stream, VsockEffectError> {
+        let (local, peer) = duplex(1024);
+        self.peers.lock().unwrap().push(peer);
+        Ok(local)
+    }
+
+    async fn close(&self, _: Self::Stream) -> Result<(), VsockEffectError> {
+        *self.closes.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct FakeStreams {
+    next: Arc<Mutex<u64>>,
+    closes: Arc<Mutex<usize>>,
+    peers: Arc<Mutex<Vec<DuplexStream>>>,
+}
+
+#[async_trait]
+impl NamedStreamPort for FakeStreams {
+    type Stream = DuplexStream;
+
+    async fn open_named_stream(&self) -> Result<(NamedStreamId, Self::Stream), NamedStreamError> {
+        let mut next = self.next.lock().unwrap();
+        *next += 1;
+        let (local, peer) = duplex(1024);
+        self.peers.lock().unwrap().push(peer);
+        Ok((NamedStreamId::from_core(*next), local))
+    }
+
+    async fn close_named_stream(&self, _: NamedStreamId) -> Result<(), NamedStreamError> {
+        *self.closes.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+fn session() -> ReadySession {
+    let identity = GuestIdentity::new(
+        ResourceRef::parse("Guest/guest-a").unwrap(),
+        ZoneId::parse("work").unwrap(),
+        PeerCid::from_core(42).unwrap(),
+        "boot-a",
+    )
+    .unwrap();
+    let key = GuestControlKey::from_core([1; 32]);
+    let mut authority = SessionAuthority::new(identity.clone(), key.clone(), 1);
+    authority
+        .authenticate(SessionProof::sign(&key, &identity, [2; 32], 1))
+        .unwrap()
+}
+
+fn request() -> OpenTransportRequest {
+    OpenTransportRequest::new(
+        OpaqueEndpointId::parse("endpoint-a").unwrap(),
+        OpaqueBindingId::parse("binding-a").unwrap(),
+        TransportRole::Initiator,
+        1_000,
+    )
+}
+
+#[test]
+fn open_observe_and_close_release_the_bridge() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let effect = FakeEffect {
+            peers: Arc::new(Mutex::new(Vec::new())),
+            closes: Arc::new(Mutex::new(0)),
+        };
+        let effect_closes = Arc::clone(&effect.closes);
+        let effect_peers = Arc::clone(&effect.peers);
+        let streams = FakeStreams {
+            next: Arc::new(Mutex::new(0)),
+            closes: Arc::new(Mutex::new(0)),
+            peers: Arc::new(Mutex::new(Vec::new())),
+        };
+        let stream_closes = Arc::clone(&streams.closes);
+        let stream_peers = Arc::clone(&streams.peers);
+        let service = VsockTransportService::new(effect, streams);
+        let opened = service.open_transport(&session(), request()).await.unwrap();
+        let mut effect_peer = effect_peers.lock().unwrap().pop().unwrap();
+        let mut stream_peer = stream_peers.lock().unwrap().pop().unwrap();
+        effect_peer.write_all(b"guest-to-core").await.unwrap();
+        let mut received = [0_u8; 13];
+        stream_peer.read_exact(&mut received).await.unwrap();
+        assert_eq!(&received, b"guest-to-core");
+        stream_peer.write_all(b"core-to-guest").await.unwrap();
+        let mut received = [0_u8; 13];
+        effect_peer.read_exact(&mut received).await.unwrap();
+        assert_eq!(&received, b"core-to-guest");
+        let observed = service
+            .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+                transport_handle: opened.transport_handle,
+                include_bytes: true,
+            })
+            .await
+            .unwrap();
+        assert_eq!(observed.phase, TransportPhase::Acquired);
+        service
+            .close_transport(d2b_provider_transport_vsock::CloseTransportRequest {
+                transport_handle: opened.transport_handle,
+            })
+            .await
+            .unwrap();
+        assert_eq!(*effect_closes.lock().unwrap(), 1);
+        assert_eq!(*stream_closes.lock().unwrap(), 1);
+        assert_eq!(
+            service
+                .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+                    transport_handle: opened.transport_handle,
+                    include_bytes: false,
+                })
+                .await
+                .unwrap()
+                .phase,
+            TransportPhase::Released
+        );
+        assert_eq!(
+            service
+                .observe_transport(d2b_provider_transport_vsock::ObserveTransportRequest {
+                    transport_handle: d2b_provider_transport_vsock::TransportHandle::from_core(999),
+                    include_bytes: false,
+                })
+                .await
+                .unwrap_err(),
+            ServiceError::UnknownTransportHandle
+        );
+    });
+}

--- a/packages/d2b-provider-transport-vsock/tests/state_volume.rs
+++ b/packages/d2b-provider-transport-vsock/tests/state_volume.rs
@@ -1,0 +1,13 @@
+use d2b_provider_transport_vsock::{EMPTY_STATE_SCHEMA, STATE_LAYOUT_USER, StateVolumeSpec};
+
+#[test]
+fn state_volume_spec_matches_canonical_schema() {
+    assert_eq!(EMPTY_STATE_SCHEMA, "empty");
+    assert!(StateVolumeSpec::default().validate());
+}
+
+#[test]
+fn state_volume_uses_user_layout_not_component_principal() {
+    assert_eq!(STATE_LAYOUT_USER, "User/d2b-transport-vsock");
+    assert!(!STATE_LAYOUT_USER.contains("ComponentPrincipal"));
+}

--- a/packages/d2b-provider-transport-vsock/tests/topology.rs
+++ b/packages/d2b-provider-transport-vsock/tests/topology.rs
@@ -1,0 +1,48 @@
+use d2b_provider_transport_vsock::{
+    ParentStoreResourceCensus, TopologyError, TransportLimits, VsockTransportSettings, ZoneLinkSpec,
+};
+
+fn spec() -> ZoneLinkSpec {
+    ZoneLinkSpec {
+        child_zone_name: "k1".to_owned(),
+        transport_provider_ref: "Provider/transport-vsock".to_owned(),
+        transport_settings: VsockTransportSettings::new("Guest/k1-vm").unwrap(),
+        transport_credentials: Vec::new(),
+        disabled: false,
+        limits: TransportLimits::default(),
+    }
+}
+
+#[test]
+fn canonical_zonelink_fields_are_child_local_and_credentials_are_empty() {
+    spec().validate("k1").unwrap();
+}
+
+#[test]
+fn legacy_provider_fields_and_parent_reciprocal_rows_are_rejected() {
+    let mut invalid = spec();
+    invalid.transport_provider_ref = "Provider/legacy-vsock".to_owned();
+    assert_eq!(invalid.validate("k1"), Err(TopologyError::ProviderMismatch));
+    assert_eq!(
+        (ParentStoreResourceCensus {
+            provider_rows: 1,
+            zone_link_rows: 0,
+        })
+        .validate(),
+        Err(TopologyError::ParentStoreReciprocalResource)
+    );
+}
+
+#[test]
+fn transport_credentials_must_be_empty_and_child_name_self_matches() {
+    let mut invalid = spec();
+    invalid.transport_credentials.push("secret".to_owned());
+    assert_eq!(
+        invalid.validate("k1"),
+        Err(TopologyError::CredentialsNotEmpty)
+    );
+    assert_eq!(
+        spec().validate("parent"),
+        Err(TopologyError::ChildZoneMismatch)
+    );
+}

--- a/tests/unit/nix/cases/provider-runtime-contracts.nix
+++ b/tests/unit/nix/cases/provider-runtime-contracts.nix
@@ -182,7 +182,40 @@ let
     };
     d2b.zones.child = {
       parentZone = "local-root";
-      resources = { };
+      resources = {
+        child-guest = {
+          type = "Guest";
+          spec = { };
+        };
+        transport-vsock = {
+          type = "Provider";
+          spec = {
+            config = {
+              executionRef = "Guest/child-guest";
+            };
+          };
+        };
+        child-vsock-link = {
+          type = "ZoneLink";
+          spec = {
+            childZoneName = "child";
+            transportProviderRef = "Provider/transport-vsock";
+            transportSettings = {
+              guestRef = "Guest/child-guest";
+              portClass = "d2b-link";
+              connectTimeoutSeconds = 30;
+            };
+            transportCredentials = [ ];
+            disabled = false;
+            limits = {
+              maxActiveStreams = 32;
+              maxPendingIntents = 256;
+              reconnectMaxAttempts = 10;
+              reconnectWindowSecs = 300;
+            };
+          };
+        };
+      };
     };
   };
 
@@ -364,6 +397,46 @@ in
       ({ ... }: {
         d2b.zones.local-root.resources.relay-send.spec.consumerRef =
           lib.mkForce "Provider/runtime-azure-container-apps";
+      })
+    ];
+    expected = true;
+  };
+
+  "provider-runtime-contracts-accepts-vsock-settings" = {
+    expr = hasFailure "Provider/transport-vsock" [
+      contractBase
+    ];
+    expected = false;
+  };
+
+  "provider-runtime-contracts-rejects-vsock-raw-cid" = {
+    expr = hasFailure "allocator-owned fields" [
+      contractBase
+      ({ ... }: {
+        d2b.zones.child.resources.child-vsock-link.spec.transportSettings.cid =
+          lib.mkForce 42;
+      })
+    ];
+    expected = true;
+  };
+
+  "provider-runtime-contracts-rejects-vsock-credentials" = {
+    expr = hasFailure "must be empty for Provider/transport-vsock" [
+      contractBase
+      ({ ... }: {
+        d2b.zones.child.resources.child-vsock-link.spec.transportCredentials =
+          lib.mkForce [ "Credential/relay-listen" ];
+      })
+    ];
+    expected = true;
+  };
+
+  "provider-runtime-contracts-rejects-vsock-timeout" = {
+    expr = hasFailure "connectTimeoutSeconds must be between 1 and 60" [
+      contractBase
+      ({ ... }: {
+        d2b.zones.child.resources.child-vsock-link.spec.transportSettings.connectTimeoutSeconds =
+          lib.mkForce 61;
       })
     ];
     expected = true;

--- a/tests/unit/nix/cases/realms.nix
+++ b/tests/unit/nix/cases/realms.nix
@@ -1826,6 +1826,29 @@ let
     };
     expected = true;
   };
+  "realms/zone-control-vsock-transport-refuses-credentials" = {
+    expr = hasZoneControlFailure "transportCredentials" {
+      d2b.zones.child.resources.child-guest = {
+        type = "Guest";
+        spec = { };
+      };
+      d2b.zones.child.resources.transport-vsock = {
+        type = "Provider";
+        spec = {
+          config.executionRef = "Guest/child-guest";
+        };
+      };
+      d2b.zones.child.resources.child-uplink.spec.transportProviderRef =
+        "Provider/transport-vsock";
+      d2b.zones.child.resources.child-uplink.spec.transportSettings = {
+        guestRef = "Guest/child-guest";
+      };
+      d2b.zones.child.resources.child-uplink.spec.transportCredentials = [
+        "Credential/not-permitted"
+      ];
+    };
+    expected = true;
+  };
   "realms/zone-control-zone-link-child-name-is-local" = {
     expr = hasZoneControlFailure "must equal the enclosing Zone name" {
       d2b.zones.child.resources.child-uplink.spec.childZoneName = "other";

--- a/tests/unit/nix/cases/test-infrastructure.nix
+++ b/tests/unit/nix/cases/test-infrastructure.nix
@@ -39,8 +39,10 @@ let
   flakeSource = builtins.readFile (flakeRoot + "/flake.nix");
   hostDaemonSource =
     builtins.readFile (flakeRoot + "/nixos-modules/host-daemon.nix");
-  providerSchemaPath =
-    "docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json";
+  providerSchemaPaths = [
+    "docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json"
+    "docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json"
+  ];
   shardEntryLines = builtins.filter
     (line: lib.hasInfix ''"test-infrastructure.nix"'' line)
     (lib.splitString "\n" flakeSource);
@@ -102,8 +104,8 @@ in
 
   "test-infrastructure/provider-runtime-schema-is-staged-with-rust-sources" = {
     expr = {
-      flakeSource = lib.hasInfix providerSchemaPath flakeSource;
-      hostDaemonSource = lib.hasInfix providerSchemaPath hostDaemonSource;
+      flakeSource = lib.all (path: lib.hasInfix path flakeSource) providerSchemaPaths;
+      hostDaemonSource = lib.all (path: lib.hasInfix path hostDaemonSource) providerSchemaPaths;
     };
     expected = {
       flakeSource = true;

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -669,6 +669,7 @@ provider-projection-fields/all-eight-published-fields-match
 provider-projection-fields/every-published-field-mismatch-is-rejected
 provider-projection-fields/legacy-absent-version-is-version-skew
 provider-runtime-contracts/accepts-valid-runtime-provider-bindings
+provider-runtime-contracts-accepts-vsock-settings
 provider-runtime-contracts-allows-aca-without-optional-pull-credential
 provider-runtime-contracts-enforces-vm-arm-credential-scope
 provider-runtime-contracts/rejects-cross-zone-provider-reference
@@ -677,6 +678,9 @@ provider-runtime-contracts-rejects-process-on-wrong-owning-guest
 provider-runtime-contracts-rejects-relay-role-credential-shape
 provider-runtime-contracts-rejects-runtime-credential-with-wrong-provider
 provider-runtime-contracts/rejects-unknown-same-zone-provider-reference
+provider-runtime-contracts-rejects-vsock-credentials
+provider-runtime-contracts-rejects-vsock-raw-cid
+provider-runtime-contracts-rejects-vsock-timeout
 provider-runtime-contracts-requires-acquire-token-for-runtime-credential
 provider-runtime-contracts-requires-exact-relay-settings
 provider-runtime-contracts-requires-provider-resolution-for-processes
@@ -729,6 +733,7 @@ realms/zone-control-role-keeps-resource-and-session-verbs-closed
 realms/zone-control-seals-parent-map-without-zone-spec-parent
 realms/zone-control-unix-transport-keeps-settings-closed
 realms/zone-control-unix-transport-refuses-credentials
+realms/zone-control-vsock-transport-refuses-credentials
 realms/zone-control-zone-link-child-name-is-local
 realms/zone-control-zone-link-limits-are-bounded
 realms/zone-control-zone-link-requires-transport-provider-shape


### PR DESCRIPTION
## Summary

- Add refusal coverage for Guest, Zone, CID, replay, and signature mismatches.
- Keep CID authority reserved until listener closure is confirmed and degrade restart adoption on observation errors.
- Redact relay observations and bound service effect opening and endpoint cleanup, preserving degraded state on unconfirmed close.

## Verification

- `cargo test --manifest-path packages/Cargo.toml -p d2b-provider-transport-vsock --tests --no-fail-fast`
- `cargo test --manifest-path packages/Cargo.toml -p d2bd guest_control --lib --no-fail-fast`
- `cargo fmt --manifest-path packages/Cargo.toml -p d2b-provider-transport-vsock -- --check`
- `nix build .#d2b-provider-transport-vsock --no-link --print-build-logs`