### PR TITLE
credential: bind Entra leases to Guest authorization

### DIFF
--- a/changelog.d/feat-spec001-credential-entra.md
+++ b/changelog.d/feat-spec001-credential-entra.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Bound Entra credential acquisition, refresh, authorization, redacted status,
+  bounded degradation, and finalization cleanup to the owning Guest and Zone.

--- a/changelog.d/feat-spec001-credential-entra.md
+++ b/changelog.d/feat-spec001-credential-entra.md
@@ -2,3 +2,6 @@
 
 - Bound Entra credential acquisition, refresh, authorization, redacted status,
   bounded degradation, and finalization cleanup to the owning Guest and Zone.
+- Require exact authenticated Guest, Provider, and Zone bindings before any
+  client effect, preserve committed refresh metadata after post-commit
+  validation failures, and prevent finalized credentials from minting again.

--- a/packages/d2b-contracts/src/v3/credential/service.rs
+++ b/packages/d2b-contracts/src/v3/credential/service.rs
@@ -8,7 +8,9 @@ use super::{
     OperationClass,
 };
 use crate::v3::component_session::MAX_PROTECTED_PLAINTEXT_BYTES;
-use crate::v3::{ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash};
+use crate::v3::{
+    AuthenticatedSubjectContext, ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash,
+};
 
 /// Canonical service package routed by the Zone bus.
 pub const CREDENTIAL_SERVICE_NAME: &str = "d2b.credential.v3";
@@ -593,6 +595,7 @@ impl fmt::Debug for CredentialResponse {
 #[derive(Clone, PartialEq, Eq)]
 pub struct CredentialAuthorization {
     delivery_session_params: Option<DeliverySessionParams>,
+    authenticated_subject: Option<AuthenticatedSubjectContext>,
 }
 
 impl CredentialAuthorization {
@@ -612,12 +615,29 @@ impl CredentialAuthorization {
         }
         Ok(Self {
             delivery_session_params,
+            authenticated_subject: None,
         })
+    }
+
+    /// Construct an authorization result carrying trusted subject context.
+    pub fn new_for_subject(
+        method: CredentialMethod,
+        delivery_session_params: Option<DeliverySessionParams>,
+        authenticated_subject: AuthenticatedSubjectContext,
+    ) -> Result<Self, CredentialServiceError> {
+        let mut authorization = Self::new(method, delivery_session_params)?;
+        authorization.authenticated_subject = Some(authenticated_subject);
+        Ok(authorization)
     }
 
     /// Borrow the adapter-authorized delivery binding, when the method needs one.
     pub const fn delivery_session_params(&self) -> Option<&DeliverySessionParams> {
         self.delivery_session_params.as_ref()
+    }
+
+    /// Borrow trusted subject context supplied by the authenticated adapter.
+    pub const fn authenticated_subject_context(&self) -> Option<&AuthenticatedSubjectContext> {
+        self.authenticated_subject.as_ref()
     }
 }
 

--- a/packages/d2b-provider-credential-entra/src/controller.rs
+++ b/packages/d2b-provider-credential-entra/src/controller.rs
@@ -33,8 +33,8 @@ pub struct EntraEndpointPolicy {
 }
 
 impl EntraEndpointPolicy {
-    /// Require canonical provider visibility and exact orchestration and
-    /// consumer subjects.
+    /// Require canonical provider visibility and exact provider, consumer,
+    /// and Guest execution references.
     pub fn new(
         visibility: &str,
         provider_ref: ResourceRef,

--- a/packages/d2b-provider-credential-entra/src/controller.rs
+++ b/packages/d2b-provider-credential-entra/src/controller.rs
@@ -18,8 +18,11 @@ use d2b_contracts::v3::credential_controller::{
     CredentialTelemetryOperation, CredentialTelemetryOutcome, observe_credential,
     reconcile_credential, revoke_credential,
 };
+use d2b_contracts::v3::{AuthenticatedSubjectContext, Locality};
 
-use crate::{EntraClientState, EntraPlacement, LOGIN_ENDPOINT_PURPOSE, PROVIDER_REF};
+use crate::{
+    EntraClientState, EntraPlacement, EntraResourceHealth, LOGIN_ENDPOINT_PURPOSE, PROVIDER_REF,
+};
 
 /// Canonical provider-visible Endpoint policy for the Entrablau service.
 #[derive(Clone, PartialEq, Eq)]
@@ -59,6 +62,15 @@ impl EntraEndpointPolicy {
     pub fn allows_subject(&self, subject: &ResourceRef) -> bool {
         subject == &self.provider_ref || subject == &self.consumer_ref
     }
+
+    /// Check a trusted authenticated subject without accepting relay authority.
+    pub fn allows_authenticated_subject(&self, subject: &AuthenticatedSubjectContext) -> bool {
+        subject.transport_binding().locality() == Locality::Local
+            && self.allows_subject(subject.subject_ref())
+            && subject.provider_ref().is_none_or(|provider| {
+                provider == &self.provider_ref || provider == &self.consumer_ref
+            })
+    }
 }
 
 impl core::fmt::Debug for EntraEndpointPolicy {
@@ -74,6 +86,10 @@ pub struct EntraStatusProjection {
     pub status: CredentialStatus,
     /// Closed client state.
     pub client_state: EntraClientState,
+    /// Typed owning-resource health.
+    pub resource_health: EntraResourceHealth,
+    /// Bounded refresh retry position.
+    pub refresh_attempts: u16,
 }
 
 impl core::fmt::Debug for EntraStatusProjection {
@@ -103,6 +119,17 @@ impl EntraController {
         client_state: EntraClientState,
         metadata: Option<&CredentialMetadata>,
     ) -> Result<EntraStatusProjection, CredentialServiceError> {
+        self.reconcile_with_health(client_state, metadata, EntraResourceHealth::Ready, 0)
+    }
+
+    /// Project bounded non-secret state with owning-resource health.
+    pub fn reconcile_with_health(
+        &self,
+        client_state: EntraClientState,
+        metadata: Option<&CredentialMetadata>,
+        resource_health: EntraResourceHealth,
+        refresh_attempts: u16,
+    ) -> Result<EntraStatusProjection, CredentialServiceError> {
         let lease = metadata
             .map(|metadata| {
                 CredentialLeaseStatus::new(
@@ -128,7 +155,29 @@ impl EntraController {
         Ok(EntraStatusProjection {
             status,
             client_state,
+            resource_health,
+            refresh_attempts,
         })
+    }
+
+    /// Project status only for an authorized local subject.
+    pub fn project_for_subject(
+        &self,
+        policy: &EntraEndpointPolicy,
+        subject: &AuthenticatedSubjectContext,
+        client_state: EntraClientState,
+        metadata: Option<&CredentialMetadata>,
+        resource_health: EntraResourceHealth,
+        refresh_attempts: u16,
+    ) -> Result<EntraStatusProjection, CredentialServiceError> {
+        if !policy.allows_authenticated_subject(subject)
+            || self.placement.validate_zone(subject.zone_ref()).is_err()
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::OperationDenied,
+            ));
+        }
+        self.reconcile_with_health(client_state, metadata, resource_health, refresh_attempts)
     }
 
     /// Build a caller-initiated audit record after the authorization decision.

--- a/packages/d2b-provider-credential-entra/src/controller.rs
+++ b/packages/d2b-provider-credential-entra/src/controller.rs
@@ -29,6 +29,7 @@ use crate::{
 pub struct EntraEndpointPolicy {
     provider_ref: ResourceRef,
     consumer_ref: ResourceRef,
+    execution_ref: ResourceRef,
 }
 
 impl EntraEndpointPolicy {
@@ -38,10 +39,12 @@ impl EntraEndpointPolicy {
         visibility: &str,
         provider_ref: ResourceRef,
         consumer_ref: ResourceRef,
+        execution_ref: ResourceRef,
     ) -> Result<Self, CredentialServiceError> {
         if visibility != "provider"
             || provider_ref.to_canonical_string() != PROVIDER_REF
             || consumer_ref.resource_type().as_str() != "Provider"
+            || execution_ref.resource_type().as_str() != "Guest"
         {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::OperationDenied,
@@ -50,6 +53,7 @@ impl EntraEndpointPolicy {
         Ok(Self {
             provider_ref,
             consumer_ref,
+            execution_ref,
         })
     }
 
@@ -67,9 +71,10 @@ impl EntraEndpointPolicy {
     pub fn allows_authenticated_subject(&self, subject: &AuthenticatedSubjectContext) -> bool {
         subject.transport_binding().locality() == Locality::Local
             && self.allows_subject(subject.subject_ref())
-            && subject.provider_ref().is_none_or(|provider| {
-                provider == &self.provider_ref || provider == &self.consumer_ref
-            })
+            && subject.execution_ref() == Some(&self.execution_ref)
+            && subject
+                .provider_ref()
+                .is_some_and(|provider| provider == &self.provider_ref)
     }
 }
 
@@ -172,6 +177,7 @@ impl EntraController {
     ) -> Result<EntraStatusProjection, CredentialServiceError> {
         if !policy.allows_authenticated_subject(subject)
             || self.placement.validate_zone(subject.zone_ref()).is_err()
+            || subject.execution_ref() != Some(self.placement.execution_ref())
         {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::OperationDenied,
@@ -291,7 +297,8 @@ mod tests {
 
     fn controller() -> EntraController {
         EntraController::new(
-            EntraPlacement::new(
+            EntraPlacement::new_in_zone(
+                ResourceRef::parse("Zone/work").unwrap(),
                 PlacementBinding::GuestAgent,
                 ResourceRef::parse("Guest/consumer").unwrap(),
                 ResourceRef::parse("Guest/identity").unwrap(),

--- a/packages/d2b-provider-credential-entra/src/lib.rs
+++ b/packages/d2b-provider-credential-entra/src/lib.rs
@@ -34,6 +34,8 @@ pub const PROVIDER_REF: &str = "Provider/credential-entra";
 pub const LOGIN_ENDPOINT_PURPOSE: &str = "credential-entra.d2bus.org/entra-login-token";
 /// Maximum active leases per Provider instance.
 pub const MAX_LOCAL_LEASES: u32 = 256;
+/// Maximum refresh failures retained for one Credential before retry stops.
+pub const MAX_REFRESH_ATTEMPTS: u16 = 3;
 
 /// Boxed asynchronous result returned by the injected identity-Guest client.
 pub type EntraFuture<'a, T> =
@@ -160,6 +162,7 @@ impl std::error::Error for EntraProviderError {}
 #[derive(Clone, PartialEq, Eq)]
 pub struct EntraPlacement {
     binding: PlacementBinding,
+    zone_ref: Option<ResourceRef>,
     execution_ref: ResourceRef,
     identity_guest_ref: ResourceRef,
     login_endpoint_ref: ResourceRef,
@@ -190,6 +193,7 @@ impl EntraPlacement {
         }
         Ok(Self {
             binding,
+            zone_ref: None,
             execution_ref,
             identity_guest_ref,
             login_endpoint_ref,
@@ -197,9 +201,50 @@ impl EntraPlacement {
         })
     }
 
+    /// Validate placement with an authoritative Zone binding.
+    pub fn new_in_zone(
+        zone_ref: ResourceRef,
+        binding: PlacementBinding,
+        execution_ref: ResourceRef,
+        identity_guest_ref: ResourceRef,
+        login_endpoint_ref: ResourceRef,
+        endpoint_generation: u64,
+    ) -> Result<Self, EntraProviderError> {
+        if zone_ref.resource_type().as_str() != "Zone" {
+            return Err(EntraProviderError::InvalidEndpoint);
+        }
+        let mut placement = Self::new(
+            binding,
+            execution_ref,
+            identity_guest_ref,
+            login_endpoint_ref,
+            endpoint_generation,
+        )?;
+        placement.zone_ref = Some(zone_ref);
+        Ok(placement)
+    }
+
     /// Return the placement binding.
     pub const fn binding(&self) -> PlacementBinding {
         self.binding
+    }
+
+    /// Borrow the authoritative Zone binding, when configured.
+    pub const fn zone_ref(&self) -> Option<&ResourceRef> {
+        self.zone_ref.as_ref()
+    }
+
+    /// Reject a request resolved against a different Zone.
+    pub fn validate_zone(&self, zone_ref: &ResourceRef) -> Result<(), EntraProviderError> {
+        if zone_ref.resource_type().as_str() != "Zone"
+            || self
+                .zone_ref
+                .as_ref()
+                .is_some_and(|expected| expected != zone_ref)
+        {
+            return Err(EntraProviderError::InvalidEndpoint);
+        }
+        Ok(())
     }
 
     /// Borrow the consumer execution Guest.
@@ -417,6 +462,28 @@ impl fmt::Debug for EntraCredentialProviderFactory {
 struct LeaseRecord {
     idempotency_key: String,
     metadata: CredentialMetadata,
+    refresh_attempts: u16,
+    health: EntraResourceHealth,
+}
+
+/// Typed non-secret health for one Entra Credential resource.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntraResourceHealth {
+    /// The owning resource has a usable lease and no transient failure.
+    Ready,
+    /// The owning resource is degraded after a bounded refresh failure.
+    Degraded,
+    /// The owning resource has no usable lease after revocation.
+    Revoked,
+}
+
+/// Result of revoking all handles owned by one Credential resource.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntraOwnedHandleCleanup {
+    /// Number of handles successfully revoked by this call.
+    pub revoked: u32,
+    /// Number of handles that remain owned after this call.
+    pub remaining: u32,
 }
 
 /// Entra implementation of the prepared Credential service.
@@ -467,6 +534,95 @@ impl EntraCredentialProvider {
                 CredentialServiceErrorCode::InvariantFailure,
             ))
         }
+    }
+
+    /// Return the active lease count without exposing lease identity.
+    pub fn active_lease_count(&self) -> u32 {
+        self.leases
+            .lock()
+            .map(|leases| {
+                leases
+                    .values()
+                    .filter(|record| record.metadata.state == CredentialLeaseState::Active)
+                    .count() as u32
+            })
+            .unwrap_or(0)
+    }
+
+    /// Return the typed health of one Credential resource.
+    pub fn resource_health(&self, credential_ref: &ResourceRef) -> Option<EntraResourceHealth> {
+        self.leases.lock().ok().and_then(|leases| {
+            leases
+                .get(&credential_ref.to_canonical_string())
+                .map(|record| record.health)
+        })
+    }
+
+    /// Return the bounded refresh retry position for one Credential resource.
+    pub fn refresh_retry_state(&self, credential_ref: &ResourceRef) -> Option<(u16, u16)> {
+        self.leases.lock().ok().and_then(|leases| {
+            leases
+                .get(&credential_ref.to_canonical_string())
+                .map(|record| (record.refresh_attempts, MAX_REFRESH_ATTEMPTS))
+        })
+    }
+
+    /// Revoke all handles owned by one Credential before finalization clears
+    /// its Provider finalizer.
+    pub fn revoke_owned_handles(
+        &self,
+        credential_ref: &ResourceRef,
+        deadline_ms: u64,
+    ) -> Result<EntraOwnedHandleCleanup, CredentialServiceError> {
+        if credential_ref.resource_type().as_str() != "Credential" {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::Malformed,
+            ));
+        }
+        let _mutation = self.mutation_guard()?;
+        let key = credential_ref.to_canonical_string();
+        let record = self
+            .leases
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .get(&key)
+            .cloned();
+        let Some(record) = record else {
+            return Ok(EntraOwnedHandleCleanup {
+                revoked: 0,
+                remaining: 0,
+            });
+        };
+        if record.metadata.state == CredentialLeaseState::Revoked {
+            return Ok(EntraOwnedHandleCleanup {
+                revoked: 0,
+                remaining: 0,
+            });
+        }
+        let deadline = Self::operation_deadline(deadline_ms)?;
+        let lease = EntraLeaseRef {
+            credential_ref: credential_ref.clone(),
+            metadata: record.metadata,
+            endpoint_generation: self.placement.endpoint_generation(),
+        };
+        Self::poll_client(self.client.revoke_lease(&lease), deadline)?;
+        let mut leases = self.leases.lock().map_err(|_| {
+            CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+        })?;
+        let Some(record) = leases.get_mut(&key) else {
+            return Ok(EntraOwnedHandleCleanup {
+                revoked: 1,
+                remaining: 0,
+            });
+        };
+        record.metadata.state = CredentialLeaseState::Revoked;
+        record.metadata.outcome = CredentialOutcomeCode::Revoked;
+        record.health = EntraResourceHealth::Revoked;
+        record.refresh_attempts = 0;
+        Ok(EntraOwnedHandleCleanup {
+            revoked: 1,
+            remaining: 0,
+        })
     }
 
     pub(crate) fn mutation_guard(&self) -> Result<MutexGuard<'_, ()>, CredentialServiceError> {
@@ -563,6 +719,18 @@ impl EntraCredentialProvider {
             state: CredentialLeaseState::Active,
             outcome: CredentialOutcomeCode::Success,
         })
+    }
+
+    pub(crate) fn record_refresh_failure(&self, key: &str) {
+        if let Ok(mut leases) = self.leases.lock()
+            && let Some(record) = leases.get_mut(key)
+        {
+            record.refresh_attempts = record
+                .refresh_attempts
+                .saturating_add(1)
+                .min(MAX_REFRESH_ATTEMPTS);
+            record.health = EntraResourceHealth::Degraded;
+        }
     }
 }
 

--- a/packages/d2b-provider-credential-entra/src/lib.rs
+++ b/packages/d2b-provider-credential-entra/src/lib.rs
@@ -236,12 +236,7 @@ impl EntraPlacement {
 
     /// Reject a request resolved against a different Zone.
     pub fn validate_zone(&self, zone_ref: &ResourceRef) -> Result<(), EntraProviderError> {
-        if zone_ref.resource_type().as_str() != "Zone"
-            || self
-                .zone_ref
-                .as_ref()
-                .is_some_and(|expected| expected != zone_ref)
-        {
+        if zone_ref.resource_type().as_str() != "Zone" || self.zone_ref.as_ref() != Some(zone_ref) {
             return Err(EntraProviderError::InvalidEndpoint);
         }
         Ok(())
@@ -431,6 +426,9 @@ impl EntraCredentialProviderFactory {
         if consumer_ref.resource_type().as_str() != "Provider" {
             return Err(EntraProviderError::InvalidConsumer);
         }
+        if placement.zone_ref.is_none() {
+            return Err(EntraProviderError::InvalidEndpoint);
+        }
         Ok(Self {
             config,
             placement,
@@ -447,6 +445,7 @@ impl EntraCredentialProviderFactory {
             consumer_ref: self.consumer_ref,
             client: self.client,
             leases: Mutex::new(BTreeMap::new()),
+            lifecycle: Mutex::new(BTreeMap::new()),
             mutation_gate: Mutex::new(()),
         }
     }
@@ -464,6 +463,12 @@ struct LeaseRecord {
     metadata: CredentialMetadata,
     refresh_attempts: u16,
     health: EntraResourceHealth,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EntraLifecycleState {
+    Draining,
+    Finalized,
 }
 
 /// Typed non-secret health for one Entra Credential resource.
@@ -493,6 +498,7 @@ pub struct EntraCredentialProvider {
     consumer_ref: ResourceRef,
     client: Arc<dyn EntraCredentialClient>,
     leases: Mutex<BTreeMap<String, LeaseRecord>>,
+    lifecycle: Mutex<BTreeMap<String, EntraLifecycleState>>,
     mutation_gate: Mutex<()>,
 }
 
@@ -581,6 +587,18 @@ impl EntraCredentialProvider {
         }
         let _mutation = self.mutation_guard()?;
         let key = credential_ref.to_canonical_string();
+        {
+            let mut lifecycle = self.lifecycle.lock().map_err(|_| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+            if lifecycle.get(&key) == Some(&EntraLifecycleState::Finalized) {
+                return Ok(EntraOwnedHandleCleanup {
+                    revoked: 0,
+                    remaining: 0,
+                });
+            }
+            lifecycle.insert(key.clone(), EntraLifecycleState::Draining);
+        }
         let record = self
             .leases
             .lock()
@@ -588,12 +606,24 @@ impl EntraCredentialProvider {
             .get(&key)
             .cloned();
         let Some(record) = record else {
+            self.lifecycle
+                .lock()
+                .map_err(|_| {
+                    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+                })?
+                .insert(key, EntraLifecycleState::Finalized);
             return Ok(EntraOwnedHandleCleanup {
                 revoked: 0,
                 remaining: 0,
             });
         };
         if record.metadata.state == CredentialLeaseState::Revoked {
+            self.lifecycle
+                .lock()
+                .map_err(|_| {
+                    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+                })?
+                .insert(key, EntraLifecycleState::Finalized);
             return Ok(EntraOwnedHandleCleanup {
                 revoked: 0,
                 remaining: 0,
@@ -610,6 +640,12 @@ impl EntraCredentialProvider {
             CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
         })?;
         let Some(record) = leases.get_mut(&key) else {
+            self.lifecycle
+                .lock()
+                .map_err(|_| {
+                    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+                })?
+                .insert(key, EntraLifecycleState::Finalized);
             return Ok(EntraOwnedHandleCleanup {
                 revoked: 1,
                 remaining: 0,
@@ -619,6 +655,10 @@ impl EntraCredentialProvider {
         record.metadata.outcome = CredentialOutcomeCode::Revoked;
         record.health = EntraResourceHealth::Revoked;
         record.refresh_attempts = 0;
+        self.lifecycle
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .insert(key, EntraLifecycleState::Finalized);
         Ok(EntraOwnedHandleCleanup {
             revoked: 1,
             remaining: 0,
@@ -703,10 +743,19 @@ impl EntraCredentialProvider {
         grant: EntraLeaseGrant,
         requested_expiry_unix_ms: u64,
     ) -> Result<CredentialMetadata, CredentialServiceError> {
-        if grant.rotation_generation == 0
-            || grant.expires_at_unix_ms == 0
-            || grant.expires_at_unix_ms > requested_expiry_unix_ms
-        {
+        let metadata = Self::committed_grant_metadata(grant)?;
+        if metadata.expires_at_unix_ms > requested_expiry_unix_ms {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::InvariantFailure,
+            ));
+        }
+        Ok(metadata)
+    }
+
+    pub(crate) fn committed_grant_metadata(
+        grant: EntraLeaseGrant,
+    ) -> Result<CredentialMetadata, CredentialServiceError> {
+        if grant.rotation_generation == 0 || grant.expires_at_unix_ms == 0 {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::InvariantFailure,
             ));
@@ -719,6 +768,43 @@ impl EntraCredentialProvider {
             state: CredentialLeaseState::Active,
             outcome: CredentialOutcomeCode::Success,
         })
+    }
+
+    pub(crate) fn ensure_lifecycle_active(&self, key: &str) -> Result<(), CredentialServiceError> {
+        if self
+            .lifecycle
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .contains_key(key)
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn adopt_committed_refresh(
+        &self,
+        key: &str,
+        idempotency_key: &str,
+        grant: EntraLeaseGrant,
+    ) -> Result<bool, CredentialServiceError> {
+        let metadata = match Self::committed_grant_metadata(grant) {
+            Ok(metadata) => metadata,
+            Err(_) => return Ok(false),
+        };
+        let mut leases = self.leases.lock().map_err(|_| {
+            CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+        })?;
+        let Some(record) = leases.get_mut(key) else {
+            return Ok(false);
+        };
+        record.idempotency_key = idempotency_key.to_owned();
+        record.metadata = metadata;
+        record.refresh_attempts = 0;
+        record.health = EntraResourceHealth::Degraded;
+        Ok(true)
     }
 
     pub(crate) fn record_refresh_failure(&self, key: &str) {

--- a/packages/d2b-provider-credential-entra/src/service.rs
+++ b/packages/d2b-provider-credential-entra/src/service.rs
@@ -51,9 +51,13 @@ impl EntraCredentialProvider {
             .ok_or_else(denied)?;
         if subject.transport_binding().locality() != Locality::Local
             || subject.subject_ref() != self.consumer_ref()
+            || subject.execution_ref() != Some(self.placement.execution_ref())
             || subject
                 .execution_ref()
-                .is_some_and(|execution| execution != self.placement.execution_ref())
+                .is_none_or(|execution| execution.resource_type().as_str() != "Guest")
+            || subject
+                .provider_ref()
+                .is_none_or(|provider| provider.to_canonical_string() != crate::PROVIDER_REF)
         {
             return Err(denied());
         }
@@ -78,6 +82,7 @@ impl EntraCredentialProvider {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
+        self.ensure_lifecycle_active(&key)?;
         {
             let mut leases = self.leases.lock().map_err(|_| invariant())?;
             leases.retain(|_, record| record.metadata.state == CredentialLeaseState::Active);
@@ -131,6 +136,7 @@ impl EntraCredentialProvider {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
+        self.ensure_lifecycle_active(&key)?;
         let record = self
             .leases
             .lock()
@@ -138,6 +144,11 @@ impl EntraCredentialProvider {
             .get(&key)
             .cloned()
             .ok_or_else(expired)?;
+        if record.metadata.state != CredentialLeaseState::Active {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::LeaseRevoked,
+            ));
+        }
         if record.refresh_attempts >= crate::MAX_REFRESH_ATTEMPTS {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::ProviderUnavailable,
@@ -168,10 +179,13 @@ impl EntraCredentialProvider {
                 return Err(error);
             }
         };
-        let metadata = match Self::grant_metadata(grant, request.requested_expiry_unix_ms()) {
+        let metadata = match Self::grant_metadata(grant.clone(), request.requested_expiry_unix_ms())
+        {
             Ok(metadata) => metadata,
             Err(error) => {
-                self.record_refresh_failure(&key);
+                if !self.adopt_committed_refresh(&key, request.idempotency_key(), grant)? {
+                    self.record_refresh_failure(&key);
+                }
                 return Err(error);
             }
         };

--- a/packages/d2b-provider-credential-entra/src/service.rs
+++ b/packages/d2b-provider-credential-entra/src/service.rs
@@ -1,5 +1,6 @@
 //! Credential service dispatch for the identity-Guest client.
 
+use d2b_contracts::v3::Locality;
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
     CredentialProvider, CredentialRequest, CredentialResponse, CredentialServiceError,
@@ -15,6 +16,7 @@ impl CredentialProvider for EntraCredentialProvider {
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
     ) -> Result<CredentialResponse, CredentialServiceError> {
+        self.authorize_request(request, authorization)?;
         match method {
             CredentialMethod::AcquireToken => self.acquire(request, authorization),
             CredentialMethod::RefreshToken => self.refresh(request, authorization),
@@ -27,7 +29,43 @@ impl CredentialProvider for EntraCredentialProvider {
     }
 }
 
+impl CredentialProvider for &EntraCredentialProvider {
+    fn dispatch(
+        &self,
+        method: CredentialMethod,
+        request: &CredentialRequest,
+        authorization: &CredentialAuthorization,
+    ) -> Result<CredentialResponse, CredentialServiceError> {
+        (*self).dispatch(method, request, authorization)
+    }
+}
+
 impl EntraCredentialProvider {
+    fn authorize_request(
+        &self,
+        request: &CredentialRequest,
+        authorization: &CredentialAuthorization,
+    ) -> Result<(), CredentialServiceError> {
+        let subject = authorization
+            .authenticated_subject_context()
+            .ok_or_else(denied)?;
+        if subject.transport_binding().locality() != Locality::Local
+            || subject.subject_ref() != self.consumer_ref()
+            || subject
+                .execution_ref()
+                .is_some_and(|execution| execution != self.placement.execution_ref())
+        {
+            return Err(denied());
+        }
+        self.placement
+            .validate_zone(subject.zone_ref())
+            .map_err(|_| denied())?;
+        if request.credential_ref().resource_type().as_str() != "Credential" {
+            return Err(denied());
+        }
+        Ok(())
+    }
+
     fn acquire(
         &self,
         request: &CredentialRequest,
@@ -71,6 +109,8 @@ impl EntraCredentialProvider {
             LeaseRecord {
                 idempotency_key: request.idempotency_key().to_owned(),
                 metadata: metadata.clone(),
+                refresh_attempts: 0,
+                health: crate::EntraResourceHealth::Ready,
             },
         );
         Ok(CredentialResponse::AcquireToken(DeliveryResponse {
@@ -98,24 +138,50 @@ impl EntraCredentialProvider {
             .get(&key)
             .cloned()
             .ok_or_else(expired)?;
+        if record.refresh_attempts >= crate::MAX_REFRESH_ATTEMPTS {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            ));
+        }
         let lease = EntraLeaseRef {
             credential_ref: request.credential_ref().clone(),
-            metadata: record.metadata,
+            metadata: record.metadata.clone(),
             endpoint_generation: self.placement.endpoint_generation(),
         };
-        let inspection = Self::poll_client(self.client.inspect_lease(&lease), deadline)?;
+        let inspection = match Self::poll_client(self.client.inspect_lease(&lease), deadline) {
+            Ok(inspection) => inspection,
+            Err(error) => {
+                self.record_refresh_failure(&key);
+                return Err(error);
+            }
+        };
         if inspection.state != CredentialLeaseState::Active
             || inspection.rotation_generation != lease.metadata.rotation_generation
         {
+            self.record_refresh_failure(&key);
             return Err(invariant());
         }
-        let grant = Self::poll_client(self.client.refresh_lease(&lease), deadline)?;
-        let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
+        let grant = match Self::poll_client(self.client.refresh_lease(&lease), deadline) {
+            Ok(grant) => grant,
+            Err(error) => {
+                self.record_refresh_failure(&key);
+                return Err(error);
+            }
+        };
+        let metadata = match Self::grant_metadata(grant, request.requested_expiry_unix_ms()) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                self.record_refresh_failure(&key);
+                return Err(error);
+            }
+        };
         self.leases.lock().map_err(|_| invariant())?.insert(
-            key,
+            key.clone(),
             LeaseRecord {
                 idempotency_key: request.idempotency_key().to_owned(),
                 metadata: metadata.clone(),
+                refresh_attempts: 0,
+                health: crate::EntraResourceHealth::Ready,
             },
         );
         Ok(CredentialResponse::RefreshToken(DeliveryResponse {
@@ -151,6 +217,7 @@ impl EntraCredentialProvider {
             }
         };
         record.metadata.outcome = outcome;
+        record.health = crate::EntraResourceHealth::Revoked;
         Ok(CredentialResponse::RevokeToken(MetadataResponse {
             metadata: record.metadata.clone(),
         }))
@@ -187,6 +254,10 @@ impl EntraCredentialProvider {
 
 fn invariant() -> CredentialServiceError {
     CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+}
+
+fn denied() -> CredentialServiceError {
+    CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
 }
 
 fn expired() -> CredentialServiceError {

--- a/packages/d2b-provider-credential-entra/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-entra/tests/common/mod.rs
@@ -9,7 +9,11 @@ use d2b_contracts::v3::credential::{
     CredentialServiceError, CredentialServiceErrorCode, CredentialSourceVersion,
     DeliveryRouteDigest, DeliverySessionParams, PlacementBinding, dispatch_authorized_provider,
 };
-use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid};
+use d2b_contracts::v3::{
+    AuthenticatedSubjectContext, BindingDigest, EvidenceClass, Locality, ReconnectGeneration,
+    ResourceGeneration, ResourceRef, ResourceUid, SchemaFingerprint, ServiceName, SessionBinding,
+    SessionPurpose, TranscriptHash, TransportBinding,
+};
 use d2b_provider_credential_entra::{
     EntraClientError, EntraClientState, EntraConfig, EntraCredentialClient,
     EntraCredentialProvider, EntraCredentialProviderFactory, EntraFuture, EntraLeaseGrant,
@@ -27,6 +31,7 @@ pub struct FakeEntraClient {
     pub refresh_calls: AtomicUsize,
     pub revoke_calls: AtomicUsize,
     pub issue_error: Mutex<Option<EntraClientError>>,
+    pub refresh_error: Mutex<Option<EntraClientError>>,
     pub observed_request: Mutex<Option<(String, String, String)>>,
     pub token_canary: String,
     pub endpoint_canary: String,
@@ -44,6 +49,7 @@ impl FakeEntraClient {
             refresh_calls: AtomicUsize::new(0),
             revoke_calls: AtomicUsize::new(0),
             issue_error: Mutex::new(None),
+            refresh_error: Mutex::new(None),
             observed_request: Mutex::new(None),
             token_canary: format!("entra-token-canary-{nonce}"),
             endpoint_canary: format!("entra-endpoint-canary-{nonce}"),
@@ -105,9 +111,13 @@ impl EntraCredentialClient for FakeEntraClient {
 
     fn refresh_lease(&self, lease: &EntraLeaseRef) -> EntraFuture<'_, EntraLeaseRenewal> {
         self.refresh_calls.fetch_add(1, Ordering::SeqCst);
+        let error = *self.refresh_error.lock().unwrap();
         let expiry = lease.metadata().expires_at_unix_ms;
         let inspection = &self.inspection;
         Box::pin(async move {
+            if let Some(error) = error {
+                return Err(error);
+            }
             let grant = EntraLeaseGrant {
                 lease_handle: CredentialLeaseHandle::parse("entra-lease").unwrap(),
                 source_version: CredentialSourceVersion::parse("entra-source-2").unwrap(),
@@ -133,7 +143,8 @@ impl EntraCredentialClient for FakeEntraClient {
 pub fn setup() -> (EntraCredentialProvider, Arc<FakeEntraClient>) {
     let client = Arc::new(FakeEntraClient::new());
     let config = EntraConfig::new("tenant-1234", 64).unwrap();
-    let placement = EntraPlacement::new(
+    let placement = EntraPlacement::new_in_zone(
+        ResourceRef::parse("Zone/work").unwrap(),
         PlacementBinding::GuestAgent,
         ResourceRef::parse("Guest/consumer").unwrap(),
         ResourceRef::parse("Guest/identity").unwrap(),
@@ -149,6 +160,38 @@ pub fn setup() -> (EntraCredentialProvider, Arc<FakeEntraClient>) {
     )
     .unwrap();
     (factory.construct(), client)
+}
+
+pub fn subject_context() -> AuthenticatedSubjectContext {
+    subject_context_for(
+        ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+        ResourceRef::parse("Zone/work").unwrap(),
+        Locality::Local,
+    )
+}
+
+pub fn subject_context_for(
+    subject_ref: ResourceRef,
+    zone_ref: ResourceRef,
+    locality: Locality,
+) -> AuthenticatedSubjectContext {
+    let digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    AuthenticatedSubjectContext::new(
+        subject_ref,
+        ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),
+        zone_ref,
+        EvidenceClass::UnixPeer,
+        SessionPurpose::parse("credential").unwrap(),
+        ServiceName::parse("d2b.credential.v3").unwrap(),
+        SessionBinding::new(
+            SchemaFingerprint::parse(digest).unwrap(),
+            TransportBinding::new(locality, BindingDigest::parse(digest).unwrap()),
+            ReconnectGeneration::new(1).unwrap(),
+            TranscriptHash::from_bytes([0x5a; 32]),
+        ),
+    )
+    .with_execution_ref(ResourceRef::parse("Guest/consumer").unwrap())
+    .with_provider_ref(ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap())
 }
 
 pub fn request(idempotency: &str) -> CredentialRequest {
@@ -206,9 +249,10 @@ impl TestAdmission for Admission {
                 CredentialServiceErrorCode::OperationDenied,
             ));
         }
-        CredentialAuthorization::new(
+        CredentialAuthorization::new_for_subject(
             method,
             method.requires_delivery().then(|| delivery(method, 1)),
+            subject_context(),
         )
     }
 }

--- a/packages/d2b-provider-credential-entra/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-entra/tests/common/mod.rs
@@ -175,8 +175,24 @@ pub fn subject_context_for(
     zone_ref: ResourceRef,
     locality: Locality,
 ) -> AuthenticatedSubjectContext {
+    subject_context_with_bindings(
+        subject_ref,
+        zone_ref,
+        locality,
+        Some(ResourceRef::parse("Guest/consumer").unwrap()),
+        Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+    )
+}
+
+pub fn subject_context_with_bindings(
+    subject_ref: ResourceRef,
+    zone_ref: ResourceRef,
+    locality: Locality,
+    execution_ref: Option<ResourceRef>,
+    provider_ref: Option<ResourceRef>,
+) -> AuthenticatedSubjectContext {
     let digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    AuthenticatedSubjectContext::new(
+    let context = AuthenticatedSubjectContext::new(
         subject_ref,
         ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),
         zone_ref,
@@ -189,9 +205,15 @@ pub fn subject_context_for(
             ReconnectGeneration::new(1).unwrap(),
             TranscriptHash::from_bytes([0x5a; 32]),
         ),
-    )
-    .with_execution_ref(ResourceRef::parse("Guest/consumer").unwrap())
-    .with_provider_ref(ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap())
+    );
+    let mut context = context;
+    if let Some(execution) = execution_ref {
+        context = context.with_execution_ref(execution);
+    }
+    if let Some(provider) = provider_ref {
+        context = context.with_provider_ref(provider);
+    }
+    context
 }
 
 pub fn request(idempotency: &str) -> CredentialRequest {

--- a/packages/d2b-provider-credential-entra/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-entra/tests/common/mod.rs
@@ -32,6 +32,7 @@ pub struct FakeEntraClient {
     pub revoke_calls: AtomicUsize,
     pub issue_error: Mutex<Option<EntraClientError>>,
     pub refresh_error: Mutex<Option<EntraClientError>>,
+    pub revoke_error: Mutex<Option<EntraClientError>>,
     pub observed_request: Mutex<Option<(String, String, String)>>,
     pub token_canary: String,
     pub endpoint_canary: String,
@@ -50,6 +51,7 @@ impl FakeEntraClient {
             revoke_calls: AtomicUsize::new(0),
             issue_error: Mutex::new(None),
             refresh_error: Mutex::new(None),
+            revoke_error: Mutex::new(None),
             observed_request: Mutex::new(None),
             token_canary: format!("entra-token-canary-{nonce}"),
             endpoint_canary: format!("entra-endpoint-canary-{nonce}"),
@@ -136,7 +138,13 @@ impl EntraCredentialClient for FakeEntraClient {
 
     fn revoke_lease(&self, _lease: &EntraLeaseRef) -> EntraFuture<'_, EntraLeaseRevocation> {
         self.revoke_calls.fetch_add(1, Ordering::SeqCst);
-        Box::pin(async { Ok(EntraLeaseRevocation::Revoked) })
+        let error = *self.revoke_error.lock().unwrap();
+        Box::pin(async move {
+            if let Some(error) = error {
+                return Err(error);
+            }
+            Ok(EntraLeaseRevocation::Revoked)
+        })
     }
 }
 

--- a/packages/d2b-provider-credential-entra/tests/conformance.rs
+++ b/packages/d2b-provider-credential-entra/tests/conformance.rs
@@ -94,11 +94,25 @@ fn exact_role_subresources_and_endpoint_policy_are_closed() {
 
     let provider = ResourceRef::parse("Provider/credential-entra").unwrap();
     let consumer = ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap();
-    let policy = EntraEndpointPolicy::new("provider", provider.clone(), consumer.clone()).unwrap();
+    let policy = EntraEndpointPolicy::new(
+        "provider",
+        provider.clone(),
+        consumer.clone(),
+        ResourceRef::parse("Guest/consumer").unwrap(),
+    )
+    .unwrap();
     assert_eq!(policy.purpose(), LOGIN_ENDPOINT_PURPOSE);
     assert!(policy.allows_subject(&provider));
     assert!(policy.allows_subject(&consumer));
-    assert!(EntraEndpointPolicy::new("zone", provider, consumer).is_err());
+    assert!(
+        EntraEndpointPolicy::new(
+            "zone",
+            provider,
+            consumer,
+            ResourceRef::parse("Guest/consumer").unwrap(),
+        )
+        .is_err()
+    );
 }
 
 #[test]

--- a/packages/d2b-provider-credential-entra/tests/controller.rs
+++ b/packages/d2b-provider-credential-entra/tests/controller.rs
@@ -1,0 +1,69 @@
+mod common;
+
+use d2b_contracts::v3::credential::CredentialServiceErrorCode;
+use d2b_contracts::v3::{Locality, ResourceRef};
+use d2b_provider_credential_entra::{
+    EntraClientState, EntraController, EntraEndpointPolicy, EntraPlacement, EntraResourceHealth,
+};
+
+use common::{subject_context, subject_context_for};
+
+fn controller() -> (EntraController, EntraEndpointPolicy) {
+    let placement = EntraPlacement::new_in_zone(
+        ResourceRef::parse("Zone/work").unwrap(),
+        d2b_contracts::v3::credential::PlacementBinding::GuestAgent,
+        ResourceRef::parse("Guest/consumer").unwrap(),
+        ResourceRef::parse("Guest/identity").unwrap(),
+        ResourceRef::parse("Endpoint/entra-login").unwrap(),
+        7,
+    )
+    .unwrap();
+    let policy = EntraEndpointPolicy::new(
+        "provider",
+        ResourceRef::parse("Provider/credential-entra").unwrap(),
+        ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+    )
+    .unwrap();
+    (EntraController::new(placement), policy)
+}
+
+#[test]
+fn status_projection_is_typed_redacted_and_locality_bound() {
+    let (controller, policy) = controller();
+    let projection = controller
+        .project_for_subject(
+            &policy,
+            &subject_context(),
+            EntraClientState::Ready,
+            None,
+            EntraResourceHealth::Degraded,
+            2,
+        )
+        .unwrap();
+    assert_eq!(projection.resource_health, EntraResourceHealth::Degraded);
+    assert_eq!(projection.refresh_attempts, 2);
+    assert_eq!(
+        format!("{projection:?}"),
+        "EntraStatusProjection(<redacted>)"
+    );
+
+    let relay = subject_context_for(
+        ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+        ResourceRef::parse("Zone/work").unwrap(),
+        Locality::AdjacentZone,
+    );
+    assert_eq!(
+        controller
+            .project_for_subject(
+                &policy,
+                &relay,
+                EntraClientState::Ready,
+                None,
+                EntraResourceHealth::Ready,
+                0,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+}

--- a/packages/d2b-provider-credential-entra/tests/controller.rs
+++ b/packages/d2b-provider-credential-entra/tests/controller.rs
@@ -6,7 +6,7 @@ use d2b_provider_credential_entra::{
     EntraClientState, EntraController, EntraEndpointPolicy, EntraPlacement, EntraResourceHealth,
 };
 
-use common::{subject_context, subject_context_for};
+use common::{subject_context, subject_context_for, subject_context_with_bindings};
 
 fn controller() -> (EntraController, EntraEndpointPolicy) {
     let placement = EntraPlacement::new_in_zone(
@@ -22,6 +22,7 @@ fn controller() -> (EntraController, EntraEndpointPolicy) {
         "provider",
         ResourceRef::parse("Provider/credential-entra").unwrap(),
         ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+        ResourceRef::parse("Guest/consumer").unwrap(),
     )
     .unwrap();
     (EntraController::new(placement), policy)
@@ -57,6 +58,73 @@ fn status_projection_is_typed_redacted_and_locality_bound() {
             .project_for_subject(
                 &policy,
                 &relay,
+                EntraClientState::Ready,
+                None,
+                EntraResourceHealth::Ready,
+                0,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+}
+
+#[test]
+fn endpoint_policy_requires_guest_execution_and_exact_provider() {
+    let (_, policy) = controller();
+    for (label, execution_ref, provider_ref) in [
+        (
+            "missing execution",
+            None,
+            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+        ),
+        (
+            "host execution",
+            Some(ResourceRef::parse("Host/workstation").unwrap()),
+            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+        ),
+        (
+            "wrong Guest execution",
+            Some(ResourceRef::parse("Guest/other").unwrap()),
+            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+        ),
+        (
+            "missing provider",
+            Some(ResourceRef::parse("Guest/consumer").unwrap()),
+            None,
+        ),
+        (
+            "wrong provider",
+            Some(ResourceRef::parse("Guest/consumer").unwrap()),
+            Some(ResourceRef::parse("Provider/other").unwrap()),
+        ),
+    ] {
+        let subject = subject_context_with_bindings(
+            ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+            ResourceRef::parse("Zone/work").unwrap(),
+            Locality::Local,
+            execution_ref,
+            provider_ref,
+        );
+        assert!(!policy.allows_authenticated_subject(&subject), "{label}");
+    }
+}
+
+#[test]
+fn status_projection_requires_the_committed_guest_execution() {
+    let (controller, policy) = controller();
+    let wrong_guest = subject_context_with_bindings(
+        ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+        ResourceRef::parse("Zone/work").unwrap(),
+        Locality::Local,
+        Some(ResourceRef::parse("Guest/other").unwrap()),
+        Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+    );
+    assert_eq!(
+        controller
+            .project_for_subject(
+                &policy,
+                &wrong_guest,
                 EntraClientState::Ready,
                 None,
                 EntraResourceHealth::Ready,

--- a/packages/d2b-provider-credential-entra/tests/delivery.rs
+++ b/packages/d2b-provider-credential-entra/tests/delivery.rs
@@ -7,7 +7,7 @@ use d2b_contracts::v3::credential::{
 };
 use d2b_provider_credential_entra::EntraCredentialProvider;
 
-use common::{ProviderHarness, TestAdmission, admitted, delivery, request, setup};
+use common::{ProviderHarness, TestAdmission, admitted, delivery, request, setup, subject_context};
 
 #[test]
 fn provider_returns_exactly_the_read_only_adapter_binding() {
@@ -44,7 +44,11 @@ impl TestAdmission for FixedAdmission {
         method: CredentialMethod,
         _request: &CredentialRequest,
     ) -> Result<CredentialAuthorization, CredentialServiceError> {
-        CredentialAuthorization::new(method, Some(self.authorized.clone()))
+        CredentialAuthorization::new_for_subject(
+            method,
+            Some(self.authorized.clone()),
+            subject_context(),
+        )
     }
 }
 

--- a/packages/d2b-provider-credential-entra/tests/faults.rs
+++ b/packages/d2b-provider-credential-entra/tests/faults.rs
@@ -5,9 +5,11 @@ use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::Duration;
 
+use d2b_contracts::v3::Locality;
 use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
-    CredentialMethod, CredentialRequest, CredentialServiceErrorCode, PlacementBinding,
+    CredentialAuthorization, CredentialMethod, CredentialRequest, CredentialServiceErrorCode,
+    PlacementBinding, dispatch_authorized_provider,
 };
 use d2b_provider_credential_entra::{
     EntraClientError, EntraClientState, EntraConfig, EntraCredentialClient,
@@ -15,7 +17,7 @@ use d2b_provider_credential_entra::{
     EntraLeaseRef, EntraLeaseRenewal, EntraLeaseRequest, EntraLeaseRevocation, EntraPlacement,
 };
 
-use common::{Admission, ProviderHarness, admitted, request, setup};
+use common::{Admission, ProviderHarness, admitted, delivery, request, setup, subject_context_for};
 
 #[test]
 fn interaction_required_is_unavailable_not_denied() {
@@ -50,6 +52,118 @@ fn exact_consumer_mismatch_is_denied_before_client_dispatch() {
 }
 
 #[test]
+fn unauthorized_and_relay_subjects_cannot_resolve_or_refresh() {
+    let (provider, client) = setup();
+    let unauthorized_request = request("idem-unauthorized");
+    let missing_context = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap();
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &unauthorized_request,
+            &missing_context,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    let unauthorized = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+        subject_context_for(
+            ResourceRef::parse("User/alice").unwrap(),
+            ResourceRef::parse("Zone/work").unwrap(),
+            Locality::Local,
+        ),
+    )
+    .unwrap();
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &unauthorized_request,
+            &unauthorized,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+
+    ProviderHarness::new(&provider, admitted())
+        .call(CredentialMethod::AcquireToken, request("idem-authorized"))
+        .unwrap();
+    let unauthorized_inspect = CredentialAuthorization::new_for_subject(
+        CredentialMethod::InspectMetadata,
+        None,
+        subject_context_for(
+            ResourceRef::parse("User/alice").unwrap(),
+            ResourceRef::parse("Zone/work").unwrap(),
+            Locality::Local,
+        ),
+    )
+    .unwrap();
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::InspectMetadata,
+            &request("idem-inspect-unauthorized"),
+            &unauthorized_inspect,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    let unauthorized_refresh = CredentialAuthorization::new_for_subject(
+        CredentialMethod::RefreshToken,
+        Some(delivery(CredentialMethod::RefreshToken, 1)),
+        subject_context_for(
+            ResourceRef::parse("User/alice").unwrap(),
+            ResourceRef::parse("Zone/work").unwrap(),
+            Locality::Local,
+        ),
+    )
+    .unwrap();
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &request("idem-refresh-unauthorized"),
+            &unauthorized_refresh,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+
+    let relay = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+        subject_context_for(
+            ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+            ResourceRef::parse("Zone/work").unwrap(),
+            Locality::AdjacentZone,
+        ),
+    )
+    .unwrap();
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &unauthorized_request,
+            &relay,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
 fn generation_and_unsupported_operation_fail_closed() {
     let (provider, client) = setup();
     assert_eq!(
@@ -76,6 +190,76 @@ fn generation_and_unsupported_operation_fail_closed() {
         CredentialServiceErrorCode::Malformed
     );
     assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn refresh_failure_degrades_only_the_owning_resource_with_bounded_retry() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-refresh-failure"),
+        )
+        .unwrap();
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            CredentialRequest::new(
+                ResourceRef::parse("Credential/other-entra").unwrap(),
+                "operation-other",
+                "idem-other",
+                common::EXPIRY,
+                15_000,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    *client.refresh_error.lock().unwrap() = Some(EntraClientError::Unavailable);
+
+    for attempt in 0..d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS {
+        assert_eq!(
+            server
+                .call(
+                    CredentialMethod::RefreshToken,
+                    request(&format!("idem-refresh-failure-refresh-{attempt}"))
+                )
+                .unwrap_err()
+                .code(),
+            CredentialServiceErrorCode::ProviderUnavailable
+        );
+    }
+    let refresh_calls = client.refresh_calls.load(Ordering::SeqCst);
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::RefreshToken,
+                request("idem-refresh-failure-bounded")
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(
+        client.refresh_calls.load(Ordering::SeqCst),
+        refresh_calls,
+        "refresh retry must stop at the bounded attempt ceiling"
+    );
+    assert_eq!(
+        provider.resource_health(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some(d2b_provider_credential_entra::EntraResourceHealth::Degraded)
+    );
+    assert_eq!(
+        provider.refresh_retry_state(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some((
+            d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS,
+            d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS,
+        ))
+    );
+    assert_eq!(
+        provider.resource_health(&ResourceRef::parse("Credential/other-entra").unwrap()),
+        Some(d2b_provider_credential_entra::EntraResourceHealth::Ready)
+    );
 }
 
 #[test]

--- a/packages/d2b-provider-credential-entra/tests/faults.rs
+++ b/packages/d2b-provider-credential-entra/tests/faults.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use d2b_contracts::v3::Locality;
 use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
-    CredentialAuthorization, CredentialMethod, CredentialRequest, CredentialServiceErrorCode,
-    PlacementBinding, dispatch_authorized_provider,
+    CredentialAuthorization, CredentialMethod, CredentialRequest, CredentialResponse,
+    CredentialServiceErrorCode, PlacementBinding, dispatch_authorized_provider,
 };
 use d2b_provider_credential_entra::{
     EntraClientError, EntraClientState, EntraConfig, EntraCredentialClient,
@@ -17,7 +17,10 @@ use d2b_provider_credential_entra::{
     EntraLeaseRef, EntraLeaseRenewal, EntraLeaseRequest, EntraLeaseRevocation, EntraPlacement,
 };
 
-use common::{Admission, ProviderHarness, admitted, delivery, request, setup, subject_context_for};
+use common::{
+    Admission, ProviderHarness, admitted, delivery, request, setup, subject_context_for,
+    subject_context_with_bindings,
+};
 
 #[test]
 fn interaction_required_is_unavailable_not_denied() {
@@ -164,6 +167,97 @@ fn unauthorized_and_relay_subjects_cannot_resolve_or_refresh() {
 }
 
 #[test]
+fn missing_or_mismatched_authenticated_claims_are_denied_before_client_dispatch() {
+    let cases = [
+        (
+            "missing execution",
+            None,
+            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+        ),
+        (
+            "host execution",
+            Some(ResourceRef::parse("Host/workstation").unwrap()),
+            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+        ),
+        (
+            "wrong Guest execution",
+            Some(ResourceRef::parse("Guest/other").unwrap()),
+            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+        ),
+        (
+            "missing provider",
+            Some(ResourceRef::parse("Guest/consumer").unwrap()),
+            None,
+        ),
+        (
+            "wrong provider",
+            Some(ResourceRef::parse("Guest/consumer").unwrap()),
+            Some(ResourceRef::parse("Provider/other").unwrap()),
+        ),
+    ];
+
+    for (index, (label, execution_ref, provider_ref)) in cases.into_iter().enumerate() {
+        let (provider, client) = setup();
+        let authorization = CredentialAuthorization::new_for_subject(
+            CredentialMethod::AcquireToken,
+            Some(delivery(CredentialMethod::AcquireToken, 1)),
+            subject_context_with_bindings(
+                ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+                ResourceRef::parse("Zone/work").unwrap(),
+                Locality::Local,
+                execution_ref,
+                provider_ref,
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            dispatch_authorized_provider(
+                &provider,
+                CredentialMethod::AcquireToken,
+                &request(&format!("idem-claims-{index}")),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+            CredentialServiceErrorCode::OperationDenied,
+            "{label}"
+        );
+        assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0, "{label}");
+    }
+}
+
+#[test]
+fn same_credential_name_from_another_zone_is_denied_before_client_dispatch() {
+    let (provider, client) = setup();
+    let authorization = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+        subject_context_with_bindings(
+            ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+            ResourceRef::parse("Zone/personal").unwrap(),
+            Locality::Local,
+            Some(ResourceRef::parse("Guest/consumer").unwrap()),
+            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("idem-cross-zone"),
+            &authorization,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
 fn generation_and_unsupported_operation_fail_closed() {
     let (provider, client) = setup();
     assert_eq!(
@@ -263,13 +357,81 @@ fn refresh_failure_degrades_only_the_owning_resource_with_bounded_retry() {
 }
 
 #[test]
+fn committed_remote_refresh_metadata_is_adopted_for_later_recovery() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-refresh-adopt"),
+        )
+        .unwrap();
+
+    let too_short = CredentialRequest::new(
+        ResourceRef::parse("Credential/work-entra").unwrap(),
+        "operation-refresh-adopt",
+        "idem-refresh-too-short",
+        10_000,
+        5_000,
+    )
+    .unwrap();
+    assert_eq!(
+        server
+            .call(CredentialMethod::RefreshToken, too_short)
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(client.refresh_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        provider.refresh_retry_state(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some((0, d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS))
+    );
+
+    let inspected = server
+        .call(
+            CredentialMethod::InspectMetadata,
+            request("idem-inspect-adopted"),
+        )
+        .unwrap();
+    let inspected_metadata = match inspected {
+        CredentialResponse::InspectMetadata(response) => response.metadata,
+        other => panic!("unexpected response: {other:?}"),
+    };
+    assert_eq!(inspected_metadata.rotation_generation, 2);
+
+    let refreshed = server
+        .call(
+            CredentialMethod::RefreshToken,
+            request("idem-refresh-after-adopt"),
+        )
+        .unwrap();
+    let refreshed_metadata = match refreshed {
+        CredentialResponse::RefreshToken(response) => response.metadata,
+        other => panic!("unexpected response: {other:?}"),
+    };
+    assert_eq!(refreshed_metadata.rotation_generation, 2);
+    assert_eq!(
+        provider.resource_health(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some(d2b_provider_credential_entra::EntraResourceHealth::Ready)
+    );
+    assert_eq!(
+        provider.refresh_retry_state(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some((0, d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS))
+    );
+    assert_eq!(client.inspect_calls.load(Ordering::SeqCst), 3);
+    assert_eq!(client.refresh_calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
 fn client_call_stops_at_request_deadline() {
     let client = Arc::new(NeverClient {
         issue_calls: AtomicUsize::new(0),
     });
     let provider = EntraCredentialProviderFactory::new(
         EntraConfig::new("tenant-1234", 64).unwrap(),
-        EntraPlacement::new(
+        EntraPlacement::new_in_zone(
+            ResourceRef::parse("Zone/work").unwrap(),
             PlacementBinding::GuestAgent,
             ResourceRef::parse("Guest/consumer").unwrap(),
             ResourceRef::parse("Guest/identity").unwrap(),

--- a/packages/d2b-provider-credential-entra/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-entra/tests/lifecycle.rs
@@ -13,9 +13,10 @@ use d2b_contracts::v3::credential::{
     CredentialServiceErrorCode, CredentialSourceVersion, PlacementBinding,
 };
 use d2b_provider_credential_entra::{
-    EntraClientState, EntraConfig, EntraCredentialClient, EntraCredentialProvider,
-    EntraCredentialProviderFactory, EntraFuture, EntraLeaseGrant, EntraLeaseInspection,
-    EntraLeaseRef, EntraLeaseRenewal, EntraLeaseRequest, EntraLeaseRevocation, EntraPlacement,
+    EntraClientError, EntraClientState, EntraConfig, EntraCredentialClient,
+    EntraCredentialProvider, EntraCredentialProviderFactory, EntraFuture, EntraLeaseGrant,
+    EntraLeaseInspection, EntraLeaseRef, EntraLeaseRenewal, EntraLeaseRequest,
+    EntraLeaseRevocation, EntraPlacement,
 };
 
 use common::{ProviderHarness, admitted, request, setup};
@@ -173,6 +174,42 @@ fn finalized_credential_cannot_mint_again() {
         CredentialServiceErrorCode::ProviderUnavailable
     );
     assert_eq!(client.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn draining_credential_cannot_mint_while_revocation_retries() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-draining-before-revoke"),
+        )
+        .unwrap();
+    *client.revoke_error.lock().unwrap() = Some(EntraClientError::Unavailable);
+
+    assert_eq!(
+        provider
+            .revoke_owned_handles(
+                &ResourceRef::parse("Credential/work-entra").unwrap(),
+                15_000,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-draining-after-failure"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
 }
 
 struct BlockingClient {

--- a/packages/d2b-provider-credential-entra/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-entra/tests/lifecycle.rs
@@ -145,6 +145,36 @@ fn finalization_revokes_owned_handles_before_clearing_provider_state() {
     );
 }
 
+#[test]
+fn finalized_credential_cannot_mint_again() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-finalize-once"),
+        )
+        .unwrap();
+    provider
+        .revoke_owned_handles(
+            &ResourceRef::parse("Credential/work-entra").unwrap(),
+            15_000,
+        )
+        .unwrap();
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-after-finalize"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 1);
+}
+
 struct BlockingClient {
     entered: Mutex<Option<mpsc::Sender<()>>>,
     state: Mutex<BlockingState>,
@@ -233,7 +263,8 @@ fn provider_with_client(
 ) -> EntraCredentialProvider {
     EntraCredentialProviderFactory::new(
         EntraConfig::new("tenant-1234", max_leases).unwrap(),
-        EntraPlacement::new(
+        EntraPlacement::new_in_zone(
+            ResourceRef::parse("Zone/work").unwrap(),
             PlacementBinding::GuestAgent,
             ResourceRef::parse("Guest/consumer").unwrap(),
             ResourceRef::parse("Guest/identity").unwrap(),

--- a/packages/d2b-provider-credential-entra/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-entra/tests/lifecycle.rs
@@ -120,6 +120,31 @@ fn revocation_releases_capacity() {
     assert_eq!(client.issue_calls.load(Ordering::SeqCst), 2);
 }
 
+#[test]
+fn finalization_revokes_owned_handles_before_clearing_provider_state() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(CredentialMethod::AcquireToken, request("idem-finalize"))
+        .unwrap();
+
+    let cleanup = provider
+        .revoke_owned_handles(
+            &ResourceRef::parse("Credential/work-entra").unwrap(),
+            15_000,
+        )
+        .unwrap();
+
+    assert_eq!(cleanup.revoked, 1);
+    assert_eq!(cleanup.remaining, 0);
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        provider.active_lease_count(),
+        0,
+        "finalization must not clear state before owned revocation"
+    );
+}
+
 struct BlockingClient {
     entered: Mutex<Option<mpsc::Sender<()>>>,
     state: Mutex<BlockingState>,

--- a/packages/d2b-provider-credential-entra/tests/placement.rs
+++ b/packages/d2b-provider-credential-entra/tests/placement.rs
@@ -16,6 +16,7 @@ fn guest_user_and_system_domains_are_accepted_but_host_system_is_rejected() {
             .is_ok()
         );
     }
+
     assert_eq!(
         EntraPlacement::new(
             PlacementBinding::HostSystem,
@@ -25,5 +26,23 @@ fn guest_user_and_system_domains_are_accepted_but_host_system_is_rejected() {
             1,
         ),
         Err(EntraProviderError::InvalidPlacement)
+    );
+}
+
+#[test]
+fn zone_bound_placement_rejects_a_cross_zone_binding() {
+    let placement = EntraPlacement::new_in_zone(
+        ResourceRef::parse("Zone/work").unwrap(),
+        PlacementBinding::GuestAgent,
+        ResourceRef::parse("Guest/consumer").unwrap(),
+        ResourceRef::parse("Guest/identity").unwrap(),
+        ResourceRef::parse("Endpoint/entra-login").unwrap(),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(
+        placement.validate_zone(&ResourceRef::parse("Zone/personal").unwrap()),
+        Err(EntraProviderError::InvalidEndpoint)
     );
 }

--- a/packages/d2b-provider-credential-entra/tests/placement.rs
+++ b/packages/d2b-provider-credential-entra/tests/placement.rs
@@ -46,3 +46,20 @@ fn zone_bound_placement_rejects_a_cross_zone_binding() {
         Err(EntraProviderError::InvalidEndpoint)
     );
 }
+
+#[test]
+fn unbound_placement_never_validates_against_a_zone() {
+    let placement = EntraPlacement::new(
+        PlacementBinding::GuestAgent,
+        ResourceRef::parse("Guest/consumer").unwrap(),
+        ResourceRef::parse("Guest/identity").unwrap(),
+        ResourceRef::parse("Endpoint/entra-login").unwrap(),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(
+        placement.validate_zone(&ResourceRef::parse("Zone/work").unwrap()),
+        Err(EntraProviderError::InvalidEndpoint)
+    );
+}


### PR DESCRIPTION
## Summary
- Keep Entra credential acquisition and refresh inside the owning Guest and Zone boundary.
- Enforce trusted local subject authorization and reject unauthorized or relay requests.
- Project typed redacted health, bound refresh degradation, and finalization revocation.

## Verification
- `cargo test -p d2b-provider-credential-entra --lib --tests`
- `cargo test -p d2b-contracts --lib credential`
- `bash scripts/changelog-check.sh`