### PR TITLE
runtime: complete qemu media lifecycle contracts

### DIFF
--- a/changelog.d/feat-spec001-runtime-qemu-media.md
+++ b/changelog.d/feat-spec001-runtime-qemu-media.md
@@ -3,3 +3,8 @@
 - Add a typed qemu-media Guest runtime with broker-owned process launch,
   Host-global KVM admission, QMP health and hotplug handling, restart
   adoption, ordered finalization, and redacted audit/telemetry projections.
+
+### Changed
+
+- Treat pause-at-boot as an initial QMP proof and bound greeting timeouts to
+  fresh launches while adopted runners retry through health degradation.

--- a/changelog.d/feat-spec001-runtime-qemu-media.md
+++ b/changelog.d/feat-spec001-runtime-qemu-media.md
@@ -8,3 +8,5 @@
 
 - Treat pause-at-boot as an initial QMP proof and bound greeting timeouts to
   fresh launches while adopted runners retry through health degradation.
+- Keep a failed fresh-launch generation terminal until finalization so a
+  stopping runner cannot be adopted or reserve device authority again.

--- a/changelog.d/feat-spec001-runtime-qemu-media.md
+++ b/changelog.d/feat-spec001-runtime-qemu-media.md
@@ -1,0 +1,5 @@
+### Added
+
+- Add a typed qemu-media Guest runtime with broker-owned process launch,
+  Host-global KVM admission, QMP health and hotplug handling, restart
+  adoption, ordered finalization, and redacted audit/telemetry projections.

--- a/docs/specs/providers/ADR-046-provider-runtime-qemu-media.md
+++ b/docs/specs/providers/ADR-046-provider-runtime-qemu-media.md
@@ -97,7 +97,7 @@ spec:
   artifactId:    runtime-qemu-media   # plain bounded ID; resolves in d2b.artifacts
   config:
     controllerExecutionRef: Host/host-system
-    qemuBinaryArtifactId:   qemu-system-x86_64
+    qemuBinaryArtifactId:   qemu-system-x86-64
     qmpReadyTimeoutSeconds: 30
     qmpOperationTimeoutSeconds: 60
     pausedAtBootDefault:    true
@@ -139,7 +139,7 @@ It is never specified directly in Nix.
 | Field | Type | Required | Default | Bounds | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `controllerExecutionRef` | ResourceRef | **yes** | - | `Host/<n>` | Host on which the runtime-qemu-media controller Process runs |
-| `qemuBinaryArtifactId` | string | yes | `"qemu-system-x86_64"` | `^[a-z][a-z0-9-]*$` | Artifact catalog ID for the QEMU binary closure |
+| `qemuBinaryArtifactId` | string | yes | `"qemu-system-x86-64"` | `^[a-z][a-z0-9-]*$` | Artifact catalog ID for the QEMU binary closure |
 | `qmpReadyTimeoutSeconds` | u32 | no | `30` | 5-300 | Deadline for initial QMP greeting after process start |
 | `qmpOperationTimeoutSeconds` | u32 | no | `60` | 5-300 | Per-QMP-command timeout |
 | `pausedAtBootDefault` | bool | no | `true` | - | Default `pauseAtBoot` if not set in Guest spec.provider.settings |
@@ -173,20 +173,23 @@ metadata:
 spec:
   providerRef: Provider/runtime-qemu-media
   systemArtifactId: null                    # no NixOS guest system; media-boot only
-  vcpu: 4
-  memoryMib: 8192
+  defaultDomain: system
+  allowedDomains: [system]
+  defaultUserRef: null
+  budget: {}
   networkAttachments:
     - networkRef: Network/corp-net
-      macAddress: null                      # null → stable-derived by controller
-      ipv4Address: null                     # null → DHCP
+      default: true
   deviceAttachments:
     - deviceRef: Device/host-kvm            # KVM acceleration; explicit required dependency
       exclusive: false
   volumeAttachmentDefaults: []
   provider:                                  # see §5
     schemaId: runtime-qemu-media.d2bus.org/Guest/spec
-    schemaVersion: 1.0.0
+    schemaVersion: 1.0
     settings:
+      vcpu: 4
+      memoryMib: 8192
       bootMediaRef: Volume/corp-iso-boot-media
       bootMediaView: guest-attach
       removableVolumeRefs:
@@ -258,11 +261,15 @@ an unsupported optional base capability only through its signed capability matri
 plus provider-neutral `unsupported-capability`. `spec.provider` aligns with
 `status.provider` for `Provider/runtime-qemu-media`.
 
-`vcpu` and `memoryMib` are promoted Guest base fields (`spec.vcpu` and
-`spec.memoryMib`); they are not Provider extension fields.
+`vcpu` and `memoryMib` are qemu-media Provider settings. They are not fields
+of the canonical Guest base object. The canonical base contains only the
+shared execution policy and optional `systemArtifactId`; `providerRef` and
+`provider` are universal `ResourceSpec` layers.
 
 | Field | Type | Required | Default | Bounds | Notes |
 | --- | --- | --- | --- | --- | --- |
+| `vcpu` | u16 | no | `2` | 1-1024 | Virtual CPU count |
+| `memoryMib` | u32 | no | `4096` | 128-524288 | Guest memory in MiB |
 | `bootMediaRef` | ResourceRef? | no | `null` | `Volume/<n>` | Primary boot Volume; nil = direct kernel boot if kernelArtifactId set (not yet supported) |
 | `bootMediaView` | string | no | `"guest-attach"` | `^[a-z][a-z0-9-]*$` | View within the boot Volume from which the controller derives the virtio-blk attachment |
 | `removableVolumeRefs` | list | no | `[]` | max 4 entries | Runtime-hotpluggable media Volumes |
@@ -683,8 +690,11 @@ spec:
   # --- Network ---
   # Core/ProviderSupervisor resolves the opaque Network ref and inserts the
   # pre-authorized tap OwnedFd directly into the LaunchTicket inherited-fd
-  # table. The controller never receives the fd; networkUsage remains null.
-  networkUsage: null
+  # table. The controller never receives the fd.
+  networkUsage:
+    networkRef: Network/corp-net
+    ports: []
+    allowEgress: true
 
   # --- Device ---
   deviceUsage:
@@ -1365,7 +1375,7 @@ d2b.artifacts = {
     package = pkgs.d2b-provider-runtime-qemu-media;
     type    = "provider";
   };
-  qemu-system-x86_64 = {
+  qemu-system-x86-64 = {
     package = pkgs.qemu-kvm;   # or pkgs.qemu_full, depending on site policy
     type    = "config-bundle"; # sealed QEMU binary closure; not a provider
   };
@@ -1390,7 +1400,7 @@ d2b.zones.corp.resources.runtime-qemu-media = {
     artifactId = "runtime-qemu-media";
     config = {
       controllerExecutionRef  = "Host/host-system";  # required
-      qemuBinaryArtifactId    = "qemu-system-x86_64";
+      qemuBinaryArtifactId    = "qemu-system-x86-64";
       networkProviderRef      = "Provider/network-local";
       volumeProviderRef       = "Provider/volume-local";
       displayProviderRef      = "Provider/display-wayland";  # omit if no display Guests

--- a/docs/specs/providers/ADR-046-provider-runtime-qemu-media.md
+++ b/docs/specs/providers/ADR-046-provider-runtime-qemu-media.md
@@ -140,7 +140,7 @@ It is never specified directly in Nix.
 | --- | --- | --- | --- | --- | --- |
 | `controllerExecutionRef` | ResourceRef | **yes** | - | `Host/<n>` | Host on which the runtime-qemu-media controller Process runs |
 | `qemuBinaryArtifactId` | string | yes | `"qemu-system-x86-64"` | `^[a-z][a-z0-9-]*$` | Artifact catalog ID for the QEMU binary closure |
-| `qmpReadyTimeoutSeconds` | u32 | no | `30` | 5-300 | Deadline for initial QMP greeting after process start |
+| `qmpReadyTimeoutSeconds` | u32 | no | `30` | 5-300 | Deadline for the current initial QMP greeting wait after a fresh launch |
 | `qmpOperationTimeoutSeconds` | u32 | no | `60` | 5-300 | Per-QMP-command timeout |
 | `pausedAtBootDefault` | bool | no | `true` | - | Default `pauseAtBoot` if not set in Guest spec.provider.settings |
 | `displayProviderRef` | ResourceRef? | no | `null` | `Provider/<n>` | Provider for WaylandSession resources; required when any Guest sets `displayWindow: true` |
@@ -1014,6 +1014,10 @@ tmpfs is unmounted only after the runner Process pidfd signals exit.
    the Process Provider delivers the validated `qmp` endpoint connection
    attachment (an owned fd; not a raw socket path) to the controller via the
    ProviderSupervisor ComponentSession channel.
+
+   The greeting deadline applies to this current wait for a freshly launched
+   runner. An adopted runner with temporary QMP unavailability remains under
+   health retry and is not stopped solely because its process is old.
 
 10. **Pause-at-boot (if pauseAtBoot):** Controller receives the QMP
     attachment. QEMU starts in `-S` (paused) state. Controller records

--- a/flake.nix
+++ b/flake.nix
@@ -310,6 +310,7 @@
           "external-vm-kind-rejections.nix"
           "external-vm-kind-runtime.nix"
           "niri-vm-borders.nix"
+          "guest-qemu-media-spec.nix"
           "provider-runtime-contracts.nix"
           "requested-vm-config.nix"
           "security-key-gating.nix"

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -2636,6 +2636,7 @@ let
     (zoneName: zone:
       let
         resources = zone.resources or { };
+        kvmRequired = cfg.qemuMediaRuntime.kvmRequired or true;
         provider = resources.runtime-qemu-media or null;
         providerSpec = if provider == null then { } else provider.spec or { };
         providerConfig = providerSpec.config or { };
@@ -2669,6 +2670,10 @@ let
               settings = extension.settings or { };
               bootMediaRef = settings.bootMediaRef or null;
               removable = settings.removableVolumeRefs or [ ];
+              deviceAttachments = spec.deviceAttachments or [ ];
+              declaresKvm = lib.any
+                (attachment: (attachment.deviceRef or null) == "Device/host-kvm")
+                deviceAttachments;
               displayWindow = settings.displayWindow or false;
               forbidden = [
                 "hostPath"
@@ -2686,6 +2691,11 @@ let
               {
                 assertion = (spec.systemArtifactId or null) == null;
                 message = "d2b.zones.${zoneName}.resources.${guestName}.spec.systemArtifactId must be null for runtime-qemu-media.";
+              }
+              {
+                assertion = !kvmRequired
+                  || (declaresKvm && resolves "Device" "Device/host-kvm");
+                message = "d2b.zones.${zoneName}.resources.${guestName}: runtime-qemu-media Guest must declare Device/host-kvm in deviceAttachments.";
               }
               {
                 assertion = bootMediaRef == null || resolves "Volume" bootMediaRef;

--- a/nixos-modules/assertions.nix
+++ b/nixos-modules/assertions.nix
@@ -2628,6 +2628,113 @@ let
     ++ deviceProviderShapeAssertions
     ++ deviceSharedArbitrationAssertions
     ++ deviceDuplicateLabelAssertions;
+
+  # v3 runtime-qemu-media Provider/Guest assertions. These are deliberately
+  # scoped to the media Provider and do not relax the legacy VM assertions
+  # above. Raw locators remain forbidden in the Provider extension.
+  qemuMediaResourceAssertions = lib.flatten (lib.mapAttrsToList
+    (zoneName: zone:
+      let
+        resources = zone.resources or { };
+        provider = resources.runtime-qemu-media or null;
+        providerSpec = if provider == null then { } else provider.spec or { };
+        providerConfig = providerSpec.config or { };
+        parseRef = value:
+          let parts = if builtins.isString value then lib.splitString "/" value else [ ];
+          in if lib.length parts == 2 then {
+            type = builtins.elemAt parts 0;
+            name = builtins.elemAt parts 1;
+          } else null;
+        resolves = expectedType: value:
+          let
+            parsed = parseRef value;
+            target =
+              if parsed != null && builtins.hasAttr parsed.name resources
+              then resources.${parsed.name}
+              else null;
+          in parsed != null
+            && parsed.type == expectedType
+            && target != null
+            && target.type == expectedType;
+        guestRows = lib.filterAttrs
+          (_: resource:
+            resource.type == "Guest"
+            && (resource.spec.providerRef or null) == "Provider/runtime-qemu-media")
+          resources;
+        guestAssertions = lib.flatten (lib.mapAttrsToList
+          (guestName: guest:
+            let
+              spec = guest.spec or { };
+              extension = spec.provider or { };
+              settings = extension.settings or { };
+              bootMediaRef = settings.bootMediaRef or null;
+              removable = settings.removableVolumeRefs or [ ];
+              displayWindow = settings.displayWindow or false;
+              forbidden = [
+                "hostPath"
+                "socketPath"
+                "argv"
+                "commandLine"
+                "credential"
+                "credentialRef"
+              ];
+            in [
+              {
+                assertion = provider != null;
+                message = "d2b.zones.${zoneName}.resources.${guestName}: runtime-qemu-media Provider is not declared in the same Zone.";
+              }
+              {
+                assertion = (spec.systemArtifactId or null) == null;
+                message = "d2b.zones.${zoneName}.resources.${guestName}.spec.systemArtifactId must be null for runtime-qemu-media.";
+              }
+              {
+                assertion = bootMediaRef == null || resolves "Volume" bootMediaRef;
+                message = "d2b.zones.${zoneName}.resources.${guestName}: bootMediaRef must resolve to a same-Zone Volume.";
+              }
+              {
+                assertion = builtins.isList removable && lib.length removable <= 4;
+                message = "d2b.zones.${zoneName}.resources.${guestName}: removableVolumeRefs must contain at most four entries.";
+              }
+              {
+                assertion = builtins.isList removable
+                  && lib.all
+                    (entry:
+                      builtins.isAttrs entry
+                      && resolves "Volume" (entry.volumeRef or null)
+                      && builtins.isString (entry.view or null)
+                      && builtins.match "^[a-z][a-z0-9-]{0,62}$" (entry.view or "") != null)
+                    removable;
+                message = "d2b.zones.${zoneName}.resources.${guestName}: removableVolumeRefs must use same-Zone Volume refs and bounded views.";
+              }
+              {
+                assertion = !lib.any (key: builtins.hasAttr key settings) forbidden;
+                message = "d2b.zones.${zoneName}.resources.${guestName}.spec.provider.settings must not contain raw locators, argv, or credentials.";
+              }
+              {
+                assertion = !displayWindow
+                  || (providerConfig.displayProviderRef or null) != null;
+                message = "d2b.zones.${zoneName}: displayProviderRef is required when a runtime-qemu-media Guest requests displayWindow.";
+              }
+            ])
+          guestRows);
+      in [
+        {
+          assertion = provider == null
+            || resolves "Host" (providerConfig.controllerExecutionRef or null);
+          message = "d2b.zones.${zoneName}.resources.runtime-qemu-media.spec.config.controllerExecutionRef must resolve to a same-Zone Host.";
+        }
+        {
+          assertion = provider == null
+            || resolves "Provider" (providerConfig.networkProviderRef or null);
+          message = "d2b.zones.${zoneName}.resources.runtime-qemu-media.spec.config.networkProviderRef must resolve to a same-Zone Provider.";
+        }
+        {
+          assertion = provider == null
+            || resolves "Provider" (providerConfig.volumeProviderRef or null);
+          message = "d2b.zones.${zoneName}.resources.runtime-qemu-media.spec.config.volumeProviderRef must resolve to a same-Zone Provider.";
+        }
+      ] ++ guestAssertions)
+    (cfg.zones or { }));
 in
 {
   imports = [
@@ -2666,6 +2773,7 @@ in
     ++ securityKeyUsbipMutualExclusionAssertions
     ++ securityKeyDeviceAssertions
     ++ deviceCrossResourceAssertions
+    ++ qemuMediaResourceAssertions
     ++ zoneTopologyAssertions
   );
 

--- a/nixos-modules/options-guest-qemu-media.nix
+++ b/nixos-modules/options-guest-qemu-media.nix
@@ -1,0 +1,46 @@
+# Bounded qemu-media Provider defaults for v3 resource declarations.
+#
+# Guest media, Device, Network, and Volume references remain Zone resources.
+# This option group carries only Provider-wide bounded defaults; it never
+# accepts paths, argv, bus IDs, credentials, or fd numbers.
+{ lib, ... }:
+
+{
+  options.d2b.qemuMediaRuntime = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable the v3 runtime-qemu-media Provider defaults.";
+    };
+
+    kvmRequired = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Require Device/host-kvm for qemu-media Guests.";
+    };
+
+    qmpReadyTimeoutSeconds = lib.mkOption {
+      type = lib.types.ints.between 5 300;
+      default = 30;
+      description = "Bounded QMP capability greeting deadline.";
+    };
+
+    qmpOperationTimeoutSeconds = lib.mkOption {
+      type = lib.types.ints.between 5 300;
+      default = 60;
+      description = "Bounded QMP command deadline.";
+    };
+
+    runtimeTmpfsQuotaBytes = lib.mkOption {
+      type = lib.types.ints.between (1024 * 1024) (256 * 1024 * 1024);
+      default = 10 * 1024 * 1024;
+      description = "Per-Guest runtime tmpfs byte quota.";
+    };
+
+    runtimeTmpfsQuotaInodes = lib.mkOption {
+      type = lib.types.ints.between 64 65536;
+      default = 1024;
+      description = "Per-Guest runtime tmpfs inode quota.";
+    };
+  };
+}

--- a/nixos-modules/options.nix
+++ b/nixos-modules/options.nix
@@ -32,6 +32,7 @@
     ./options-envs.nix
     ./options-realms.nix
     ./options-vms.nix
+    ./options-guest-qemu-media.nix
     ./options-daemon.nix
     ./options-gateway.nix
   ];

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -1358,6 +1358,14 @@ dependencies = [
 [[package]]
 name = "d2b-provider-runtime-qemu-media"
 version = "0.0.0-bootstrap"
+dependencies = [
+ "d2b-contracts",
+ "d2b-process-conformance",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2",
+]
 
 [[package]]
 name = "d2b-provider-shell-terminal"

--- a/packages/d2b-provider-runtime-qemu-media/Cargo.toml
+++ b/packages/d2b-provider-runtime-qemu-media/Cargo.toml
@@ -7,3 +7,14 @@ license.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+d2b-contracts = { path = "../d2b-contracts", version = "0.0.0-bootstrap" }
+d2b-process-conformance = { path = "../d2b-process-conformance", version = "0.0.0-bootstrap" }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/packages/d2b-provider-runtime-qemu-media/Cargo.toml
+++ b/packages/d2b-provider-runtime-qemu-media/Cargo.toml
@@ -18,3 +18,7 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+
+[[test]]
+name = "qemu_media_integration"
+path = "integration/mod.rs"

--- a/packages/d2b-provider-runtime-qemu-media/README.md
+++ b/packages/d2b-provider-runtime-qemu-media/README.md
@@ -1,12 +1,13 @@
 # `d2b-provider-runtime-qemu-media`
 
-This is the canonical crate root for `Provider/runtime-qemu-media`. It is a
-compile-safe scaffold; semantic Provider behavior is intentionally not present
-here.
+Canonical implementation of `Provider/runtime-qemu-media`. The Provider
+reconciles one manual-only QEMU Guest runtime per declared Guest resource.
+`d2bd` owns lifecycle orchestration, Core owns attachment authorization, and
+the broker/ProviderSupervisor owns privileged spawn and pidfd evidence.
 
 See [Create a Provider](../../docs/how-to/create-provider.md) and the
 [runtime-qemu-media dossier](../../docs/specs/providers/ADR-046-provider-runtime-qemu-media.md)
-for the implementation contract.
+for the full contract.
 
 ## Provider identity
 
@@ -18,44 +19,55 @@ for the implementation contract.
 
 ## Config schema
 
-The Provider-specific configuration is defined by the runtime-qemu-media
-dossier. This scaffold does not publish a configuration schema.
+`ProviderConfig` requires a Host controller placement, bounded QMP deadlines,
+opaque Network and Volume Provider references, and bounded runtime tmpfs
+quotas. Configuration is projected to the controller only; worker Processes
+receive no root Provider config, ResourceAPI authority, or d2b-bus authority.
 
 ## Exported resource types
 
-The resource types are defined by the dossier. This scaffold exports no
-resource implementation.
+The crate validates the locator-free Guest settings and status extension,
+including Volume media references, bounded provider phases, and the
+manual-only `paused-at-boot` state. Runtime Volumes, Process specs, Endpoint
+attachments, and Device/host-kvm observations remain opaque Core resources.
 
 ## Controllers / services / workers / binaries
 
-None are implemented in this scaffold. Controllers, services, workers, and
-binaries belong to the owning Provider implementation.
+`QemuMediaController` gates launch on media, Network, display, and
+Host-global KVM readiness; the QEMU worker is the signed
+`qemu-media-runner` Process template. QMP capability negotiation, health,
+media hotplug, restart adoption, and finalization are typed seams over
+Core-owned effects.
 
 ## Placement and dependencies
 
-No runtime placement is declared, and the scaffold has no workspace
-dependencies.
+The controller runs on the configured Host. A Guest may depend on
+Volume/virtio-blk media, Network refs, Device/host-kvm, and an optional
+display-wayland WaylandSession. No Provider state Volume is declared.
 
 ## RBAC requirements
 
-The scaffold requests no permissions and performs no resource or effect
-operations.
+The controller watches Guest, Volume, Network, Device, Process, and optional
+WaylandSession resources. It requests only typed Core effects and never names
+a broker operation, host path, socket path, executable path, argv, fd, or
+numeric principal.
 
 ## Security posture
 
-No host, broker, filesystem, network, process, credential, or device effect is
-reachable from this scaffold.
+Host-global Device ownership is reserved before effects start and held until
+media effects close. Process adoption verifies the complete identity tuple
+before pidfd acquisition; ambiguous candidates are quarantined. Audit and
+telemetry projections are bounded and redacted.
 
 ## State and telemetry
 
-The scaffold owns no state and emits no telemetry.
+Operational state is status-first and restart-rehydratable from the Zone store,
+operation ledger, and external process observations. No Provider state Volume
+or secret/path-bearing diagnostics are used. Audit events and metric labels
+use fixed semantic vocabularies.
 
 ## Build and test
 
 ```bash
-cargo check -p d2b-provider-runtime-qemu-media
 cargo test -p d2b-provider-runtime-qemu-media
 ```
-
-The current test targets are structural compile checks. Executable scenarios
-belong to the owning implementation.

--- a/packages/d2b-provider-runtime-qemu-media/integration/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/integration/mod.rs
@@ -1,0 +1,19 @@
+//! Fake-host integration fixtures for the qemu-media Provider.
+
+mod scaffold;
+
+#[cfg(test)]
+mod tests {
+    use super::scaffold;
+
+    #[test]
+    fn fixture_contains_guest_runtime_volume_and_process() {
+        let (guest, volume, process) = scaffold::fixture();
+        assert_eq!(
+            guest.provider_ref.to_canonical_string(),
+            "Provider/runtime-qemu-media"
+        );
+        assert_eq!(volume.cleanup_policy(), "vm-stop-with-proof");
+        assert_eq!(process.template, "qemu-media-runner");
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/integration/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/integration/mod.rs
@@ -11,10 +11,10 @@ mod tests {
     fn fixture_contains_guest_runtime_volume_and_process() {
         let (guest, volume, process) = scaffold::fixture();
         assert_eq!(
-            guest.provider_ref.to_canonical_string(),
+            guest.provider_ref().unwrap().to_canonical_string(),
             "Provider/runtime-qemu-media"
         );
         assert_eq!(volume.cleanup_policy(), "vm-stop-with-proof");
-        assert_eq!(process.template, "qemu-media-runner");
+        assert_eq!(process.execution().template().as_str(), "qemu-media-runner");
     }
 }

--- a/packages/d2b-provider-runtime-qemu-media/integration/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/integration/mod.rs
@@ -1,3 +1,4 @@
+//! integration-target: container
 //! Fake-host integration fixtures for the qemu-media Provider.
 
 mod scaffold;

--- a/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
+++ b/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
@@ -1,4 +1,4 @@
-//! integration-target: fake-host
+//! integration-target: container
 
 use d2b_provider_runtime_qemu_media::{
     GuestProviderSpecSettings, GuestSpec, ProcessSpec, RuntimeVolumeSpec,

--- a/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
+++ b/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
@@ -5,15 +5,11 @@ use d2b_provider_runtime_qemu_media::{
 };
 
 /// Build the cross-resource fixture used by the fake-host integration lane.
-pub fn fixture() -> (
-    GuestSpec,
-    RuntimeVolumeSpec,
-    ProcessSpec,
-) {
-    let guest_ref = d2b_contracts::v3::ResourceRef::parse("Guest/media-vm")
-        .expect("fixture Guest ref");
-    let volume_ref = d2b_contracts::v3::ResourceRef::parse("Volume/runtime")
-        .expect("fixture Volume ref");
+pub fn fixture() -> (GuestSpec, RuntimeVolumeSpec, ProcessSpec) {
+    let guest_ref =
+        d2b_contracts::v3::ResourceRef::parse("Guest/media-vm").expect("fixture Guest ref");
+    let volume_ref =
+        d2b_contracts::v3::ResourceRef::parse("Volume/runtime").expect("fixture Volume ref");
     let guest = GuestSpec::new(
         "Provider/runtime-qemu-media",
         Some(d2b_contracts::v3::ResourceRef::parse("Volume/boot").expect("fixture Volume ref")),
@@ -22,9 +18,8 @@ pub fn fixture() -> (
         GuestProviderSpecSettings::default(),
     )
     .expect("fixture Guest");
-    let volume =
-        RuntimeVolumeSpec::new(guest_ref.clone(), "corp", 10 * 1024 * 1024, 1024)
-            .expect("fixture runtime Volume");
+    let volume = RuntimeVolumeSpec::new(guest_ref.clone(), "corp", 10 * 1024 * 1024, 1024)
+        .expect("fixture runtime Volume");
     let process = ProcessSpec::new(
         guest_ref,
         d2b_contracts::v3::ResourceRef::parse("Host/host-system").expect("fixture Host ref"),

--- a/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
+++ b/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
@@ -1,17 +1,21 @@
 //! integration-target: container
 
 use d2b_provider_runtime_qemu_media::{
-    GuestProviderSpecSettings, GuestSpec, ProcessSpec, RuntimeVolumeSpec,
+    GuestProviderSpecSettings, ProcessSpec, RuntimeVolumeSpec, build_guest_resource_spec,
+    build_process_spec,
 };
 
 /// Build the cross-resource fixture used by the fake-host integration lane.
-pub fn fixture() -> (GuestSpec, RuntimeVolumeSpec, ProcessSpec) {
+pub fn fixture() -> (
+    d2b_contracts::v3::ResourceSpec,
+    RuntimeVolumeSpec,
+    ProcessSpec,
+) {
     let guest_ref =
         d2b_contracts::v3::ResourceRef::parse("Guest/media-vm").expect("fixture Guest ref");
     let volume_ref =
         d2b_contracts::v3::ResourceRef::parse("Volume/runtime").expect("fixture Volume ref");
-    let guest = GuestSpec::new(
-        "Provider/runtime-qemu-media",
+    let guest = build_guest_resource_spec(
         Some(d2b_contracts::v3::ResourceRef::parse("Volume/boot").expect("fixture Volume ref")),
         2,
         4096,
@@ -20,8 +24,7 @@ pub fn fixture() -> (GuestSpec, RuntimeVolumeSpec, ProcessSpec) {
     .expect("fixture Guest");
     let volume = RuntimeVolumeSpec::new(guest_ref.clone(), "corp", 10 * 1024 * 1024, 1024)
         .expect("fixture runtime Volume");
-    let process = ProcessSpec::new(
-        guest_ref,
+    let process = build_process_spec(
         d2b_contracts::v3::ResourceRef::parse("Host/host-system").expect("fixture Host ref"),
         volume_ref,
         Some(d2b_contracts::v3::ResourceRef::parse("Device/host-kvm").expect("fixture Device ref")),

--- a/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
+++ b/packages/d2b-provider-runtime-qemu-media/integration/scaffold.rs
@@ -1,1 +1,37 @@
-//! integration-target: container
+//! integration-target: fake-host
+
+use d2b_provider_runtime_qemu_media::{
+    GuestProviderSpecSettings, GuestSpec, ProcessSpec, RuntimeVolumeSpec,
+};
+
+/// Build the cross-resource fixture used by the fake-host integration lane.
+pub fn fixture() -> (
+    GuestSpec,
+    RuntimeVolumeSpec,
+    ProcessSpec,
+) {
+    let guest_ref = d2b_contracts::v3::ResourceRef::parse("Guest/media-vm")
+        .expect("fixture Guest ref");
+    let volume_ref = d2b_contracts::v3::ResourceRef::parse("Volume/runtime")
+        .expect("fixture Volume ref");
+    let guest = GuestSpec::new(
+        "Provider/runtime-qemu-media",
+        Some(d2b_contracts::v3::ResourceRef::parse("Volume/boot").expect("fixture Volume ref")),
+        2,
+        4096,
+        GuestProviderSpecSettings::default(),
+    )
+    .expect("fixture Guest");
+    let volume =
+        RuntimeVolumeSpec::new(guest_ref.clone(), "corp", 10 * 1024 * 1024, 1024)
+            .expect("fixture runtime Volume");
+    let process = ProcessSpec::new(
+        guest_ref,
+        d2b_contracts::v3::ResourceRef::parse("Host/host-system").expect("fixture Host ref"),
+        volume_ref,
+        Some(d2b_contracts::v3::ResourceRef::parse("Device/host-kvm").expect("fixture Device ref")),
+        Vec::<d2b_contracts::v3::ResourceRef>::new(),
+    )
+    .expect("fixture Process");
+    (guest, volume, process)
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/adoption.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/adoption.rs
@@ -38,7 +38,7 @@ impl ProcessIdentity {
     /// Return whether this identity matches a Core-provided process token.
     pub fn matches_process_token(&self, value: &str) -> bool {
         let digest = Sha256::digest(value.as_bytes());
-        self.executable_digest == digest[..]
+        self.template_digest == digest[..]
     }
 }
 
@@ -63,5 +63,31 @@ pub fn verify_identity(expected: &ProcessIdentity, observed: &ProcessIdentity) -
         AdoptionOutcome::Adopted
     } else {
         AdoptionOutcome::Quarantined
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(value: &str) -> [u8; 32] {
+        let mut result = [0_u8; 32];
+        result.copy_from_slice(&Sha256::digest(value.as_bytes()));
+        result
+    }
+
+    #[test]
+    fn process_token_matches_template_digest_not_executable_digest() {
+        let mut identity = ProcessIdentity::for_test("actual-qemu-binary");
+        identity.template_digest = digest("qemu-media-runner");
+        assert!(identity.matches_process_token("qemu-media-runner"));
+        assert!(!identity.matches_process_token("actual-qemu-binary"));
+    }
+
+    #[test]
+    fn inverted_template_and_executable_digests_fail_closed() {
+        let mut identity = ProcessIdentity::for_test("qemu-media-runner");
+        identity.template_digest = digest("actual-qemu-binary");
+        assert!(!identity.matches_process_token("qemu-media-runner"));
     }
 }

--- a/packages/d2b-provider-runtime-qemu-media/src/adoption.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/adoption.rs
@@ -1,0 +1,61 @@
+//! Restart-safe QEMU process identity evidence.
+
+use sha2::{Digest, Sha256};
+
+/// Verified process identity tuple.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    /// Process id evidence.
+    pub pid: u32,
+    /// Kernel start-time evidence.
+    pub start_time_ticks: u64,
+    /// Owning cgroup digest.
+    pub cgroup_digest: [u8; 32],
+    /// Executable digest.
+    pub executable_digest: [u8; 32],
+    /// Signed template digest.
+    pub template_digest: [u8; 32],
+    /// Resource generation.
+    pub generation: u64,
+}
+
+impl ProcessIdentity {
+    /// Construct deterministic identity evidence for hermetic tests.
+    pub fn for_test(value: &str) -> Self {
+        let digest = Sha256::digest(value.as_bytes());
+        let mut bytes = [0_u8; 32];
+        bytes.copy_from_slice(&digest);
+        Self {
+            pid: 42,
+            start_time_ticks: 7,
+            cgroup_digest: bytes,
+            executable_digest: bytes,
+            template_digest: bytes,
+            generation: 1,
+        }
+    }
+}
+
+impl core::fmt::Debug for ProcessIdentity {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("ProcessIdentity(<redacted>)")
+    }
+}
+
+/// Result of comparing an observed process identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdoptionOutcome {
+    /// The process matches the durable identity.
+    Adopted,
+    /// The process cannot be safely reused.
+    Quarantined,
+}
+
+/// Verify every process identity binding before opening a pidfd.
+pub fn verify_identity(expected: &ProcessIdentity, observed: &ProcessIdentity) -> AdoptionOutcome {
+    if expected == observed {
+        AdoptionOutcome::Adopted
+    } else {
+        AdoptionOutcome::Quarantined
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/adoption.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/adoption.rs
@@ -34,6 +34,12 @@ impl ProcessIdentity {
             generation: 1,
         }
     }
+
+    /// Return whether this identity matches a Core-provided process token.
+    pub fn matches_process_token(&self, value: &str) -> bool {
+        let digest = Sha256::digest(value.as_bytes());
+        self.executable_digest == digest[..]
+    }
 }
 
 impl core::fmt::Debug for ProcessIdentity {

--- a/packages/d2b-provider-runtime-qemu-media/src/audit.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/audit.rs
@@ -1,0 +1,157 @@
+//! Redacted qemu-media audit events.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+/// Closed audit event kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditEventKind {
+    /// Guest row created.
+    GuestCreated,
+    /// Runner launch started.
+    RunnerLaunching,
+    /// QMP became ready.
+    QmpReady,
+    /// Guest is running.
+    GuestRunning,
+    /// Guest remains paused at boot.
+    GuestPausedAtBoot,
+    /// Guest resumed.
+    GuestResumed,
+    /// Media was hotplugged.
+    MediaHotplugAttached,
+    /// Media was detached.
+    MediaHotplugDetached,
+    /// Guest stop started.
+    GuestStopping,
+    /// Runner exited.
+    RunnerExited,
+    /// Guest finalization completed.
+    GuestDeleted,
+    /// Dependency degraded.
+    DependencyDegraded,
+    /// Provider phase failed.
+    ProviderPhaseFailed,
+    /// WaylandSession was created.
+    WaylandSessionCreated,
+    /// WaylandSession was deleted.
+    WaylandSessionDeleted,
+}
+
+impl AuditEventKind {
+    /// All event kinds.
+    pub const ALL: [Self; 15] = [
+        Self::GuestCreated,
+        Self::RunnerLaunching,
+        Self::QmpReady,
+        Self::GuestRunning,
+        Self::GuestPausedAtBoot,
+        Self::GuestResumed,
+        Self::MediaHotplugAttached,
+        Self::MediaHotplugDetached,
+        Self::GuestStopping,
+        Self::RunnerExited,
+        Self::GuestDeleted,
+        Self::DependencyDegraded,
+        Self::ProviderPhaseFailed,
+        Self::WaylandSessionCreated,
+        Self::WaylandSessionDeleted,
+    ];
+
+    /// Return the stable wire name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::GuestCreated => "guest/created",
+            Self::RunnerLaunching => "guest/runner-launching",
+            Self::QmpReady => "guest/qmp-ready",
+            Self::GuestRunning => "guest/running",
+            Self::GuestPausedAtBoot => "guest/paused-at-boot",
+            Self::GuestResumed => "guest/resumed",
+            Self::MediaHotplugAttached => "guest/media-hotplug-attached",
+            Self::MediaHotplugDetached => "guest/media-hotplug-detached",
+            Self::GuestStopping => "guest/stopping",
+            Self::RunnerExited => "guest/runner-exited",
+            Self::GuestDeleted => "guest/deleted",
+            Self::DependencyDegraded => "guest/dependency-degraded",
+            Self::ProviderPhaseFailed => "guest/provider-phase-failed",
+            Self::WaylandSessionCreated => "guest/wayland-session-created",
+            Self::WaylandSessionDeleted => "guest/wayland-session-deleted",
+        }
+    }
+}
+
+/// Closed audit outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuditOutcome {
+    /// Mutation or observation succeeded.
+    Success,
+    /// Operation remains pending.
+    Pending,
+    /// Operation is degraded.
+    Degraded,
+    /// Operation failed.
+    Failed,
+    /// Operation was denied.
+    Denied,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuditWire<'a> {
+    kind: &'static str,
+    outcome: AuditOutcome,
+    zone: &'a str,
+    guest: &'a str,
+    operation: &'a str,
+}
+
+/// Redacted audit record.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuditRecord {
+    kind: AuditEventKind,
+    outcome: AuditOutcome,
+    zone_digest: String,
+    guest_digest: String,
+    operation_digest: String,
+}
+
+impl AuditRecord {
+    /// Construct an audit record from untrusted identity inputs.
+    pub fn new(
+        kind: AuditEventKind,
+        outcome: AuditOutcome,
+        zone: &str,
+        guest: &str,
+        operation: &str,
+    ) -> Self {
+        Self {
+            kind,
+            outcome,
+            zone_digest: digest(zone),
+            guest_digest: digest(guest),
+            operation_digest: digest(operation),
+        }
+    }
+
+    /// Render the bounded redacted JSON payload.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(&AuditWire {
+            kind: self.kind.as_str(),
+            outcome: self.outcome,
+            zone: &self.zone_digest,
+            guest: &self.guest_digest,
+            operation: &self.operation_digest,
+        })
+    }
+}
+
+impl core::fmt::Debug for AuditRecord {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("AuditRecord(<redacted>)")
+    }
+}
+
+fn digest(value: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(value.as_bytes()))
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/config.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/config.rs
@@ -2,7 +2,7 @@
 
 use d2b_contracts::v3::ResourceRef;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Default QMP greeting timeout in seconds.
 pub const DEFAULT_QMP_READY_TIMEOUT_SECONDS: u32 = 30;
@@ -14,7 +14,7 @@ pub const DEFAULT_RUNTIME_TMPFS_QUOTA_BYTES: u64 = 10 * 1024 * 1024;
 pub const DEFAULT_RUNTIME_TMPFS_QUOTA_INODES: u32 = 1024;
 
 /// Provider root configuration.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProviderConfig {
     /// Host on which the controller Process runs.
@@ -38,6 +38,50 @@ pub struct ProviderConfig {
     pub runtime_tmpfs_quota_bytes: u64,
     /// Runtime tmpfs inode quota.
     pub runtime_tmpfs_quota_inodes: u32,
+}
+
+impl<'de> Deserialize<'de> for ProviderConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Wire {
+            controller_execution_ref: ResourceRef,
+            #[serde(default = "default_qemu_artifact")]
+            qemu_binary_artifact_id: String,
+            #[serde(default = "default_qmp_ready")]
+            qmp_ready_timeout_seconds: u32,
+            #[serde(default = "default_qmp_operation")]
+            qmp_operation_timeout_seconds: u32,
+            #[serde(default = "default_true")]
+            paused_at_boot_default: bool,
+            #[serde(default)]
+            display_provider_ref: Option<ResourceRef>,
+            network_provider_ref: ResourceRef,
+            volume_provider_ref: ResourceRef,
+            #[serde(default = "default_runtime_bytes")]
+            runtime_tmpfs_quota_bytes: u64,
+            #[serde(default = "default_runtime_inodes")]
+            runtime_tmpfs_quota_inodes: u32,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        let config = Self {
+            controller_execution_ref: wire.controller_execution_ref,
+            qemu_binary_artifact_id: wire.qemu_binary_artifact_id,
+            qmp_ready_timeout_seconds: wire.qmp_ready_timeout_seconds,
+            qmp_operation_timeout_seconds: wire.qmp_operation_timeout_seconds,
+            paused_at_boot_default: wire.paused_at_boot_default,
+            display_provider_ref: wire.display_provider_ref,
+            network_provider_ref: wire.network_provider_ref,
+            volume_provider_ref: wire.volume_provider_ref,
+            runtime_tmpfs_quota_bytes: wire.runtime_tmpfs_quota_bytes,
+            runtime_tmpfs_quota_inodes: wire.runtime_tmpfs_quota_inodes,
+        };
+        config.validate().map_err(serde::de::Error::custom)?;
+        Ok(config)
+    }
 }
 
 impl Default for ProviderConfig {
@@ -203,4 +247,28 @@ fn valid_token(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn default_qemu_artifact() -> String {
+    "qemu-system-x86_64".to_owned()
+}
+
+const fn default_qmp_ready() -> u32 {
+    DEFAULT_QMP_READY_TIMEOUT_SECONDS
+}
+
+const fn default_qmp_operation() -> u32 {
+    DEFAULT_QMP_OPERATION_TIMEOUT_SECONDS
+}
+
+const fn default_runtime_bytes() -> u64 {
+    DEFAULT_RUNTIME_TMPFS_QUOTA_BYTES
+}
+
+const fn default_runtime_inodes() -> u32 {
+    DEFAULT_RUNTIME_TMPFS_QUOTA_INODES
 }

--- a/packages/d2b-provider-runtime-qemu-media/src/config.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/config.rs
@@ -88,7 +88,7 @@ impl Default for ProviderConfig {
     fn default() -> Self {
         Self {
             controller_execution_ref: ResourceRef::parse("Guest/invalid").expect("valid reference"),
-            qemu_binary_artifact_id: "qemu-system-x86_64".to_owned(),
+            qemu_binary_artifact_id: "qemu-system-x86-64".to_owned(),
             qmp_ready_timeout_seconds: DEFAULT_QMP_READY_TIMEOUT_SECONDS,
             qmp_operation_timeout_seconds: DEFAULT_QMP_OPERATION_TIMEOUT_SECONDS,
             paused_at_boot_default: true,
@@ -289,7 +289,7 @@ const fn default_true() -> bool {
 }
 
 fn default_qemu_artifact() -> String {
-    "qemu-system-x86_64".to_owned()
+    "qemu-system-x86-64".to_owned()
 }
 
 const fn default_qmp_ready() -> u32 {

--- a/packages/d2b-provider-runtime-qemu-media/src/config.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/config.rs
@@ -152,10 +152,17 @@ impl ProviderConfig {
     pub fn project_controller(&self) -> ControllerConfigProjection {
         ControllerConfigProjection {
             controller_execution_ref: self.controller_execution_ref.to_canonical_string(),
+            qemu_binary_artifact_id: self.qemu_binary_artifact_id.clone(),
             qmp_ready_timeout_seconds: self.qmp_ready_timeout_seconds,
             qmp_operation_timeout_seconds: self.qmp_operation_timeout_seconds,
             paused_at_boot_default: self.paused_at_boot_default,
+            display_provider_ref: self
+                .display_provider_ref
+                .as_ref()
+                .map(ResourceRef::to_canonical_string),
             display_provider_configured: self.display_provider_ref.is_some(),
+            network_provider_ref: self.network_provider_ref.to_canonical_string(),
+            volume_provider_ref: self.volume_provider_ref.to_canonical_string(),
             runtime_tmpfs_quota_bytes: self.runtime_tmpfs_quota_bytes,
             runtime_tmpfs_quota_inodes: self.runtime_tmpfs_quota_inodes,
         }
@@ -196,14 +203,22 @@ impl core::fmt::Debug for ProviderConfig {
 pub struct ControllerConfigProjection {
     /// Host placement reference.
     pub controller_execution_ref: String,
+    /// Artifact catalog identifier for the QEMU binary closure.
+    pub qemu_binary_artifact_id: String,
     /// QMP greeting deadline.
     pub qmp_ready_timeout_seconds: u32,
     /// QMP operation deadline.
     pub qmp_operation_timeout_seconds: u32,
     /// Pause-at-boot default.
     pub paused_at_boot_default: bool,
+    /// Optional display Provider reference.
+    pub display_provider_ref: Option<String>,
     /// Whether display Provider configuration is available.
     pub display_provider_configured: bool,
+    /// Network Provider reference.
+    pub network_provider_ref: String,
+    /// Volume Provider reference.
+    pub volume_provider_ref: String,
     /// Runtime tmpfs byte quota.
     pub runtime_tmpfs_quota_bytes: u64,
     /// Runtime tmpfs inode quota.
@@ -214,6 +229,26 @@ impl ControllerConfigProjection {
     /// Borrow the controller placement reference.
     pub fn controller_execution_ref(&self) -> &str {
         &self.controller_execution_ref
+    }
+
+    /// Borrow the QEMU binary artifact identifier.
+    pub fn qemu_binary_artifact_id(&self) -> &str {
+        &self.qemu_binary_artifact_id
+    }
+
+    /// Borrow the optional display Provider reference.
+    pub fn display_provider_ref(&self) -> Option<&str> {
+        self.display_provider_ref.as_deref()
+    }
+
+    /// Borrow the Network Provider reference.
+    pub fn network_provider_ref(&self) -> &str {
+        &self.network_provider_ref
+    }
+
+    /// Borrow the Volume Provider reference.
+    pub fn volume_provider_ref(&self) -> &str {
+        &self.volume_provider_ref
     }
 }
 

--- a/packages/d2b-provider-runtime-qemu-media/src/config.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/config.rs
@@ -1,0 +1,206 @@
+//! Bounded Provider configuration and controller-only projection.
+
+use d2b_contracts::v3::ResourceRef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Default QMP greeting timeout in seconds.
+pub const DEFAULT_QMP_READY_TIMEOUT_SECONDS: u32 = 30;
+/// Default QMP command timeout in seconds.
+pub const DEFAULT_QMP_OPERATION_TIMEOUT_SECONDS: u32 = 60;
+/// Default runtime tmpfs quota in bytes.
+pub const DEFAULT_RUNTIME_TMPFS_QUOTA_BYTES: u64 = 10 * 1024 * 1024;
+/// Default runtime tmpfs inode quota.
+pub const DEFAULT_RUNTIME_TMPFS_QUOTA_INODES: u32 = 1024;
+
+/// Provider root configuration.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProviderConfig {
+    /// Host on which the controller Process runs.
+    pub controller_execution_ref: ResourceRef,
+    /// Artifact catalog id for QEMU.
+    pub qemu_binary_artifact_id: String,
+    /// Initial QMP greeting deadline.
+    pub qmp_ready_timeout_seconds: u32,
+    /// Per-command QMP deadline.
+    pub qmp_operation_timeout_seconds: u32,
+    /// Default pause-at-boot setting.
+    pub paused_at_boot_default: bool,
+    /// Optional display Provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_provider_ref: Option<ResourceRef>,
+    /// Network Provider.
+    pub network_provider_ref: ResourceRef,
+    /// Volume Provider.
+    pub volume_provider_ref: ResourceRef,
+    /// Runtime tmpfs byte quota.
+    pub runtime_tmpfs_quota_bytes: u64,
+    /// Runtime tmpfs inode quota.
+    pub runtime_tmpfs_quota_inodes: u32,
+}
+
+impl Default for ProviderConfig {
+    fn default() -> Self {
+        Self {
+            controller_execution_ref: ResourceRef::parse("Guest/invalid").expect("valid reference"),
+            qemu_binary_artifact_id: "qemu-system-x86_64".to_owned(),
+            qmp_ready_timeout_seconds: DEFAULT_QMP_READY_TIMEOUT_SECONDS,
+            qmp_operation_timeout_seconds: DEFAULT_QMP_OPERATION_TIMEOUT_SECONDS,
+            paused_at_boot_default: true,
+            display_provider_ref: None,
+            network_provider_ref: ResourceRef::parse("Provider/network-local")
+                .expect("valid reference"),
+            volume_provider_ref: ResourceRef::parse("Provider/volume-local")
+                .expect("valid reference"),
+            runtime_tmpfs_quota_bytes: DEFAULT_RUNTIME_TMPFS_QUOTA_BYTES,
+            runtime_tmpfs_quota_inodes: DEFAULT_RUNTIME_TMPFS_QUOTA_INODES,
+        }
+    }
+}
+
+impl ProviderConfig {
+    /// Construct a Provider configuration with defaults for bounded values.
+    pub fn new(
+        controller_execution_ref: impl Into<String>,
+        qemu_binary_artifact_id: impl Into<String>,
+        network_provider_ref: impl Into<String>,
+        volume_provider_ref: impl Into<String>,
+        display_provider_ref: Option<String>,
+    ) -> Result<Self, ProviderConfigError> {
+        let config = Self {
+            controller_execution_ref: parse_ref(controller_execution_ref.into())?,
+            qemu_binary_artifact_id: qemu_binary_artifact_id.into(),
+            qmp_ready_timeout_seconds: DEFAULT_QMP_READY_TIMEOUT_SECONDS,
+            qmp_operation_timeout_seconds: DEFAULT_QMP_OPERATION_TIMEOUT_SECONDS,
+            paused_at_boot_default: true,
+            display_provider_ref: display_provider_ref.map(parse_ref).transpose()?,
+            network_provider_ref: parse_ref(network_provider_ref.into())?,
+            volume_provider_ref: parse_ref(volume_provider_ref.into())?,
+            runtime_tmpfs_quota_bytes: DEFAULT_RUNTIME_TMPFS_QUOTA_BYTES,
+            runtime_tmpfs_quota_inodes: DEFAULT_RUNTIME_TMPFS_QUOTA_INODES,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validate all Provider bounds and typed references.
+    pub fn validate(&self) -> Result<(), ProviderConfigError> {
+        if self.controller_execution_ref.resource_type().as_str() != "Host"
+            || self.network_provider_ref.resource_type().as_str() != "Provider"
+            || self.volume_provider_ref.resource_type().as_str() != "Provider"
+            || self
+                .display_provider_ref
+                .as_ref()
+                .is_some_and(|reference| reference.resource_type().as_str() != "Provider")
+            || !valid_token(&self.qemu_binary_artifact_id)
+            || !(5..=300).contains(&self.qmp_ready_timeout_seconds)
+            || !(5..=300).contains(&self.qmp_operation_timeout_seconds)
+            || !(1024 * 1024..=256 * 1024 * 1024).contains(&self.runtime_tmpfs_quota_bytes)
+            || !(64..=65_536).contains(&self.runtime_tmpfs_quota_inodes)
+        {
+            return Err(ProviderConfigError::Invalid);
+        }
+        Ok(())
+    }
+
+    /// Project the fields needed by the controller Process only.
+    pub fn project_controller(&self) -> ControllerConfigProjection {
+        ControllerConfigProjection {
+            controller_execution_ref: self.controller_execution_ref.to_canonical_string(),
+            qmp_ready_timeout_seconds: self.qmp_ready_timeout_seconds,
+            qmp_operation_timeout_seconds: self.qmp_operation_timeout_seconds,
+            paused_at_boot_default: self.paused_at_boot_default,
+            display_provider_configured: self.display_provider_ref.is_some(),
+            runtime_tmpfs_quota_bytes: self.runtime_tmpfs_quota_bytes,
+            runtime_tmpfs_quota_inodes: self.runtime_tmpfs_quota_inodes,
+        }
+    }
+
+    /// Return the intentionally empty worker projection.
+    pub const fn project_worker(&self) -> WorkerConfigProjection {
+        WorkerConfigProjection
+    }
+}
+
+impl core::fmt::Debug for ProviderConfig {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("ProviderConfig")
+            .field("controller_execution_ref", &"<redacted>")
+            .field("qemu_binary_artifact_id", &"<redacted>")
+            .field("qmp_ready_timeout_seconds", &self.qmp_ready_timeout_seconds)
+            .field(
+                "qmp_operation_timeout_seconds",
+                &self.qmp_operation_timeout_seconds,
+            )
+            .field("paused_at_boot_default", &self.paused_at_boot_default)
+            .field("display_provider_ref", &self.display_provider_ref.is_some())
+            .field("network_provider_ref", &"<redacted>")
+            .field("volume_provider_ref", &"<redacted>")
+            .field("runtime_tmpfs_quota_bytes", &self.runtime_tmpfs_quota_bytes)
+            .field(
+                "runtime_tmpfs_quota_inodes",
+                &self.runtime_tmpfs_quota_inodes,
+            )
+            .finish()
+    }
+}
+
+/// Controller-only projection of Provider configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerConfigProjection {
+    /// Host placement reference.
+    pub controller_execution_ref: String,
+    /// QMP greeting deadline.
+    pub qmp_ready_timeout_seconds: u32,
+    /// QMP operation deadline.
+    pub qmp_operation_timeout_seconds: u32,
+    /// Pause-at-boot default.
+    pub paused_at_boot_default: bool,
+    /// Whether display Provider configuration is available.
+    pub display_provider_configured: bool,
+    /// Runtime tmpfs byte quota.
+    pub runtime_tmpfs_quota_bytes: u64,
+    /// Runtime tmpfs inode quota.
+    pub runtime_tmpfs_quota_inodes: u32,
+}
+
+impl ControllerConfigProjection {
+    /// Borrow the controller placement reference.
+    pub fn controller_execution_ref(&self) -> &str {
+        &self.controller_execution_ref
+    }
+}
+
+/// Empty worker configuration projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct WorkerConfigProjection;
+
+/// Provider configuration validation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderConfigError {
+    /// A typed reference or bound is invalid.
+    Invalid,
+}
+
+impl core::fmt::Display for ProviderConfigError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("runtime-qemu-media-config-invalid")
+    }
+}
+
+impl std::error::Error for ProviderConfigError {}
+
+fn parse_ref(value: String) -> Result<ResourceRef, ProviderConfigError> {
+    ResourceRef::parse(&value).map_err(|_| ProviderConfigError::Invalid)
+}
+
+fn valid_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && value.as_bytes()[0].is_ascii_lowercase()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/device_watch.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/device_watch.rs
@@ -93,7 +93,11 @@ impl DeviceAdmission {
         if observation.phase != DevicePhase::Ready {
             return Err(DeviceAdmissionError::NotReady);
         }
-        if observation.owner_ref.as_ref() != Some(guest_ref) {
+        if observation
+            .owner_ref
+            .as_ref()
+            .is_some_and(|owner| owner != guest_ref)
+        {
             return Err(DeviceAdmissionError::WrongOwner);
         }
         if observation.platform != PlatformClass::X86_64Linux {

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/device_watch.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/device_watch.rs
@@ -1,0 +1,167 @@
+//! Host-global KVM Device admission.
+
+use std::collections::BTreeMap;
+
+use d2b_contracts::v3::ResourceRef;
+
+/// Observed Device phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DevicePhase {
+    /// Device has not reached Ready.
+    Pending,
+    /// Device is ready.
+    Ready,
+    /// Device failed closed.
+    Failed,
+    /// Device is degraded.
+    Degraded,
+}
+
+/// Host platform class required by the QEMU media runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformClass {
+    /// Supported x86_64 Linux platform.
+    X86_64Linux,
+    /// Unsupported platform.
+    Other,
+}
+
+/// Core-derived Device observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceObservation {
+    /// Device reference.
+    pub device_ref: ResourceRef,
+    /// Device phase.
+    pub phase: DevicePhase,
+    /// Current owner proof.
+    pub owner_ref: Option<ResourceRef>,
+    /// Host platform.
+    pub platform: PlatformClass,
+    /// Opaque Host-global authority key.
+    pub authority_key: [u8; 32],
+    /// Verified process identity binding.
+    pub process_identity: Option<String>,
+    /// Signed media contract identifier.
+    pub media_contract: String,
+}
+
+/// Device admission failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceAdmissionError {
+    /// Device is not ready.
+    NotReady,
+    /// Device is owned by another resource.
+    WrongOwner,
+    /// Platform is not supported.
+    UnsupportedPlatform,
+    /// Process identity proof is missing or wrong.
+    ProcessIdentityMismatch,
+    /// Media contract is not the required version.
+    MediaContractMismatch,
+    /// Device is not a KVM Device.
+    WrongDevice,
+}
+
+impl DeviceAdmissionError {
+    /// Return a stable redacted error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::NotReady => "kvm-device-unavailable",
+            Self::WrongOwner => "kvm-device-owner-mismatch",
+            Self::UnsupportedPlatform => "kvm-platform-unsupported",
+            Self::ProcessIdentityMismatch => "kvm-process-identity-mismatch",
+            Self::MediaContractMismatch => "qemu-media-contract-mismatch",
+            Self::WrongDevice => "kvm-device-ref-invalid",
+        }
+    }
+}
+
+/// Validate a KVM Device before a runner effect begins.
+pub struct DeviceAdmission;
+
+impl DeviceAdmission {
+    /// Check owner, platform, process identity, and media contract.
+    pub fn validate(
+        guest_ref: &ResourceRef,
+        observation: &DeviceObservation,
+        expected_process_identity: &str,
+        expected_contract: &str,
+    ) -> Result<(), DeviceAdmissionError> {
+        if observation.device_ref.to_canonical_string() != "Device/host-kvm" {
+            return Err(DeviceAdmissionError::WrongDevice);
+        }
+        if observation.phase != DevicePhase::Ready {
+            return Err(DeviceAdmissionError::NotReady);
+        }
+        if observation.owner_ref.as_ref() != Some(guest_ref) {
+            return Err(DeviceAdmissionError::WrongOwner);
+        }
+        if observation.platform != PlatformClass::X86_64Linux {
+            return Err(DeviceAdmissionError::UnsupportedPlatform);
+        }
+        if observation.process_identity.as_deref() != Some(expected_process_identity) {
+            return Err(DeviceAdmissionError::ProcessIdentityMismatch);
+        }
+        if observation.media_contract != expected_contract {
+            return Err(DeviceAdmissionError::MediaContractMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// A retained Host-global authority reservation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorityReservation {
+    key: [u8; 32],
+    owner_ref: ResourceRef,
+}
+
+impl AuthorityReservation {
+    /// Borrow the owner of this reservation.
+    pub const fn owner_ref(&self) -> &ResourceRef {
+        &self.owner_ref
+    }
+}
+
+/// Single-owner Host-global authority index.
+#[derive(Debug, Default)]
+pub struct HostGlobalAuthorityIndex {
+    owners: BTreeMap<[u8; 32], ResourceRef>,
+}
+
+impl HostGlobalAuthorityIndex {
+    /// Construct an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reserve a key before an asynchronous effect starts.
+    pub fn reserve(
+        &mut self,
+        key: [u8; 32],
+        owner_ref: ResourceRef,
+    ) -> Result<AuthorityReservation, DeviceAdmissionError> {
+        if let Some(existing) = self.owners.get(&key) {
+            if existing != &owner_ref {
+                return Err(DeviceAdmissionError::WrongOwner);
+            }
+            return Err(DeviceAdmissionError::WrongOwner);
+        }
+        self.owners.insert(key, owner_ref.clone());
+        Ok(AuthorityReservation { key, owner_ref })
+    }
+
+    /// Release a reservation only for its original owner.
+    pub fn release(
+        &mut self,
+        reservation: AuthorityReservation,
+    ) -> Result<(), DeviceAdmissionError> {
+        match self.owners.get(&reservation.key) {
+            Some(owner) if owner == &reservation.owner_ref => {
+                self.owners.remove(&reservation.key);
+                Ok(())
+            }
+            _ => Err(DeviceAdmissionError::WrongOwner),
+        }
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/display.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/display.rs
@@ -1,0 +1,89 @@
+//! WaylandSession dependency projection.
+
+use d2b_contracts::v3::ResourceRef;
+use serde::{Deserialize, Serialize};
+
+/// WaylandSession lifecycle phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisplaySessionPhase {
+    /// Session is pending.
+    Pending,
+    /// Session is ready.
+    Ready,
+    /// Session failed.
+    Failed,
+}
+
+/// Opaque endpoint attachment returned by display-wayland.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DisplayAttachment {
+    /// Endpoint ResourceRef.
+    pub endpoint_ref: ResourceRef,
+    /// Opaque attachment class.
+    pub attachment_class: String,
+}
+
+/// Observed WaylandSession status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisplayObservation {
+    /// Session phase.
+    pub phase: DisplaySessionPhase,
+    /// Optional endpoint attachment.
+    pub attachment: Option<DisplayAttachment>,
+}
+
+/// Resource spec for the delegated WaylandSession.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WaylandSessionSpec {
+    /// Display Provider reference.
+    pub provider_ref: ResourceRef,
+    /// Guest owner reference.
+    pub guest_ref: ResourceRef,
+}
+
+impl WaylandSessionSpec {
+    /// Construct the exact minimal delegated display spec.
+    pub fn new(
+        display_provider_ref: Option<ResourceRef>,
+        guest_ref: ResourceRef,
+    ) -> Result<Self, DisplaySessionError> {
+        let provider_ref = display_provider_ref.ok_or(DisplaySessionError::ProviderMissing)?;
+        if provider_ref.to_canonical_string() != "Provider/display-wayland"
+            || guest_ref.resource_type().as_str() != "Guest"
+        {
+            return Err(DisplaySessionError::InvalidReference);
+        }
+        Ok(Self {
+            provider_ref,
+            guest_ref,
+        })
+    }
+
+    /// Read the endpoint attachment from a Ready status.
+    pub fn endpoint_attachment(
+        observation: &DisplayObservation,
+    ) -> Result<&DisplayAttachment, DisplaySessionError> {
+        if observation.phase != DisplaySessionPhase::Ready {
+            return Err(DisplaySessionError::NotReady);
+        }
+        observation
+            .attachment
+            .as_ref()
+            .ok_or(DisplaySessionError::AttachmentMissing)
+    }
+}
+
+/// Display dependency failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisplaySessionError {
+    /// The Provider ref was omitted.
+    ProviderMissing,
+    /// A ref had the wrong type or Provider.
+    InvalidReference,
+    /// The session is not ready.
+    NotReady,
+    /// A Ready session had no endpoint attachment.
+    AttachmentMissing,
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/hotplug.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/hotplug.rs
@@ -1,0 +1,62 @@
+//! QMP media hotplug orchestration.
+
+use crate::qmp::{QmpError, QmpSession, QmpTransport};
+
+/// Hotplug operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HotplugOperation {
+    /// Attach a Volume.
+    Attach,
+    /// Detach a Volume.
+    Detach,
+}
+
+/// Hotplug result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HotplugResult {
+    /// QMP accepted the transaction.
+    Ready,
+    /// The Guest must retry after a transient QMP failure.
+    Degraded,
+}
+
+/// Typed hotplug controller over one negotiated QMP session.
+pub struct HotplugController<T> {
+    session: QmpSession<T>,
+}
+
+impl<T: QmpTransport> HotplugController<T> {
+    /// Construct a hotplug controller.
+    pub fn new(session: QmpSession<T>) -> Self {
+        Self { session }
+    }
+
+    /// Attach one media fd slot.
+    pub fn attach(
+        &mut self,
+        node_name: &str,
+        fd_slot: i32,
+        read_only: bool,
+    ) -> Result<HotplugResult, QmpError> {
+        self.session
+            .attach_media(node_name, fd_slot, read_only)
+            .map(|_| HotplugResult::Ready)
+    }
+
+    /// Detach one media node.
+    pub fn detach(&mut self, node_name: &str) -> Result<HotplugResult, QmpError> {
+        self.session
+            .detach_media(node_name)
+            .map(|_| HotplugResult::Ready)
+    }
+
+    /// Borrow the QMP command evidence.
+    pub fn commands(&self) -> &[crate::qmp::QmpCommand] {
+        self.session.commands()
+    }
+
+    /// Consume the controller and return its session.
+    pub fn into_session(self) -> QmpSession<T> {
+        self.session
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/media_watch.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/media_watch.rs
@@ -94,6 +94,7 @@ pub struct MediaReadiness {
 pub struct MediaWatch {
     guest_ref: ResourceRef,
     boot_media_ref: Option<ResourceRef>,
+    boot_media_view: String,
     removable_refs: Vec<RemovableVolumeRef>,
 }
 
@@ -107,8 +108,15 @@ impl MediaWatch {
         Self {
             guest_ref,
             boot_media_ref,
+            boot_media_view: "guest-attach".to_owned(),
             removable_refs,
         }
+    }
+
+    /// Set the configured boot Volume view.
+    pub fn with_boot_media_view(mut self, view: impl Into<String>) -> Self {
+        self.boot_media_view = view.into();
+        self
     }
 
     /// Validate all required Volume observations.
@@ -132,7 +140,7 @@ impl MediaWatch {
                 if observation.phase != VolumePhase::Ready {
                     return Err(MediaObservationError::NotReady);
                 }
-                observation.has_virtio_blk_for(&self.guest_ref, "guest-attach")
+                observation.has_virtio_blk_for(&self.guest_ref, &self.boot_media_view)
             }
         };
         if !boot_ready {

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/media_watch.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/media_watch.rs
@@ -1,0 +1,182 @@
+//! Volume readiness and virtio-blk attachment validation.
+
+use d2b_contracts::v3::ResourceRef;
+
+use crate::types::RemovableVolumeRef;
+
+/// Volume phase observed by the controller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VolumePhase {
+    /// Volume is not ready.
+    Pending,
+    /// Volume is ready for attachment.
+    Ready,
+    /// Volume failed closed.
+    Failed,
+    /// Volume was deleted.
+    Deleted,
+}
+
+/// One Volume attachment observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VolumeAttachment {
+    /// Guest execution reference.
+    pub execution_ref: ResourceRef,
+    /// Attachment transport.
+    pub transport: String,
+    /// Named view.
+    pub view: String,
+    /// Access mode.
+    pub access: String,
+}
+
+/// One watched Volume observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VolumeObservation {
+    /// Volume reference.
+    pub volume_ref: ResourceRef,
+    /// Observed Zone.
+    pub zone: String,
+    /// Volume phase.
+    pub phase: VolumePhase,
+    /// Current attachments.
+    pub attachments: Vec<VolumeAttachment>,
+}
+
+impl VolumeObservation {
+    /// Build a pending observation.
+    pub fn pending(volume_ref: ResourceRef) -> Self {
+        Self {
+            volume_ref,
+            zone: "default".to_owned(),
+            phase: VolumePhase::Pending,
+            attachments: Vec::new(),
+        }
+    }
+
+    /// Build a ready virtio-blk observation for hermetic tests.
+    pub fn ready_virtio_blk(volume_ref: ResourceRef) -> Self {
+        let guest_ref = ResourceRef::parse("Guest/media-vm").expect("fixture ref");
+        Self {
+            volume_ref,
+            zone: "default".to_owned(),
+            phase: VolumePhase::Ready,
+            attachments: vec![VolumeAttachment {
+                execution_ref: guest_ref,
+                transport: "virtio-blk".to_owned(),
+                view: "guest-attach".to_owned(),
+                access: "read-only".to_owned(),
+            }],
+        }
+    }
+
+    /// Return whether this Volume has a matching virtio-blk attachment.
+    pub fn has_virtio_blk_for(&self, guest_ref: &ResourceRef, view: &str) -> bool {
+        self.attachments.iter().any(|attachment| {
+            attachment.execution_ref == *guest_ref
+                && attachment.transport == "virtio-blk"
+                && attachment.view == view
+        })
+    }
+}
+
+/// Result of media dependency observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaReadiness {
+    /// Boot media is ready.
+    pub boot_ready: bool,
+    /// All removable media are ready.
+    pub removable_ready: bool,
+}
+
+/// Media dependency watch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaWatch {
+    guest_ref: ResourceRef,
+    boot_media_ref: Option<ResourceRef>,
+    removable_refs: Vec<RemovableVolumeRef>,
+}
+
+impl MediaWatch {
+    /// Construct a media watch.
+    pub fn new(
+        guest_ref: ResourceRef,
+        boot_media_ref: Option<ResourceRef>,
+        removable_refs: Vec<RemovableVolumeRef>,
+    ) -> Self {
+        Self {
+            guest_ref,
+            boot_media_ref,
+            removable_refs,
+        }
+    }
+
+    /// Validate all required Volume observations.
+    pub fn observe(
+        &self,
+        observations: impl IntoIterator<Item = VolumeObservation>,
+    ) -> Result<MediaReadiness, MediaObservationError> {
+        let observations: Vec<_> = observations.into_iter().collect();
+        let find = |reference: &ResourceRef| {
+            observations
+                .iter()
+                .find(|observation| observation.volume_ref == *reference)
+        };
+        let boot_ready = match &self.boot_media_ref {
+            None => true,
+            Some(reference) => {
+                let observation = find(reference).ok_or(MediaObservationError::Missing)?;
+                if observation.phase == VolumePhase::Failed {
+                    return Err(MediaObservationError::Failed);
+                }
+                if observation.phase != VolumePhase::Ready {
+                    return Err(MediaObservationError::NotReady);
+                }
+                observation.has_virtio_blk_for(&self.guest_ref, "guest-attach")
+            }
+        };
+        if !boot_ready {
+            return Err(MediaObservationError::MissingVirtioBlk);
+        }
+        for removable in &self.removable_refs {
+            let observation = find(&removable.volume_ref).ok_or(MediaObservationError::Missing)?;
+            if observation.phase == VolumePhase::Failed {
+                return Err(MediaObservationError::Failed);
+            }
+            if observation.phase != VolumePhase::Ready {
+                return Err(MediaObservationError::NotReady);
+            }
+            if !observation.has_virtio_blk_for(&self.guest_ref, &removable.view) {
+                return Err(MediaObservationError::MissingVirtioBlk);
+            }
+        }
+        Ok(MediaReadiness {
+            boot_ready,
+            removable_ready: true,
+        })
+    }
+}
+
+/// Media dependency observation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaObservationError {
+    /// A required Volume was absent.
+    Missing,
+    /// A Volume was not ready.
+    NotReady,
+    /// A Volume failed.
+    Failed,
+    /// A Volume has no matching virtio-blk attachment.
+    MissingVirtioBlk,
+}
+
+impl MediaObservationError {
+    /// Return the stable condition code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Missing | Self::NotReady => "media-volume-not-ready",
+            Self::Failed => "media-volume-failed",
+            Self::MissingVirtioBlk => "media-volume-access-denied",
+        }
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/mod.rs
@@ -1,0 +1,37 @@
+//! Controller-side dependency and process projections.
+
+pub mod device_watch;
+pub mod display;
+pub mod hotplug;
+pub mod media_watch;
+pub mod network;
+pub mod process_builder;
+pub mod reconcile;
+pub mod status;
+pub mod volume;
+
+pub use device_watch::{
+    AuthorityReservation, DeviceAdmission, DeviceAdmissionError, DeviceObservation, DevicePhase,
+    HostGlobalAuthorityIndex, PlatformClass,
+};
+pub use display::{
+    DisplayAttachment, DisplayObservation, DisplaySessionError, DisplaySessionPhase,
+    WaylandSessionSpec,
+};
+pub use hotplug::{HotplugController, HotplugOperation, HotplugResult};
+pub use media_watch::{
+    MediaObservationError, MediaReadiness, MediaWatch, VolumeAttachment, VolumeObservation,
+    VolumePhase,
+};
+pub use network::{NetworkLaunchError, NetworkLaunchEvent, TapAttachment, TapLaunchRouter};
+pub use process_builder::{
+    AttachmentKind, AttachmentSlot, LaunchTicket, ProcessSpec, ProcessSpecError,
+};
+pub use reconcile::{
+    QemuMediaController, QemuMediaDependencies, QemuMediaEffectPort, QemuMediaError,
+    QemuMediaPhase, QemuMediaReconcileOutcome, QemuMediaRecoveryState,
+};
+pub use status::status_for;
+pub use volume::{
+    LayoutEntry, RuntimeVolumeSpec, RuntimeVolumeView, VolumeLayoutType, VolumeQuota,
+};

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/mod.rs
@@ -26,6 +26,7 @@ pub use media_watch::{
 pub use network::{NetworkLaunchError, NetworkLaunchEvent, TapAttachment, TapLaunchRouter};
 pub use process_builder::{
     AttachmentKind, AttachmentSlot, LaunchTicket, ProcessSpec, ProcessSpecError,
+    build_process_spec, validate_process_spec,
 };
 pub use reconcile::{
     QemuMediaController, QemuMediaDependencies, QemuMediaEffectPort, QemuMediaError,

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/network.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/network.rs
@@ -1,0 +1,106 @@
+//! Opaque Network attachment routing and fd lifetime evidence.
+
+use d2b_contracts::v3::ResourceRef;
+
+/// One connected tap attachment owned by Core until child handoff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TapAttachment {
+    /// Authorizing Network reference.
+    pub network_ref: ResourceRef,
+    /// Whether the parent copy still has close-on-exec set.
+    pub cloexec: bool,
+    /// Whether the parent copy is closed.
+    pub closed: bool,
+}
+
+/// Network routing event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkLaunchEvent {
+    /// Create the persistent tap realization.
+    CreatePersistentTap,
+    /// Apply bridge isolation flags.
+    SetBridgePortFlags,
+    /// Transfer the child fd slot.
+    AttachToLaunchTicket,
+    /// Close all parent fd copies.
+    CloseFdCopies,
+    /// Remove the generation-fenced tap realization.
+    DeletePersistentTap,
+}
+
+/// Network routing failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkLaunchError {
+    /// Network authorization or resolution failed.
+    Unavailable,
+    /// A launch was attempted after the attachment was closed.
+    Closed,
+}
+
+/// Core-owned Network attachment router.
+#[derive(Debug, Clone)]
+pub struct TapLaunchRouter {
+    attachment: TapAttachment,
+    events: Vec<NetworkLaunchEvent>,
+}
+
+impl TapLaunchRouter {
+    /// Prepare a tap attachment in the canonical effect order.
+    pub fn prepare(network_ref: ResourceRef) -> Result<Self, NetworkLaunchError> {
+        if network_ref.resource_type().as_str() != "Network" {
+            return Err(NetworkLaunchError::Unavailable);
+        }
+        Ok(Self {
+            attachment: TapAttachment {
+                network_ref,
+                cloexec: true,
+                closed: false,
+            },
+            events: vec![
+                NetworkLaunchEvent::CreatePersistentTap,
+                NetworkLaunchEvent::SetBridgePortFlags,
+            ],
+        })
+    }
+
+    /// Attach the child slot immediately before spawn.
+    pub fn attach_to_launch_ticket(&mut self) -> Result<(), NetworkLaunchError> {
+        if self.attachment.closed {
+            return Err(NetworkLaunchError::Closed);
+        }
+        self.attachment.cloexec = false;
+        self.events.push(NetworkLaunchEvent::AttachToLaunchTicket);
+        Ok(())
+    }
+
+    /// Record successful child handoff and restore the parent CLOEXEC posture.
+    pub fn child_handoff_complete(&mut self) {
+        self.attachment.cloexec = true;
+    }
+
+    /// Close copies before deleting the tap on a failed launch.
+    pub fn fail_launch(&mut self) {
+        self.attachment.closed = true;
+        self.attachment.cloexec = true;
+        self.events.push(NetworkLaunchEvent::CloseFdCopies);
+        self.events.push(NetworkLaunchEvent::DeletePersistentTap);
+    }
+
+    /// Close copies before normal generation-fenced cleanup.
+    pub fn finish(&mut self) {
+        self.attachment.closed = true;
+        self.attachment.cloexec = true;
+        self.events.push(NetworkLaunchEvent::CloseFdCopies);
+        self.events.push(NetworkLaunchEvent::DeletePersistentTap);
+    }
+
+    /// Borrow the attachment evidence.
+    pub const fn attachment(&self) -> &TapAttachment {
+        &self.attachment
+    }
+
+    /// Borrow the ordered effect evidence.
+    pub fn events(&self) -> &[NetworkLaunchEvent] {
+        &self.events
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/process_builder.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/process_builder.rs
@@ -118,12 +118,26 @@ impl ProcessSpec {
 
     /// Validate the no-ambient-authority Process shape.
     pub fn validate(&self) -> Result<(), ProcessSpecError> {
-        if self.process_class != "worker"
+        if self.provider_ref.to_canonical_string() != PROCESS_PROVIDER_REF
+            || self.execution_ref.resource_type().as_str() != "Host"
+            || self.runtime_volume_ref.resource_type().as_str() != "Volume"
+            || self
+                .device_ref
+                .as_ref()
+                .is_some_and(|reference| reference.resource_type().as_str() != "Device")
+            || self
+                .network_refs
+                .iter()
+                .any(|reference| reference.resource_type().as_str() != "Network")
+            || self.process_class != "worker"
             || self.template != PROCESS_TEMPLATE
+            || self.namespace_classes != ["pid".to_owned(), "mount".to_owned()]
             || !self.capability_classes.is_empty()
             || !self.no_new_privileges
             || !self.read_only_root
+            || self.seccomp_class != "qemu-media-runner"
             || self.restart_policy != "never"
+            || self.desired_lifecycle != "running"
         {
             return Err(ProcessSpecError::InvalidShape);
         }
@@ -195,8 +209,19 @@ impl LaunchTicket {
         self.process.validate()?;
         let mut slots = std::collections::BTreeSet::new();
         for attachment in &self.attachments {
-            if !slots.insert(&attachment.slot) {
+            if !valid_slot(&attachment.slot) || !slots.insert(&attachment.slot) {
                 return Err(ProcessSpecError::DuplicateAttachmentSlot);
+            }
+            let expected = match attachment.kind {
+                AttachmentKind::Kvm => "Device",
+                AttachmentKind::Tap => "Network",
+                AttachmentKind::Media => "Volume",
+                AttachmentKind::Display | AttachmentKind::Qmp | AttachmentKind::Serial => {
+                    "Endpoint"
+                }
+            };
+            if attachment.source_ref.resource_type().as_str() != expected {
+                return Err(ProcessSpecError::InvalidReference);
             }
         }
         Ok(())
@@ -212,4 +237,13 @@ pub enum ProcessSpecError {
     InvalidShape,
     /// Two attachment slots have the same label.
     DuplicateAttachmentSlot,
+}
+
+fn valid_slot(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && value.as_bytes()[0].is_ascii_lowercase()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
 }

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/process_builder.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/process_builder.rs
@@ -1,10 +1,18 @@
-//! Opaque Process ResourceSpec and LaunchTicket construction.
+//! Canonical Process ResourceSpec and LaunchTicket construction.
 
-use d2b_contracts::v3::ResourceRef;
+pub use d2b_contracts::v3::ProcessSpec;
+use d2b_contracts::v3::{
+    DesiredLifecycle, DeviceAccess, DeviceUsageSpec, EnvironmentClass, ExecutionSpec,
+    HealthCheckClass, HealthCheckSpec, MountAccess, MountSpec, NamespaceClass, NetworkUsageSpec,
+    ProcessClass, ReadinessClass, ReadinessSpec, RestartClass, RestartPolicySpec, SandboxSpec,
+    TelemetrySpec,
+};
+use d2b_contracts::v3::{
+    ResourceRef,
+    execution_policy::{BoundedToken, BudgetSpec, CountBudget, DurationMs, ExecutionDomain},
+};
 use serde::{Deserialize, Serialize};
 
-/// Process spec provider.
-pub const PROCESS_PROVIDER_REF: &str = "Provider/system-minijail";
 /// Process template id.
 pub const PROCESS_TEMPLATE: &str = "qemu-media-runner";
 
@@ -38,111 +46,162 @@ pub struct AttachmentSlot {
     pub source_ref: ResourceRef,
 }
 
-/// Canonical qemu-media Process ResourceSpec projection.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct ProcessSpec {
-    /// Process Provider.
-    pub provider_ref: ResourceRef,
-    /// Process execution reference.
-    pub execution_ref: ResourceRef,
-    /// Worker class.
-    pub process_class: String,
-    /// Signed template id.
-    pub template: String,
-    /// Runtime Volume ref.
-    pub runtime_volume_ref: ResourceRef,
-    /// KVM Device ref.
-    pub device_ref: Option<ResourceRef>,
-    /// Network refs.
-    pub network_refs: Vec<ResourceRef>,
-    /// Sandbox classes.
-    pub namespace_classes: Vec<String>,
-    /// Sandbox capabilities.
-    pub capability_classes: Vec<String>,
-    /// Sandbox seccomp class.
-    pub seccomp_class: String,
-    /// Whether no-new-privileges is required.
-    pub no_new_privileges: bool,
-    /// Whether the root filesystem is read-only.
-    pub read_only_root: bool,
-    /// Process restart policy.
-    pub restart_policy: String,
-    /// Desired lifecycle.
-    pub desired_lifecycle: String,
-}
-
-impl ProcessSpec {
-    /// Construct the canonical worker Process spec.
-    pub fn new(
-        guest_ref: ResourceRef,
-        execution_ref: ResourceRef,
-        runtime_volume_ref: ResourceRef,
-        device_ref: Option<ResourceRef>,
-        network_refs: impl IntoIterator<Item = ResourceRef>,
-    ) -> Result<Self, ProcessSpecError> {
-        if guest_ref.resource_type().as_str() != "Guest"
-            || execution_ref.resource_type().as_str() != "Host"
-            || runtime_volume_ref.resource_type().as_str() != "Volume"
-            || device_ref
-                .as_ref()
-                .is_some_and(|reference| reference.resource_type().as_str() != "Device")
-        {
-            return Err(ProcessSpecError::InvalidReference);
-        }
-        let network_refs: Vec<_> = network_refs.into_iter().collect();
-        if network_refs
+/// Construct the canonical qemu-media worker Process base spec.
+pub fn build_process_spec(
+    execution_ref: ResourceRef,
+    runtime_volume_ref: ResourceRef,
+    device_ref: Option<ResourceRef>,
+    network_refs: impl IntoIterator<Item = ResourceRef>,
+) -> Result<ProcessSpec, ProcessSpecError> {
+    if execution_ref.resource_type().as_str() != "Host"
+        || runtime_volume_ref.resource_type().as_str() != "Volume"
+        || device_ref
+            .as_ref()
+            .is_some_and(|reference| reference.resource_type().as_str() != "Device")
+    {
+        return Err(ProcessSpecError::InvalidReference);
+    }
+    let network_refs: Vec<_> = network_refs.into_iter().collect();
+    if network_refs.len() > 1
+        || network_refs
             .iter()
             .any(|reference| reference.resource_type().as_str() != "Network")
-        {
-            return Err(ProcessSpecError::InvalidReference);
-        }
-        Ok(Self {
-            provider_ref: ResourceRef::parse(PROCESS_PROVIDER_REF)
-                .expect("frozen Process Provider ref"),
-            execution_ref,
-            process_class: "worker".to_owned(),
-            template: PROCESS_TEMPLATE.to_owned(),
-            runtime_volume_ref,
-            device_ref,
-            network_refs,
-            namespace_classes: vec!["pid".to_owned(), "mount".to_owned()],
-            capability_classes: Vec::new(),
-            seccomp_class: "qemu-media-runner".to_owned(),
-            no_new_privileges: true,
-            read_only_root: true,
-            restart_policy: "never".to_owned(),
-            desired_lifecycle: "running".to_owned(),
-        })
+    {
+        return Err(ProcessSpecError::InvalidReference);
     }
 
-    /// Validate the no-ambient-authority Process shape.
-    pub fn validate(&self) -> Result<(), ProcessSpecError> {
-        if self.provider_ref.to_canonical_string() != PROCESS_PROVIDER_REF
-            || self.execution_ref.resource_type().as_str() != "Host"
-            || self.runtime_volume_ref.resource_type().as_str() != "Volume"
-            || self
-                .device_ref
-                .as_ref()
-                .is_some_and(|reference| reference.resource_type().as_str() != "Device")
-            || self
-                .network_refs
-                .iter()
-                .any(|reference| reference.resource_type().as_str() != "Network")
-            || self.process_class != "worker"
-            || self.template != PROCESS_TEMPLATE
-            || self.namespace_classes != ["pid".to_owned(), "mount".to_owned()]
-            || !self.capability_classes.is_empty()
-            || !self.no_new_privileges
-            || !self.read_only_root
-            || self.seccomp_class != "qemu-media-runner"
-            || self.restart_policy != "never"
-            || self.desired_lifecycle != "running"
-        {
-            return Err(ProcessSpecError::InvalidShape);
-        }
-        Ok(())
+    let runtime_mount = MountSpec::new(
+        runtime_volume_ref,
+        BoundedToken::parse("runner").map_err(|_| ProcessSpecError::InvalidShape)?,
+        "/run/qemu",
+        MountAccess::ReadWrite,
+        true,
+    )
+    .map_err(|_| ProcessSpecError::InvalidShape)?;
+    let sandbox = SandboxSpec::new(
+        vec![NamespaceClass::Pid, NamespaceClass::Mount],
+        Vec::new(),
+        BoundedToken::parse(PROCESS_TEMPLATE).map_err(|_| ProcessSpecError::InvalidShape)?,
+        true,
+        false,
+        EnvironmentClass::Minimal,
+        true,
+        Some("0022".to_owned()),
+        200,
+        None,
+    )
+    .map_err(|_| ProcessSpecError::InvalidShape)?;
+    let budget = BudgetSpec::new(
+        None,
+        None,
+        Some(CountBudget { limit: Some(512) }),
+        Some(CountBudget { limit: Some(1024) }),
+        None,
+        None,
+        None,
+    )
+    .map_err(|_| ProcessSpecError::InvalidShape)?;
+    let network_usage = network_refs
+        .into_iter()
+        .next()
+        .map(|network_ref| NetworkUsageSpec::new(Some(network_ref), Vec::new(), true))
+        .transpose()
+        .map_err(|_| ProcessSpecError::InvalidShape)?;
+    let device_usage = device_ref
+        .map(|device_ref| {
+            DeviceUsageSpec::new(device_ref, DeviceAccess::Shared, "kvm-acceleration")
+        })
+        .transpose()
+        .map_err(|_| ProcessSpecError::InvalidShape)?
+        .into_iter()
+        .collect();
+    let execution = ExecutionSpec::new(
+        execution_ref,
+        Some(ExecutionDomain::System),
+        None,
+        ProcessClass::Worker,
+        BoundedToken::parse(PROCESS_TEMPLATE).map_err(|_| ProcessSpecError::InvalidShape)?,
+        None,
+        Vec::new(),
+        vec![runtime_mount],
+        sandbox,
+        budget,
+        network_usage,
+        device_usage,
+        TelemetrySpec::default(),
+    )
+    .map_err(|_| ProcessSpecError::InvalidShape)?;
+    let process = ProcessSpec::new(
+        execution,
+        DesiredLifecycle::Running,
+        RestartPolicySpec::new(
+            RestartClass::Never,
+            duration("1s", 0, 60_000)?,
+            duration("60s", 1_000, 3_600_000)?,
+            2_000,
+            None,
+            duration("300s", 0, 86_400_000)?,
+        )
+        .map_err(|_| ProcessSpecError::InvalidShape)?,
+        ReadinessSpec::new(
+            duration("0s", 0, 300_000)?,
+            duration("30s", 1_000, 300_000)?,
+            1,
+            1,
+            ReadinessClass::ProviderDefined,
+        )
+        .map_err(|_| ProcessSpecError::InvalidShape)?,
+        HealthCheckSpec::new(
+            true,
+            duration("10s", 1_000, 3_600_000)?,
+            duration("5s", 1_000, 60_000)?,
+            3,
+            HealthCheckClass::ProviderDefined,
+        )
+        .map_err(|_| ProcessSpecError::InvalidShape)?,
+        d2b_contracts::v3::AdoptionPolicy::AdoptOnRestart,
+        duration("30s", 0, 3_600_000)?,
+    )
+    .map_err(|_| ProcessSpecError::InvalidShape)?;
+    validate_process_spec(&process)?;
+    Ok(process)
+}
+
+/// Validate a qemu-media Process against the canonical v3 Process contract.
+pub fn validate_process_spec(process: &ProcessSpec) -> Result<(), ProcessSpecError> {
+    let encoded = serde_json::to_vec(process).map_err(|_| ProcessSpecError::InvalidShape)?;
+    let decoded: ProcessSpec =
+        serde_json::from_slice(&encoded).map_err(|_| ProcessSpecError::InvalidShape)?;
+    if decoded != *process {
+        return Err(ProcessSpecError::InvalidShape);
     }
+    let execution = process.execution();
+    if execution.execution_ref().resource_type().as_str() != "Host"
+        || execution.process_class() != ProcessClass::Worker
+        || execution.template().as_str() != PROCESS_TEMPLATE
+        || execution.sandbox().namespace_classes() != [NamespaceClass::Pid, NamespaceClass::Mount]
+        || !execution.sandbox().capability_classes().is_empty()
+        || !execution.sandbox().no_new_privileges()
+        || execution.sandbox().start_root()
+        || !execution.sandbox().read_only_root()
+        || execution.sandbox().seccomp_class().as_str() != PROCESS_TEMPLATE
+        || execution.device_usage().len() > 1
+        || process.restart_policy().class() != RestartClass::Never
+        || process.desired_lifecycle() != DesiredLifecycle::Running
+    {
+        return Err(ProcessSpecError::InvalidShape);
+    }
+    if execution.mounts().len() != 1
+        || execution.mounts()[0].mount_path() != "/run/qemu"
+        || execution.mounts()[0].view().as_str() != "runner"
+    {
+        return Err(ProcessSpecError::InvalidShape);
+    }
+    Ok(())
+}
+
+fn duration(value: &str, min_millis: u64, max_millis: u64) -> Result<DurationMs, ProcessSpecError> {
+    DurationMs::parse(value, min_millis, max_millis).map_err(|_| ProcessSpecError::InvalidShape)
 }
 
 /// Opaque Core LaunchTicket.
@@ -162,20 +221,24 @@ impl LaunchTicket {
         media_refs: impl IntoIterator<Item = ResourceRef>,
         display_ref: Option<ResourceRef>,
     ) -> Result<Self, ProcessSpecError> {
-        process.validate()?;
+        validate_process_spec(&process)?;
         let mut attachments = Vec::new();
-        if let Some(device_ref) = &process.device_ref {
+        if let Some(device_ref) = process.execution().device_usage().first() {
             attachments.push(AttachmentSlot {
                 slot: "kvm".to_owned(),
                 kind: AttachmentKind::Kvm,
-                source_ref: device_ref.clone(),
+                source_ref: device_ref.device_ref().clone(),
             });
         }
-        for (index, reference) in process.network_refs.iter().enumerate() {
+        if let Some(network_ref) = process
+            .execution()
+            .network_usage()
+            .and_then(|usage| usage.network_ref())
+        {
             attachments.push(AttachmentSlot {
-                slot: format!("tap-{index}"),
+                slot: "tap-0".to_owned(),
                 kind: AttachmentKind::Tap,
-                source_ref: reference.clone(),
+                source_ref: network_ref.clone(),
             });
         }
         for (index, reference) in media_refs.into_iter().enumerate() {
@@ -206,7 +269,7 @@ impl LaunchTicket {
 
     /// Validate unique slot labels and typed sources.
     pub fn validate(&self) -> Result<(), ProcessSpecError> {
-        self.process.validate()?;
+        validate_process_spec(&self.process)?;
         let mut slots = std::collections::BTreeSet::new();
         for attachment in &self.attachments {
             if !valid_slot(&attachment.slot) || !slots.insert(&attachment.slot) {

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/process_builder.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/process_builder.rs
@@ -1,0 +1,215 @@
+//! Opaque Process ResourceSpec and LaunchTicket construction.
+
+use d2b_contracts::v3::ResourceRef;
+use serde::{Deserialize, Serialize};
+
+/// Process spec provider.
+pub const PROCESS_PROVIDER_REF: &str = "Provider/system-minijail";
+/// Process template id.
+pub const PROCESS_TEMPLATE: &str = "qemu-media-runner";
+
+/// Attachment kind delivered through Core's private LaunchTicket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AttachmentKind {
+    /// KVM device fd.
+    Kvm,
+    /// Network tap fd.
+    Tap,
+    /// Media Volume fd.
+    Media,
+    /// Wayland display fd.
+    Display,
+    /// QMP Endpoint connection.
+    Qmp,
+    /// Serial Endpoint connection.
+    Serial,
+}
+
+/// One opaque LaunchTicket slot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AttachmentSlot {
+    /// Slot label.
+    pub slot: String,
+    /// Slot kind.
+    pub kind: AttachmentKind,
+    /// Authorizing ResourceRef.
+    pub source_ref: ResourceRef,
+}
+
+/// Canonical qemu-media Process ResourceSpec projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProcessSpec {
+    /// Process Provider.
+    pub provider_ref: ResourceRef,
+    /// Process execution reference.
+    pub execution_ref: ResourceRef,
+    /// Worker class.
+    pub process_class: String,
+    /// Signed template id.
+    pub template: String,
+    /// Runtime Volume ref.
+    pub runtime_volume_ref: ResourceRef,
+    /// KVM Device ref.
+    pub device_ref: Option<ResourceRef>,
+    /// Network refs.
+    pub network_refs: Vec<ResourceRef>,
+    /// Sandbox classes.
+    pub namespace_classes: Vec<String>,
+    /// Sandbox capabilities.
+    pub capability_classes: Vec<String>,
+    /// Sandbox seccomp class.
+    pub seccomp_class: String,
+    /// Whether no-new-privileges is required.
+    pub no_new_privileges: bool,
+    /// Whether the root filesystem is read-only.
+    pub read_only_root: bool,
+    /// Process restart policy.
+    pub restart_policy: String,
+    /// Desired lifecycle.
+    pub desired_lifecycle: String,
+}
+
+impl ProcessSpec {
+    /// Construct the canonical worker Process spec.
+    pub fn new(
+        guest_ref: ResourceRef,
+        execution_ref: ResourceRef,
+        runtime_volume_ref: ResourceRef,
+        device_ref: Option<ResourceRef>,
+        network_refs: impl IntoIterator<Item = ResourceRef>,
+    ) -> Result<Self, ProcessSpecError> {
+        if guest_ref.resource_type().as_str() != "Guest"
+            || execution_ref.resource_type().as_str() != "Host"
+            || runtime_volume_ref.resource_type().as_str() != "Volume"
+            || device_ref
+                .as_ref()
+                .is_some_and(|reference| reference.resource_type().as_str() != "Device")
+        {
+            return Err(ProcessSpecError::InvalidReference);
+        }
+        let network_refs: Vec<_> = network_refs.into_iter().collect();
+        if network_refs
+            .iter()
+            .any(|reference| reference.resource_type().as_str() != "Network")
+        {
+            return Err(ProcessSpecError::InvalidReference);
+        }
+        Ok(Self {
+            provider_ref: ResourceRef::parse(PROCESS_PROVIDER_REF)
+                .expect("frozen Process Provider ref"),
+            execution_ref,
+            process_class: "worker".to_owned(),
+            template: PROCESS_TEMPLATE.to_owned(),
+            runtime_volume_ref,
+            device_ref,
+            network_refs,
+            namespace_classes: vec!["pid".to_owned(), "mount".to_owned()],
+            capability_classes: Vec::new(),
+            seccomp_class: "qemu-media-runner".to_owned(),
+            no_new_privileges: true,
+            read_only_root: true,
+            restart_policy: "never".to_owned(),
+            desired_lifecycle: "running".to_owned(),
+        })
+    }
+
+    /// Validate the no-ambient-authority Process shape.
+    pub fn validate(&self) -> Result<(), ProcessSpecError> {
+        if self.process_class != "worker"
+            || self.template != PROCESS_TEMPLATE
+            || !self.capability_classes.is_empty()
+            || !self.no_new_privileges
+            || !self.read_only_root
+            || self.restart_policy != "never"
+        {
+            return Err(ProcessSpecError::InvalidShape);
+        }
+        Ok(())
+    }
+}
+
+/// Opaque Core LaunchTicket.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LaunchTicket {
+    /// Process resource template.
+    pub process: ProcessSpec,
+    /// Authorized attachment slots.
+    pub attachments: Vec<AttachmentSlot>,
+}
+
+impl LaunchTicket {
+    /// Construct a ticket from already-authorized refs.
+    pub fn new(
+        process: ProcessSpec,
+        media_refs: impl IntoIterator<Item = ResourceRef>,
+        display_ref: Option<ResourceRef>,
+    ) -> Result<Self, ProcessSpecError> {
+        process.validate()?;
+        let mut attachments = Vec::new();
+        if let Some(device_ref) = &process.device_ref {
+            attachments.push(AttachmentSlot {
+                slot: "kvm".to_owned(),
+                kind: AttachmentKind::Kvm,
+                source_ref: device_ref.clone(),
+            });
+        }
+        for (index, reference) in process.network_refs.iter().enumerate() {
+            attachments.push(AttachmentSlot {
+                slot: format!("tap-{index}"),
+                kind: AttachmentKind::Tap,
+                source_ref: reference.clone(),
+            });
+        }
+        for (index, reference) in media_refs.into_iter().enumerate() {
+            if reference.resource_type().as_str() != "Volume" {
+                return Err(ProcessSpecError::InvalidReference);
+            }
+            attachments.push(AttachmentSlot {
+                slot: format!("media-{index}"),
+                kind: AttachmentKind::Media,
+                source_ref: reference,
+            });
+        }
+        if let Some(reference) = display_ref {
+            if reference.resource_type().as_str() != "Endpoint" {
+                return Err(ProcessSpecError::InvalidReference);
+            }
+            attachments.push(AttachmentSlot {
+                slot: "display".to_owned(),
+                kind: AttachmentKind::Display,
+                source_ref: reference,
+            });
+        }
+        Ok(Self {
+            process,
+            attachments,
+        })
+    }
+
+    /// Validate unique slot labels and typed sources.
+    pub fn validate(&self) -> Result<(), ProcessSpecError> {
+        self.process.validate()?;
+        let mut slots = std::collections::BTreeSet::new();
+        for attachment in &self.attachments {
+            if !slots.insert(&attachment.slot) {
+                return Err(ProcessSpecError::DuplicateAttachmentSlot);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Process spec failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessSpecError {
+    /// A reference has the wrong ResourceType.
+    InvalidReference,
+    /// The canonical Process shape was changed.
+    InvalidShape,
+    /// Two attachment slots have the same label.
+    DuplicateAttachmentSlot,
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
@@ -68,7 +68,7 @@ pub enum QemuMediaError {
     QmpNotReady,
     /// Finalization could not prove process closure.
     FinalizationIncomplete,
-    /// The controller was already finalized.
+    /// The controller cannot accept a normal reconcile transition.
     InvalidState,
 }
 
@@ -336,7 +336,12 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
         dependencies: &QemuMediaDependencies,
         effect: &mut E,
     ) -> Result<QemuMediaReconcileOutcome, QemuMediaError> {
-        if !self.finalizer_installed {
+        if !self.finalizer_installed
+            || matches!(
+                self.phase,
+                QemuMediaPhase::Failed | QemuMediaPhase::Finalizing | QemuMediaPhase::Finalized
+            )
+        {
             return Err(QemuMediaError::InvalidState);
         }
         let Some(device) = dependencies.device.as_ref() else {
@@ -410,6 +415,8 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
             if self.initial_qmp_wait_pending
                 && dependencies.qmp_elapsed_seconds >= self.config.qmp_ready_timeout_seconds
             {
+                self.initial_qmp_wait_pending = false;
+                self.phase = QemuMediaPhase::Failed;
                 if effect.stop(&identity).is_ok() && matches!(effect.observe(), Ok(None)) {
                     self.process_stopped = true;
                     if self.authority_reserved && !self.authority_released {
@@ -418,7 +425,6 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
                         self.authority_reserved = false;
                     }
                 }
-                self.phase = QemuMediaPhase::Failed;
                 return Err(QemuMediaError::QmpNotReady);
             }
             self.phase = if self.initial_qmp_wait_pending {

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
@@ -1,0 +1,368 @@
+//! QEMU media Guest lifecycle controller.
+
+use crate::{
+    adoption::{AdoptionOutcome, ProcessIdentity, verify_identity},
+    config::{ProviderConfig, ProviderConfigError},
+    controller::{
+        DeviceAdmission, DeviceAdmissionError, DeviceObservation, LaunchTicket, ProcessSpec,
+        ProcessSpecError,
+    },
+    qmp::QmpVmStatus,
+    types::{GuestProviderSpecSettings, GuestSpecError},
+};
+use d2b_contracts::v3::ResourceRef;
+use std::marker::PhantomData;
+
+/// QEMU media lifecycle phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QemuMediaPhase {
+    /// Dependencies are pending.
+    Pending,
+    /// The QEMU Process is starting.
+    Starting,
+    /// Waiting for QMP greeting and capability negotiation.
+    WaitingQmp,
+    /// QEMU is paused after QMP readiness.
+    PausedAtBoot,
+    /// QEMU is running.
+    Ready,
+    /// A retryable observation or cleanup failed.
+    Degraded,
+    /// The current generation failed closed.
+    Failed,
+    /// Finalizer cleanup is in progress.
+    Finalizing,
+    /// Finalizer cleanup completed.
+    Finalized,
+}
+
+/// Reconcile result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QemuMediaReconcileOutcome {
+    /// Process and device health converged.
+    Ready,
+    /// Dependencies or health require a retry.
+    Retry {
+        /// Suggested retry delay in milliseconds.
+        after_ms: u32,
+    },
+    /// The current state was degraded but not terminal.
+    Degraded,
+}
+
+/// Closed QEMU media controller failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QemuMediaError {
+    /// Provider or Process configuration is invalid.
+    InvalidConfiguration,
+    /// A dependency is absent or not ready.
+    DependencyNotReady,
+    /// Device admission failed.
+    Device(DeviceAdmissionError),
+    /// Process identity was ambiguous.
+    AdoptionAmbiguous,
+    /// A typed effect failed.
+    Effect,
+    /// QMP health did not become ready.
+    QmpNotReady,
+    /// Finalization could not prove process closure.
+    FinalizationIncomplete,
+    /// The controller was already finalized.
+    InvalidState,
+}
+
+impl QemuMediaError {
+    /// Return the stable Provider error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::InvalidConfiguration => "runtime-qemu-media-invalid-configuration",
+            Self::DependencyNotReady => "dependency-not-ready",
+            Self::Device(error) => error.code(),
+            Self::AdoptionAmbiguous => "process-adoption-ambiguous",
+            Self::Effect => "runtime-qemu-media-effect-failed",
+            Self::QmpNotReady => "qmp-greeting-timeout",
+            Self::FinalizationIncomplete => "runtime-qemu-media-finalization-incomplete",
+            Self::InvalidState => "runtime-qemu-media-invalid-state",
+        }
+    }
+}
+
+impl core::fmt::Display for QemuMediaError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for QemuMediaError {}
+
+impl From<ProviderConfigError> for QemuMediaError {
+    fn from(_: ProviderConfigError) -> Self {
+        Self::InvalidConfiguration
+    }
+}
+
+impl From<GuestSpecError> for QemuMediaError {
+    fn from(_: GuestSpecError) -> Self {
+        Self::InvalidConfiguration
+    }
+}
+
+impl From<ProcessSpecError> for QemuMediaError {
+    fn from(_: ProcessSpecError) -> Self {
+        Self::InvalidConfiguration
+    }
+}
+
+/// Dependency snapshot supplied by Core's authenticated watch path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QemuMediaDependencies {
+    /// KVM Device observation.
+    pub device: Option<DeviceObservation>,
+    /// Network dependencies are all ready.
+    pub network_ready: bool,
+    /// Media Volume dependencies are all ready.
+    pub media_ready: bool,
+    /// Optional display dependency is ready.
+    pub display_ready: bool,
+    /// QMP Endpoint greeting and capability exchange completed.
+    pub qmp_ready: bool,
+    /// Current QMP VM state.
+    pub qmp_status: Option<QmpVmStatus>,
+}
+
+impl Default for QemuMediaDependencies {
+    fn default() -> Self {
+        Self {
+            device: None,
+            network_ready: false,
+            media_ready: false,
+            display_ready: true,
+            qmp_ready: false,
+            qmp_status: None,
+        }
+    }
+}
+
+impl QemuMediaDependencies {
+    /// Construct a fully-ready dependency snapshot.
+    pub fn ready(device: DeviceObservation) -> Self {
+        Self {
+            device: Some(device),
+            network_ready: true,
+            media_ready: true,
+            display_ready: true,
+            qmp_ready: true,
+            qmp_status: Some(QmpVmStatus::Paused),
+        }
+    }
+}
+
+/// Typed effect boundary owned by Core/ProviderSupervisor.
+pub trait QemuMediaEffectPort {
+    /// Launch the broker-spawned Process from an opaque LaunchTicket.
+    fn launch(&mut self, ticket: &LaunchTicket) -> Result<ProcessIdentity, QemuMediaError>;
+    /// Observe an existing candidate without opening a pidfd.
+    fn observe(&mut self) -> Result<Option<ProcessIdentity>, QemuMediaError>;
+    /// Open a pidfd after identity verification.
+    fn open_pidfd(&mut self, identity: &ProcessIdentity) -> Result<(), QemuMediaError>;
+    /// Close all QMP/media effects before stopping the Process.
+    fn close_media_effects(&mut self) -> Result<(), QemuMediaError> {
+        Ok(())
+    }
+    /// Stop exactly one verified Process.
+    fn stop(&mut self, identity: &ProcessIdentity) -> Result<(), QemuMediaError>;
+    /// Release the retained Host-global Device authority.
+    fn release_device_authority(&mut self) -> Result<(), QemuMediaError> {
+        Ok(())
+    }
+    /// Delete the controller-created runtime Volume after Process exit.
+    fn delete_runtime_volume(&mut self) -> Result<(), QemuMediaError> {
+        Ok(())
+    }
+}
+
+/// Durable non-secret recovery state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QemuMediaRecoveryState {
+    /// Current phase.
+    pub phase: QemuMediaPhase,
+    /// Whether the finalizer remains installed.
+    pub finalizer_installed: bool,
+    /// Expected process identity, if a prior launch committed it.
+    pub expected_identity: Option<ProcessIdentity>,
+}
+
+/// QEMU media lifecycle controller.
+pub struct QemuMediaController<E> {
+    config: ProviderConfig,
+    settings: GuestProviderSpecSettings,
+    process: ProcessSpec,
+    guest_ref: ResourceRef,
+    phase: QemuMediaPhase,
+    expected_identity: Option<ProcessIdentity>,
+    finalizer_installed: bool,
+    marker: PhantomData<E>,
+}
+
+impl<E> QemuMediaController<E> {
+    /// Construct a controller with explicit Provider and Process contracts.
+    pub fn new(
+        config: ProviderConfig,
+        settings: GuestProviderSpecSettings,
+        process: ProcessSpec,
+        guest_ref: ResourceRef,
+    ) -> Result<Self, QemuMediaError> {
+        config.validate()?;
+        settings.validate()?;
+        process.validate()?;
+        if guest_ref.resource_type().as_str() != "Guest" {
+            return Err(QemuMediaError::InvalidConfiguration);
+        }
+        Ok(Self {
+            config,
+            settings,
+            process,
+            guest_ref,
+            phase: QemuMediaPhase::Pending,
+            expected_identity: None,
+            finalizer_installed: true,
+            marker: PhantomData,
+        })
+    }
+
+    /// Return the current phase.
+    pub const fn phase(&self) -> QemuMediaPhase {
+        self.phase
+    }
+
+    /// Return whether the Guest finalizer remains installed.
+    pub const fn finalizer_installed(&self) -> bool {
+        self.finalizer_installed
+    }
+
+    /// Set the durable expected identity used for restart adoption.
+    pub fn set_expected_identity(&mut self, identity: ProcessIdentity) {
+        self.expected_identity = Some(identity);
+    }
+
+    /// Export non-secret restart state.
+    pub fn recovery_state(&self) -> QemuMediaRecoveryState {
+        QemuMediaRecoveryState {
+            phase: self.phase,
+            finalizer_installed: self.finalizer_installed,
+            expected_identity: self.expected_identity.clone(),
+        }
+    }
+
+    /// Restore non-secret restart state.
+    pub fn restore_recovery_state(
+        mut self,
+        recovery: QemuMediaRecoveryState,
+    ) -> Result<Self, QemuMediaError> {
+        if !recovery.finalizer_installed && recovery.phase != QemuMediaPhase::Finalized {
+            return Err(QemuMediaError::InvalidConfiguration);
+        }
+        self.phase = recovery.phase;
+        self.finalizer_installed = recovery.finalizer_installed;
+        self.expected_identity = recovery.expected_identity;
+        Ok(self)
+    }
+
+    /// Test-only state setup used by hermetic finalizer tests.
+    #[doc(hidden)]
+    pub fn mark_ready_for_test(&mut self) {
+        self.phase = QemuMediaPhase::Ready;
+        self.finalizer_installed = true;
+    }
+}
+
+impl<E: QemuMediaEffectPort> QemuMediaController<E> {
+    /// Reconcile dependencies, process identity, and QMP readiness.
+    pub fn reconcile(
+        &mut self,
+        dependencies: &QemuMediaDependencies,
+        effect: &mut E,
+    ) -> Result<QemuMediaReconcileOutcome, QemuMediaError> {
+        if !self.finalizer_installed {
+            return Err(QemuMediaError::InvalidState);
+        }
+        let Some(device) = dependencies.device.as_ref() else {
+            self.phase = QemuMediaPhase::Pending;
+            return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 500 });
+        };
+        if !dependencies.network_ready
+            || !dependencies.media_ready
+            || (self.settings.display_window && !dependencies.display_ready)
+        {
+            self.phase = QemuMediaPhase::Pending;
+            return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 500 });
+        }
+        let expected_process = device.process_identity.as_deref().unwrap_or("qemu-media");
+        DeviceAdmission::validate(&self.guest_ref, device, expected_process, "qemu-media/v1")
+            .map_err(QemuMediaError::Device)?;
+
+        let observed = effect.observe()?;
+        let identity = match observed {
+            Some(candidate) => {
+                let Some(expected) = self.expected_identity.as_ref() else {
+                    self.phase = QemuMediaPhase::Degraded;
+                    return Err(QemuMediaError::AdoptionAmbiguous);
+                };
+                if verify_identity(expected, &candidate) != AdoptionOutcome::Adopted {
+                    self.phase = QemuMediaPhase::Degraded;
+                    return Err(QemuMediaError::AdoptionAmbiguous);
+                }
+                self.phase = QemuMediaPhase::Starting;
+                effect.open_pidfd(&candidate)?;
+                candidate
+            }
+            None => {
+                self.phase = QemuMediaPhase::Starting;
+                let ticket =
+                    LaunchTicket::new(self.process.clone(), Vec::<ResourceRef>::new(), None)?;
+                let candidate = effect.launch(&ticket)?;
+                self.expected_identity = Some(candidate.clone());
+                effect.open_pidfd(&candidate)?;
+                candidate
+            }
+        };
+
+        if !dependencies.qmp_ready {
+            self.phase = QemuMediaPhase::WaitingQmp;
+            return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 250 });
+        }
+        self.expected_identity = Some(identity);
+        self.phase = if self.settings.pause_at_boot {
+            QemuMediaPhase::PausedAtBoot
+        } else {
+            QemuMediaPhase::Ready
+        };
+        Ok(QemuMediaReconcileOutcome::Ready)
+    }
+
+    /// Finalize QMP/media effects, then stop the Process and release authority.
+    pub fn finalize(&mut self, effect: &mut E) -> Result<(), QemuMediaError> {
+        if !self.finalizer_installed {
+            return Ok(());
+        }
+        self.phase = QemuMediaPhase::Finalizing;
+        effect.close_media_effects()?;
+        if let Some(identity) = self.expected_identity.as_ref() {
+            effect.stop(identity)?;
+            if effect.observe()?.is_some() {
+                self.phase = QemuMediaPhase::Degraded;
+                return Err(QemuMediaError::FinalizationIncomplete);
+            }
+        }
+        effect.release_device_authority()?;
+        effect.delete_runtime_volume()?;
+        self.finalizer_installed = false;
+        self.phase = QemuMediaPhase::Finalized;
+        Ok(())
+    }
+
+    /// Borrow the controller's Provider configuration projection.
+    pub const fn config(&self) -> &ProviderConfig {
+        &self.config
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
@@ -3,7 +3,7 @@
 use crate::{
     adoption::{AdoptionOutcome, ProcessIdentity, verify_identity},
     config::{ProviderConfig, ProviderConfigError},
-    controller::process_builder::PROCESS_TEMPLATE,
+    controller::process_builder::{PROCESS_TEMPLATE, validate_process_spec},
     controller::{
         DeviceAdmission, DeviceAdmissionError, DeviceObservation, LaunchTicket, ProcessSpec,
         ProcessSpecError,
@@ -242,7 +242,7 @@ impl<E> QemuMediaController<E> {
         config.validate()?;
         let config = config.project_controller();
         settings.validate()?;
-        process.validate()?;
+        validate_process_spec(&process)?;
         if guest_ref.resource_type().as_str() != "Guest" {
             return Err(QemuMediaError::InvalidConfiguration);
         }

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
@@ -321,6 +321,10 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
                 let ticket =
                     LaunchTicket::new(self.process.clone(), Vec::<ResourceRef>::new(), None)?;
                 let candidate = effect.launch(&ticket)?;
+                if !candidate.matches_process_token(expected_process) {
+                    self.phase = QemuMediaPhase::Failed;
+                    return Err(QemuMediaError::AdoptionAmbiguous);
+                }
                 self.expected_identity = Some(candidate.clone());
                 effect.open_pidfd(&candidate)?;
                 candidate

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
@@ -3,6 +3,7 @@
 use crate::{
     adoption::{AdoptionOutcome, ProcessIdentity, verify_identity},
     config::{ProviderConfig, ProviderConfigError},
+    controller::process_builder::PROCESS_TEMPLATE,
     controller::{
         DeviceAdmission, DeviceAdmissionError, DeviceObservation, LaunchTicket, ProcessSpec,
         ProcessSpecError,
@@ -128,6 +129,14 @@ pub struct QemuMediaDependencies {
     pub qmp_ready: bool,
     /// Current QMP VM state.
     pub qmp_status: Option<QmpVmStatus>,
+    /// Authorized media Volume refs for the LaunchTicket.
+    pub media_refs: Vec<ResourceRef>,
+    /// Authorized display Endpoint ref for the LaunchTicket.
+    pub display_ref: Option<ResourceRef>,
+    /// Controller-created runtime Volume is Ready.
+    pub runtime_volume_ready: bool,
+    /// Elapsed seconds since runner launch while waiting for QMP.
+    pub qmp_elapsed_seconds: u32,
 }
 
 impl Default for QemuMediaDependencies {
@@ -139,6 +148,10 @@ impl Default for QemuMediaDependencies {
             display_ready: true,
             qmp_ready: false,
             qmp_status: None,
+            media_refs: Vec::new(),
+            display_ref: None,
+            runtime_volume_ready: false,
+            qmp_elapsed_seconds: 0,
         }
     }
 }
@@ -153,6 +166,10 @@ impl QemuMediaDependencies {
             display_ready: true,
             qmp_ready: true,
             qmp_status: Some(QmpVmStatus::Paused),
+            media_refs: Vec::new(),
+            display_ref: None,
+            runtime_volume_ready: true,
+            qmp_elapsed_seconds: 0,
         }
     }
 }
@@ -165,20 +182,22 @@ pub trait QemuMediaEffectPort {
     fn observe(&mut self) -> Result<Option<ProcessIdentity>, QemuMediaError>;
     /// Open a pidfd after identity verification.
     fn open_pidfd(&mut self, identity: &ProcessIdentity) -> Result<(), QemuMediaError>;
+    /// Reserve the Host-global Device authority before launch or adoption.
+    fn reserve_device_authority(
+        &mut self,
+        authority_key: [u8; 32],
+        owner_ref: &ResourceRef,
+    ) -> Result<(), QemuMediaError>;
     /// Close all QMP/media effects before stopping the Process.
-    fn close_media_effects(&mut self) -> Result<(), QemuMediaError> {
-        Ok(())
-    }
+    fn close_media_effects(&mut self) -> Result<(), QemuMediaError>;
+    /// Continue a paused Guest when pauseAtBoot is false.
+    fn continue_guest(&mut self) -> Result<(), QemuMediaError>;
     /// Stop exactly one verified Process.
     fn stop(&mut self, identity: &ProcessIdentity) -> Result<(), QemuMediaError>;
     /// Release the retained Host-global Device authority.
-    fn release_device_authority(&mut self) -> Result<(), QemuMediaError> {
-        Ok(())
-    }
+    fn release_device_authority(&mut self) -> Result<(), QemuMediaError>;
     /// Delete the controller-created runtime Volume after Process exit.
-    fn delete_runtime_volume(&mut self) -> Result<(), QemuMediaError> {
-        Ok(())
-    }
+    fn delete_runtime_volume(&mut self) -> Result<(), QemuMediaError>;
 }
 
 /// Durable non-secret recovery state.
@@ -190,17 +209,25 @@ pub struct QemuMediaRecoveryState {
     pub finalizer_installed: bool,
     /// Expected process identity, if a prior launch committed it.
     pub expected_identity: Option<ProcessIdentity>,
+    /// Whether authority was reserved.
+    pub authority_reserved: bool,
 }
 
 /// QEMU media lifecycle controller.
 pub struct QemuMediaController<E> {
-    config: ProviderConfig,
+    config: crate::config::ControllerConfigProjection,
     settings: GuestProviderSpecSettings,
     process: ProcessSpec,
     guest_ref: ResourceRef,
     phase: QemuMediaPhase,
     expected_identity: Option<ProcessIdentity>,
     finalizer_installed: bool,
+    authority_reserved: bool,
+    pidfd_opened: bool,
+    media_closed: bool,
+    process_stopped: bool,
+    authority_released: bool,
+    runtime_volume_deleted: bool,
     marker: PhantomData<E>,
 }
 
@@ -213,6 +240,7 @@ impl<E> QemuMediaController<E> {
         guest_ref: ResourceRef,
     ) -> Result<Self, QemuMediaError> {
         config.validate()?;
+        let config = config.project_controller();
         settings.validate()?;
         process.validate()?;
         if guest_ref.resource_type().as_str() != "Guest" {
@@ -226,6 +254,12 @@ impl<E> QemuMediaController<E> {
             phase: QemuMediaPhase::Pending,
             expected_identity: None,
             finalizer_installed: true,
+            authority_reserved: false,
+            pidfd_opened: false,
+            media_closed: false,
+            process_stopped: false,
+            authority_released: false,
+            runtime_volume_deleted: false,
             marker: PhantomData,
         })
     }
@@ -251,6 +285,7 @@ impl<E> QemuMediaController<E> {
             phase: self.phase,
             finalizer_installed: self.finalizer_installed,
             expected_identity: self.expected_identity.clone(),
+            authority_reserved: self.authority_reserved,
         }
     }
 
@@ -265,6 +300,13 @@ impl<E> QemuMediaController<E> {
         self.phase = recovery.phase;
         self.finalizer_installed = recovery.finalizer_installed;
         self.expected_identity = recovery.expected_identity;
+        self.authority_reserved =
+            recovery.authority_reserved && recovery.phase != QemuMediaPhase::Finalized;
+        self.pidfd_opened = false;
+        self.media_closed = false;
+        self.process_stopped = recovery.phase == QemuMediaPhase::Finalized;
+        self.authority_released = recovery.phase == QemuMediaPhase::Finalized;
+        self.runtime_volume_deleted = recovery.phase == QemuMediaPhase::Finalized;
         Ok(self)
     }
 
@@ -273,6 +315,7 @@ impl<E> QemuMediaController<E> {
     pub fn mark_ready_for_test(&mut self) {
         self.phase = QemuMediaPhase::Ready;
         self.finalizer_installed = true;
+        self.authority_reserved = true;
     }
 }
 
@@ -292,14 +335,19 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
         };
         if !dependencies.network_ready
             || !dependencies.media_ready
+            || !dependencies.runtime_volume_ready
             || (self.settings.display_window && !dependencies.display_ready)
         {
             self.phase = QemuMediaPhase::Pending;
             return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 500 });
         }
-        let expected_process = device.process_identity.as_deref().unwrap_or("qemu-media");
+        let expected_process = PROCESS_TEMPLATE;
         DeviceAdmission::validate(&self.guest_ref, device, expected_process, "qemu-media/v1")
             .map_err(QemuMediaError::Device)?;
+        if !self.authority_reserved {
+            effect.reserve_device_authority(device.authority_key, &self.guest_ref)?;
+            self.authority_reserved = true;
+        }
 
         let observed = effect.observe()?;
         let identity = match observed {
@@ -313,27 +361,73 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
                     return Err(QemuMediaError::AdoptionAmbiguous);
                 }
                 self.phase = QemuMediaPhase::Starting;
-                effect.open_pidfd(&candidate)?;
+                if !self.pidfd_opened {
+                    effect.open_pidfd(&candidate)?;
+                    self.pidfd_opened = true;
+                }
                 candidate
             }
             None => {
-                self.phase = QemuMediaPhase::Starting;
-                let ticket =
-                    LaunchTicket::new(self.process.clone(), Vec::<ResourceRef>::new(), None)?;
-                let candidate = effect.launch(&ticket)?;
-                if !candidate.matches_process_token(expected_process) {
+                if self.expected_identity.is_some() {
                     self.phase = QemuMediaPhase::Failed;
                     return Err(QemuMediaError::AdoptionAmbiguous);
                 }
+                self.phase = QemuMediaPhase::Starting;
+                let ticket = LaunchTicket::new(
+                    self.process.clone(),
+                    dependencies.media_refs.clone(),
+                    dependencies.display_ref.clone(),
+                )?;
+                let candidate = effect.launch(&ticket)?;
+                if !candidate.matches_process_token(expected_process) {
+                    let _ = effect.stop(&candidate);
+                    self.phase = QemuMediaPhase::Failed;
+                    return Err(QemuMediaError::AdoptionAmbiguous);
+                }
+                if let Err(error) = effect.open_pidfd(&candidate) {
+                    let _ = effect.stop(&candidate);
+                    self.phase = QemuMediaPhase::Failed;
+                    return Err(error);
+                }
+                self.pidfd_opened = true;
                 self.expected_identity = Some(candidate.clone());
-                effect.open_pidfd(&candidate)?;
                 candidate
             }
         };
 
         if !dependencies.qmp_ready {
+            if dependencies.qmp_elapsed_seconds >= self.config.qmp_ready_timeout_seconds {
+                if effect.stop(&identity).is_ok() && matches!(effect.observe(), Ok(None)) {
+                    self.process_stopped = true;
+                    if self.authority_reserved && !self.authority_released {
+                        effect.release_device_authority()?;
+                        self.authority_released = true;
+                        self.authority_reserved = false;
+                    }
+                }
+                self.phase = QemuMediaPhase::Failed;
+                return Err(QemuMediaError::QmpNotReady);
+            }
             self.phase = QemuMediaPhase::WaitingQmp;
             return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 250 });
+        }
+        let Some(qmp_status) = dependencies.qmp_status else {
+            self.phase = QemuMediaPhase::WaitingQmp;
+            return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 250 });
+        };
+        match qmp_status {
+            QmpVmStatus::Stopped => {
+                self.phase = QemuMediaPhase::Failed;
+                return Err(QemuMediaError::QmpNotReady);
+            }
+            QmpVmStatus::Paused if !self.settings.pause_at_boot => {
+                effect.continue_guest()?;
+            }
+            QmpVmStatus::Running if self.settings.pause_at_boot => {
+                self.phase = QemuMediaPhase::Degraded;
+                return Err(QemuMediaError::QmpNotReady);
+            }
+            QmpVmStatus::Paused | QmpVmStatus::Running => {}
         }
         self.expected_identity = Some(identity);
         self.phase = if self.settings.pause_at_boot {
@@ -350,23 +444,53 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
             return Ok(());
         }
         self.phase = QemuMediaPhase::Finalizing;
-        effect.close_media_effects()?;
+        if !self.media_closed {
+            effect.close_media_effects()?;
+            self.media_closed = true;
+        }
+        let observed = effect.observe()?;
+        if self.expected_identity.is_none() && observed.is_some() {
+            self.phase = QemuMediaPhase::Degraded;
+            return Err(QemuMediaError::AdoptionAmbiguous);
+        }
         if let Some(identity) = self.expected_identity.as_ref() {
-            effect.stop(identity)?;
-            if effect.observe()?.is_some() {
-                self.phase = QemuMediaPhase::Degraded;
-                return Err(QemuMediaError::FinalizationIncomplete);
+            if let Some(candidate) = observed {
+                if verify_identity(identity, &candidate) != AdoptionOutcome::Adopted {
+                    self.phase = QemuMediaPhase::Degraded;
+                    return Err(QemuMediaError::AdoptionAmbiguous);
+                }
+                if !self.pidfd_opened {
+                    effect.open_pidfd(&candidate)?;
+                    self.pidfd_opened = true;
+                }
+                if !self.process_stopped {
+                    effect.stop(identity)?;
+                    self.process_stopped = true;
+                }
+                if effect.observe()?.is_some() {
+                    self.phase = QemuMediaPhase::Degraded;
+                    return Err(QemuMediaError::FinalizationIncomplete);
+                }
+            } else {
+                self.process_stopped = true;
             }
         }
-        effect.release_device_authority()?;
-        effect.delete_runtime_volume()?;
+        if self.authority_reserved && !self.authority_released {
+            effect.release_device_authority()?;
+            self.authority_released = true;
+            self.authority_reserved = false;
+        }
+        if !self.runtime_volume_deleted {
+            effect.delete_runtime_volume()?;
+            self.runtime_volume_deleted = true;
+        }
         self.finalizer_installed = false;
         self.phase = QemuMediaPhase::Finalized;
         Ok(())
     }
 
     /// Borrow the controller's Provider configuration projection.
-    pub const fn config(&self) -> &ProviderConfig {
+    pub const fn config(&self) -> &crate::config::ControllerConfigProjection {
         &self.config
     }
 }

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/reconcile.rs
@@ -135,7 +135,7 @@ pub struct QemuMediaDependencies {
     pub display_ref: Option<ResourceRef>,
     /// Controller-created runtime Volume is Ready.
     pub runtime_volume_ready: bool,
-    /// Elapsed seconds since runner launch while waiting for QMP.
+    /// Elapsed seconds in the current initial QMP greeting wait.
     pub qmp_elapsed_seconds: u32,
 }
 
@@ -211,6 +211,8 @@ pub struct QemuMediaRecoveryState {
     pub expected_identity: Option<ProcessIdentity>,
     /// Whether authority was reserved.
     pub authority_reserved: bool,
+    /// Whether the pause-at-boot initial state was observed.
+    pub initial_pause_observed: bool,
 }
 
 /// QEMU media lifecycle controller.
@@ -223,6 +225,8 @@ pub struct QemuMediaController<E> {
     expected_identity: Option<ProcessIdentity>,
     finalizer_installed: bool,
     authority_reserved: bool,
+    initial_qmp_wait_pending: bool,
+    initial_pause_observed: bool,
     pidfd_opened: bool,
     media_closed: bool,
     process_stopped: bool,
@@ -255,6 +259,8 @@ impl<E> QemuMediaController<E> {
             expected_identity: None,
             finalizer_installed: true,
             authority_reserved: false,
+            initial_qmp_wait_pending: false,
+            initial_pause_observed: false,
             pidfd_opened: false,
             media_closed: false,
             process_stopped: false,
@@ -286,6 +292,7 @@ impl<E> QemuMediaController<E> {
             finalizer_installed: self.finalizer_installed,
             expected_identity: self.expected_identity.clone(),
             authority_reserved: self.authority_reserved,
+            initial_pause_observed: self.initial_pause_observed,
         }
     }
 
@@ -302,6 +309,8 @@ impl<E> QemuMediaController<E> {
         self.expected_identity = recovery.expected_identity;
         self.authority_reserved =
             recovery.authority_reserved && recovery.phase != QemuMediaPhase::Finalized;
+        self.initial_qmp_wait_pending = false;
+        self.initial_pause_observed = recovery.initial_pause_observed;
         self.pidfd_opened = false;
         self.media_closed = false;
         self.process_stopped = recovery.phase == QemuMediaPhase::Finalized;
@@ -316,6 +325,7 @@ impl<E> QemuMediaController<E> {
         self.phase = QemuMediaPhase::Ready;
         self.finalizer_installed = true;
         self.authority_reserved = true;
+        self.initial_pause_observed = self.settings.pause_at_boot;
     }
 }
 
@@ -391,12 +401,15 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
                 }
                 self.pidfd_opened = true;
                 self.expected_identity = Some(candidate.clone());
+                self.initial_qmp_wait_pending = true;
                 candidate
             }
         };
 
         if !dependencies.qmp_ready {
-            if dependencies.qmp_elapsed_seconds >= self.config.qmp_ready_timeout_seconds {
+            if self.initial_qmp_wait_pending
+                && dependencies.qmp_elapsed_seconds >= self.config.qmp_ready_timeout_seconds
+            {
                 if effect.stop(&identity).is_ok() && matches!(effect.observe(), Ok(None)) {
                     self.process_stopped = true;
                     if self.authority_reserved && !self.authority_released {
@@ -408,9 +421,14 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
                 self.phase = QemuMediaPhase::Failed;
                 return Err(QemuMediaError::QmpNotReady);
             }
-            self.phase = QemuMediaPhase::WaitingQmp;
+            self.phase = if self.initial_qmp_wait_pending {
+                QemuMediaPhase::WaitingQmp
+            } else {
+                QemuMediaPhase::Degraded
+            };
             return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 250 });
         }
+        self.initial_qmp_wait_pending = false;
         let Some(qmp_status) = dependencies.qmp_status else {
             self.phase = QemuMediaPhase::WaitingQmp;
             return Ok(QemuMediaReconcileOutcome::Retry { after_ms: 250 });
@@ -423,14 +441,17 @@ impl<E: QemuMediaEffectPort> QemuMediaController<E> {
             QmpVmStatus::Paused if !self.settings.pause_at_boot => {
                 effect.continue_guest()?;
             }
-            QmpVmStatus::Running if self.settings.pause_at_boot => {
+            QmpVmStatus::Paused => {
+                self.initial_pause_observed = true;
+            }
+            QmpVmStatus::Running if self.settings.pause_at_boot && !self.initial_pause_observed => {
                 self.phase = QemuMediaPhase::Degraded;
                 return Err(QemuMediaError::QmpNotReady);
             }
-            QmpVmStatus::Paused | QmpVmStatus::Running => {}
+            QmpVmStatus::Running => {}
         }
         self.expected_identity = Some(identity);
-        self.phase = if self.settings.pause_at_boot {
+        self.phase = if self.settings.pause_at_boot && matches!(qmp_status, QmpVmStatus::Paused) {
             QemuMediaPhase::PausedAtBoot
         } else {
             QemuMediaPhase::Ready

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/status.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/status.rs
@@ -1,0 +1,26 @@
+//! Guest status projection helpers.
+
+use crate::types::{GuestPhase, GuestStatus, ProviderPhase};
+
+/// Build a bounded status from process and QMP observations.
+pub fn status_for(process_ready: bool, qmp_ready: bool, paused_at_boot: bool) -> GuestStatus {
+    let phase = if process_ready && qmp_ready {
+        GuestPhase::Ready
+    } else {
+        GuestPhase::Pending
+    };
+    let provider_phase = if !process_ready {
+        ProviderPhase::LaunchingRunner
+    } else if !qmp_ready {
+        ProviderPhase::WaitingQmp
+    } else if paused_at_boot {
+        ProviderPhase::PausedAtBoot
+    } else {
+        ProviderPhase::Running
+    };
+    let mut status = GuestStatus::new(phase, provider_phase);
+    status.resource.runtime_ready = process_ready;
+    status.resource.bootstrap_ready = qmp_ready;
+    status.resource.active_process_count = u16::from(process_ready);
+    status
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/volume.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/volume.rs
@@ -1,0 +1,213 @@
+//! Controller-created runtime Volume specification.
+
+use d2b_contracts::v3::ResourceRef;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Runtime Volume finalizer.
+pub const RUNTIME_VOLUME_FINALIZER: &str = "runtime-qemu-media.d2bus.org/runtime-volume";
+
+/// Runtime Volume layout entry type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VolumeLayoutType {
+    /// Runtime directory.
+    Directory,
+    /// QMP or serial socket.
+    UnixSocket,
+}
+
+/// Runtime Volume layout entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LayoutEntry {
+    /// Relative layout path.
+    pub path: String,
+    /// Entry type.
+    pub entry_type: VolumeLayoutType,
+    /// Required mode.
+    pub mode: String,
+    /// Cleanup policy.
+    pub cleanup_policy: String,
+    /// Adoption policy.
+    pub adoption_policy: String,
+    /// Restart policy.
+    pub restart_policy: String,
+}
+
+/// Runtime Volume named view.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RuntimeVolumeView {
+    /// Relative view path.
+    pub path: String,
+    /// View rights.
+    pub rights: Vec<String>,
+}
+
+/// Runtime Volume hard quota.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VolumeQuota {
+    /// Byte limit.
+    pub max_bytes: u64,
+    /// Inode limit.
+    pub max_inodes: u32,
+    /// Enforcement mode.
+    pub enforcement: String,
+}
+
+/// Controller-created runtime tmpfs Volume.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RuntimeVolumeSpec {
+    /// Deterministic Volume name.
+    pub name: String,
+    /// Zone containing the Volume.
+    pub zone: String,
+    /// Owning Guest.
+    pub owner_ref: ResourceRef,
+    /// Provider reference.
+    pub provider_ref: ResourceRef,
+    /// Source kind.
+    pub source_kind: String,
+    /// Source policy identifier.
+    pub source_policy_id: String,
+    /// Layout entries.
+    pub layout: Vec<LayoutEntry>,
+    /// Named views.
+    pub views: Vec<(String, RuntimeVolumeView)>,
+    /// Hard quota.
+    pub quota: VolumeQuota,
+    /// Finalizer.
+    pub finalizer: String,
+}
+
+impl RuntimeVolumeSpec {
+    /// Build the canonical per-Guest runtime Volume.
+    pub fn new(
+        guest_ref: ResourceRef,
+        zone: impl Into<String>,
+        quota_bytes: u64,
+        quota_inodes: u32,
+    ) -> Result<Self, VolumeSpecError> {
+        if guest_ref.resource_type().as_str() != "Guest"
+            || !(1024 * 1024..=256 * 1024 * 1024).contains(&quota_bytes)
+            || !(64..=65_536).contains(&quota_inodes)
+        {
+            return Err(VolumeSpecError::Invalid);
+        }
+        let zone = zone.into();
+        if zone.is_empty() || zone.len() > 63 || !valid_token(&zone) {
+            return Err(VolumeSpecError::Invalid);
+        }
+        let name = format!(
+            "{}-runtime",
+            short_guest_key(&guest_ref.to_canonical_string())
+        );
+        let layout = vec![
+            layout("", VolumeLayoutType::Directory, "0700", "directory"),
+            layout("qmp.sock", VolumeLayoutType::UnixSocket, "0600", "qmp"),
+            layout(
+                "serial.sock",
+                VolumeLayoutType::UnixSocket,
+                "0600",
+                "serial",
+            ),
+        ];
+        Ok(Self {
+            name,
+            zone,
+            owner_ref: guest_ref,
+            provider_ref: ResourceRef::parse("Provider/volume-local")
+                .expect("frozen Volume Provider ref"),
+            source_kind: "tmpfs".to_owned(),
+            source_policy_id: "runtime-qemu-media-runtime-tmpfs".to_owned(),
+            layout,
+            views: vec![(
+                "runner".to_owned(),
+                RuntimeVolumeView {
+                    path: String::new(),
+                    rights: vec![
+                        "read".to_owned(),
+                        "write".to_owned(),
+                        "create".to_owned(),
+                        "delete".to_owned(),
+                        "traverse".to_owned(),
+                    ],
+                },
+            )],
+            quota: VolumeQuota {
+                max_bytes: quota_bytes,
+                max_inodes: quota_inodes,
+                enforcement: "hard".to_owned(),
+            },
+            finalizer: RUNTIME_VOLUME_FINALIZER.to_owned(),
+        })
+    }
+
+    /// Return the owner reference.
+    pub const fn owner_ref(&self) -> &ResourceRef {
+        &self.owner_ref
+    }
+
+    /// Return the required cleanup policy.
+    pub fn cleanup_policy(&self) -> &str {
+        self.layout
+            .first()
+            .map(|entry| entry.cleanup_policy.as_str())
+            .unwrap_or("")
+    }
+
+    /// Validate the canonical runtime Volume shape.
+    pub fn validate(&self) -> Result<(), VolumeSpecError> {
+        if self.source_kind != "tmpfs"
+            || self.source_policy_id != "runtime-qemu-media-runtime-tmpfs"
+            || self.finalizer != RUNTIME_VOLUME_FINALIZER
+            || self.layout.len() != 3
+            || self.views.len() != 1
+            || self.layout.iter().any(|entry| {
+                entry.cleanup_policy != "vm-stop-with-proof"
+                    || entry.adoption_policy != "quarantine-on-ambiguity"
+                    || entry.restart_policy != "preserve-across-controller-restart"
+            })
+        {
+            return Err(VolumeSpecError::Invalid);
+        }
+        Ok(())
+    }
+}
+
+/// Runtime Volume specification failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VolumeSpecError {
+    /// The shape or bound is invalid.
+    Invalid,
+}
+
+fn layout(path: &str, entry_type: VolumeLayoutType, mode: &str, _purpose: &str) -> LayoutEntry {
+    LayoutEntry {
+        path: path.to_owned(),
+        entry_type,
+        mode: mode.to_owned(),
+        cleanup_policy: "vm-stop-with-proof".to_owned(),
+        adoption_policy: "quarantine-on-ambiguity".to_owned(),
+        restart_policy: "preserve-across-controller-restart".to_owned(),
+    }
+}
+
+fn short_guest_key(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    digest[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn valid_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.as_bytes()[0].is_ascii_lowercase()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/controller/volume.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/controller/volume.rs
@@ -91,7 +91,25 @@ impl RuntimeVolumeSpec {
         quota_bytes: u64,
         quota_inodes: u32,
     ) -> Result<Self, VolumeSpecError> {
+        Self::new_with_provider(
+            guest_ref,
+            zone,
+            ResourceRef::parse("Provider/volume-local").expect("frozen Volume Provider ref"),
+            quota_bytes,
+            quota_inodes,
+        )
+    }
+
+    /// Build the runtime Volume with an explicit typed Volume Provider.
+    pub fn new_with_provider(
+        guest_ref: ResourceRef,
+        zone: impl Into<String>,
+        provider_ref: ResourceRef,
+        quota_bytes: u64,
+        quota_inodes: u32,
+    ) -> Result<Self, VolumeSpecError> {
         if guest_ref.resource_type().as_str() != "Guest"
+            || provider_ref.resource_type().as_str() != "Provider"
             || !(1024 * 1024..=256 * 1024 * 1024).contains(&quota_bytes)
             || !(64..=65_536).contains(&quota_inodes)
         {
@@ -106,37 +124,55 @@ impl RuntimeVolumeSpec {
             short_guest_key(&guest_ref.to_canonical_string())
         );
         let layout = vec![
-            layout("", VolumeLayoutType::Directory, "0700", "directory"),
-            layout("qmp.sock", VolumeLayoutType::UnixSocket, "0600", "qmp"),
+            layout(
+                "",
+                VolumeLayoutType::Directory,
+                "0700",
+                "preserve-across-controller-restart",
+            ),
+            layout(
+                "qmp.sock",
+                VolumeLayoutType::UnixSocket,
+                "0600",
+                "clear-on-runner-restart",
+            ),
             layout(
                 "serial.sock",
                 VolumeLayoutType::UnixSocket,
                 "0600",
-                "serial",
+                "clear-on-runner-restart",
             ),
         ];
         Ok(Self {
             name,
             zone,
             owner_ref: guest_ref,
-            provider_ref: ResourceRef::parse("Provider/volume-local")
-                .expect("frozen Volume Provider ref"),
+            provider_ref,
             source_kind: "tmpfs".to_owned(),
             source_policy_id: "runtime-qemu-media-runtime-tmpfs".to_owned(),
             layout,
-            views: vec![(
-                "runner".to_owned(),
-                RuntimeVolumeView {
-                    path: String::new(),
-                    rights: vec![
-                        "read".to_owned(),
-                        "write".to_owned(),
-                        "create".to_owned(),
-                        "delete".to_owned(),
-                        "traverse".to_owned(),
-                    ],
-                },
-            )],
+            views: vec![
+                (
+                    "runner".to_owned(),
+                    RuntimeVolumeView {
+                        path: String::new(),
+                        rights: vec![
+                            "read".to_owned(),
+                            "write".to_owned(),
+                            "create".to_owned(),
+                            "delete".to_owned(),
+                            "traverse".to_owned(),
+                        ],
+                    },
+                ),
+                (
+                    "controller-observe".to_owned(),
+                    RuntimeVolumeView {
+                        path: String::new(),
+                        rights: vec!["read".to_owned(), "traverse".to_owned()],
+                    },
+                ),
+            ],
             quota: VolumeQuota {
                 max_bytes: quota_bytes,
                 max_inodes: quota_inodes,
@@ -161,16 +197,64 @@ impl RuntimeVolumeSpec {
 
     /// Validate the canonical runtime Volume shape.
     pub fn validate(&self) -> Result<(), VolumeSpecError> {
-        if self.source_kind != "tmpfs"
+        let expected_layout = vec![
+            layout(
+                "",
+                VolumeLayoutType::Directory,
+                "0700",
+                "preserve-across-controller-restart",
+            ),
+            layout(
+                "qmp.sock",
+                VolumeLayoutType::UnixSocket,
+                "0600",
+                "clear-on-runner-restart",
+            ),
+            layout(
+                "serial.sock",
+                VolumeLayoutType::UnixSocket,
+                "0600",
+                "clear-on-runner-restart",
+            ),
+        ];
+        let expected_views = vec![
+            (
+                "runner".to_owned(),
+                RuntimeVolumeView {
+                    path: String::new(),
+                    rights: vec![
+                        "read".to_owned(),
+                        "write".to_owned(),
+                        "create".to_owned(),
+                        "delete".to_owned(),
+                        "traverse".to_owned(),
+                    ],
+                },
+            ),
+            (
+                "controller-observe".to_owned(),
+                RuntimeVolumeView {
+                    path: String::new(),
+                    rights: vec!["read".to_owned(), "traverse".to_owned()],
+                },
+            ),
+        ];
+        let expected_name = format!(
+            "{}-runtime",
+            short_guest_key(&self.owner_ref.to_canonical_string())
+        );
+        if self.owner_ref.resource_type().as_str() != "Guest"
+            || self.provider_ref.resource_type().as_str() != "Provider"
+            || !valid_token(&self.zone)
+            || self.name != expected_name
+            || self.source_kind != "tmpfs"
             || self.source_policy_id != "runtime-qemu-media-runtime-tmpfs"
             || self.finalizer != RUNTIME_VOLUME_FINALIZER
-            || self.layout.len() != 3
-            || self.views.len() != 1
-            || self.layout.iter().any(|entry| {
-                entry.cleanup_policy != "vm-stop-with-proof"
-                    || entry.adoption_policy != "quarantine-on-ambiguity"
-                    || entry.restart_policy != "preserve-across-controller-restart"
-            })
+            || self.layout != expected_layout
+            || self.views != expected_views
+            || !(1024 * 1024..=256 * 1024 * 1024).contains(&self.quota.max_bytes)
+            || !(64..=65_536).contains(&self.quota.max_inodes)
+            || self.quota.enforcement != "hard"
         {
             return Err(VolumeSpecError::Invalid);
         }
@@ -185,14 +269,19 @@ pub enum VolumeSpecError {
     Invalid,
 }
 
-fn layout(path: &str, entry_type: VolumeLayoutType, mode: &str, _purpose: &str) -> LayoutEntry {
+fn layout(
+    path: &str,
+    entry_type: VolumeLayoutType,
+    mode: &str,
+    restart_policy: &str,
+) -> LayoutEntry {
     LayoutEntry {
         path: path.to_owned(),
         entry_type,
         mode: mode.to_owned(),
         cleanup_policy: "vm-stop-with-proof".to_owned(),
         adoption_policy: "quarantine-on-ambiguity".to_owned(),
-        restart_policy: "preserve-across-controller-restart".to_owned(),
+        restart_policy: restart_policy.to_owned(),
     }
 }
 
@@ -206,6 +295,7 @@ fn short_guest_key(value: &str) -> String {
 
 fn valid_token(value: &str) -> bool {
     !value.is_empty()
+        && value.len() <= 63
         && value.as_bytes()[0].is_ascii_lowercase()
         && value
             .bytes()

--- a/packages/d2b-provider-runtime-qemu-media/src/descriptor.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/descriptor.rs
@@ -1,0 +1,70 @@
+//! Signed Provider descriptor projection.
+
+/// Descriptor validation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DescriptorError {
+    /// The signed descriptor is missing a required contract.
+    MissingContract,
+    /// A Provider state Volume was declared.
+    StateVolumeDeclared,
+}
+
+impl core::fmt::Display for DescriptorError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::MissingContract => "runtime-qemu-media-descriptor-contract-missing",
+            Self::StateVolumeDeclared => "runtime-qemu-media-state-volume-forbidden",
+        })
+    }
+}
+
+impl std::error::Error for DescriptorError {}
+
+/// Immutable qemu-media Provider descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QemuMediaProviderDescriptor {
+    /// Signed schema version.
+    pub schema_version: u32,
+    /// Whether the descriptor declares Provider state namespaces.
+    pub provider_state_volume: bool,
+}
+
+impl Default for QemuMediaProviderDescriptor {
+    fn default() -> Self {
+        Self {
+            schema_version: 1,
+            provider_state_volume: false,
+        }
+    }
+}
+
+impl QemuMediaProviderDescriptor {
+    /// ResourceTypes owned by the Provider.
+    pub const fn resource_types(&self) -> &'static [&'static str] {
+        &["Guest"]
+    }
+
+    /// Provider state namespaces. This list is intentionally empty.
+    pub const fn state_namespaces(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    /// Process templates declared by the signed descriptor.
+    pub const fn process_templates(&self) -> &'static [&'static str] {
+        &["qemu-media-runner", "runtime-qemu-media-controller"]
+    }
+
+    /// Validate the closed descriptor contract.
+    pub const fn validate(&self) -> Result<(), DescriptorError> {
+        if self.schema_version == 0 {
+            Err(DescriptorError::MissingContract)
+        } else if self.provider_state_volume {
+            Err(DescriptorError::StateVolumeDeclared)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Compatibility alias used by Provider catalog code.
+pub type ProviderDescriptor = QemuMediaProviderDescriptor;

--- a/packages/d2b-provider-runtime-qemu-media/src/lib.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/lib.rs
@@ -1,4 +1,54 @@
-//! Canonical crate root for `Provider/runtime-qemu-media`.
-//!
-//! The crate root is intentionally compile-safe and contains no semantic
-//! Provider implementation.
+//! Canonical `Provider/runtime-qemu-media` implementation.
+
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+pub mod adoption;
+pub mod audit;
+pub mod config;
+pub mod controller;
+pub mod descriptor;
+pub mod qmp;
+pub mod state;
+pub mod telemetry;
+pub mod types;
+
+pub use adoption::{AdoptionOutcome, ProcessIdentity, verify_identity};
+pub use audit::{AuditEventKind, AuditOutcome, AuditRecord};
+pub use config::{
+    ControllerConfigProjection, ProviderConfig, ProviderConfigError, WorkerConfigProjection,
+};
+pub use controller::{
+    AttachmentKind, AttachmentSlot, AuthorityReservation, DeviceAdmission, DeviceAdmissionError,
+    DeviceObservation, DevicePhase, DisplayAttachment, DisplayObservation, DisplaySessionError,
+    DisplaySessionPhase, HostGlobalAuthorityIndex, HotplugController, HotplugOperation,
+    HotplugResult, LaunchTicket, LayoutEntry, MediaObservationError, MediaReadiness, MediaWatch,
+    NetworkLaunchError, NetworkLaunchEvent, PlatformClass, ProcessSpec, ProcessSpecError,
+    QemuMediaController, QemuMediaDependencies, QemuMediaEffectPort, QemuMediaError,
+    QemuMediaPhase, QemuMediaReconcileOutcome, QemuMediaRecoveryState, RuntimeVolumeSpec,
+    RuntimeVolumeView, TapAttachment, TapLaunchRouter, VolumeAttachment, VolumeLayoutType,
+    VolumeObservation, VolumePhase, VolumeQuota, WaylandSessionSpec,
+};
+pub use descriptor::{DescriptorError, ProviderDescriptor, QemuMediaProviderDescriptor};
+pub use qmp::{
+    QmpCommand, QmpError, QmpGreeting, QmpHealth, QmpReply, QmpSession, QmpTransport, QmpVmStatus,
+    ScriptedQmpTransport,
+};
+pub use state::{GuestObservation, RuntimeState, StateError};
+pub use telemetry::{
+    MetricOutcome, QmpOperation, SpanKind, TelemetryError, TelemetryField, TelemetryFrame,
+    TelemetrySpan,
+};
+pub use types::{
+    Bios, ConditionStatus, CpuModel, DeviceAttachment, ExtraFeature, GuestCondition, GuestPhase,
+    GuestProviderDetails, GuestProviderSpecSettings, GuestProviderStatus, GuestRuntimeStatus,
+    GuestSpec, GuestSpecError, GuestStatus, MachineType, NetworkAttachment, ProviderPhase,
+    RemovableVolumeRef, RtcBase,
+};
+
+/// Stable Provider implementation identifier.
+pub const QEMU_MEDIA_IMPLEMENTATION_ID: &str = "qemu-media";
+/// Stable Provider resource reference.
+pub const PROVIDER_REF: &str = "Provider/runtime-qemu-media";
+/// Stable Guest finalizer.
+pub const FINALIZER: &str = "runtime-qemu-media.d2bus.org/guest-cleanup";

--- a/packages/d2b-provider-runtime-qemu-media/src/lib.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/lib.rs
@@ -27,7 +27,8 @@ pub use controller::{
     QemuMediaController, QemuMediaDependencies, QemuMediaEffectPort, QemuMediaError,
     QemuMediaPhase, QemuMediaReconcileOutcome, QemuMediaRecoveryState, RuntimeVolumeSpec,
     RuntimeVolumeView, TapAttachment, TapLaunchRouter, VolumeAttachment, VolumeLayoutType,
-    VolumeObservation, VolumePhase, VolumeQuota, WaylandSessionSpec,
+    VolumeObservation, VolumePhase, VolumeQuota, WaylandSessionSpec, build_process_spec,
+    validate_process_spec,
 };
 pub use descriptor::{DescriptorError, ProviderDescriptor, QemuMediaProviderDescriptor};
 pub use qmp::{
@@ -41,9 +42,9 @@ pub use telemetry::{
 };
 pub use types::{
     Bios, ConditionStatus, CpuModel, DeviceAttachment, ExtraFeature, GuestCondition, GuestPhase,
-    GuestProviderDetails, GuestProviderSpecSettings, GuestProviderStatus, GuestRuntimeStatus,
-    GuestSpec, GuestSpecError, GuestStatus, MachineType, NetworkAttachment, ProviderPhase,
-    RemovableVolumeRef, RtcBase,
+    GuestProviderDetails, GuestProviderSpecSettings, GuestProviderStatus, GuestResourceSpecError,
+    GuestRuntimeStatus, GuestSpec, GuestSpecError, GuestStatus, MachineType, NetworkAttachment,
+    ProviderPhase, RemovableVolumeRef, RtcBase, build_guest_resource_spec,
 };
 
 /// Stable Provider implementation identifier.

--- a/packages/d2b-provider-runtime-qemu-media/src/qmp/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/qmp/mod.rs
@@ -1,0 +1,398 @@
+//! QMP capability negotiation and typed command dispatch.
+
+use std::collections::VecDeque;
+
+/// A typed QMP command accepted by the Provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QmpCommand {
+    /// Negotiate QMP capabilities.
+    Capabilities,
+    /// Continue a paused VM.
+    Cont,
+    /// Request guest ACPI powerdown.
+    SystemPowerdown,
+    /// Query guest status.
+    QueryStatus,
+    /// Add a block backend from an inherited fd slot.
+    BlockdevAdd {
+        /// QMP node name.
+        node_name: String,
+        /// Inherited LaunchTicket fd slot.
+        fd_slot: i32,
+        /// Read-only policy.
+        read_only: bool,
+    },
+    /// Add a guest device backed by a block node.
+    DeviceAdd {
+        /// QEMU device id.
+        device_id: String,
+        /// Block node name.
+        drive: String,
+    },
+    /// Remove a guest device.
+    DeviceDel {
+        /// QEMU device id.
+        device_id: String,
+    },
+    /// Remove a block backend.
+    BlockdevDel {
+        /// QMP node name.
+        node_name: String,
+    },
+    /// Query current block devices.
+    QueryBlock,
+}
+
+impl QmpCommand {
+    /// Return the wire command name.
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::Capabilities => "qmp_capabilities",
+            Self::Cont => "cont",
+            Self::SystemPowerdown => "system_powerdown",
+            Self::QueryStatus => "query-status",
+            Self::BlockdevAdd { .. } => "blockdev-add",
+            Self::DeviceAdd { .. } => "device_add",
+            Self::DeviceDel { .. } => "device_del",
+            Self::BlockdevDel { .. } => "blockdev-del",
+            Self::QueryBlock => "query-block",
+        }
+    }
+}
+
+/// QMP greeting received from the runner Endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QmpGreeting {
+    /// QEMU version string.
+    pub version: String,
+}
+
+/// QMP guest status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QmpVmStatus {
+    /// Guest is running.
+    Running,
+    /// Guest is paused.
+    Paused,
+    /// Guest has stopped.
+    Stopped,
+}
+
+/// Typed QMP command response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QmpReply {
+    /// Command succeeded without a status payload.
+    Ok,
+    /// Command succeeded with a guest status.
+    Status(QmpVmStatus),
+}
+
+impl QmpReply {
+    /// Construct an empty successful response.
+    pub const fn ok() -> Self {
+        Self::Ok
+    }
+
+    /// Construct a status response.
+    pub const fn status(status: QmpVmStatus) -> Self {
+        Self::Status(status)
+    }
+}
+
+/// Stable QMP failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QmpError {
+    /// Greeting was not received.
+    GreetingTimeout,
+    /// Greeting was malformed.
+    GreetingInvalid,
+    /// Capability negotiation failed.
+    CapabilitiesFailed,
+    /// Command was attempted before negotiation.
+    NotReady,
+    /// QMP returned an error.
+    CommandFailed,
+    /// A command or health probe timed out.
+    Timeout,
+    /// A response did not match the expected typed payload.
+    Protocol,
+    /// An inherited fd slot was invalid.
+    InvalidFdSlot,
+    /// A QMP object identifier was invalid.
+    InvalidObjectId,
+}
+
+impl QmpError {
+    /// Return the stable Provider error code.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::GreetingTimeout => "qmp-greeting-timeout",
+            Self::GreetingInvalid => "qmp-greeting-invalid",
+            Self::CapabilitiesFailed => "qmp-capabilities-failed",
+            Self::NotReady => "qmp-not-ready",
+            Self::CommandFailed => "qmp-command-failed",
+            Self::Timeout => "qmp-command-timeout",
+            Self::Protocol => "qmp-protocol-invalid",
+            Self::InvalidFdSlot => "qmp-fd-slot-invalid",
+            Self::InvalidObjectId => "qmp-object-id-invalid",
+        }
+    }
+}
+
+impl core::fmt::Display for QmpError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for QmpError {}
+
+/// Minimal transport seam. Endpoint resolution and fd ownership stay outside
+/// the Provider and are represented by this injected typed boundary.
+pub trait QmpTransport {
+    /// Receive the initial greeting.
+    fn receive_greeting(&mut self) -> Result<QmpGreeting, QmpError>;
+    /// Execute one typed command.
+    fn execute(&mut self, command: &QmpCommand) -> Result<QmpReply, QmpError>;
+}
+
+/// Scripted transport used by hermetic tests and fake integration fixtures.
+#[derive(Debug, Clone)]
+pub struct ScriptedQmpTransport {
+    greeting: Option<QmpGreeting>,
+    replies: VecDeque<Result<QmpReply, QmpError>>,
+}
+
+impl ScriptedQmpTransport {
+    /// Construct an empty scripted transport.
+    pub fn new() -> Self {
+        Self {
+            greeting: None,
+            replies: VecDeque::new(),
+        }
+    }
+
+    /// Set the greeting version.
+    pub fn with_greeting(mut self, version: impl Into<String>) -> Self {
+        self.greeting = Some(QmpGreeting {
+            version: version.into(),
+        });
+        self
+    }
+
+    /// Append a successful response.
+    pub fn with_reply(mut self, reply: QmpReply) -> Self {
+        self.replies.push_back(Ok(reply));
+        self
+    }
+
+    /// Append a failed response.
+    pub fn with_error(mut self, error: QmpError) -> Self {
+        self.replies.push_back(Err(error));
+        self
+    }
+}
+
+impl Default for ScriptedQmpTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QmpTransport for ScriptedQmpTransport {
+    fn receive_greeting(&mut self) -> Result<QmpGreeting, QmpError> {
+        self.greeting.take().ok_or(QmpError::GreetingTimeout)
+    }
+
+    fn execute(&mut self, _command: &QmpCommand) -> Result<QmpReply, QmpError> {
+        self.replies.pop_front().unwrap_or(Err(QmpError::Timeout))
+    }
+}
+
+/// A negotiated QMP session.
+#[derive(Debug)]
+pub struct QmpSession<T> {
+    transport: T,
+    negotiated: bool,
+    greeting: Option<QmpGreeting>,
+    commands: Vec<QmpCommand>,
+    health: QmpHealth,
+}
+
+impl<T: QmpTransport> QmpSession<T> {
+    /// Construct a session over an authenticated Endpoint transport.
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport,
+            negotiated: false,
+            greeting: None,
+            commands: Vec::new(),
+            health: QmpHealth::new(3),
+        }
+    }
+
+    /// Negotiate QMP capabilities.
+    pub fn negotiate(&mut self) -> Result<(), QmpError> {
+        let greeting = self.transport.receive_greeting()?;
+        if greeting.version.is_empty() || greeting.version.len() > 64 {
+            return Err(QmpError::GreetingInvalid);
+        }
+        self.greeting = Some(greeting);
+        self.execute(QmpCommand::Capabilities)?;
+        self.negotiated = true;
+        Ok(())
+    }
+
+    /// Continue a paused VM.
+    pub fn cont(&mut self) -> Result<(), QmpError> {
+        self.execute(QmpCommand::Cont).map(|_| ())
+    }
+
+    /// Request graceful guest shutdown.
+    pub fn system_powerdown(&mut self) -> Result<(), QmpError> {
+        self.execute(QmpCommand::SystemPowerdown).map(|_| ())
+    }
+
+    /// Query guest status.
+    pub fn query_status(&mut self) -> Result<QmpVmStatus, QmpError> {
+        match self.execute(QmpCommand::QueryStatus)? {
+            QmpReply::Status(status) => Ok(status),
+            QmpReply::Ok => Err(QmpError::Protocol),
+        }
+    }
+
+    /// Attach one media fd slot through the QMP block/device sequence.
+    pub fn attach_media(
+        &mut self,
+        node_name: &str,
+        fd_slot: i32,
+        read_only: bool,
+    ) -> Result<(), QmpError> {
+        validate_object_id(node_name)?;
+        if fd_slot < 3 {
+            return Err(QmpError::InvalidFdSlot);
+        }
+        self.execute(QmpCommand::BlockdevAdd {
+            node_name: node_name.to_owned(),
+            fd_slot,
+            read_only,
+        })?;
+        self.execute(QmpCommand::DeviceAdd {
+            device_id: node_name.to_owned(),
+            drive: node_name.to_owned(),
+        })?;
+        Ok(())
+    }
+
+    /// Detach one media node through the reverse QMP sequence.
+    pub fn detach_media(&mut self, node_name: &str) -> Result<(), QmpError> {
+        validate_object_id(node_name)?;
+        self.execute(QmpCommand::DeviceDel {
+            device_id: node_name.to_owned(),
+        })?;
+        self.execute(QmpCommand::BlockdevDel {
+            node_name: node_name.to_owned(),
+        })?;
+        Ok(())
+    }
+
+    /// Query current block devices.
+    pub fn query_block(&mut self) -> Result<(), QmpError> {
+        self.execute(QmpCommand::QueryBlock).map(|_| ())
+    }
+
+    /// Borrow the negotiated greeting.
+    pub fn greeting(&self) -> Option<&QmpGreeting> {
+        self.greeting.as_ref()
+    }
+
+    /// Borrow dispatched commands.
+    pub fn commands(&self) -> &[QmpCommand] {
+        &self.commands
+    }
+
+    /// Borrow session health.
+    pub const fn health(&self) -> &QmpHealth {
+        &self.health
+    }
+
+    /// Record a health probe success.
+    pub fn record_health_success(&mut self) {
+        self.health.record_success();
+    }
+
+    /// Record a health probe failure.
+    pub fn record_health_failure(&mut self) -> Result<(), QmpError> {
+        self.health.record_failure()
+    }
+
+    fn execute(&mut self, command: QmpCommand) -> Result<QmpReply, QmpError> {
+        if !matches!(command, QmpCommand::Capabilities)
+            && !self.negotiated
+            && self.greeting.is_none()
+        {
+            return Err(QmpError::NotReady);
+        }
+        self.commands.push(command.clone());
+        self.transport.execute(&command)
+    }
+}
+
+/// Bounded QMP health tracker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QmpHealth {
+    threshold: u8,
+    failures: u8,
+    phase: &'static str,
+}
+
+impl QmpHealth {
+    /// Construct a health tracker with a non-zero failure threshold.
+    pub fn new(threshold: u8) -> Self {
+        Self {
+            threshold: threshold.max(1),
+            failures: 0,
+            phase: "ready",
+        }
+    }
+
+    /// Record a successful health probe.
+    pub fn record_success(&mut self) {
+        self.failures = 0;
+        self.phase = "ready";
+    }
+
+    /// Record a failure and degrade at the threshold.
+    pub fn record_failure(&mut self) -> Result<(), QmpError> {
+        self.failures = self.failures.saturating_add(1);
+        if self.failures >= self.threshold {
+            self.phase = "degraded";
+            Err(QmpError::CommandFailed)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Return the closed health phase.
+    pub const fn phase(&self) -> &'static str {
+        self.phase
+    }
+
+    /// Return consecutive failures.
+    pub const fn failures(&self) -> u8 {
+        self.failures
+    }
+}
+
+fn validate_object_id(value: &str) -> Result<(), QmpError> {
+    if value.is_empty()
+        || value.len() > 63
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        Err(QmpError::InvalidObjectId)
+    } else {
+        Ok(())
+    }
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/qmp/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/qmp/mod.rs
@@ -233,12 +233,17 @@ impl<T: QmpTransport> QmpSession<T> {
 
     /// Negotiate QMP capabilities.
     pub fn negotiate(&mut self) -> Result<(), QmpError> {
+        self.negotiated = false;
+        self.greeting = None;
         let greeting = self.transport.receive_greeting()?;
         if greeting.version.is_empty() || greeting.version.len() > 64 {
             return Err(QmpError::GreetingInvalid);
         }
         self.greeting = Some(greeting);
-        self.execute(QmpCommand::Capabilities)?;
+        if let Err(error) = self.execute(QmpCommand::Capabilities) {
+            self.greeting = None;
+            return Err(error);
+        }
         self.negotiated = true;
         Ok(())
     }
@@ -277,10 +282,15 @@ impl<T: QmpTransport> QmpSession<T> {
             fd_slot,
             read_only,
         })?;
-        self.execute(QmpCommand::DeviceAdd {
+        if let Err(error) = self.execute(QmpCommand::DeviceAdd {
             device_id: node_name.to_owned(),
             drive: node_name.to_owned(),
-        })?;
+        }) {
+            let _ = self.execute(QmpCommand::BlockdevDel {
+                node_name: node_name.to_owned(),
+            });
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -327,13 +337,13 @@ impl<T: QmpTransport> QmpSession<T> {
     }
 
     fn execute(&mut self, command: QmpCommand) -> Result<QmpReply, QmpError> {
-        if !matches!(command, QmpCommand::Capabilities)
-            && !self.negotiated
-            && self.greeting.is_none()
-        {
+        if !matches!(command, QmpCommand::Capabilities) && !self.negotiated {
             return Err(QmpError::NotReady);
         }
         self.commands.push(command.clone());
+        if self.commands.len() > 128 {
+            self.commands.remove(0);
+        }
         self.transport.execute(&command)
     }
 }

--- a/packages/d2b-provider-runtime-qemu-media/src/state.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/state.rs
@@ -1,0 +1,114 @@
+//! Status-first restart state with no Provider state Volume.
+
+use std::collections::BTreeMap;
+
+use crate::types::ProviderPhase;
+
+/// Maximum retained per-Guest observations.
+pub const MAX_GUEST_OBSERVATIONS: usize = 256;
+/// Maximum retained error detail bytes.
+pub const MAX_ERROR_DETAIL_BYTES: usize = 256;
+
+/// One redacted observation re-derived from the resource store and process ledger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuestObservation {
+    /// Current provider phase.
+    pub provider_phase: ProviderPhase,
+    /// Whether a matching process was observed.
+    pub process_present: bool,
+    /// Whether QMP health was successful.
+    pub qmp_ready: bool,
+    /// Bounded error code, if any.
+    pub error_code: Option<&'static str>,
+}
+
+/// Status-first Provider operational state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeState {
+    observations: BTreeMap<String, GuestObservation>,
+    reconcile_count: u64,
+    last_error: Option<String>,
+}
+
+impl Default for RuntimeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RuntimeState {
+    /// Construct empty state. No state Volume or path is involved.
+    pub fn new() -> Self {
+        Self {
+            observations: BTreeMap::new(),
+            reconcile_count: 0,
+            last_error: None,
+        }
+    }
+
+    /// Record a bounded Guest observation.
+    pub fn record(
+        &mut self,
+        guest_key: impl Into<String>,
+        observation: GuestObservation,
+    ) -> Result<(), StateError> {
+        let guest_key = guest_key.into();
+        if self.observations.len() >= MAX_GUEST_OBSERVATIONS
+            && !self.observations.contains_key(&guest_key)
+        {
+            return Err(StateError::TooManyGuests);
+        }
+        if guest_key.is_empty() || guest_key.len() > 128 || guest_key.contains('/') {
+            return Err(StateError::InvalidGuestKey);
+        }
+        self.observations.insert(guest_key, observation);
+        self.reconcile_count = self.reconcile_count.saturating_add(1);
+        Ok(())
+    }
+
+    /// Record a bounded error code without attacker-authored text.
+    pub fn record_error(&mut self, code: impl Into<String>) -> Result<(), StateError> {
+        let code = code.into();
+        if code.is_empty()
+            || code.len() > MAX_ERROR_DETAIL_BYTES
+            || !code.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+            })
+        {
+            return Err(StateError::InvalidErrorCode);
+        }
+        self.last_error = Some(code);
+        Ok(())
+    }
+
+    /// Borrow the status observation for a Guest.
+    pub fn observation(&self, guest_key: &str) -> Option<&GuestObservation> {
+        self.observations.get(guest_key)
+    }
+
+    /// Return the bounded reconcile count.
+    pub const fn reconcile_count(&self) -> u64 {
+        self.reconcile_count
+    }
+
+    /// Return whether a Provider state Volume is required.
+    pub const fn requires_state_volume(&self) -> bool {
+        false
+    }
+
+    /// Return whether the controller can reconstruct state from external observations.
+    pub const fn restart_rehydratable(&self) -> bool {
+        true
+    }
+}
+
+/// Status-first state failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateError {
+    /// Too many Guest observations are retained.
+    TooManyGuests,
+    /// Guest key is not a bounded opaque key.
+    InvalidGuestKey,
+    /// Error code is not a closed bounded code.
+    InvalidErrorCode,
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/telemetry.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/telemetry.rs
@@ -1,0 +1,228 @@
+//! Closed-label metrics and OTEL span projections.
+
+/// Closed telemetry outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricOutcome {
+    /// Operation succeeded.
+    Success,
+    /// Operation is pending.
+    Pending,
+    /// Operation degraded.
+    Degraded,
+    /// Operation failed.
+    Failed,
+}
+
+impl MetricOutcome {
+    /// Return the stable metric label.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Pending => "pending",
+            Self::Degraded => "degraded",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// QMP operation label used by metrics and spans.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QmpOperation {
+    /// Capability exchange.
+    Capabilities,
+    /// Continue.
+    Cont,
+    /// Graceful shutdown.
+    SystemPowerdown,
+    /// Status query.
+    QueryStatus,
+    /// Media attach.
+    Attach,
+    /// Media detach.
+    Detach,
+}
+
+impl QmpOperation {
+    /// Return the stable operation label.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Capabilities => "capabilities",
+            Self::Cont => "cont",
+            Self::SystemPowerdown => "system-powerdown",
+            Self::QueryStatus => "query-status",
+            Self::Attach => "attach",
+            Self::Detach => "detach",
+        }
+    }
+}
+
+/// Span kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpanKind {
+    /// Guest reconcile span.
+    Reconcile,
+    /// Runner launch span.
+    RunnerLaunch,
+    /// QMP connect span.
+    QmpConnect,
+    /// QMP command span.
+    QmpCommand,
+    /// Media hotplug span.
+    MediaHotplug,
+    /// Finalization span.
+    Finalize,
+}
+
+/// One bounded telemetry field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelemetryField {
+    /// Fixed field key.
+    pub key: &'static str,
+    /// Bounded semantic value.
+    pub value: String,
+}
+
+/// Metrics frame with trusted resource attributes and closed metric labels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelemetryFrame {
+    resource_attributes: Vec<TelemetryField>,
+    metric_labels: Vec<TelemetryField>,
+}
+
+impl TelemetryFrame {
+    /// Construct the baseline Provider frame.
+    pub fn new(zone: &str, outcome: MetricOutcome) -> Self {
+        Self {
+            resource_attributes: vec![
+                TelemetryField {
+                    key: "d2b.zone",
+                    value: zone.to_owned(),
+                },
+                TelemetryField {
+                    key: "d2b.provider",
+                    value: "runtime-qemu-media".to_owned(),
+                },
+                TelemetryField {
+                    key: "service.name",
+                    value: "d2b-runtime-qemu-media-controller".to_owned(),
+                },
+            ],
+            metric_labels: vec![
+                TelemetryField {
+                    key: "provider",
+                    value: "runtime-qemu-media".to_owned(),
+                },
+                TelemetryField {
+                    key: "outcome",
+                    value: outcome.as_str().to_owned(),
+                },
+            ],
+        }
+    }
+
+    /// Borrow trusted resource attributes.
+    pub fn resource_attributes(&self) -> &[TelemetryField] {
+        &self.resource_attributes
+    }
+
+    /// Borrow metric labels.
+    pub fn metric_labels(&self) -> &[TelemetryField] {
+        &self.metric_labels
+    }
+
+    /// Validate all frame fields.
+    pub fn validate(&self) -> Result<(), TelemetryError> {
+        for field in self.resource_attributes.iter().chain(&self.metric_labels) {
+            Self::validate_field(field.key, &field.value)?;
+        }
+        Ok(())
+    }
+
+    /// Validate one metric or resource field.
+    pub fn validate_field(key: &str, value: &str) -> Result<(), TelemetryError> {
+        let allowed = [
+            "d2b.zone",
+            "d2b.provider",
+            "service.name",
+            "provider",
+            "outcome",
+            "operation",
+            "phase",
+            "dep_type",
+        ];
+        if !allowed.contains(&key)
+            || value.is_empty()
+            || value.len() > 128
+            || value.contains('/')
+            || value.contains('\n')
+            || matches!(key, "vm" | "zone_id" | "zone_uid" | "guest" | "resource")
+        {
+            return Err(TelemetryError::FieldRejected);
+        }
+        if key == "outcome" && !["success", "pending", "degraded", "failed"].contains(&value) {
+            return Err(TelemetryError::FieldRejected);
+        }
+        if key == "provider" && value != "runtime-qemu-media" {
+            return Err(TelemetryError::FieldRejected);
+        }
+        Ok(())
+    }
+
+    /// Construct a fixed semantic QMP span.
+    pub fn span(kind: SpanKind, operation: QmpOperation, outcome: MetricOutcome) -> TelemetrySpan {
+        TelemetrySpan {
+            kind,
+            attributes: vec![
+                TelemetryField {
+                    key: "operation",
+                    value: operation.as_str().to_owned(),
+                },
+                TelemetryField {
+                    key: "outcome",
+                    value: outcome.as_str().to_owned(),
+                },
+            ],
+        }
+    }
+
+    /// Validate an OTEL span attribute.
+    pub fn validate_span_attribute(key: &str, value: &str) -> Result<(), TelemetryError> {
+        if !["phase", "outcome", "command", "operation"].contains(&key)
+            || value.is_empty()
+            || value.len() > 64
+            || value.contains('/')
+            || value.contains('\n')
+        {
+            return Err(TelemetryError::SpanAttributeRejected);
+        }
+        Ok(())
+    }
+}
+
+/// Fixed semantic OTEL span.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelemetrySpan {
+    /// Span kind.
+    pub kind: SpanKind,
+    /// Fixed semantic attributes.
+    pub attributes: Vec<TelemetryField>,
+}
+
+impl TelemetrySpan {
+    /// Validate the span attributes.
+    pub fn validate(&self) -> Result<(), TelemetryError> {
+        for field in &self.attributes {
+            TelemetryFrame::validate_span_attribute(field.key, &field.value)?;
+        }
+        Ok(())
+    }
+}
+
+/// Telemetry validation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetryError {
+    /// Metric field is not in the closed policy.
+    FieldRejected,
+    /// Span attribute is not in the closed policy.
+    SpanAttributeRejected,
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
@@ -1,0 +1,708 @@
+//! Strict, locator-free Guest resource types for the qemu-media Provider.
+
+use std::collections::BTreeSet;
+
+use d2b_contracts::v3::ResourceRef;
+use schemars::JsonSchema;
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Maximum removable media attachments on one Guest.
+pub const MAX_REMOVABLE_VOLUMES: usize = 4;
+/// Maximum bytes in a provider phase.
+pub const MAX_PROVIDER_PHASE_BYTES: usize = 64;
+/// Provider schema identifier for Guest settings.
+pub const GUEST_SPEC_SCHEMA_ID: &str = "runtime-qemu-media.d2bus.org/Guest/spec";
+/// Provider schema identifier for Guest status.
+pub const GUEST_STATUS_SCHEMA_ID: &str = "runtime-qemu-media.d2bus.org/Guest/status";
+/// Provider reference implemented by this crate.
+pub const PROVIDER_REF: &str = "Provider/runtime-qemu-media";
+
+/// QEMU CPU model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum CpuModel {
+    /// Host CPU model.
+    Host,
+    /// Maximum available emulated CPU model.
+    Max,
+    /// Broad compatibility CPU model.
+    Qemu64,
+}
+
+/// QEMU machine type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum MachineType {
+    /// Modern Q35 machine.
+    Q35,
+    /// Legacy PC machine.
+    Pc,
+}
+
+/// QEMU firmware selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Bios {
+    /// OVMF firmware.
+    Ovmf,
+    /// SeaBIOS firmware.
+    Seabios,
+}
+
+/// Guest RTC base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum RtcBase {
+    /// UTC guest clock.
+    Utc,
+    /// Local-time guest clock.
+    Localtime,
+}
+
+/// Signed capability values accepted by `extraFeatures`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExtraFeature {
+    /// Virtio random device.
+    VirtioRng,
+    /// Virtio balloon device.
+    VirtioBalloon,
+    /// Firmware SMM support.
+    Smm,
+    /// USB 3 controller support.
+    Usb3,
+}
+
+/// A removable Volume reference and its named view.
+#[derive(Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovableVolumeRef {
+    /// Referenced Volume.
+    pub volume_ref: ResourceRef,
+    /// Named Volume view.
+    pub view: String,
+}
+
+impl RemovableVolumeRef {
+    /// Validate a removable Volume reference.
+    pub fn new(volume_ref: ResourceRef, view: impl Into<String>) -> Result<Self, GuestSpecError> {
+        if volume_ref.resource_type().as_str() != "Volume" {
+            return Err(GuestSpecError::InvalidVolumeRef);
+        }
+        let view = view.into();
+        validate_token(&view).map_err(|_| GuestSpecError::InvalidView)?;
+        Ok(Self { volume_ref, view })
+    }
+}
+
+impl<'de> Deserialize<'de> for RemovableVolumeRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Wire {
+            volume_ref: ResourceRef,
+            view: String,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        Self::new(wire.volume_ref, wire.view).map_err(serde::de::Error::custom)
+    }
+}
+
+impl core::fmt::Debug for RemovableVolumeRef {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("RemovableVolumeRef(<redacted>)")
+    }
+}
+
+/// Opaque network dependency.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NetworkAttachment {
+    /// Referenced Network.
+    pub network_ref: ResourceRef,
+}
+
+impl NetworkAttachment {
+    /// Construct a Network attachment.
+    pub fn new(network_ref: ResourceRef) -> Result<Self, GuestSpecError> {
+        if network_ref.resource_type().as_str() != "Network" {
+            return Err(GuestSpecError::InvalidNetworkRef);
+        }
+        Ok(Self { network_ref })
+    }
+}
+
+/// Opaque device dependency.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DeviceAttachment {
+    /// Referenced Device.
+    pub device_ref: ResourceRef,
+    /// Whether the Guest requests exclusive access.
+    #[serde(default)]
+    pub exclusive: bool,
+}
+
+impl DeviceAttachment {
+    /// Construct a Device attachment.
+    pub fn new(device_ref: ResourceRef, exclusive: bool) -> Result<Self, GuestSpecError> {
+        if device_ref.resource_type().as_str() != "Device" {
+            return Err(GuestSpecError::InvalidDeviceRef);
+        }
+        Ok(Self {
+            device_ref,
+            exclusive,
+        })
+    }
+}
+
+/// Guest provider-specific settings.
+#[derive(Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GuestProviderSpecSettings {
+    /// Optional boot Volume.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boot_media_ref: Option<ResourceRef>,
+    /// Boot Volume view.
+    pub boot_media_view: String,
+    /// Removable media Volumes.
+    pub removable_volume_refs: Vec<RemovableVolumeRef>,
+    /// CPU model.
+    pub cpu_model: CpuModel,
+    /// Machine type.
+    pub machine_type: MachineType,
+    /// Firmware.
+    pub bios: Bios,
+    /// Start QEMU paused.
+    pub pause_at_boot: bool,
+    /// Create a WaylandSession for a host window.
+    pub display_window: bool,
+    /// Publish a serial Endpoint.
+    pub serial_console: bool,
+    /// Add an absolute USB tablet.
+    pub tablet: bool,
+    /// Guest RTC base.
+    pub rtc_base: RtcBase,
+    /// Signed optional features.
+    pub extra_features: Vec<ExtraFeature>,
+}
+
+impl Default for GuestProviderSpecSettings {
+    fn default() -> Self {
+        Self {
+            boot_media_ref: None,
+            boot_media_view: "guest-attach".to_owned(),
+            removable_volume_refs: Vec::new(),
+            cpu_model: CpuModel::Host,
+            machine_type: MachineType::Q35,
+            bios: Bios::Ovmf,
+            pause_at_boot: true,
+            display_window: false,
+            serial_console: true,
+            tablet: true,
+            rtc_base: RtcBase::Utc,
+            extra_features: Vec::new(),
+        }
+    }
+}
+
+impl GuestProviderSpecSettings {
+    /// Validate every provider setting bound.
+    pub fn validate(&self) -> Result<(), GuestSpecError> {
+        if self
+            .boot_media_ref
+            .as_ref()
+            .is_some_and(|reference| reference.resource_type().as_str() != "Volume")
+        {
+            return Err(GuestSpecError::InvalidVolumeRef);
+        }
+        validate_token(&self.boot_media_view).map_err(|_| GuestSpecError::InvalidView)?;
+        if self.removable_volume_refs.len() > MAX_REMOVABLE_VOLUMES {
+            return Err(GuestSpecError::TooManyRemovableVolumes);
+        }
+        let mut refs = BTreeSet::new();
+        for removable in &self.removable_volume_refs {
+            if !refs.insert(removable.volume_ref.to_canonical_string()) {
+                return Err(GuestSpecError::DuplicateVolumeRef);
+            }
+        }
+        if self.extra_features.len() > 16 {
+            return Err(GuestSpecError::TooManyExtraFeatures);
+        }
+        let mut features = self.extra_features.clone();
+        features.sort();
+        features.dedup();
+        if features.len() != self.extra_features.len() {
+            return Err(GuestSpecError::DuplicateExtraFeature);
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for GuestProviderSpecSettings {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Wire {
+            #[serde(default)]
+            boot_media_ref: Option<ResourceRef>,
+            #[serde(default = "default_boot_media_view")]
+            boot_media_view: String,
+            #[serde(default)]
+            removable_volume_refs: Vec<RemovableVolumeRef>,
+            #[serde(default = "default_cpu_model")]
+            cpu_model: CpuModel,
+            #[serde(default = "default_machine_type")]
+            machine_type: MachineType,
+            #[serde(default = "default_bios")]
+            bios: Bios,
+            #[serde(default = "default_true")]
+            pause_at_boot: bool,
+            #[serde(default)]
+            display_window: bool,
+            #[serde(default = "default_true")]
+            serial_console: bool,
+            #[serde(default = "default_true")]
+            tablet: bool,
+            #[serde(default = "default_rtc_base")]
+            rtc_base: RtcBase,
+            #[serde(default)]
+            extra_features: Vec<ExtraFeature>,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        let settings = Self {
+            boot_media_ref: wire.boot_media_ref,
+            boot_media_view: wire.boot_media_view,
+            removable_volume_refs: wire.removable_volume_refs,
+            cpu_model: wire.cpu_model,
+            machine_type: wire.machine_type,
+            bios: wire.bios,
+            pause_at_boot: wire.pause_at_boot,
+            display_window: wire.display_window,
+            serial_console: wire.serial_console,
+            tablet: wire.tablet,
+            rtc_base: wire.rtc_base,
+            extra_features: wire.extra_features,
+        };
+        settings.validate().map_err(serde::de::Error::custom)?;
+        Ok(settings)
+    }
+}
+
+impl core::fmt::Debug for GuestProviderSpecSettings {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("GuestProviderSpecSettings")
+            .field("boot_media_ref", &self.boot_media_ref.is_some())
+            .field("removable_volume_refs", &self.removable_volume_refs.len())
+            .field("cpu_model", &self.cpu_model)
+            .field("machine_type", &self.machine_type)
+            .field("bios", &self.bios)
+            .field("pause_at_boot", &self.pause_at_boot)
+            .field("display_window", &self.display_window)
+            .field("serial_console", &self.serial_console)
+            .field("tablet", &self.tablet)
+            .field("rtc_base", &self.rtc_base)
+            .field("extra_features", &self.extra_features)
+            .finish()
+    }
+}
+
+/// Provider-specific Guest spec envelope.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GuestProviderSpec {
+    /// Extension schema identifier.
+    pub schema_id: String,
+    /// Extension schema version.
+    pub schema_version: String,
+    /// Provider settings.
+    pub settings: GuestProviderSpecSettings,
+}
+
+/// Guest ResourceSpec owned by this Provider.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GuestSpec {
+    /// Provider reference.
+    pub provider_ref: ResourceRef,
+    /// Optional NixOS system artifact.
+    pub system_artifact_id: Option<String>,
+    /// Virtual CPU count.
+    pub vcpu: u16,
+    /// Guest memory in MiB.
+    pub memory_mib: u32,
+    /// Network dependencies.
+    #[serde(default)]
+    pub network_attachments: Vec<NetworkAttachment>,
+    /// Device dependencies.
+    #[serde(default)]
+    pub device_attachments: Vec<DeviceAttachment>,
+    /// Provider extension.
+    pub provider: GuestProviderSpec,
+}
+
+impl GuestSpec {
+    /// Construct the minimal valid qemu-media Guest spec.
+    pub fn new(
+        provider_ref: impl Into<String>,
+        boot_media_ref: Option<ResourceRef>,
+        vcpu: u16,
+        memory_mib: u32,
+        mut settings: GuestProviderSpecSettings,
+    ) -> Result<Self, GuestSpecError> {
+        let provider_ref = provider_ref.into();
+        let provider_ref =
+            ResourceRef::parse(&provider_ref).map_err(|_| GuestSpecError::InvalidProviderRef)?;
+        if provider_ref.to_canonical_string() != PROVIDER_REF {
+            return Err(GuestSpecError::InvalidProviderRef);
+        }
+        if vcpu == 0 || vcpu > 1024 || !(128..=524_288).contains(&memory_mib) {
+            return Err(GuestSpecError::InvalidResources);
+        }
+        settings.boot_media_ref = boot_media_ref;
+        settings.validate()?;
+        Ok(Self {
+            provider_ref,
+            system_artifact_id: None,
+            vcpu,
+            memory_mib,
+            network_attachments: Vec::new(),
+            device_attachments: Vec::new(),
+            provider: GuestProviderSpec {
+                schema_id: GUEST_SPEC_SCHEMA_ID.to_owned(),
+                schema_version: "1.0.0".to_owned(),
+                settings,
+            },
+        })
+    }
+
+    /// Validate the complete Guest spec.
+    pub fn validate(&self) -> Result<(), GuestSpecError> {
+        if self.provider_ref.to_canonical_string() != PROVIDER_REF {
+            return Err(GuestSpecError::InvalidProviderRef);
+        }
+        if self.vcpu == 0 || self.vcpu > 1024 || !(128..=524_288).contains(&self.memory_mib) {
+            return Err(GuestSpecError::InvalidResources);
+        }
+        if self.system_artifact_id.is_some() {
+            return Err(GuestSpecError::SystemArtifactUnsupported);
+        }
+        if self.provider.schema_id != GUEST_SPEC_SCHEMA_ID
+            || self.provider.schema_version != "1.0.0"
+        {
+            return Err(GuestSpecError::SchemaMismatch);
+        }
+        self.provider.settings.validate()
+    }
+}
+
+impl core::fmt::Debug for GuestSpec {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("GuestSpec")
+            .field("provider_ref", &self.provider_ref)
+            .field("system_artifact_id", &self.system_artifact_id.is_some())
+            .field("vcpu", &self.vcpu)
+            .field("memory_mib", &self.memory_mib)
+            .field("network_attachments", &self.network_attachments.len())
+            .field("device_attachments", &self.device_attachments.len())
+            .finish()
+    }
+}
+
+/// Common Guest phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "PascalCase")]
+pub enum GuestPhase {
+    /// Dependencies are pending.
+    Pending,
+    /// Runner and QMP are ready.
+    Ready,
+    /// The Guest is usable with a degraded condition.
+    Degraded,
+    /// A required dependency or runner failed.
+    Failed,
+    /// Terminal deleted phase.
+    Deleted,
+    /// The controller lost current process observation.
+    Unknown,
+}
+
+/// Backend provider phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderPhase {
+    /// Newly created resource.
+    Empty,
+    /// Dependencies are pending.
+    WaitingDependencies,
+    /// Runtime Volume is being created.
+    CreatingRuntimeVolume,
+    /// LaunchTicket has been sealed.
+    LaunchingRunner,
+    /// Waiting for QMP greeting.
+    WaitingQmp,
+    /// QEMU is paused at boot.
+    PausedAtBoot,
+    /// QEMU is running.
+    Running,
+    /// Graceful shutdown is in progress.
+    Stopping,
+    /// Runner exited unexpectedly.
+    RunnerFailed,
+    /// Finalization is draining.
+    FinalizePending,
+}
+
+impl ProviderPhase {
+    /// Return the wire value used in `status.provider.details`.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Empty => "",
+            Self::WaitingDependencies => "waiting-dependencies",
+            Self::CreatingRuntimeVolume => "creating-runtime-volume",
+            Self::LaunchingRunner => "launching-runner",
+            Self::WaitingQmp => "waiting-qmp",
+            Self::PausedAtBoot => "paused-at-boot",
+            Self::Running => "running",
+            Self::Stopping => "stopping",
+            Self::RunnerFailed => "runner-failed",
+            Self::FinalizePending => "finalize-pending",
+        }
+    }
+
+    /// Parse a provider phase from a bounded wire value.
+    pub fn parse(value: &str) -> Result<Self, GuestSpecError> {
+        match value {
+            "" => Ok(Self::Empty),
+            "waiting-dependencies" => Ok(Self::WaitingDependencies),
+            "creating-runtime-volume" => Ok(Self::CreatingRuntimeVolume),
+            "launching-runner" => Ok(Self::LaunchingRunner),
+            "waiting-qmp" => Ok(Self::WaitingQmp),
+            "paused-at-boot" => Ok(Self::PausedAtBoot),
+            "running" => Ok(Self::Running),
+            "stopping" => Ok(Self::Stopping),
+            "runner-failed" => Ok(Self::RunnerFailed),
+            "finalize-pending" => Ok(Self::FinalizePending),
+            _ => Err(GuestSpecError::InvalidProviderPhase),
+        }
+    }
+}
+
+/// Condition boolean state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ConditionStatus {
+    /// Condition holds.
+    True,
+    /// Condition does not hold.
+    False,
+}
+
+/// Bounded Guest condition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GuestCondition {
+    /// Closed condition type.
+    pub condition_type: String,
+    /// Current condition state.
+    pub status: ConditionStatus,
+    /// Closed reason code.
+    pub reason: String,
+}
+
+/// Common Guest runtime status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GuestRuntimeStatus {
+    /// Whether the runner is ready.
+    pub runtime_ready: bool,
+    /// Whether the QMP session is ready.
+    pub bootstrap_ready: bool,
+    /// Number of active worker processes.
+    pub active_process_count: u16,
+}
+
+/// Provider status details.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GuestProviderDetails {
+    /// Backend lifecycle detail.
+    pub provider_phase: String,
+}
+
+/// Provider status extension.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GuestProviderStatus {
+    /// Provider reference.
+    pub provider_ref: ResourceRef,
+    /// Status schema identifier.
+    pub schema_id: String,
+    /// Status schema version.
+    pub schema_version: String,
+    /// Observed Provider generation.
+    pub observed_provider_generation: u64,
+    /// Backend details.
+    pub details: GuestProviderDetails,
+}
+
+/// Redacted Guest status projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GuestStatus {
+    /// Common phase.
+    pub phase: GuestPhase,
+    /// Common runtime status.
+    pub resource: GuestRuntimeStatus,
+    /// Provider extension.
+    pub provider: GuestProviderStatus,
+    /// Bounded conditions.
+    #[serde(default)]
+    pub conditions: Vec<GuestCondition>,
+}
+
+impl GuestStatus {
+    /// Construct a status with the provider phase.
+    pub fn new(phase: GuestPhase, provider_phase: ProviderPhase) -> Self {
+        Self {
+            phase,
+            resource: GuestRuntimeStatus {
+                runtime_ready: false,
+                bootstrap_ready: false,
+                active_process_count: 0,
+            },
+            provider: GuestProviderStatus {
+                provider_ref: ResourceRef::parse(PROVIDER_REF).expect("frozen provider ref"),
+                schema_id: GUEST_STATUS_SCHEMA_ID.to_owned(),
+                schema_version: "1.0.0".to_owned(),
+                observed_provider_generation: 0,
+                details: GuestProviderDetails {
+                    provider_phase: provider_phase.as_str().to_owned(),
+                },
+            },
+            conditions: Vec::new(),
+        }
+    }
+
+    /// Construct a status from a wire provider phase.
+    pub fn from_provider_phase(value: &str) -> Result<Self, GuestSpecError> {
+        if value.len() > MAX_PROVIDER_PHASE_BYTES {
+            return Err(GuestSpecError::ProviderPhaseTooLong);
+        }
+        Ok(Self::new(GuestPhase::Pending, ProviderPhase::parse(value)?))
+    }
+
+    /// Return the common phase.
+    pub const fn phase(&self) -> GuestPhase {
+        self.phase
+    }
+
+    /// Return the parsed provider phase.
+    pub fn provider_phase(&self) -> ProviderPhase {
+        ProviderPhase::parse(&self.provider.details.provider_phase).unwrap_or(ProviderPhase::Empty)
+    }
+}
+
+/// Guest specification validation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuestSpecError {
+    /// Provider reference is not runtime-qemu-media.
+    InvalidProviderRef,
+    /// VCPU or memory is outside the closed bounds.
+    InvalidResources,
+    /// A Volume reference had the wrong ResourceType.
+    InvalidVolumeRef,
+    /// A Network reference had the wrong ResourceType.
+    InvalidNetworkRef,
+    /// A Device reference had the wrong ResourceType.
+    InvalidDeviceRef,
+    /// A Volume view was not a bounded token.
+    InvalidView,
+    /// Too many removable Volumes were requested.
+    TooManyRemovableVolumes,
+    /// A Volume was named more than once.
+    DuplicateVolumeRef,
+    /// An optional feature was named more than once.
+    DuplicateExtraFeature,
+    /// Too many optional features were requested.
+    TooManyExtraFeatures,
+    /// Provider schema identity did not match.
+    SchemaMismatch,
+    /// A media Guest cannot request a NixOS system artifact.
+    SystemArtifactUnsupported,
+    /// Provider phase is not in the closed set.
+    InvalidProviderPhase,
+    /// Provider phase exceeded its bound.
+    ProviderPhaseTooLong,
+}
+
+impl core::fmt::Display for GuestSpecError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidProviderRef => "qemu-media-provider-ref-invalid",
+            Self::InvalidResources => "qemu-media-guest-resources-invalid",
+            Self::InvalidVolumeRef => "qemu-media-volume-ref-invalid",
+            Self::InvalidNetworkRef => "qemu-media-network-ref-invalid",
+            Self::InvalidDeviceRef => "qemu-media-device-ref-invalid",
+            Self::InvalidView => "qemu-media-volume-view-invalid",
+            Self::TooManyRemovableVolumes => "qemu-media-too-many-removable-volumes",
+            Self::DuplicateVolumeRef => "qemu-media-duplicate-volume-ref",
+            Self::DuplicateExtraFeature => "qemu-media-duplicate-extra-feature",
+            Self::TooManyExtraFeatures => "qemu-media-too-many-extra-features",
+            Self::SchemaMismatch => "qemu-media-schema-mismatch",
+            Self::SystemArtifactUnsupported => "qemu-media-system-artifact-unsupported",
+            Self::InvalidProviderPhase => "qemu-media-provider-phase-invalid",
+            Self::ProviderPhaseTooLong => "qemu-media-provider-phase-too-long",
+        })
+    }
+}
+
+impl std::error::Error for GuestSpecError {}
+
+fn validate_token(value: &str) -> Result<(), ()> {
+    if value.is_empty()
+        || value.len() > 63
+        || !value.as_bytes()[0].is_ascii_lowercase()
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        Err(())
+    } else {
+        Ok(())
+    }
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+fn default_boot_media_view() -> String {
+    "guest-attach".to_owned()
+}
+
+const fn default_cpu_model() -> CpuModel {
+    CpuModel::Host
+}
+
+const fn default_machine_type() -> MachineType {
+    MachineType::Q35
+}
+
+const fn default_bios() -> Bios {
+    Bios::Ovmf
+}
+
+const fn default_rtc_base() -> RtcBase {
+    RtcBase::Utc
+}

--- a/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
@@ -2,9 +2,14 @@
 
 use std::collections::BTreeSet;
 
-use d2b_contracts::v3::ResourceRef;
+use d2b_contracts::v3::{
+    CanonicalJsonObject, ProviderSpecExtension, ResourceRef, ResourceSpec, SchemaVersion,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
+
+pub use d2b_contracts::v3::GuestSpec;
+pub use d2b_contracts::v3::execution_policy::{DeviceAttachment, NetworkAttachment};
 
 /// Maximum removable media attachments on one Guest.
 pub const MAX_REMOVABLE_VOLUMES: usize = 4;
@@ -119,52 +124,14 @@ impl core::fmt::Debug for RemovableVolumeRef {
     }
 }
 
-/// Opaque network dependency.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct NetworkAttachment {
-    /// Referenced Network.
-    pub network_ref: ResourceRef,
-}
-
-impl NetworkAttachment {
-    /// Construct a Network attachment.
-    pub fn new(network_ref: ResourceRef) -> Result<Self, GuestSpecError> {
-        if network_ref.resource_type().as_str() != "Network" {
-            return Err(GuestSpecError::InvalidNetworkRef);
-        }
-        Ok(Self { network_ref })
-    }
-}
-
-/// Opaque device dependency.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct DeviceAttachment {
-    /// Referenced Device.
-    pub device_ref: ResourceRef,
-    /// Whether the Guest requests exclusive access.
-    #[serde(default)]
-    pub exclusive: bool,
-}
-
-impl DeviceAttachment {
-    /// Construct a Device attachment.
-    pub fn new(device_ref: ResourceRef, exclusive: bool) -> Result<Self, GuestSpecError> {
-        if device_ref.resource_type().as_str() != "Device" {
-            return Err(GuestSpecError::InvalidDeviceRef);
-        }
-        Ok(Self {
-            device_ref,
-            exclusive,
-        })
-    }
-}
-
 /// Guest provider-specific settings.
 #[derive(Clone, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GuestProviderSpecSettings {
+    /// Virtual CPU count.
+    pub vcpu: u16,
+    /// Guest memory in MiB.
+    pub memory_mib: u32,
     /// Optional boot Volume.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boot_media_ref: Option<ResourceRef>,
@@ -195,6 +162,8 @@ pub struct GuestProviderSpecSettings {
 impl Default for GuestProviderSpecSettings {
     fn default() -> Self {
         Self {
+            vcpu: 2,
+            memory_mib: 4096,
             boot_media_ref: None,
             boot_media_view: "guest-attach".to_owned(),
             removable_volume_refs: Vec::new(),
@@ -214,6 +183,9 @@ impl Default for GuestProviderSpecSettings {
 impl GuestProviderSpecSettings {
     /// Validate every provider setting bound.
     pub fn validate(&self) -> Result<(), GuestSpecError> {
+        if self.vcpu == 0 || self.vcpu > 1024 || !(128..=524_288).contains(&self.memory_mib) {
+            return Err(GuestSpecError::InvalidResources);
+        }
         if self
             .boot_media_ref
             .as_ref()
@@ -252,6 +224,10 @@ impl<'de> Deserialize<'de> for GuestProviderSpecSettings {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase", deny_unknown_fields)]
         struct Wire {
+            #[serde(default = "default_vcpu")]
+            vcpu: u16,
+            #[serde(default = "default_memory_mib")]
+            memory_mib: u32,
             #[serde(default)]
             boot_media_ref: Option<ResourceRef>,
             #[serde(default = "default_boot_media_view")]
@@ -279,6 +255,8 @@ impl<'de> Deserialize<'de> for GuestProviderSpecSettings {
         }
         let wire = Wire::deserialize(deserializer)?;
         let settings = Self {
+            vcpu: wire.vcpu,
+            memory_mib: wire.memory_mib,
             boot_media_ref: wire.boot_media_ref,
             boot_media_view: wire.boot_media_view,
             removable_volume_refs: wire.removable_volume_refs,
@@ -316,153 +294,71 @@ impl core::fmt::Debug for GuestProviderSpecSettings {
     }
 }
 
-/// Provider-specific Guest spec envelope.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct GuestProviderSpec {
-    /// Extension schema identifier.
-    pub schema_id: String,
-    /// Extension schema version.
-    pub schema_version: String,
-    /// Provider settings.
-    pub settings: GuestProviderSpecSettings,
+/// Construct a qemu-media Guest `ResourceSpec` from the canonical Guest base
+/// and the Provider-owned settings envelope.
+pub fn build_guest_resource_spec(
+    boot_media_ref: Option<ResourceRef>,
+    vcpu: u16,
+    memory_mib: u32,
+    mut settings: GuestProviderSpecSettings,
+) -> Result<ResourceSpec, GuestResourceSpecError> {
+    let provider_ref =
+        ResourceRef::parse(PROVIDER_REF).map_err(|_| GuestResourceSpecError::InvalidProviderRef)?;
+    settings.boot_media_ref = boot_media_ref;
+    settings.vcpu = vcpu;
+    settings.memory_mib = memory_mib;
+    settings.validate()?;
+
+    let base = GuestSpec::system_default();
+    let base = serde_json::to_vec(&base).map_err(|_| GuestResourceSpecError::CanonicalJson)?;
+    let base =
+        CanonicalJsonObject::parse(&base).map_err(|_| GuestResourceSpecError::CanonicalJson)?;
+    let settings =
+        serde_json::to_vec(&settings).map_err(|_| GuestResourceSpecError::CanonicalJson)?;
+    let settings =
+        CanonicalJsonObject::parse(&settings).map_err(|_| GuestResourceSpecError::CanonicalJson)?;
+    let provider = ProviderSpecExtension::new(
+        d2b_contracts::v3::ExtensionSchemaId::parse(GUEST_SPEC_SCHEMA_ID)
+            .map_err(|_| GuestResourceSpecError::SchemaMismatch)?,
+        SchemaVersion::parse("1.0").map_err(|_| GuestResourceSpecError::SchemaMismatch)?,
+        settings,
+    )
+    .map_err(|_| GuestResourceSpecError::SchemaMismatch)?;
+    ResourceSpec::new(Some(provider_ref), None, base, Some(provider))
+        .map_err(|_| GuestResourceSpecError::CanonicalJson)
 }
 
-/// Guest ResourceSpec owned by this Provider.
-#[derive(Clone, PartialEq, Eq, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct GuestSpec {
-    /// Provider reference.
-    pub provider_ref: ResourceRef,
-    /// Optional NixOS system artifact.
-    pub system_artifact_id: Option<String>,
-    /// Virtual CPU count.
-    pub vcpu: u16,
-    /// Guest memory in MiB.
-    pub memory_mib: u32,
-    /// Network dependencies.
-    #[serde(default)]
-    pub network_attachments: Vec<NetworkAttachment>,
-    /// Device dependencies.
-    #[serde(default)]
-    pub device_attachments: Vec<DeviceAttachment>,
-    /// Provider extension.
-    pub provider: GuestProviderSpec,
+/// Failure while building the canonical Guest ResourceSpec envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuestResourceSpecError {
+    /// The fixed qemu-media Provider reference could not be parsed.
+    InvalidProviderRef,
+    /// Provider settings are invalid.
+    InvalidSettings,
+    /// The canonical Provider extension schema is invalid.
+    SchemaMismatch,
+    /// The canonical JSON base or settings object could not be rendered.
+    CanonicalJson,
 }
 
-impl<'de> Deserialize<'de> for GuestSpec {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "camelCase", deny_unknown_fields)]
-        struct Wire {
-            provider_ref: ResourceRef,
-            #[serde(default)]
-            system_artifact_id: Option<String>,
-            vcpu: u16,
-            memory_mib: u32,
-            #[serde(default)]
-            network_attachments: Vec<NetworkAttachment>,
-            #[serde(default)]
-            device_attachments: Vec<DeviceAttachment>,
-            provider: GuestProviderSpec,
-        }
-        let wire = Wire::deserialize(deserializer)?;
-        let spec = Self {
-            provider_ref: wire.provider_ref,
-            system_artifact_id: wire.system_artifact_id,
-            vcpu: wire.vcpu,
-            memory_mib: wire.memory_mib,
-            network_attachments: wire.network_attachments,
-            device_attachments: wire.device_attachments,
-            provider: wire.provider,
-        };
-        spec.validate().map_err(serde::de::Error::custom)?;
-        Ok(spec)
+impl From<GuestSpecError> for GuestResourceSpecError {
+    fn from(_: GuestSpecError) -> Self {
+        Self::InvalidSettings
     }
 }
 
-impl GuestSpec {
-    /// Construct the minimal valid qemu-media Guest spec.
-    pub fn new(
-        provider_ref: impl Into<String>,
-        boot_media_ref: Option<ResourceRef>,
-        vcpu: u16,
-        memory_mib: u32,
-        mut settings: GuestProviderSpecSettings,
-    ) -> Result<Self, GuestSpecError> {
-        let provider_ref = provider_ref.into();
-        let provider_ref =
-            ResourceRef::parse(&provider_ref).map_err(|_| GuestSpecError::InvalidProviderRef)?;
-        if provider_ref.to_canonical_string() != PROVIDER_REF {
-            return Err(GuestSpecError::InvalidProviderRef);
-        }
-        if vcpu == 0 || vcpu > 1024 || !(128..=524_288).contains(&memory_mib) {
-            return Err(GuestSpecError::InvalidResources);
-        }
-        settings.boot_media_ref = boot_media_ref;
-        settings.validate()?;
-        Ok(Self {
-            provider_ref,
-            system_artifact_id: None,
-            vcpu,
-            memory_mib,
-            network_attachments: Vec::new(),
-            device_attachments: Vec::new(),
-            provider: GuestProviderSpec {
-                schema_id: GUEST_SPEC_SCHEMA_ID.to_owned(),
-                schema_version: "1.0.0".to_owned(),
-                settings,
-            },
+impl core::fmt::Display for GuestResourceSpecError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidProviderRef => "qemu-media-provider-ref-invalid",
+            Self::InvalidSettings => "qemu-media-guest-settings-invalid",
+            Self::SchemaMismatch => "qemu-media-schema-mismatch",
+            Self::CanonicalJson => "qemu-media-canonical-json-invalid",
         })
     }
-
-    /// Validate the complete Guest spec.
-    pub fn validate(&self) -> Result<(), GuestSpecError> {
-        if self.provider_ref.to_canonical_string() != PROVIDER_REF {
-            return Err(GuestSpecError::InvalidProviderRef);
-        }
-        if self.vcpu == 0 || self.vcpu > 1024 || !(128..=524_288).contains(&self.memory_mib) {
-            return Err(GuestSpecError::InvalidResources);
-        }
-        if self.system_artifact_id.is_some() {
-            return Err(GuestSpecError::SystemArtifactUnsupported);
-        }
-        if self
-            .network_attachments
-            .iter()
-            .any(|attachment| attachment.network_ref.resource_type().as_str() != "Network")
-            || self
-                .device_attachments
-                .iter()
-                .any(|attachment| attachment.device_ref.resource_type().as_str() != "Device")
-        {
-            return Err(GuestSpecError::InvalidReference);
-        }
-        if self.provider.schema_id != GUEST_SPEC_SCHEMA_ID
-            || self.provider.schema_version != "1.0.0"
-        {
-            return Err(GuestSpecError::SchemaMismatch);
-        }
-        self.provider.settings.validate()
-    }
 }
 
-impl core::fmt::Debug for GuestSpec {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        formatter
-            .debug_struct("GuestSpec")
-            .field("provider_ref", &self.provider_ref)
-            .field("system_artifact_id", &self.system_artifact_id.is_some())
-            .field("vcpu", &self.vcpu)
-            .field("memory_mib", &self.memory_mib)
-            .field("network_attachments", &self.network_attachments.len())
-            .field("device_attachments", &self.device_attachments.len())
-            .finish()
-    }
-}
+impl std::error::Error for GuestResourceSpecError {}
 
 /// Common Guest phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -767,6 +663,14 @@ fn validate_token(value: &str) -> Result<(), ()> {
 
 const fn default_true() -> bool {
     true
+}
+
+const fn default_vcpu() -> u16 {
+    2
+}
+
+const fn default_memory_mib() -> u32 {
+    4096
 }
 
 fn default_boot_media_view() -> String {

--- a/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
@@ -329,7 +329,7 @@ pub struct GuestProviderSpec {
 }
 
 /// Guest ResourceSpec owned by this Provider.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GuestSpec {
     /// Provider reference.
@@ -348,6 +348,40 @@ pub struct GuestSpec {
     pub device_attachments: Vec<DeviceAttachment>,
     /// Provider extension.
     pub provider: GuestProviderSpec,
+}
+
+impl<'de> Deserialize<'de> for GuestSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Wire {
+            provider_ref: ResourceRef,
+            #[serde(default)]
+            system_artifact_id: Option<String>,
+            vcpu: u16,
+            memory_mib: u32,
+            #[serde(default)]
+            network_attachments: Vec<NetworkAttachment>,
+            #[serde(default)]
+            device_attachments: Vec<DeviceAttachment>,
+            provider: GuestProviderSpec,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        let spec = Self {
+            provider_ref: wire.provider_ref,
+            system_artifact_id: wire.system_artifact_id,
+            vcpu: wire.vcpu,
+            memory_mib: wire.memory_mib,
+            network_attachments: wire.network_attachments,
+            device_attachments: wire.device_attachments,
+            provider: wire.provider,
+        };
+        spec.validate().map_err(serde::de::Error::custom)?;
+        Ok(spec)
+    }
 }
 
 impl GuestSpec {
@@ -557,7 +591,7 @@ pub struct GuestProviderStatus {
 }
 
 /// Redacted Guest status projection.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GuestStatus {
     /// Common phase.
@@ -569,6 +603,40 @@ pub struct GuestStatus {
     /// Bounded conditions.
     #[serde(default)]
     pub conditions: Vec<GuestCondition>,
+}
+
+impl<'de> Deserialize<'de> for GuestStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Wire {
+            phase: GuestPhase,
+            resource: GuestRuntimeStatus,
+            provider: GuestProviderStatus,
+            #[serde(default)]
+            conditions: Vec<GuestCondition>,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        if wire.conditions.len() > 16
+            || wire.provider.provider_ref.to_canonical_string() != PROVIDER_REF
+            || wire.provider.schema_id != GUEST_STATUS_SCHEMA_ID
+            || wire.provider.schema_version != "1.0.0"
+            || wire.provider.details.provider_phase.len() > MAX_PROVIDER_PHASE_BYTES
+        {
+            return Err(serde::de::Error::custom(GuestSpecError::SchemaMismatch));
+        }
+        ProviderPhase::parse(&wire.provider.details.provider_phase)
+            .map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            phase: wire.phase,
+            resource: wire.resource,
+            provider: wire.provider,
+            conditions: wire.conditions,
+        })
+    }
 }
 
 impl GuestStatus {

--- a/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/types/guest.rs
@@ -430,6 +430,17 @@ impl GuestSpec {
         if self.system_artifact_id.is_some() {
             return Err(GuestSpecError::SystemArtifactUnsupported);
         }
+        if self
+            .network_attachments
+            .iter()
+            .any(|attachment| attachment.network_ref.resource_type().as_str() != "Network")
+            || self
+                .device_attachments
+                .iter()
+                .any(|attachment| attachment.device_ref.resource_type().as_str() != "Device")
+        {
+            return Err(GuestSpecError::InvalidReference);
+        }
         if self.provider.schema_id != GUEST_SPEC_SCHEMA_ID
             || self.provider.schema_version != "1.0.0"
         {
@@ -694,6 +705,8 @@ pub enum GuestSpecError {
     InvalidNetworkRef,
     /// A Device reference had the wrong ResourceType.
     InvalidDeviceRef,
+    /// A base attachment reference had the wrong ResourceType.
+    InvalidReference,
     /// A Volume view was not a bounded token.
     InvalidView,
     /// Too many removable Volumes were requested.
@@ -722,6 +735,7 @@ impl core::fmt::Display for GuestSpecError {
             Self::InvalidVolumeRef => "qemu-media-volume-ref-invalid",
             Self::InvalidNetworkRef => "qemu-media-network-ref-invalid",
             Self::InvalidDeviceRef => "qemu-media-device-ref-invalid",
+            Self::InvalidReference => "qemu-media-reference-invalid",
             Self::InvalidView => "qemu-media-volume-view-invalid",
             Self::TooManyRemovableVolumes => "qemu-media-too-many-removable-volumes",
             Self::DuplicateVolumeRef => "qemu-media-duplicate-volume-ref",

--- a/packages/d2b-provider-runtime-qemu-media/src/types/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/types/mod.rs
@@ -4,7 +4,7 @@ mod guest;
 
 pub use guest::{
     Bios, ConditionStatus, CpuModel, DeviceAttachment, ExtraFeature, GuestCondition, GuestPhase,
-    GuestProviderDetails, GuestProviderSpecSettings, GuestProviderStatus, GuestRuntimeStatus,
-    GuestSpec, GuestSpecError, GuestStatus, MachineType, NetworkAttachment, ProviderPhase,
-    RemovableVolumeRef, RtcBase,
+    GuestProviderDetails, GuestProviderSpecSettings, GuestProviderStatus, GuestResourceSpecError,
+    GuestRuntimeStatus, GuestSpec, GuestSpecError, GuestStatus, MachineType, NetworkAttachment,
+    ProviderPhase, RemovableVolumeRef, RtcBase, build_guest_resource_spec,
 };

--- a/packages/d2b-provider-runtime-qemu-media/src/types/mod.rs
+++ b/packages/d2b-provider-runtime-qemu-media/src/types/mod.rs
@@ -1,0 +1,10 @@
+//! Resource specifications and status projections for qemu-media Guests.
+
+mod guest;
+
+pub use guest::{
+    Bios, ConditionStatus, CpuModel, DeviceAttachment, ExtraFeature, GuestCondition, GuestPhase,
+    GuestProviderDetails, GuestProviderSpecSettings, GuestProviderStatus, GuestRuntimeStatus,
+    GuestSpec, GuestSpecError, GuestStatus, MachineType, NetworkAttachment, ProviderPhase,
+    RemovableVolumeRef, RtcBase,
+};

--- a/packages/d2b-provider-runtime-qemu-media/tests/audit_telemetry.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/audit_telemetry.rs
@@ -1,0 +1,57 @@
+use d2b_provider_runtime_qemu_media::{
+    AuditEventKind, AuditOutcome, AuditRecord, MetricOutcome, QmpOperation, SpanKind,
+    TelemetryFrame,
+};
+
+#[test]
+fn audit_events_are_bounded_and_redacted() {
+    let record = AuditRecord::new(
+        AuditEventKind::QmpReady,
+        AuditOutcome::Success,
+        "corp",
+        "Guest/media-vm",
+        "operation-1",
+    );
+    let json = record.to_json().unwrap();
+    assert!(json.contains("qmp-ready"));
+    assert!(!json.contains("/run"));
+    assert!(!json.contains("argv"));
+    assert!(!json.contains("socket"));
+    assert!(!json.contains("pid"));
+}
+
+#[test]
+fn every_audit_kind_has_a_stable_wire_name() {
+    for kind in AuditEventKind::ALL {
+        assert!(!kind.as_str().is_empty());
+        assert!(kind.as_str().starts_with("guest/"));
+    }
+}
+
+#[test]
+fn telemetry_labels_are_closed_and_zone_is_a_resource_attribute() {
+    let frame = TelemetryFrame::new("corp", MetricOutcome::Success);
+    assert!(frame.validate().is_ok());
+    assert!(
+        frame
+            .resource_attributes()
+            .iter()
+            .any(|field| field.key == "d2b.zone")
+    );
+    assert!(frame.metric_labels().iter().all(|field| {
+        ["provider", "outcome", "operation", "phase", "dep_type"].contains(&field.key)
+    }));
+    assert!(TelemetryFrame::validate_field("vm", "media-vm").is_err());
+    assert!(TelemetryFrame::validate_field("outcome", "caller-controlled").is_err());
+}
+
+#[test]
+fn span_attributes_use_fixed_semantic_values() {
+    let span = TelemetryFrame::span(
+        SpanKind::QmpCommand,
+        QmpOperation::QueryStatus,
+        MetricOutcome::Success,
+    );
+    assert!(span.validate().is_ok());
+    assert!(TelemetryFrame::validate_span_attribute("guest", "Guest/media-vm").is_err());
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
@@ -15,10 +15,12 @@ fn provider_config_requires_host_and_projects_controller_only() {
     .unwrap();
     assert!(config.validate().is_ok());
     assert_eq!(config.project_worker(), WorkerConfigProjection);
-    assert_eq!(
-        config.project_controller().controller_execution_ref(),
-        "Host/host-system"
-    );
+    let projection = config.project_controller();
+    assert_eq!(projection.controller_execution_ref(), "Host/host-system");
+    assert_eq!(projection.qemu_binary_artifact_id(), "qemu-system-x86-64");
+    assert_eq!(projection.network_provider_ref(), "Provider/network-local");
+    assert_eq!(projection.volume_provider_ref(), "Provider/volume-local");
+    assert_eq!(projection.display_provider_ref(), None);
 }
 
 #[test]

--- a/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
@@ -14,7 +14,7 @@ fn provider_config_requires_host_and_projects_controller_only() {
     )
     .unwrap();
     assert!(config.validate().is_ok());
-    assert_eq!(config.project_worker(), WorkerConfigProjection::default());
+    assert_eq!(config.project_worker(), WorkerConfigProjection);
     assert_eq!(
         config.project_controller().controller_execution_ref(),
         "Host/host-system"

--- a/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
@@ -39,3 +39,17 @@ fn provider_config_rejects_invalid_bounds() {
     config.runtime_tmpfs_quota_bytes = 1024;
     assert!(config.validate().is_err());
 }
+
+#[test]
+fn omitted_qemu_artifact_uses_a_valid_canonical_token() {
+    let config: ProviderConfig = serde_json::from_str(
+        r#"{
+            "controllerExecutionRef":"Host/host-system",
+            "networkProviderRef":"Provider/network-local",
+            "volumeProviderRef":"Provider/volume-local"
+        }"#,
+    )
+    .unwrap();
+    assert_eq!(config.qemu_binary_artifact_id, "qemu-system-x86-64");
+    assert!(config.validate().is_ok());
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/config_schema_projection.rs
@@ -1,0 +1,39 @@
+use d2b_provider_runtime_qemu_media::{ProviderConfig, WorkerConfigProjection};
+
+#[test]
+fn provider_config_requires_host_and_projects_controller_only() {
+    let config = ProviderConfig::default();
+    assert!(config.validate().is_err());
+
+    let config = ProviderConfig::new(
+        "Host/host-system",
+        "qemu-system-x86-64",
+        "Provider/network-local",
+        "Provider/volume-local",
+        None,
+    )
+    .unwrap();
+    assert!(config.validate().is_ok());
+    assert_eq!(config.project_worker(), WorkerConfigProjection::default());
+    assert_eq!(
+        config.project_controller().controller_execution_ref(),
+        "Host/host-system"
+    );
+}
+
+#[test]
+fn provider_config_rejects_invalid_bounds() {
+    let mut config = ProviderConfig::new(
+        "Host/host-system",
+        "qemu-system-x86-64",
+        "Provider/network-local",
+        "Provider/volume-local",
+        None,
+    )
+    .unwrap();
+    config.qmp_ready_timeout_seconds = 4;
+    assert!(config.validate().is_err());
+    config.qmp_ready_timeout_seconds = 30;
+    config.runtime_tmpfs_quota_bytes = 1024;
+    assert!(config.validate().is_err());
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/conformance_guest.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/conformance_guest.rs
@@ -1,18 +1,24 @@
 use d2b_provider_runtime_qemu_media::{
     GuestPhase, GuestProviderSpecSettings, GuestSpec, GuestStatus, ProviderPhase,
+    build_guest_resource_spec,
 };
 
 #[test]
 fn guest_conformance_keeps_common_and_provider_status_layers_distinct() {
-    let spec = GuestSpec::new(
-        "Provider/runtime-qemu-media",
+    let spec = build_guest_resource_spec(
         Some(d2b_contracts::v3::ResourceRef::parse("Volume/boot").unwrap()),
         2,
         4096,
         GuestProviderSpecSettings::default(),
     )
     .unwrap();
-    spec.validate().unwrap();
+    let base: GuestSpec =
+        serde_json::from_slice(&serde_json::to_vec(&GuestSpec::system_default()).unwrap()).unwrap();
+    assert_eq!(base, GuestSpec::system_default());
+    assert_eq!(
+        spec.provider().unwrap().schema_id().to_canonical_string(),
+        "runtime-qemu-media.d2bus.org/Guest/spec"
+    );
     let status = GuestStatus::new(GuestPhase::Ready, ProviderPhase::PausedAtBoot);
     assert_eq!(status.phase(), GuestPhase::Ready);
     assert_eq!(status.provider_phase(), ProviderPhase::PausedAtBoot);

--- a/packages/d2b-provider-runtime-qemu-media/tests/conformance_guest.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/conformance_guest.rs
@@ -1,0 +1,23 @@
+use d2b_provider_runtime_qemu_media::{
+    GuestPhase, GuestProviderSpecSettings, GuestSpec, GuestStatus, ProviderPhase,
+};
+
+#[test]
+fn guest_conformance_keeps_common_and_provider_status_layers_distinct() {
+    let spec = GuestSpec::new(
+        "Provider/runtime-qemu-media",
+        Some(d2b_contracts::v3::ResourceRef::parse("Volume/boot").unwrap()),
+        2,
+        4096,
+        GuestProviderSpecSettings::default(),
+    )
+    .unwrap();
+    spec.validate().unwrap();
+    let status = GuestStatus::new(GuestPhase::Ready, ProviderPhase::PausedAtBoot);
+    assert_eq!(status.phase(), GuestPhase::Ready);
+    assert_eq!(status.provider_phase(), ProviderPhase::PausedAtBoot);
+    assert_eq!(
+        status.provider.schema_id,
+        "runtime-qemu-media.d2bus.org/Guest/status"
+    );
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/dependencies_and_process.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/dependencies_and_process.rs
@@ -1,0 +1,87 @@
+use d2b_contracts::v3::ResourceRef;
+use d2b_provider_runtime_qemu_media::{
+    DeviceAdmission, DeviceObservation, DevicePhase, HostGlobalAuthorityIndex, MediaWatch,
+    PlatformClass, ProcessSpec, RuntimeVolumeSpec, VolumeObservation, WaylandSessionSpec,
+};
+
+fn guest() -> ResourceRef {
+    ResourceRef::parse("Guest/media-vm").unwrap()
+}
+
+#[test]
+fn runtime_volume_is_ephemeral_and_waits_for_process_proof() {
+    let volume = RuntimeVolumeSpec::new(guest(), "corp", 10 * 1024 * 1024, 1024).unwrap();
+    assert_eq!(volume.cleanup_policy(), "vm-stop-with-proof");
+    assert_eq!(volume.owner_ref(), &guest());
+    assert!(volume.validate().is_ok());
+    assert!(serde_json::to_string(&volume).unwrap().contains("qmp.sock"));
+}
+
+#[test]
+fn media_watch_requires_ready_virtio_block_attachments() {
+    let boot = ResourceRef::parse("Volume/boot-media").unwrap();
+    let pending = VolumeObservation::pending(boot.clone());
+    let watch = MediaWatch::new(guest(), Some(boot.clone()), Vec::new());
+    assert_eq!(
+        watch.observe([pending]).unwrap_err().code(),
+        "media-volume-not-ready"
+    );
+
+    let ready = VolumeObservation::ready_virtio_blk(boot);
+    assert!(watch.observe([ready]).is_ok());
+}
+
+#[test]
+fn device_admission_rejects_wrong_owner_platform_and_process_contract() {
+    let key = [7_u8; 32];
+    let mut authority = HostGlobalAuthorityIndex::new();
+    let observation = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/other").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: key,
+        process_identity: Some("process-a".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    assert!(
+        DeviceAdmission::validate(&guest(), &observation, "process-a", "qemu-media/v1").is_err()
+    );
+    let owned = DeviceObservation {
+        owner_ref: Some(guest()),
+        ..observation
+    };
+    assert!(DeviceAdmission::validate(&guest(), &owned, "process-a", "qemu-media/v1").is_ok());
+    let _reservation = authority.reserve(key, guest()).unwrap();
+    assert!(authority.reserve(key, guest()).is_err());
+}
+
+#[test]
+fn display_session_has_no_managed_by_or_locator_fields() {
+    let spec = WaylandSessionSpec::new(
+        Some(ResourceRef::parse("Provider/display-wayland").unwrap()),
+        guest(),
+    )
+    .unwrap();
+    let json = serde_json::to_string(&spec).unwrap();
+    assert!(!json.contains("managedBy"));
+    assert!(!json.contains("socketPath"));
+    assert!(json.contains("guestRef"));
+}
+
+#[test]
+fn process_spec_contains_only_opaque_attachments() {
+    let process = ProcessSpec::new(
+        guest(),
+        ResourceRef::parse("Host/host-system").unwrap(),
+        ResourceRef::parse("Volume/runtime").unwrap(),
+        Some(ResourceRef::parse("Device/host-kvm").unwrap()),
+        [ResourceRef::parse("Network/corp-net").unwrap()],
+    )
+    .unwrap();
+    let json = serde_json::to_string(&process).unwrap();
+    assert!(json.contains("qemu-media-runner"));
+    assert!(!json.contains("argv"));
+    assert!(!json.contains("/nix/store"));
+    assert!(!json.contains("broker"));
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/dependencies_and_process.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/dependencies_and_process.rs
@@ -13,6 +13,17 @@ fn runtime_volume_is_ephemeral_and_waits_for_process_proof() {
     let volume = RuntimeVolumeSpec::new(guest(), "corp", 10 * 1024 * 1024, 1024).unwrap();
     assert_eq!(volume.cleanup_policy(), "vm-stop-with-proof");
     assert_eq!(volume.owner_ref(), &guest());
+    assert_eq!(
+        volume.provider_ref.to_canonical_string(),
+        "Provider/volume-local"
+    );
+    assert_eq!(volume.views.len(), 2);
+    assert_eq!(
+        volume.layout[0].restart_policy,
+        "preserve-across-controller-restart"
+    );
+    assert_eq!(volume.layout[1].restart_policy, "clear-on-runner-restart");
+    assert_eq!(volume.layout[2].restart_policy, "clear-on-runner-restart");
     assert!(volume.validate().is_ok());
     assert!(serde_json::to_string(&volume).unwrap().contains("qmp.sock"));
 }
@@ -52,6 +63,11 @@ fn device_admission_rejects_wrong_owner_platform_and_process_contract() {
         ..observation
     };
     assert!(DeviceAdmission::validate(&guest(), &owned, "process-a", "qemu-media/v1").is_ok());
+    let shared = DeviceObservation {
+        owner_ref: None,
+        ..owned
+    };
+    assert!(DeviceAdmission::validate(&guest(), &shared, "process-a", "qemu-media/v1").is_ok());
     let _reservation = authority.reserve(key, guest()).unwrap();
     assert!(authority.reserve(key, guest()).is_err());
 }

--- a/packages/d2b-provider-runtime-qemu-media/tests/dependencies_and_process.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/dependencies_and_process.rs
@@ -2,6 +2,7 @@ use d2b_contracts::v3::ResourceRef;
 use d2b_provider_runtime_qemu_media::{
     DeviceAdmission, DeviceObservation, DevicePhase, HostGlobalAuthorityIndex, MediaWatch,
     PlatformClass, ProcessSpec, RuntimeVolumeSpec, VolumeObservation, WaylandSessionSpec,
+    build_process_spec, validate_process_spec,
 };
 
 fn guest() -> ResourceRef {
@@ -87,8 +88,7 @@ fn display_session_has_no_managed_by_or_locator_fields() {
 
 #[test]
 fn process_spec_contains_only_opaque_attachments() {
-    let process = ProcessSpec::new(
-        guest(),
+    let process = build_process_spec(
         ResourceRef::parse("Host/host-system").unwrap(),
         ResourceRef::parse("Volume/runtime").unwrap(),
         Some(ResourceRef::parse("Device/host-kvm").unwrap()),
@@ -100,4 +100,37 @@ fn process_spec_contains_only_opaque_attachments() {
     assert!(!json.contains("argv"));
     assert!(!json.contains("/nix/store"));
     assert!(!json.contains("broker"));
+}
+
+#[test]
+fn process_spec_uses_canonical_contract_and_rejects_shadow_fields() {
+    let process = build_process_spec(
+        ResourceRef::parse("Host/host-system").unwrap(),
+        ResourceRef::parse("Volume/runtime").unwrap(),
+        Some(ResourceRef::parse("Device/host-kvm").unwrap()),
+        [],
+    )
+    .unwrap();
+    validate_process_spec(&process).unwrap();
+    assert!(
+        serde_json::from_str::<ProcessSpec>(
+            r#"{"providerRef":"Provider/runtime-qemu-media","template":"qemu-media-runner"}"#
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn process_validation_checks_the_canonical_execution_template() {
+    let process = build_process_spec(
+        ResourceRef::parse("Host/host-system").unwrap(),
+        ResourceRef::parse("Volume/runtime").unwrap(),
+        Some(ResourceRef::parse("Device/host-kvm").unwrap()),
+        [],
+    )
+    .unwrap();
+    let mut json = serde_json::to_value(&process).unwrap();
+    json["template"] = serde_json::json!("wrong-template");
+    let changed: ProcessSpec = serde_json::from_value(json).unwrap();
+    assert!(validate_process_spec(&changed).is_err());
 }

--- a/packages/d2b-provider-runtime-qemu-media/tests/guest_schema_roundtrip.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/guest_schema_roundtrip.rs
@@ -1,5 +1,6 @@
 use d2b_provider_runtime_qemu_media::{
     GuestPhase, GuestProviderSpecSettings, GuestSpec, GuestStatus, ProviderPhase,
+    build_guest_resource_spec,
 };
 
 #[test]
@@ -52,14 +53,39 @@ fn status_provider_phase_is_closed_and_bounded() {
 #[test]
 fn guest_spec_requires_the_runtime_provider() {
     let settings = GuestProviderSpecSettings::default();
-    assert!(GuestSpec::new("Provider/runtime-qemu-media", None, 2, 4096, settings,).is_ok());
+    let resource = build_guest_resource_spec(None, 2, 4096, settings).unwrap();
+    assert_eq!(
+        resource.provider_ref().unwrap().to_canonical_string(),
+        "Provider/runtime-qemu-media"
+    );
     assert!(
-        GuestSpec::new(
-            "Provider/other",
+        d2b_contracts::v3::ResourceSpec::new(
+            Some(d2b_contracts::v3::ResourceRef::parse("Provider/other").unwrap()),
             None,
-            2,
-            4096,
-            GuestProviderSpecSettings::default()
+            d2b_contracts::v3::CanonicalJsonObject::empty(),
+            None,
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn canonical_guest_deserializes_minimal_base_and_rejects_shadow_fields() {
+    let minimal = br#"{
+        "allowedDomains":["system"],
+        "budget":{},
+        "defaultDomain":"system",
+        "defaultUserRef":null,
+        "deviceAttachments":[],
+        "networkAttachments":[],
+        "systemArtifactId":null,
+        "volumeAttachmentDefaults":[]
+    }"#;
+    let guest: GuestSpec = serde_json::from_slice(minimal).unwrap();
+    assert_eq!(guest, GuestSpec::system_default());
+    assert!(
+        serde_json::from_slice::<GuestSpec>(
+            br#"{"providerRef":"Provider/runtime-qemu-media","vcpu":2,"memoryMib":4096}"#
         )
         .is_err()
     );

--- a/packages/d2b-provider-runtime-qemu-media/tests/guest_schema_roundtrip.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/guest_schema_roundtrip.rs
@@ -1,0 +1,66 @@
+use d2b_provider_runtime_qemu_media::{
+    GuestPhase, GuestProviderSpecSettings, GuestSpec, GuestStatus, ProviderPhase,
+};
+
+#[test]
+fn guest_settings_round_trip_without_host_locators() {
+    let json = r#"{
+        "bootMediaRef": "Volume/boot-media",
+        "bootMediaView": "guest-attach",
+        "removableVolumeRefs": [
+            {"volumeRef": "Volume/removable", "view": "guest-attach"}
+        ],
+        "cpuModel": "host",
+        "machineType": "q35",
+        "bios": "ovmf",
+        "pauseAtBoot": true,
+        "displayWindow": false,
+        "serialConsole": true,
+        "tablet": true,
+        "rtcBase": "utc",
+        "extraFeatures": []
+    }"#;
+
+    let settings: GuestProviderSpecSettings = serde_json::from_str(json).unwrap();
+    let rendered = serde_json::to_string(&settings).unwrap();
+    assert!(rendered.contains("Volume/boot-media"));
+    assert!(!rendered.contains("path"));
+    assert!(!rendered.contains("argv"));
+    assert!(!rendered.contains("credential"));
+}
+
+#[test]
+fn unknown_fields_and_invalid_refs_are_rejected() {
+    assert!(
+        serde_json::from_str::<GuestProviderSpecSettings>(
+            r#"{"bootMediaRef":"Host/not-a-volume"}"#
+        )
+        .is_err()
+    );
+    assert!(serde_json::from_str::<GuestProviderSpecSettings>(r#"{"unexpected":true}"#).is_err());
+}
+
+#[test]
+fn status_provider_phase_is_closed_and_bounded() {
+    let status = GuestStatus::new(GuestPhase::Pending, ProviderPhase::WaitingDependencies);
+    assert_eq!(status.phase(), GuestPhase::Pending);
+    assert_eq!(status.provider_phase(), ProviderPhase::WaitingDependencies);
+    assert!(GuestStatus::from_provider_phase("not-a-provider-phase").is_err());
+    assert!(GuestStatus::from_provider_phase(&"x".repeat(65)).is_err());
+}
+
+#[test]
+fn guest_spec_requires_the_runtime_provider() {
+    let settings = GuestProviderSpecSettings::default();
+    assert!(GuestSpec::new("Provider/runtime-qemu-media", None, 2, 4096, settings,).is_ok());
+    assert!(
+        GuestSpec::new(
+            "Provider/other",
+            None,
+            2,
+            4096,
+            GuestProviderSpecSettings::default()
+        )
+        .is_err()
+    );
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
@@ -2,7 +2,7 @@ use d2b_contracts::v3::ResourceRef;
 use d2b_provider_runtime_qemu_media::{
     DeviceObservation, DevicePhase, GuestProviderSpecSettings, LaunchTicket, PlatformClass,
     ProcessIdentity, ProviderConfig, QemuMediaController, QemuMediaEffectPort, QemuMediaError,
-    QemuMediaPhase, QemuMediaReconcileOutcome,
+    QemuMediaPhase, QemuMediaReconcileOutcome, QemuMediaRecoveryState,
 };
 
 #[derive(Default)]
@@ -11,13 +11,20 @@ struct FakeEffect {
     launched: usize,
     pidfd_opens: usize,
     events: Vec<&'static str>,
+    launch_slots: Vec<String>,
+    stop_clears_observation: bool,
 }
 
 impl QemuMediaEffectPort for FakeEffect {
-    fn launch(&mut self, _ticket: &LaunchTicket) -> Result<ProcessIdentity, QemuMediaError> {
+    fn launch(&mut self, ticket: &LaunchTicket) -> Result<ProcessIdentity, QemuMediaError> {
         self.launched += 1;
         self.events.push("launch");
-        let identity = ProcessIdentity::for_test("media-process");
+        self.launch_slots = ticket
+            .attachments
+            .iter()
+            .map(|attachment| attachment.slot.clone())
+            .collect();
+        let identity = ProcessIdentity::for_test("qemu-media-runner");
         self.observed = Some(identity.clone());
         Ok(identity)
     }
@@ -32,19 +39,40 @@ impl QemuMediaEffectPort for FakeEffect {
         Ok(())
     }
 
+    fn reserve_device_authority(
+        &mut self,
+        _authority_key: [u8; 32],
+        _owner_ref: &ResourceRef,
+    ) -> Result<(), QemuMediaError> {
+        self.events.push("reserve-device");
+        Ok(())
+    }
+
     fn close_media_effects(&mut self) -> Result<(), QemuMediaError> {
         self.events.push("close-media");
         Ok(())
     }
 
+    fn continue_guest(&mut self) -> Result<(), QemuMediaError> {
+        self.events.push("continue");
+        Ok(())
+    }
+
     fn stop(&mut self, _identity: &ProcessIdentity) -> Result<(), QemuMediaError> {
         self.events.push("stop");
-        self.observed = None;
+        if self.stop_clears_observation {
+            self.observed = None;
+        }
         Ok(())
     }
 
     fn release_device_authority(&mut self) -> Result<(), QemuMediaError> {
         self.events.push("release-device");
+        Ok(())
+    }
+
+    fn delete_runtime_volume(&mut self) -> Result<(), QemuMediaError> {
+        self.events.push("delete-volume");
         Ok(())
     }
 }
@@ -95,21 +123,25 @@ fn ready_requires_process_device_and_qmp_health() {
         owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
         platform: PlatformClass::X86_64Linux,
         authority_key: [4; 32],
-        process_identity: Some("media-process".to_owned()),
+        process_identity: Some("qemu-media-runner".to_owned()),
         media_contract: "qemu-media/v1".to_owned(),
     };
-    let deps = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    let mut deps = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    deps.media_refs = vec![ResourceRef::parse("Volume/boot-media").unwrap()];
+    deps.display_ref = Some(ResourceRef::parse("Endpoint/display").unwrap());
     let ready = controller.reconcile(&deps, &mut effect).unwrap();
     assert_eq!(ready, QemuMediaReconcileOutcome::Ready);
     assert_eq!(controller.phase(), QemuMediaPhase::PausedAtBoot);
+    assert_eq!(effect.launch_slots, vec!["kvm", "media-0", "display"]);
 }
 
 #[test]
 fn matching_restart_process_is_adopted_without_launch() {
     let mut controller = controller();
-    let identity = ProcessIdentity::for_test("media-process");
+    let identity = ProcessIdentity::for_test("qemu-media-runner");
     let mut effect = FakeEffect {
         observed: Some(identity.clone()),
+        stop_clears_observation: true,
         ..FakeEffect::default()
     };
     let device = DeviceObservation {
@@ -118,7 +150,7 @@ fn matching_restart_process_is_adopted_without_launch() {
         owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
         platform: PlatformClass::X86_64Linux,
         authority_key: [4; 32],
-        process_identity: Some("media-process".to_owned()),
+        process_identity: Some("qemu-media-runner".to_owned()),
         media_contract: "qemu-media/v1".to_owned(),
     };
     let deps = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
@@ -137,10 +169,82 @@ fn finalization_closes_media_before_releasing_authority() {
     let identity = ProcessIdentity::for_test("media-process");
     let mut effect = FakeEffect {
         observed: Some(identity.clone()),
+        stop_clears_observation: true,
         ..FakeEffect::default()
     };
     controller.set_expected_identity(identity);
     controller.mark_ready_for_test();
     controller.finalize(&mut effect).unwrap();
-    assert_eq!(effect.events, vec!["close-media", "stop", "release-device"]);
+    assert_eq!(
+        effect.events,
+        vec![
+            "close-media",
+            "open-pidfd",
+            "stop",
+            "release-device",
+            "delete-volume",
+        ]
+    );
+}
+
+#[test]
+fn qmp_timeout_retains_authority_until_process_exit_is_proven() {
+    let mut controller = controller();
+    let identity = ProcessIdentity::for_test("qemu-media-runner");
+    let mut effect = FakeEffect {
+        observed: Some(identity.clone()),
+        ..FakeEffect::default()
+    };
+    controller.set_expected_identity(identity);
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [9; 32],
+        process_identity: Some("qemu-media-runner".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let mut dependencies = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    dependencies.qmp_ready = false;
+    dependencies.qmp_status = None;
+    dependencies.qmp_elapsed_seconds = 30;
+
+    assert_eq!(
+        controller
+            .reconcile(&dependencies, &mut effect)
+            .unwrap_err(),
+        QemuMediaError::QmpNotReady
+    );
+    assert_eq!(effect.events, vec!["reserve-device", "open-pidfd", "stop"]);
+    assert!(controller.recovery_state().authority_reserved);
+
+    effect.observed = None;
+    controller.finalize(&mut effect).unwrap();
+    assert_eq!(
+        effect.events,
+        vec![
+            "reserve-device",
+            "open-pidfd",
+            "stop",
+            "close-media",
+            "release-device",
+            "delete-volume",
+        ]
+    );
+}
+
+#[test]
+fn finalized_recovery_state_cannot_retain_device_authority() {
+    let recovery = QemuMediaRecoveryState {
+        phase: QemuMediaPhase::Finalized,
+        finalizer_installed: false,
+        expected_identity: None,
+        authority_reserved: true,
+    };
+    let restored = controller()
+        .restore_recovery_state(recovery)
+        .unwrap()
+        .recovery_state();
+    assert!(!restored.authority_reserved);
 }

--- a/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
@@ -135,6 +135,68 @@ fn ready_requires_process_device_and_qmp_health() {
 }
 
 #[test]
+fn pause_at_boot_is_initial_proof_then_running_is_ready() {
+    let mut controller = controller();
+    let mut effect = FakeEffect::default();
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [4; 32],
+        process_identity: Some("qemu-media-runner".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let mut dependencies = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+
+    assert_eq!(
+        controller.reconcile(&dependencies, &mut effect).unwrap(),
+        QemuMediaReconcileOutcome::Ready
+    );
+    assert_eq!(controller.phase(), QemuMediaPhase::PausedAtBoot);
+
+    dependencies.qmp_status = Some(d2b_provider_runtime_qemu_media::QmpVmStatus::Running);
+    assert_eq!(
+        controller.reconcile(&dependencies, &mut effect).unwrap(),
+        QemuMediaReconcileOutcome::Ready
+    );
+    assert_eq!(controller.phase(), QemuMediaPhase::Ready);
+    assert_eq!(
+        effect.events,
+        vec!["reserve-device", "launch", "open-pidfd"]
+    );
+}
+
+#[test]
+fn pause_at_boot_rejects_running_before_pause_proof() {
+    let mut controller = controller();
+    let mut effect = FakeEffect::default();
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [4; 32],
+        process_identity: Some("qemu-media-runner".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let mut dependencies = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    dependencies.qmp_status = Some(d2b_provider_runtime_qemu_media::QmpVmStatus::Running);
+
+    assert_eq!(
+        controller
+            .reconcile(&dependencies, &mut effect)
+            .unwrap_err(),
+        QemuMediaError::QmpNotReady
+    );
+    assert_eq!(controller.phase(), QemuMediaPhase::Degraded);
+    assert_eq!(
+        effect.events,
+        vec!["reserve-device", "launch", "open-pidfd"]
+    );
+}
+
+#[test]
 fn matching_restart_process_is_adopted_without_launch() {
     let mut controller = controller();
     let identity = ProcessIdentity::for_test("qemu-media-runner");
@@ -189,6 +251,52 @@ fn finalization_closes_media_before_releasing_authority() {
 #[test]
 fn qmp_timeout_retains_authority_until_process_exit_is_proven() {
     let mut controller = controller();
+    let mut effect = FakeEffect::default();
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [9; 32],
+        process_identity: Some("qemu-media-runner".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let mut dependencies = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    dependencies.qmp_ready = false;
+    dependencies.qmp_status = None;
+    dependencies.qmp_elapsed_seconds = 30;
+
+    assert_eq!(
+        controller
+            .reconcile(&dependencies, &mut effect)
+            .unwrap_err(),
+        QemuMediaError::QmpNotReady
+    );
+    assert_eq!(
+        effect.events,
+        vec!["reserve-device", "launch", "open-pidfd", "stop"]
+    );
+    assert!(controller.recovery_state().authority_reserved);
+
+    effect.observed = None;
+    controller.finalize(&mut effect).unwrap();
+    assert_eq!(
+        effect.events,
+        vec![
+            "reserve-device",
+            "launch",
+            "open-pidfd",
+            "stop",
+            "close-media",
+            "release-device",
+            "delete-volume",
+        ]
+    );
+}
+
+#[test]
+fn adopted_runner_qmp_timeout_uses_health_retry_not_launch_age() {
+    let mut controller = controller();
     let identity = ProcessIdentity::for_test("qemu-media-runner");
     let mut effect = FakeEffect {
         observed: Some(identity.clone()),
@@ -210,27 +318,12 @@ fn qmp_timeout_retains_authority_until_process_exit_is_proven() {
     dependencies.qmp_elapsed_seconds = 30;
 
     assert_eq!(
-        controller
-            .reconcile(&dependencies, &mut effect)
-            .unwrap_err(),
-        QemuMediaError::QmpNotReady
+        controller.reconcile(&dependencies, &mut effect).unwrap(),
+        QemuMediaReconcileOutcome::Retry { after_ms: 250 }
     );
-    assert_eq!(effect.events, vec!["reserve-device", "open-pidfd", "stop"]);
+    assert_eq!(controller.phase(), QemuMediaPhase::Degraded);
+    assert_eq!(effect.events, vec!["reserve-device", "open-pidfd"]);
     assert!(controller.recovery_state().authority_reserved);
-
-    effect.observed = None;
-    controller.finalize(&mut effect).unwrap();
-    assert_eq!(
-        effect.events,
-        vec![
-            "reserve-device",
-            "open-pidfd",
-            "stop",
-            "close-media",
-            "release-device",
-            "delete-volume",
-        ]
-    );
 }
 
 #[test]
@@ -240,6 +333,7 @@ fn finalized_recovery_state_cannot_retain_device_authority() {
         finalizer_installed: false,
         expected_identity: None,
         authority_reserved: true,
+        initial_pause_observed: false,
     };
     let restored = controller()
         .restore_recovery_state(recovery)

--- a/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
@@ -90,8 +90,7 @@ fn config() -> ProviderConfig {
 
 fn controller() -> QemuMediaController<FakeEffect> {
     let settings = GuestProviderSpecSettings::default();
-    let process = d2b_provider_runtime_qemu_media::ProcessSpec::new(
-        ResourceRef::parse("Guest/media-vm").unwrap(),
+    let process = d2b_provider_runtime_qemu_media::build_process_spec(
         ResourceRef::parse("Host/host-system").unwrap(),
         ResourceRef::parse("Volume/runtime").unwrap(),
         Some(ResourceRef::parse("Device/host-kvm").unwrap()),

--- a/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
@@ -295,6 +295,129 @@ fn qmp_timeout_retains_authority_until_process_exit_is_proven() {
 }
 
 #[test]
+fn failed_qmp_timeout_does_not_adopt_a_stopping_runner() {
+    let mut controller = controller();
+    let mut effect = FakeEffect::default();
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [9; 32],
+        process_identity: Some("qemu-media-runner".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let mut dependencies = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    dependencies.qmp_ready = false;
+    dependencies.qmp_status = None;
+    dependencies.qmp_elapsed_seconds = 30;
+
+    assert_eq!(
+        controller
+            .reconcile(&dependencies, &mut effect)
+            .unwrap_err(),
+        QemuMediaError::QmpNotReady
+    );
+    assert_eq!(controller.phase(), QemuMediaPhase::Failed);
+    let events_before_reconcile = effect.events.clone();
+
+    dependencies.qmp_ready = true;
+    dependencies.qmp_status = Some(d2b_provider_runtime_qemu_media::QmpVmStatus::Running);
+    assert_eq!(
+        controller
+            .reconcile(&dependencies, &mut effect)
+            .unwrap_err(),
+        QemuMediaError::InvalidState
+    );
+    assert_eq!(controller.phase(), QemuMediaPhase::Failed);
+    assert_eq!(effect.events, events_before_reconcile);
+    assert!(controller.recovery_state().authority_reserved);
+}
+
+#[test]
+fn failed_qmp_timeout_with_exit_proven_does_not_rereserve_on_reconcile() {
+    let mut controller = controller();
+    let mut effect = FakeEffect {
+        stop_clears_observation: true,
+        ..FakeEffect::default()
+    };
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [9; 32],
+        process_identity: Some("qemu-media-runner".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let mut dependencies = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    dependencies.qmp_ready = false;
+    dependencies.qmp_status = None;
+    dependencies.qmp_elapsed_seconds = 30;
+
+    assert_eq!(
+        controller
+            .reconcile(&dependencies, &mut effect)
+            .unwrap_err(),
+        QemuMediaError::QmpNotReady
+    );
+    assert_eq!(controller.phase(), QemuMediaPhase::Failed);
+    assert!(!controller.recovery_state().authority_reserved);
+    assert_eq!(
+        effect.events,
+        vec![
+            "reserve-device",
+            "launch",
+            "open-pidfd",
+            "stop",
+            "release-device",
+        ]
+    );
+
+    dependencies.qmp_ready = true;
+    dependencies.qmp_status = Some(d2b_provider_runtime_qemu_media::QmpVmStatus::Paused);
+    assert_eq!(
+        controller
+            .reconcile(&dependencies, &mut effect)
+            .unwrap_err(),
+        QemuMediaError::InvalidState
+    );
+    assert_eq!(
+        effect.events,
+        vec![
+            "reserve-device",
+            "launch",
+            "open-pidfd",
+            "stop",
+            "release-device",
+        ]
+    );
+
+    controller.finalize(&mut effect).unwrap();
+    assert_eq!(
+        effect.events,
+        vec![
+            "reserve-device",
+            "launch",
+            "open-pidfd",
+            "stop",
+            "release-device",
+            "close-media",
+            "delete-volume",
+        ]
+    );
+    assert_eq!(
+        effect
+            .events
+            .iter()
+            .filter(|event| **event == "release-device")
+            .count(),
+        1
+    );
+    assert_eq!(controller.phase(), QemuMediaPhase::Finalized);
+}
+
+#[test]
 fn adopted_runner_qmp_timeout_uses_health_retry_not_launch_age() {
     let mut controller = controller();
     let identity = ProcessIdentity::for_test("qemu-media-runner");

--- a/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/lifecycle.rs
@@ -1,0 +1,146 @@
+use d2b_contracts::v3::ResourceRef;
+use d2b_provider_runtime_qemu_media::{
+    DeviceObservation, DevicePhase, GuestProviderSpecSettings, LaunchTicket, PlatformClass,
+    ProcessIdentity, ProviderConfig, QemuMediaController, QemuMediaEffectPort, QemuMediaError,
+    QemuMediaPhase, QemuMediaReconcileOutcome,
+};
+
+#[derive(Default)]
+struct FakeEffect {
+    observed: Option<ProcessIdentity>,
+    launched: usize,
+    pidfd_opens: usize,
+    events: Vec<&'static str>,
+}
+
+impl QemuMediaEffectPort for FakeEffect {
+    fn launch(&mut self, _ticket: &LaunchTicket) -> Result<ProcessIdentity, QemuMediaError> {
+        self.launched += 1;
+        self.events.push("launch");
+        let identity = ProcessIdentity::for_test("media-process");
+        self.observed = Some(identity.clone());
+        Ok(identity)
+    }
+
+    fn observe(&mut self) -> Result<Option<ProcessIdentity>, QemuMediaError> {
+        Ok(self.observed.clone())
+    }
+
+    fn open_pidfd(&mut self, _identity: &ProcessIdentity) -> Result<(), QemuMediaError> {
+        self.pidfd_opens += 1;
+        self.events.push("open-pidfd");
+        Ok(())
+    }
+
+    fn close_media_effects(&mut self) -> Result<(), QemuMediaError> {
+        self.events.push("close-media");
+        Ok(())
+    }
+
+    fn stop(&mut self, _identity: &ProcessIdentity) -> Result<(), QemuMediaError> {
+        self.events.push("stop");
+        self.observed = None;
+        Ok(())
+    }
+
+    fn release_device_authority(&mut self) -> Result<(), QemuMediaError> {
+        self.events.push("release-device");
+        Ok(())
+    }
+}
+
+fn config() -> ProviderConfig {
+    ProviderConfig::new(
+        "Host/host-system",
+        "qemu-system-x86-64",
+        "Provider/network-local",
+        "Provider/volume-local",
+        None,
+    )
+    .unwrap()
+}
+
+fn controller() -> QemuMediaController<FakeEffect> {
+    let settings = GuestProviderSpecSettings::default();
+    let process = d2b_provider_runtime_qemu_media::ProcessSpec::new(
+        ResourceRef::parse("Guest/media-vm").unwrap(),
+        ResourceRef::parse("Host/host-system").unwrap(),
+        ResourceRef::parse("Volume/runtime").unwrap(),
+        Some(ResourceRef::parse("Device/host-kvm").unwrap()),
+        Vec::<ResourceRef>::new(),
+    )
+    .unwrap();
+    QemuMediaController::new(
+        config(),
+        settings,
+        process,
+        ResourceRef::parse("Guest/media-vm").unwrap(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn ready_requires_process_device_and_qmp_health() {
+    let mut controller = controller();
+    let mut effect = FakeEffect::default();
+    let pending = controller
+        .reconcile(&Default::default(), &mut effect)
+        .unwrap();
+    assert!(matches!(pending, QemuMediaReconcileOutcome::Retry { .. }));
+    assert_eq!(controller.phase(), QemuMediaPhase::Pending);
+
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [4; 32],
+        process_identity: Some("media-process".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let deps = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    let ready = controller.reconcile(&deps, &mut effect).unwrap();
+    assert_eq!(ready, QemuMediaReconcileOutcome::Ready);
+    assert_eq!(controller.phase(), QemuMediaPhase::PausedAtBoot);
+}
+
+#[test]
+fn matching_restart_process_is_adopted_without_launch() {
+    let mut controller = controller();
+    let identity = ProcessIdentity::for_test("media-process");
+    let mut effect = FakeEffect {
+        observed: Some(identity.clone()),
+        ..FakeEffect::default()
+    };
+    let device = DeviceObservation {
+        device_ref: ResourceRef::parse("Device/host-kvm").unwrap(),
+        phase: DevicePhase::Ready,
+        owner_ref: Some(ResourceRef::parse("Guest/media-vm").unwrap()),
+        platform: PlatformClass::X86_64Linux,
+        authority_key: [4; 32],
+        process_identity: Some("media-process".to_owned()),
+        media_contract: "qemu-media/v1".to_owned(),
+    };
+    let deps = d2b_provider_runtime_qemu_media::QemuMediaDependencies::ready(device);
+    controller.set_expected_identity(identity);
+    assert_eq!(
+        controller.reconcile(&deps, &mut effect).unwrap(),
+        QemuMediaReconcileOutcome::Ready
+    );
+    assert_eq!(effect.launched, 0);
+    assert_eq!(effect.pidfd_opens, 1);
+}
+
+#[test]
+fn finalization_closes_media_before_releasing_authority() {
+    let mut controller = controller();
+    let identity = ProcessIdentity::for_test("media-process");
+    let mut effect = FakeEffect {
+        observed: Some(identity.clone()),
+        ..FakeEffect::default()
+    };
+    controller.set_expected_identity(identity);
+    controller.mark_ready_for_test();
+    controller.finalize(&mut effect).unwrap();
+    assert_eq!(effect.events, vec!["close-media", "stop", "release-device"]);
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/provider_layout.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/provider_layout.rs
@@ -1,0 +1,14 @@
+use d2b_provider_runtime_qemu_media::QemuMediaProviderDescriptor;
+
+#[test]
+fn descriptor_declares_guest_and_no_provider_state_volume() {
+    let descriptor = QemuMediaProviderDescriptor::default();
+    assert!(descriptor.validate().is_ok());
+    assert_eq!(descriptor.resource_types(), &["Guest"]);
+    assert!(descriptor.state_namespaces().is_empty());
+    assert!(
+        descriptor
+            .process_templates()
+            .contains(&"qemu-media-runner")
+    );
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/qmp_protocol.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/qmp_protocol.rs
@@ -1,0 +1,65 @@
+use d2b_provider_runtime_qemu_media::{
+    QmpCommand, QmpHealth, QmpReply, QmpSession, ScriptedQmpTransport,
+};
+
+#[test]
+fn capability_negotiation_and_boot_commands_are_typed() {
+    let transport = ScriptedQmpTransport::new()
+        .with_greeting("8.2")
+        .with_reply(QmpReply::ok())
+        .with_reply(QmpReply::ok())
+        .with_reply(QmpReply::ok());
+    let mut session = QmpSession::new(transport);
+    session.negotiate().unwrap();
+    session.cont().unwrap();
+    assert_eq!(
+        session.commands(),
+        &[QmpCommand::Capabilities, QmpCommand::Cont]
+    );
+    assert_eq!(session.health().phase(), "ready");
+}
+
+#[test]
+fn hotplug_attach_and_detach_use_ordered_qmp_commands() {
+    let transport = ScriptedQmpTransport::new()
+        .with_greeting("8.2")
+        .with_reply(QmpReply::ok())
+        .with_reply(QmpReply::ok())
+        .with_reply(QmpReply::ok())
+        .with_reply(QmpReply::ok())
+        .with_reply(QmpReply::ok());
+    let mut session = QmpSession::new(transport);
+    session.negotiate().unwrap();
+    session.attach_media("media-0", 3, true).unwrap();
+    session.detach_media("media-0").unwrap();
+    assert_eq!(
+        session.commands(),
+        &[
+            QmpCommand::Capabilities,
+            QmpCommand::BlockdevAdd {
+                node_name: "media-0".to_owned(),
+                fd_slot: 3,
+                read_only: true,
+            },
+            QmpCommand::DeviceAdd {
+                device_id: "media-0".to_owned(),
+                drive: "media-0".to_owned(),
+            },
+            QmpCommand::DeviceDel {
+                device_id: "media-0".to_owned(),
+            },
+            QmpCommand::BlockdevDel {
+                node_name: "media-0".to_owned(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn health_degrades_after_bounded_failures() {
+    let mut health = QmpHealth::new(2);
+    assert!(health.record_failure().is_ok());
+    assert_eq!(health.phase(), "ready");
+    assert!(health.record_failure().is_err());
+    assert_eq!(health.phase(), "degraded");
+}

--- a/packages/d2b-provider-runtime-qemu-media/tests/qmp_protocol.rs
+++ b/packages/d2b-provider-runtime-qemu-media/tests/qmp_protocol.rs
@@ -1,6 +1,8 @@
 use d2b_provider_runtime_qemu_media::{
-    QmpCommand, QmpHealth, QmpReply, QmpSession, ScriptedQmpTransport,
+    QmpCommand, QmpError, QmpGreeting, QmpHealth, QmpReply, QmpSession, QmpTransport,
+    ScriptedQmpTransport,
 };
+use std::collections::VecDeque;
 
 #[test]
 fn capability_negotiation_and_boot_commands_are_typed() {
@@ -62,4 +64,50 @@ fn health_degrades_after_bounded_failures() {
     assert_eq!(health.phase(), "ready");
     assert!(health.record_failure().is_err());
     assert_eq!(health.phase(), "degraded");
+}
+
+#[test]
+fn failed_capability_negotiation_poisoned_session_rejects_commands() {
+    let transport = ScriptedQmpTransport::new()
+        .with_greeting("8.2")
+        .with_error(QmpError::CapabilitiesFailed);
+    let mut session = QmpSession::new(transport);
+    assert!(session.negotiate().is_err());
+    assert_eq!(session.cont().unwrap_err(), QmpError::NotReady);
+}
+
+#[derive(Default)]
+struct RenegotiatingTransport {
+    greetings: VecDeque<QmpGreeting>,
+    replies: VecDeque<Result<QmpReply, QmpError>>,
+}
+
+impl QmpTransport for RenegotiatingTransport {
+    fn receive_greeting(&mut self) -> Result<QmpGreeting, QmpError> {
+        self.greetings.pop_front().ok_or(QmpError::GreetingTimeout)
+    }
+
+    fn execute(&mut self, _command: &QmpCommand) -> Result<QmpReply, QmpError> {
+        self.replies.pop_front().unwrap_or(Err(QmpError::Timeout))
+    }
+}
+
+#[test]
+fn failed_renegotiation_clears_previous_session() {
+    let mut transport = RenegotiatingTransport::default();
+    transport.greetings.push_back(QmpGreeting {
+        version: "8.2".to_owned(),
+    });
+    transport.greetings.push_back(QmpGreeting {
+        version: "8.2".to_owned(),
+    });
+    transport.replies.push_back(Ok(QmpReply::ok()));
+    transport
+        .replies
+        .push_back(Err(QmpError::CapabilitiesFailed));
+
+    let mut session = QmpSession::new(transport);
+    session.negotiate().unwrap();
+    assert!(session.negotiate().is_err());
+    assert_eq!(session.cont().unwrap_err(), QmpError::NotReady);
 }

--- a/tests/unit/nix/cases/guest-qemu-media-spec.nix
+++ b/tests/unit/nix/cases/guest-qemu-media-spec.nix
@@ -2,21 +2,21 @@
 { mkEval, ... }:
 
 let
-  positive = mkEval {
-    override = { ... }: {
+  positive = mkEval [
+    ({ ... }: {
       d2b.qemuMediaRuntime = {
         enable = true;
         kvmRequired = true;
       };
-    };
-  };
+    })
+  ];
 
   invalid = builtins.tryEval (
-    (mkEval {
-      override = { ... }: {
+    (mkEval [
+      ({ ... }: {
         d2b.qemuMediaRuntime.qmpReadyTimeoutSeconds = 4;
-      };
-    }).config.d2b.qemuMediaRuntime.qmpReadyTimeoutSeconds
+      })
+    ]).config.d2b.qemuMediaRuntime.qmpReadyTimeoutSeconds
   );
 in
 {

--- a/tests/unit/nix/cases/guest-qemu-media-spec.nix
+++ b/tests/unit/nix/cases/guest-qemu-media-spec.nix
@@ -1,5 +1,5 @@
-# Focused qemu-media Provider option coverage.
-{ mkEval, ... }:
+# Focused qemu-media Provider option and Guest dependency coverage.
+{ lib, mkEval, ... }:
 
 let
   positive = mkEval [
@@ -18,6 +18,73 @@ let
       })
     ]).config.d2b.qemuMediaRuntime.qmpReadyTimeoutSeconds
   );
+
+  guestFixture = withKvm: { ... }: {
+    d2b.qemuMediaRuntime = {
+      enable = true;
+      kvmRequired = true;
+    };
+    d2b.zones.local-root.resources = {
+      host = {
+        type = "Host";
+        spec = { };
+      };
+      network-local = {
+        type = "Provider";
+        spec = { };
+      };
+      volume-local = {
+        type = "Provider";
+        spec = { };
+      };
+      device-kvm = {
+        type = "Provider";
+        spec = {
+          config = { };
+        };
+      };
+      runtime-qemu-media = {
+        type = "Provider";
+        spec = {
+          config = {
+            controllerExecutionRef = "Host/host";
+            networkProviderRef = "Provider/network-local";
+            volumeProviderRef = "Provider/volume-local";
+          };
+        };
+      };
+      host-kvm = {
+        type = "Device";
+        spec = {
+          providerRef = "Provider/device-kvm";
+        };
+      };
+      media-vm = {
+        type = "Guest";
+        spec = {
+          providerRef = "Provider/runtime-qemu-media";
+          systemArtifactId = null;
+          deviceAttachments = lib.optional withKvm {
+            deviceRef = "Device/host-kvm";
+            exclusive = false;
+          };
+          provider = {
+            schemaId = "runtime-qemu-media.d2bus.org/Guest/spec";
+            schemaVersion = "1.0";
+            settings = { };
+          };
+        };
+      };
+    };
+  };
+
+  assertionBools = evaluated:
+    builtins.map (assertion: assertion.assertion) evaluated.config.assertions;
+  falseCount = values: lib.length (lib.filter (value: !value) values);
+  kvmRejects = {
+    missing = assertionBools (mkEval [ (guestFixture false) ]);
+    present = assertionBools (mkEval [ (guestFixture true) ]);
+  };
 in
 {
   "guest-qemu-media/defaults" = {
@@ -35,5 +102,15 @@ in
   "guest-qemu-media/invalid-qmp-timeout-rejected" = {
     expr = invalid.success;
     expected = false;
+  };
+
+  "guest-qemu-media/kvm-required-rejects-missing-device" = {
+    expr = falseCount kvmRejects.missing > falseCount kvmRejects.present;
+    expected = true;
+  };
+
+  "guest-qemu-media/kvm-required-accepts-in-zone-device" = {
+    expr = falseCount kvmRejects.present < falseCount kvmRejects.missing;
+    expected = true;
   };
 }

--- a/tests/unit/nix/cases/guest-qemu-media-spec.nix
+++ b/tests/unit/nix/cases/guest-qemu-media-spec.nix
@@ -1,0 +1,39 @@
+# Focused qemu-media Provider option coverage.
+{ mkEval, ... }:
+
+let
+  positive = mkEval {
+    override = { ... }: {
+      d2b.qemuMediaRuntime = {
+        enable = true;
+        kvmRequired = true;
+      };
+    };
+  };
+
+  invalid = builtins.tryEval (
+    (mkEval {
+      override = { ... }: {
+        d2b.qemuMediaRuntime.qmpReadyTimeoutSeconds = 4;
+      };
+    }).config.d2b.qemuMediaRuntime.qmpReadyTimeoutSeconds
+  );
+in
+{
+  "guest-qemu-media/defaults" = {
+    expr = positive.config.d2b.qemuMediaRuntime;
+    expected = {
+      enable = true;
+      kvmRequired = true;
+      qmpReadyTimeoutSeconds = 30;
+      qmpOperationTimeoutSeconds = 60;
+      runtimeTmpfsQuotaBytes = 10485760;
+      runtimeTmpfsQuotaInodes = 1024;
+    };
+  };
+
+  "guest-qemu-media/invalid-qmp-timeout-rejected" = {
+    expr = invalid.success;
+    expected = false;
+  };
+}

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -384,6 +384,8 @@ guest-exec-policy/root-user-rejected
 guest-exec-policy/uid-zero-alias-rejected
 guest-qemu-media/defaults
 guest-qemu-media/invalid-qmp-timeout-rejected
+guest-qemu-media/kvm-required-accepts-in-zone-device
+guest-qemu-media/kvm-required-rejects-missing-device
 guest-shell-policy/custom-positive
 guest-shell-policy/defaults-positive
 guest-shell-policy/enabled-positive

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -382,6 +382,8 @@ guest-exec-policy/invalid-user-rejected
 guest-exec-policy/missing-user-rejected
 guest-exec-policy/root-user-rejected
 guest-exec-policy/uid-zero-alias-rejected
+guest-qemu-media/defaults
+guest-qemu-media/invalid-qmp-timeout-rejected
 guest-shell-policy/custom-positive
 guest-shell-policy/defaults-positive
 guest-shell-policy/enabled-positive


### PR DESCRIPTION
## Summary
- Complete broker-owned QEMU media lifecycle, opaque media/process contracts, KVM authority admission, QMP recovery, and ordered finalization.
- Register and validate focused qemu-media Nix coverage.

## Verification
- `cargo test --manifest-path packages/Cargo.toml -p d2b-provider-runtime-qemu-media --lib --tests`
- `cargo fmt --manifest-path packages/Cargo.toml --all -- --check`
- `nix build --no-link --print-build-logs .#checks.x86_64-linux.nix-unit-runtime`

Base: `v3`