### PR TITLE
credential: bind managed identity leases to sessions

### DIFF
--- a/changelog.d/spec001-w6-u20-managed-identity.md
+++ b/changelog.d/spec001-w6-u20-managed-identity.md
@@ -3,4 +3,6 @@
 - Bound managed-identity Credential leases to authenticated subject, Zone,
   workload, Provider session, and bounded expiry state; restart checkpoints
   remain secret-free and finalization revokes only the owning workload's
-  handles.
+  handles. Reacquisition replaces terminal or stale-session records without
+  inflating the accepted client rotation generation, and repeated checkpoint
+  restore remains occupancy-safe and idempotent.

--- a/changelog.d/spec001-w6-u20-managed-identity.md
+++ b/changelog.d/spec001-w6-u20-managed-identity.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Bound managed-identity Credential leases to authenticated subject, Zone,
+  workload, Provider session, and bounded expiry state; restart checkpoints
+  remain secret-free and finalization revokes only the owning workload's
+  handles.

--- a/packages/d2b-contracts/src/v3/credential/service.rs
+++ b/packages/d2b-contracts/src/v3/credential/service.rs
@@ -8,7 +8,9 @@ use super::{
     OperationClass,
 };
 use crate::v3::component_session::MAX_PROTECTED_PLAINTEXT_BYTES;
-use crate::v3::{ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash};
+use crate::v3::{
+    AuthenticatedSubjectContext, ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash,
+};
 
 /// Canonical service package routed by the Zone bus.
 pub const CREDENTIAL_SERVICE_NAME: &str = "d2b.credential.v3";
@@ -429,6 +431,62 @@ impl DeliverySessionParams {
         self.operation_class
     }
 
+    /// Borrow the Credential reference bound into this delivery session.
+    pub const fn credential_ref(&self) -> &ResourceRef {
+        &self.credential_ref
+    }
+
+    /// Borrow the consumer Provider reference bound into this delivery session.
+    pub const fn consumer_provider_ref(&self) -> &ResourceRef {
+        &self.consumer_provider_ref
+    }
+
+    /// Return the Credential UID bound into this delivery session.
+    pub const fn credential_uid(&self) -> &ResourceUid {
+        &self.credential_uid
+    }
+
+    /// Return the Credential generation bound into this delivery session.
+    pub const fn credential_generation(&self) -> ResourceGeneration {
+        self.credential_generation
+    }
+
+    /// Return the consumer component generation bound into this delivery
+    /// session.
+    pub const fn consumer_component_generation(&self) -> ResourceGeneration {
+        self.consumer_component_generation
+    }
+
+    /// Borrow the audience token bound into this delivery session.
+    pub const fn audience(&self) -> &AudienceToken {
+        &self.audience
+    }
+
+    /// Return the absolute delivery-session expiry.
+    pub const fn expiry_unix_ms(&self) -> u64 {
+        self.expiry_unix_ms
+    }
+
+    /// Return the hard delivery-session deadline.
+    pub const fn deadline_unix_ms(&self) -> u64 {
+        self.deadline_unix_ms
+    }
+
+    /// Borrow the authorized route digest.
+    pub const fn route_digest(&self) -> &DeliveryRouteDigest {
+        &self.route_digest
+    }
+
+    /// Return the fixed binding schema version.
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Return the maximum plaintext record size.
+    pub const fn max_token_bytes(&self) -> u32 {
+        self.max_token_bytes
+    }
+
     /// Return the replay-safe sequence number.
     pub const fn sequence(&self) -> u64 {
         self.sequence
@@ -593,6 +651,7 @@ impl fmt::Debug for CredentialResponse {
 #[derive(Clone, PartialEq, Eq)]
 pub struct CredentialAuthorization {
     delivery_session_params: Option<DeliverySessionParams>,
+    authenticated_session: Option<CredentialSessionBinding>,
 }
 
 impl CredentialAuthorization {
@@ -612,18 +671,78 @@ impl CredentialAuthorization {
         }
         Ok(Self {
             delivery_session_params,
+            authenticated_session: None,
         })
+    }
+
+    /// Attach the authenticated Provider session established by the
+    /// ComponentSession adapter.
+    pub fn with_authenticated_session(
+        mut self,
+        session: CredentialSessionBinding,
+    ) -> Result<Self, CredentialServiceError> {
+        self.authenticated_session = Some(session);
+        Ok(self)
     }
 
     /// Borrow the adapter-authorized delivery binding, when the method needs one.
     pub const fn delivery_session_params(&self) -> Option<&DeliverySessionParams> {
         self.delivery_session_params.as_ref()
     }
+
+    /// Borrow the authenticated session, when the adapter supplied one.
+    pub const fn authenticated_session(&self) -> Option<&CredentialSessionBinding> {
+        self.authenticated_session.as_ref()
+    }
 }
 
 impl fmt::Debug for CredentialAuthorization {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("CredentialAuthorization(<redacted>)")
+    }
+}
+
+/// Authenticated, bounded lifetime context for one Credential service session.
+///
+/// The subject context is established by the ComponentSession adapter and
+/// cannot be reconstructed from a peer payload. The expiry is deliberately
+/// carried separately from the identity context because it belongs to the
+/// service admission decision rather than to the durable subject identity.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CredentialSessionBinding {
+    authenticated_subject: AuthenticatedSubjectContext,
+    expires_at_unix_ms: u64,
+}
+
+impl CredentialSessionBinding {
+    /// Bind an authenticated subject context to a nonzero session expiry.
+    pub fn new(
+        authenticated_subject: AuthenticatedSubjectContext,
+        expires_at_unix_ms: u64,
+    ) -> Result<Self, CredentialServiceError> {
+        if expires_at_unix_ms == 0 {
+            return Err(malformed());
+        }
+        Ok(Self {
+            authenticated_subject,
+            expires_at_unix_ms,
+        })
+    }
+
+    /// Borrow the authenticated subject context.
+    pub const fn authenticated_subject(&self) -> &AuthenticatedSubjectContext {
+        &self.authenticated_subject
+    }
+
+    /// Return the absolute session expiry.
+    pub const fn expires_at_unix_ms(&self) -> u64 {
+        self.expires_at_unix_ms
+    }
+}
+
+impl fmt::Debug for CredentialSessionBinding {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialSessionBinding(<redacted>)")
     }
 }
 

--- a/packages/d2b-provider-credential-managed-identity/README.md
+++ b/packages/d2b-provider-credential-managed-identity/README.md
@@ -43,10 +43,16 @@ creates one co-located agent Process per admitted Credential binding. The
 `d2b-managed-identity-agent` binary alone holds the injected
 `ManagedIdentityCredentialClient`, serves live lease operations, and terminates
 the sensitive delivery session. The controller has no client construction path.
+The standalone binaries fail closed with exit 78 until the authenticated Zone
+runtime supplies the controller source, ComponentSession transport, and
+LaunchTicket effect-port client; this crate does not invent a host-held token
+or ambient runtime fallback.
 
 ## Placement and dependencies
 
-`host-system` is accepted for a Host and `guest-agent` for a Guest.
+`host-system` is accepted for a Host and `guest-agent` for a Guest. Every
+placement is bound to one `Zone`; unbound or non-Zone placement references
+reject closed before Provider construction or client dispatch.
 `user-agent` rejects with `credential placement mismatch`. The client is
 co-located with the exact `consumerRef` execution context. Host and Guest
 dependencies must be Ready before acquisition.

--- a/packages/d2b-provider-credential-managed-identity/src/controller.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/controller.rs
@@ -305,6 +305,7 @@ mod tests {
             ManagedIdentityPlacement::new(
                 PlacementBinding::HostSystem,
                 ResourceRef::parse("Host/azure-vm").unwrap(),
+                ResourceRef::parse("Zone/dev").unwrap(),
             )
             .unwrap(),
         );
@@ -330,6 +331,7 @@ mod tests {
             ManagedIdentityPlacement::new(
                 PlacementBinding::GuestAgent,
                 ResourceRef::parse("Guest/aca-sandbox").unwrap(),
+                ResourceRef::parse("Zone/dev").unwrap(),
             )
             .unwrap(),
         );

--- a/packages/d2b-provider-credential-managed-identity/src/lib.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/lib.rs
@@ -236,26 +236,27 @@ impl std::error::Error for ManagedIdentityProviderError {}
 pub struct ManagedIdentityPlacement {
     binding: PlacementBinding,
     execution_ref: ResourceRef,
-    zone_ref: Option<ResourceRef>,
+    zone_ref: ResourceRef,
 }
 
 impl ManagedIdentityPlacement {
-    /// Validate host-system or guest-agent placement.
+    /// Validate host-system or guest-agent placement bound to one Zone.
     pub fn new(
         binding: PlacementBinding,
         execution_ref: ResourceRef,
+        zone_ref: ResourceRef,
     ) -> Result<Self, ManagedIdentityProviderError> {
         let valid = matches!(
             (binding, execution_ref.resource_type().as_str()),
             (PlacementBinding::HostSystem, "Host") | (PlacementBinding::GuestAgent, "Guest")
         );
-        if !valid {
+        if !valid || zone_ref.resource_type().as_str() != "Zone" {
             return Err(ManagedIdentityProviderError::InvalidPlacement);
         }
         Ok(Self {
             binding,
             execution_ref,
-            zone_ref: None,
+            zone_ref,
         })
     }
 
@@ -265,24 +266,7 @@ impl ManagedIdentityPlacement {
         execution_ref: ResourceRef,
         zone_ref: ResourceRef,
     ) -> Result<Self, ManagedIdentityProviderError> {
-        if zone_ref.resource_type().as_str() != "Zone" {
-            return Err(ManagedIdentityProviderError::InvalidPlacement);
-        }
-        let mut placement = Self::new(binding, execution_ref)?;
-        placement.zone_ref = Some(zone_ref);
-        Ok(placement)
-    }
-
-    /// Bind an existing placement to one Zone.
-    pub fn with_zone_ref(
-        mut self,
-        zone_ref: ResourceRef,
-    ) -> Result<Self, ManagedIdentityProviderError> {
-        if zone_ref.resource_type().as_str() != "Zone" {
-            return Err(ManagedIdentityProviderError::InvalidPlacement);
-        }
-        self.zone_ref = Some(zone_ref);
-        Ok(self)
+        Self::new(binding, execution_ref, zone_ref)
     }
 
     /// Return the placement binding.
@@ -295,9 +279,9 @@ impl ManagedIdentityPlacement {
         &self.execution_ref
     }
 
-    /// Borrow the expected Zone when this placement was explicitly Zone-bound.
-    pub fn zone_ref(&self) -> Option<&ResourceRef> {
-        self.zone_ref.as_ref()
+    /// Borrow the Zone bound to this placement.
+    pub const fn zone_ref(&self) -> &ResourceRef {
+        &self.zone_ref
     }
 }
 
@@ -609,13 +593,10 @@ impl ManagedIdentityCredentialProvider {
     fn context_matches_provider(&self, subject: &AuthenticatedSubjectContext) -> bool {
         subject.provider_ref() == Some(&self.consumer_ref)
             && subject.execution_ref() == Some(self.placement.execution_ref())
+            && subject.zone_ref() == self.placement.zone_ref()
             && subject.service().as_str() == CREDENTIAL_SERVICE_NAME
             && subject.session_purpose().as_str() == CREDENTIAL_SESSION_PURPOSE
             && subject.provider_generation().is_some()
-            && self
-                .placement
-                .zone_ref()
-                .is_none_or(|zone| subject.zone_ref() == zone)
     }
 
     /// Validate the authenticated ComponentSession binding for one method.
@@ -872,6 +853,7 @@ impl ManagedIdentityCredentialProvider {
         };
         if grant.rotation_generation == 0
             || minimum_rotation_generation == 0
+            || grant.rotation_generation < minimum_rotation_generation
             || grant.expires_at_unix_ms == 0
             || grant.expires_at_unix_ms > requested_expiry_unix_ms
             || grant.expires_at_unix_ms > max_expiry
@@ -883,7 +865,7 @@ impl ManagedIdentityCredentialProvider {
         }
         Ok(CredentialMetadata {
             lease_handle: grant.lease_handle,
-            rotation_generation: grant.rotation_generation.max(minimum_rotation_generation),
+            rotation_generation: grant.rotation_generation,
             source_version: grant.source_version,
             expires_at_unix_ms: grant.expires_at_unix_ms,
             state: CredentialLeaseState::Active,
@@ -923,7 +905,7 @@ impl ManagedIdentityCredentialProvider {
         checkpoints: impl IntoIterator<Item = ManagedIdentityLeaseCheckpoint>,
     ) -> Result<(), CredentialServiceError> {
         let now = Self::now_unix_ms();
-        let mut restored = Vec::new();
+        let mut restored: Vec<(String, LeaseRecord)> = Vec::new();
         for checkpoint in checkpoints {
             let ManagedIdentityLeaseCheckpoint {
                 credential_ref,
@@ -950,33 +932,76 @@ impl ManagedIdentityCredentialProvider {
             {
                 metadata.state = CredentialLeaseState::Expired;
             }
-            restored.push((
-                credential_ref.to_canonical_string(),
-                LeaseRecord {
-                    idempotency_key,
-                    metadata,
-                    authenticated_subject,
-                    session_expires_at_unix_ms,
-                },
-            ));
+            let key = credential_ref.to_canonical_string();
+            let record = LeaseRecord {
+                idempotency_key,
+                metadata,
+                authenticated_subject,
+                session_expires_at_unix_ms,
+            };
+            if let Some((_, existing)) = restored.iter_mut().find(|(existing_key, existing)| {
+                existing_key == &key
+                    && Self::same_owner(
+                        &existing.authenticated_subject,
+                        &record.authenticated_subject,
+                    )
+            }) {
+                *existing = record;
+            } else {
+                restored.push((key, record));
+            }
         }
         let _mutation = self.mutation_guard()?;
         let mut leases = self.leases.lock().map_err(|_| {
             CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
         })?;
-        let restored_active = restored
-            .iter()
-            .filter(|(_, record)| record.metadata.state == CredentialLeaseState::Active)
-            .count();
-        if Self::active_lease_count(&leases) + restored_active > self.config.max_leases() as usize {
+        let mut next = leases.clone();
+        for records in next.values_mut() {
+            Self::deduplicate_records(records);
+        }
+        Self::mark_expired_locked(&mut next, now);
+        for (credential_ref, record) in &restored {
+            if let Some(records) = next.get_mut(credential_ref) {
+                records.retain(|existing| {
+                    !Self::same_owner(
+                        &existing.authenticated_subject,
+                        &record.authenticated_subject,
+                    )
+                });
+            }
+        }
+        for (credential_ref, record) in restored {
+            next.entry(credential_ref).or_default().push(record);
+        }
+        next.retain(|_, records| !records.is_empty());
+        if Self::active_lease_count(&next) > self.config.max_leases() as usize {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::ProviderUnavailable,
             ));
         }
-        for (credential_ref, record) in restored {
-            leases.entry(credential_ref).or_default().push(record);
-        }
+        *leases = next;
         Ok(())
+    }
+
+    pub(crate) fn deduplicate_records(records: &mut Vec<LeaseRecord>) {
+        let mut deduplicated: Vec<LeaseRecord> = Vec::with_capacity(records.len());
+        for record in records.drain(..) {
+            if let Some(index) = deduplicated.iter().position(|existing| {
+                Self::same_owner(
+                    &existing.authenticated_subject,
+                    &record.authenticated_subject,
+                )
+            }) {
+                if record.metadata.state == CredentialLeaseState::Active
+                    || deduplicated[index].metadata.state != CredentialLeaseState::Active
+                {
+                    deduplicated[index] = record;
+                }
+            } else {
+                deduplicated.push(record);
+            }
+        }
+        *records = deduplicated;
     }
 
     /// Revoke every active handle owned by one authenticated workload.
@@ -1006,20 +1031,22 @@ impl ManagedIdentityCredentialProvider {
             leases
                 .iter()
                 .flat_map(|(credential_ref, records)| {
-                    records.iter().filter_map(|record| {
-                        (record.metadata.state == CredentialLeaseState::Active
-                            && Self::same_owner(
-                                &record.authenticated_subject,
-                                session.authenticated_subject(),
-                            ))
-                        .then(|| {
+                    records
+                        .iter()
+                        .filter(|record| {
+                            record.metadata.state == CredentialLeaseState::Active
+                                && Self::same_owner(
+                                    &record.authenticated_subject,
+                                    session.authenticated_subject(),
+                                )
+                        })
+                        .map(|record| {
                             (
                                 credential_ref.clone(),
                                 record.authenticated_subject.clone(),
                                 record.metadata.clone(),
                             )
                         })
-                    })
                 })
                 .collect::<Vec<_>>()
         };
@@ -1081,6 +1108,7 @@ mod tests {
             ManagedIdentityPlacement::new(
                 PlacementBinding::UserAgent,
                 ResourceRef::parse("Host/workstation").unwrap(),
+                ResourceRef::parse("Zone/dev").unwrap(),
             ),
             Err(ManagedIdentityProviderError::InvalidPlacement)
         );

--- a/packages/d2b-provider-credential-managed-identity/src/lib.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/lib.rs
@@ -20,14 +20,15 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread::{self, Thread};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
-    CredentialLeaseHandle, CredentialLeaseState, CredentialMetadata, CredentialOutcomeCode,
-    CredentialServiceError, CredentialServiceErrorCode, CredentialSourceVersion, OpaqueAzureRef,
-    PlacementBinding,
+    CREDENTIAL_SERVICE_NAME, CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState,
+    CredentialMetadata, CredentialMethod, CredentialOutcomeCode, CredentialRequest,
+    CredentialServiceError, CredentialServiceErrorCode, CredentialSessionBinding,
+    CredentialSourceVersion, MAX_PROVIDER_LEASE_LIFETIME_MS, OpaqueAzureRef, PlacementBinding,
 };
+use d2b_contracts::v3::{AuthenticatedSubjectContext, ResourceRef};
 
 pub use agent::ManagedIdentityAgent;
 pub use audit::{
@@ -53,6 +54,11 @@ pub const CONTROLLER_BINARY: &str = "d2b-managed-identity-controller";
 pub const AGENT_BINARY: &str = "d2b-managed-identity-agent";
 /// Exit status used while production Zone runtime registration is unavailable.
 pub const RUNTIME_UNAVAILABLE_EXIT: i32 = 78;
+/// Session purpose expected for Credential service calls.
+pub const CREDENTIAL_SESSION_PURPOSE: &str = "credential-delivery";
+/// Small values remain accepted as relative test/runtime deadlines for
+/// compatibility with the bootstrap service contract.
+const ABSOLUTE_UNIX_MS_THRESHOLD: u64 = 1_000_000_000_000;
 
 /// Enter the secret-free controller role.
 ///
@@ -230,6 +236,7 @@ impl std::error::Error for ManagedIdentityProviderError {}
 pub struct ManagedIdentityPlacement {
     binding: PlacementBinding,
     execution_ref: ResourceRef,
+    zone_ref: Option<ResourceRef>,
 }
 
 impl ManagedIdentityPlacement {
@@ -248,7 +255,34 @@ impl ManagedIdentityPlacement {
         Ok(Self {
             binding,
             execution_ref,
+            zone_ref: None,
         })
+    }
+
+    /// Validate machine placement and bind it to one Zone.
+    pub fn in_zone(
+        binding: PlacementBinding,
+        execution_ref: ResourceRef,
+        zone_ref: ResourceRef,
+    ) -> Result<Self, ManagedIdentityProviderError> {
+        if zone_ref.resource_type().as_str() != "Zone" {
+            return Err(ManagedIdentityProviderError::InvalidPlacement);
+        }
+        let mut placement = Self::new(binding, execution_ref)?;
+        placement.zone_ref = Some(zone_ref);
+        Ok(placement)
+    }
+
+    /// Bind an existing placement to one Zone.
+    pub fn with_zone_ref(
+        mut self,
+        zone_ref: ResourceRef,
+    ) -> Result<Self, ManagedIdentityProviderError> {
+        if zone_ref.resource_type().as_str() != "Zone" {
+            return Err(ManagedIdentityProviderError::InvalidPlacement);
+        }
+        self.zone_ref = Some(zone_ref);
+        Ok(self)
     }
 
     /// Return the placement binding.
@@ -259,6 +293,11 @@ impl ManagedIdentityPlacement {
     /// Borrow the execution context.
     pub const fn execution_ref(&self) -> &ResourceRef {
         &self.execution_ref
+    }
+
+    /// Borrow the expected Zone when this placement was explicitly Zone-bound.
+    pub fn zone_ref(&self) -> Option<&ResourceRef> {
+        self.zone_ref.as_ref()
     }
 }
 
@@ -275,6 +314,7 @@ pub struct ManagedIdentityLeaseRequest {
     operation_id: String,
     idempotency_key: String,
     requested_expiry_unix_ms: u64,
+    rotation_generation: u64,
 }
 
 impl ManagedIdentityLeaseRequest {
@@ -296,6 +336,11 @@ impl ManagedIdentityLeaseRequest {
     /// Return requested expiry.
     pub const fn requested_expiry_unix_ms(&self) -> u64 {
         self.requested_expiry_unix_ms
+    }
+
+    /// Return the nonzero rotation generation requested by the Provider.
+    pub const fn rotation_generation(&self) -> u64 {
+        self.rotation_generation
     }
 }
 
@@ -456,6 +501,54 @@ impl fmt::Debug for ManagedIdentityCredentialProviderFactory {
 struct LeaseRecord {
     idempotency_key: String,
     metadata: CredentialMetadata,
+    authenticated_subject: AuthenticatedSubjectContext,
+    session_expires_at_unix_ms: u64,
+}
+
+/// Non-secret restart checkpoint for one managed-identity lease.
+///
+/// The checkpoint contains only opaque metadata and authenticated ownership
+/// evidence. Token bytes remain exclusively inside the injected client.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ManagedIdentityLeaseCheckpoint {
+    credential_ref: ResourceRef,
+    idempotency_key: String,
+    metadata: CredentialMetadata,
+    authenticated_subject: AuthenticatedSubjectContext,
+    session_expires_at_unix_ms: u64,
+}
+
+impl ManagedIdentityLeaseCheckpoint {
+    /// Borrow the Credential reference.
+    pub const fn credential_ref(&self) -> &ResourceRef {
+        &self.credential_ref
+    }
+
+    /// Borrow the non-secret idempotency key.
+    pub fn idempotency_key(&self) -> &str {
+        &self.idempotency_key
+    }
+
+    /// Borrow the non-secret lease metadata.
+    pub const fn metadata(&self) -> &CredentialMetadata {
+        &self.metadata
+    }
+
+    /// Borrow the authenticated owner context.
+    pub const fn authenticated_subject(&self) -> &AuthenticatedSubjectContext {
+        &self.authenticated_subject
+    }
+
+    /// Return the session expiry captured with this checkpoint.
+    pub const fn session_expires_at_unix_ms(&self) -> u64 {
+        self.session_expires_at_unix_ms
+    }
+}
+
+impl fmt::Debug for ManagedIdentityLeaseCheckpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ManagedIdentityLeaseCheckpoint(<redacted>)")
+    }
 }
 
 /// Managed identity implementation of the prepared Credential service.
@@ -464,7 +557,7 @@ pub struct ManagedIdentityCredentialProvider {
     placement: ManagedIdentityPlacement,
     consumer_ref: ResourceRef,
     client: Arc<dyn ManagedIdentityCredentialClient>,
-    leases: Mutex<BTreeMap<String, LeaseRecord>>,
+    leases: Mutex<BTreeMap<String, Vec<LeaseRecord>>>,
     mutation_gate: Mutex<()>,
 }
 
@@ -494,6 +587,143 @@ impl ManagedIdentityCredentialProvider {
         &self.config
     }
 
+    /// Return the current Unix millisecond clock used for bounded expiry
+    /// checks.
+    pub(crate) fn now_unix_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+            .unwrap_or(0)
+    }
+
+    /// Whether a value uses the absolute Unix millisecond representation.
+    pub(crate) const fn is_absolute_unix_ms(value: u64) -> bool {
+        value >= ABSOLUTE_UNIX_MS_THRESHOLD
+    }
+
+    /// Whether an absolute Unix millisecond value has elapsed.
+    pub(crate) fn is_expired(value: u64, now_unix_ms: u64) -> bool {
+        Self::is_absolute_unix_ms(value) && value <= now_unix_ms
+    }
+
+    fn context_matches_provider(&self, subject: &AuthenticatedSubjectContext) -> bool {
+        subject.provider_ref() == Some(&self.consumer_ref)
+            && subject.execution_ref() == Some(self.placement.execution_ref())
+            && subject.service().as_str() == CREDENTIAL_SERVICE_NAME
+            && subject.session_purpose().as_str() == CREDENTIAL_SESSION_PURPOSE
+            && subject.provider_generation().is_some()
+            && self
+                .placement
+                .zone_ref()
+                .is_none_or(|zone| subject.zone_ref() == zone)
+    }
+
+    /// Validate the authenticated ComponentSession binding for one method.
+    pub(crate) fn validate_authenticated_session<'a>(
+        &self,
+        method: CredentialMethod,
+        request: &CredentialRequest,
+        authorization: &'a CredentialAuthorization,
+    ) -> Result<&'a CredentialSessionBinding, CredentialServiceError> {
+        let session = authorization.authenticated_session().ok_or_else(|| {
+            CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
+        })?;
+        let now = Self::now_unix_ms();
+        if Self::is_expired(session.expires_at_unix_ms(), now) {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::DeadlineExceeded,
+            ));
+        }
+
+        let subject = session.authenticated_subject();
+        if !self.context_matches_provider(subject) {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::OperationDenied,
+            ));
+        }
+
+        if method.requires_delivery() {
+            let delivery = authorization.delivery_session_params().ok_or_else(|| {
+                CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
+            })?;
+            if delivery.credential_ref() != request.credential_ref()
+                || delivery.consumer_provider_ref() != &self.consumer_ref
+                || delivery.operation_class() != method.operation_class()
+            {
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::OperationDenied,
+                ));
+            }
+            if Self::is_expired(delivery.expiry_unix_ms(), now)
+                || Self::is_expired(delivery.deadline_unix_ms(), now)
+            {
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::DeadlineExceeded,
+                ));
+            }
+            if Self::is_absolute_unix_ms(session.expires_at_unix_ms())
+                && Self::is_absolute_unix_ms(delivery.expiry_unix_ms())
+                && session.expires_at_unix_ms() > delivery.expiry_unix_ms()
+            {
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::OperationDenied,
+                ));
+            }
+        }
+        Ok(session)
+    }
+
+    /// Compare stable ownership dimensions while deliberately ignoring the
+    /// reconnect transcript that identifies one concrete ComponentSession.
+    pub(crate) fn same_owner(
+        left: &AuthenticatedSubjectContext,
+        right: &AuthenticatedSubjectContext,
+    ) -> bool {
+        left.subject_ref() == right.subject_ref()
+            && left.subject_uid() == right.subject_uid()
+            && left.zone_ref() == right.zone_ref()
+            && left.execution_ref() == right.execution_ref()
+            && left.provider_ref() == right.provider_ref()
+            && left.provider_generation() == right.provider_generation()
+            && left.service() == right.service()
+            && left.session_purpose() == right.session_purpose()
+    }
+
+    /// Compare the complete authenticated session, including transcript and
+    /// reconnect generation.
+    pub(crate) fn same_session(
+        left: &AuthenticatedSubjectContext,
+        right: &AuthenticatedSubjectContext,
+    ) -> bool {
+        left == right
+    }
+
+    /// Mark absolute-time active leases expired before a new operation.
+    pub(crate) fn mark_expired_locked(
+        leases: &mut BTreeMap<String, Vec<LeaseRecord>>,
+        now_unix_ms: u64,
+    ) {
+        for records in leases.values_mut() {
+            for record in records {
+                if record.metadata.state == CredentialLeaseState::Active
+                    && (Self::is_expired(record.metadata.expires_at_unix_ms, now_unix_ms)
+                        || Self::is_expired(record.session_expires_at_unix_ms, now_unix_ms))
+                {
+                    record.metadata.state = CredentialLeaseState::Expired;
+                }
+            }
+        }
+    }
+
+    /// Count active leases across all Credential owners.
+    pub(crate) fn active_lease_count(leases: &BTreeMap<String, Vec<LeaseRecord>>) -> usize {
+        leases
+            .values()
+            .flat_map(|records| records.iter())
+            .filter(|record| record.metadata.state == CredentialLeaseState::Active)
+            .count()
+    }
+
     pub(crate) fn mutation_guard(&self) -> Result<MutexGuard<'_, ()>, CredentialServiceError> {
         match self.mutation_gate.try_lock() {
             Ok(guard) => Ok(guard),
@@ -507,11 +737,68 @@ impl ManagedIdentityCredentialProvider {
     }
 
     pub(crate) fn operation_deadline(deadline_ms: u64) -> Result<Instant, CredentialServiceError> {
+        let now_unix_ms = Self::now_unix_ms();
+        let duration_ms = if Self::is_absolute_unix_ms(deadline_ms) {
+            deadline_ms.saturating_sub(now_unix_ms)
+        } else {
+            deadline_ms
+        };
+        if duration_ms == 0 {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::DeadlineExceeded,
+            ));
+        }
         Instant::now()
-            .checked_add(Duration::from_millis(deadline_ms))
+            .checked_add(Duration::from_millis(duration_ms))
             .ok_or_else(|| {
                 CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
             })
+    }
+
+    pub(crate) fn bounded_expiry(
+        requested_expiry_unix_ms: u64,
+        session_expiry_unix_ms: u64,
+        delivery_expiry_unix_ms: u64,
+    ) -> Result<u64, CredentialServiceError> {
+        let absolute = Self::is_absolute_unix_ms(requested_expiry_unix_ms)
+            || Self::is_absolute_unix_ms(session_expiry_unix_ms)
+            || Self::is_absolute_unix_ms(delivery_expiry_unix_ms);
+        if !absolute {
+            return Ok(requested_expiry_unix_ms
+                .min(session_expiry_unix_ms)
+                .min(delivery_expiry_unix_ms)
+                .min(MAX_PROVIDER_LEASE_LIFETIME_MS));
+        }
+        let now = Self::now_unix_ms();
+        let to_absolute = |value: u64| {
+            if Self::is_absolute_unix_ms(value) {
+                Some(value)
+            } else {
+                now.checked_add(value)
+            }
+        };
+        let bounded = to_absolute(requested_expiry_unix_ms)
+            .and_then(|requested| {
+                to_absolute(session_expiry_unix_ms).and_then(|session| {
+                    to_absolute(delivery_expiry_unix_ms)
+                        .map(|delivery| requested.min(session).min(delivery))
+                })
+            })
+            .ok_or_else(|| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+        let provider_max = now
+            .checked_add(MAX_PROVIDER_LEASE_LIFETIME_MS)
+            .ok_or_else(|| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+        let bounded = bounded.min(provider_max);
+        if bounded <= now {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::DeadlineExceeded,
+            ));
+        }
+        Ok(bounded)
     }
 
     pub(crate) fn poll_client<T>(
@@ -571,10 +858,24 @@ impl ManagedIdentityCredentialProvider {
     pub(crate) fn grant_metadata(
         grant: ManagedIdentityLeaseGrant,
         requested_expiry_unix_ms: u64,
+        minimum_rotation_generation: u64,
     ) -> Result<CredentialMetadata, CredentialServiceError> {
+        let now_unix_ms = Self::now_unix_ms();
+        let max_expiry = if Self::is_absolute_unix_ms(requested_expiry_unix_ms) {
+            now_unix_ms
+                .checked_add(MAX_PROVIDER_LEASE_LIFETIME_MS)
+                .ok_or_else(|| {
+                    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+                })?
+        } else {
+            MAX_PROVIDER_LEASE_LIFETIME_MS
+        };
         if grant.rotation_generation == 0
+            || minimum_rotation_generation == 0
             || grant.expires_at_unix_ms == 0
             || grant.expires_at_unix_ms > requested_expiry_unix_ms
+            || grant.expires_at_unix_ms > max_expiry
+            || Self::is_expired(grant.expires_at_unix_ms, now_unix_ms)
         {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::InvariantFailure,
@@ -582,12 +883,171 @@ impl ManagedIdentityCredentialProvider {
         }
         Ok(CredentialMetadata {
             lease_handle: grant.lease_handle,
-            rotation_generation: grant.rotation_generation,
+            rotation_generation: grant.rotation_generation.max(minimum_rotation_generation),
             source_version: grant.source_version,
             expires_at_unix_ms: grant.expires_at_unix_ms,
             state: CredentialLeaseState::Active,
             outcome: CredentialOutcomeCode::Success,
         })
+    }
+
+    /// Export bounded, non-secret lease checkpoints for a restart.
+    pub fn export_checkpoints(
+        &self,
+    ) -> Result<Vec<ManagedIdentityLeaseCheckpoint>, CredentialServiceError> {
+        let leases = self.leases.lock().map_err(|_| {
+            CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+        })?;
+        Ok(leases
+            .iter()
+            .flat_map(|(credential_ref, records)| {
+                records.iter().map(|record| ManagedIdentityLeaseCheckpoint {
+                    credential_ref: ResourceRef::parse(credential_ref)
+                        .expect("lease map keys are validated Credential refs"),
+                    idempotency_key: record.idempotency_key.clone(),
+                    metadata: record.metadata.clone(),
+                    authenticated_subject: record.authenticated_subject.clone(),
+                    session_expires_at_unix_ms: record.session_expires_at_unix_ms,
+                })
+            })
+            .collect())
+    }
+
+    /// Restore bounded lease metadata after a Provider restart.
+    ///
+    /// The injected client and all token bytes are intentionally absent from
+    /// the checkpoint. Active records are revalidated by the next live
+    /// inspect/refresh operation before they can be used.
+    pub fn restore_checkpoints(
+        &self,
+        checkpoints: impl IntoIterator<Item = ManagedIdentityLeaseCheckpoint>,
+    ) -> Result<(), CredentialServiceError> {
+        let now = Self::now_unix_ms();
+        let mut restored = Vec::new();
+        for checkpoint in checkpoints {
+            let ManagedIdentityLeaseCheckpoint {
+                credential_ref,
+                idempotency_key,
+                metadata,
+                authenticated_subject,
+                session_expires_at_unix_ms,
+            } = checkpoint;
+            if credential_ref.resource_type().as_str() != "Credential"
+                || !self.context_matches_provider(&authenticated_subject)
+                || metadata.rotation_generation == 0
+                || metadata.expires_at_unix_ms == 0
+                || idempotency_key.is_empty()
+                || session_expires_at_unix_ms == 0
+            {
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::InvariantFailure,
+                ));
+            }
+            let mut metadata = metadata;
+            if metadata.state == CredentialLeaseState::Active
+                && (Self::is_expired(metadata.expires_at_unix_ms, now)
+                    || Self::is_expired(session_expires_at_unix_ms, now))
+            {
+                metadata.state = CredentialLeaseState::Expired;
+            }
+            restored.push((
+                credential_ref.to_canonical_string(),
+                LeaseRecord {
+                    idempotency_key,
+                    metadata,
+                    authenticated_subject,
+                    session_expires_at_unix_ms,
+                },
+            ));
+        }
+        let _mutation = self.mutation_guard()?;
+        let mut leases = self.leases.lock().map_err(|_| {
+            CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+        })?;
+        let restored_active = restored
+            .iter()
+            .filter(|(_, record)| record.metadata.state == CredentialLeaseState::Active)
+            .count();
+        if Self::active_lease_count(&leases) + restored_active > self.config.max_leases() as usize {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            ));
+        }
+        for (credential_ref, record) in restored {
+            leases.entry(credential_ref).or_default().push(record);
+        }
+        Ok(())
+    }
+
+    /// Revoke every active handle owned by one authenticated workload.
+    ///
+    /// Stable owner dimensions select the records; a different workload,
+    /// subject, Zone, or Provider generation is never touched.
+    pub fn revoke_owned_handles(
+        &self,
+        session: &CredentialSessionBinding,
+        deadline_unix_ms: u64,
+    ) -> Result<usize, CredentialServiceError> {
+        let now = Self::now_unix_ms();
+        if Self::is_expired(session.expires_at_unix_ms(), now)
+            || !self.context_matches_provider(session.authenticated_subject())
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::OperationDenied,
+            ));
+        }
+        let deadline = Self::operation_deadline(deadline_unix_ms)?;
+        let _mutation = self.mutation_guard()?;
+        let owned = {
+            let mut leases = self.leases.lock().map_err(|_| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+            Self::mark_expired_locked(&mut leases, now);
+            leases
+                .iter()
+                .flat_map(|(credential_ref, records)| {
+                    records.iter().filter_map(|record| {
+                        (record.metadata.state == CredentialLeaseState::Active
+                            && Self::same_owner(
+                                &record.authenticated_subject,
+                                session.authenticated_subject(),
+                            ))
+                        .then(|| {
+                            (
+                                credential_ref.clone(),
+                                record.authenticated_subject.clone(),
+                                record.metadata.clone(),
+                            )
+                        })
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut revoked = 0;
+        for (credential_ref, authenticated_subject, metadata) in owned {
+            let lease = ManagedIdentityLeaseRef {
+                credential_ref: ResourceRef::parse(&credential_ref).map_err(|_| {
+                    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+                })?,
+                metadata: metadata.clone(),
+            };
+            let _ = Self::poll_client(self.client.revoke_lease(&lease), deadline)?;
+            let mut leases = self.leases.lock().map_err(|_| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+            let records = leases.get_mut(&credential_ref).ok_or_else(invariant)?;
+            for record in records {
+                if record.metadata == metadata
+                    && record.authenticated_subject == authenticated_subject
+                {
+                    record.metadata.state = CredentialLeaseState::Revoked;
+                    record.metadata.outcome = CredentialOutcomeCode::Revoked;
+                    revoked += 1;
+                }
+            }
+        }
+        Ok(revoked)
     }
 }
 
@@ -595,6 +1055,10 @@ impl fmt::Debug for ManagedIdentityCredentialProvider {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("ManagedIdentityCredentialProvider(<redacted>)")
     }
+}
+
+fn invariant() -> CredentialServiceError {
+    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
 }
 
 #[cfg(test)]

--- a/packages/d2b-provider-credential-managed-identity/src/service.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/service.rs
@@ -21,8 +21,8 @@ impl CredentialProvider for ManagedIdentityCredentialProvider {
         match method {
             CredentialMethod::AcquireToken => self.acquire(request, authorization),
             CredentialMethod::RefreshToken => self.refresh(request, authorization),
-            CredentialMethod::RevokeToken => self.revoke(request),
-            CredentialMethod::InspectMetadata => self.inspect(request),
+            CredentialMethod::RevokeToken => self.revoke(request, authorization),
+            CredentialMethod::InspectMetadata => self.inspect(request, authorization),
             CredentialMethod::SignChallenge => Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::Malformed,
             )),
@@ -39,42 +39,88 @@ impl ManagedIdentityCredentialProvider {
         let delivery = authorization
             .delivery_session_params()
             .cloned()
-            .ok_or_else(invariant)?;
+            .ok_or_else(operation_denied)?;
+        let session = self.validate_authenticated_session(
+            CredentialMethod::AcquireToken,
+            request,
+            authorization,
+        )?;
+        let requested_expiry = ManagedIdentityCredentialProvider::bounded_expiry(
+            request.requested_expiry_unix_ms(),
+            session.expires_at_unix_ms(),
+            delivery.expiry_unix_ms(),
+        )?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
-        {
+        let now = Self::now_unix_ms();
+        let rotation_generation = {
             let mut leases = self.leases.lock().map_err(|_| invariant())?;
-            leases.retain(|_, record| record.metadata.state == CredentialLeaseState::Active);
-            if let Some(existing) = leases.get(&key)
-                && existing.idempotency_key == request.idempotency_key()
-            {
-                return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
-                    metadata: existing.metadata.clone(),
-                    delivery_session_params: delivery,
-                }));
+            Self::mark_expired_locked(&mut leases, now);
+            let records = leases.get(&key);
+            if let Some(records) = records {
+                if records.iter().any(|record| {
+                    Self::same_owner(
+                        &record.authenticated_subject,
+                        session.authenticated_subject(),
+                    )
+                }) {
+                    if let Some(existing) = records.iter().find(|record| {
+                        record.metadata.state == CredentialLeaseState::Active
+                            && record.idempotency_key == request.idempotency_key()
+                            && Self::same_owner(
+                                &record.authenticated_subject,
+                                session.authenticated_subject(),
+                            )
+                    }) {
+                        return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
+                            metadata: existing.metadata.clone(),
+                            delivery_session_params: delivery,
+                        }));
+                    }
+                } else if !records.is_empty() {
+                    return Err(operation_denied());
+                }
             }
-            if leases.len() >= self.config.max_leases() as usize {
+            if Self::active_lease_count(&leases) >= self.config.max_leases() as usize {
                 return Err(CredentialServiceError::new(
                     CredentialServiceErrorCode::ProviderUnavailable,
                 ));
             }
-        }
+            let prior_generation = records
+                .into_iter()
+                .flatten()
+                .filter(|record| {
+                    Self::same_owner(
+                        &record.authenticated_subject,
+                        session.authenticated_subject(),
+                    )
+                })
+                .map(|record| record.metadata.rotation_generation)
+                .max()
+                .unwrap_or(0);
+            prior_generation.checked_add(1).ok_or_else(|| invariant())?
+        };
         let client_request = ManagedIdentityLeaseRequest {
             credential_ref: request.credential_ref().clone(),
             operation_id: request.operation_id().to_owned(),
             idempotency_key: request.idempotency_key().to_owned(),
-            requested_expiry_unix_ms: request.requested_expiry_unix_ms(),
+            requested_expiry_unix_ms: requested_expiry,
+            rotation_generation,
         };
         let grant = Self::poll_client(self.client.issue_lease(&client_request), deadline)?;
-        let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
-        self.leases.lock().map_err(|_| invariant())?.insert(
-            key,
-            LeaseRecord {
+        let metadata = Self::grant_metadata(grant, requested_expiry, rotation_generation)?;
+        self.leases
+            .lock()
+            .map_err(|_| invariant())?
+            .entry(key)
+            .or_default()
+            .push(LeaseRecord {
                 idempotency_key: request.idempotency_key().to_owned(),
                 metadata: metadata.clone(),
-            },
-        );
+                authenticated_subject: session.authenticated_subject().clone(),
+                session_expires_at_unix_ms: session.expires_at_unix_ms(),
+            });
         Ok(CredentialResponse::AcquireToken(DeliveryResponse {
             metadata,
             delivery_session_params: delivery,
@@ -89,36 +135,73 @@ impl ManagedIdentityCredentialProvider {
         let delivery = authorization
             .delivery_session_params()
             .cloned()
-            .ok_or_else(invariant)?;
+            .ok_or_else(operation_denied)?;
+        let session = self.validate_authenticated_session(
+            CredentialMethod::RefreshToken,
+            request,
+            authorization,
+        )?;
+        let requested_expiry = ManagedIdentityCredentialProvider::bounded_expiry(
+            request.requested_expiry_unix_ms(),
+            session.expires_at_unix_ms(),
+            delivery.expiry_unix_ms(),
+        )?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
-        let record = self
-            .leases
-            .lock()
-            .map_err(|_| invariant())?
-            .get(&key)
-            .cloned()
-            .ok_or_else(expired)?;
+        let now = Self::now_unix_ms();
+        let record = {
+            let mut leases = self.leases.lock().map_err(|_| invariant())?;
+            Self::mark_expired_locked(&mut leases, now);
+            let records = leases.get(&key).ok_or_else(expired)?;
+            let record = records
+                .iter()
+                .find(|record| {
+                    Self::same_owner(
+                        &record.authenticated_subject,
+                        session.authenticated_subject(),
+                    )
+                })
+                .ok_or_else(operation_denied)?;
+            if !Self::same_session(
+                &record.authenticated_subject,
+                session.authenticated_subject(),
+            ) {
+                return Err(operation_denied());
+            }
+            ensure_active(record)?;
+            record.clone()
+        };
         let lease = ManagedIdentityLeaseRef {
             credential_ref: request.credential_ref().clone(),
-            metadata: record.metadata,
+            metadata: record.metadata.clone(),
         };
         let inspection = Self::poll_client(self.client.inspect_lease(&lease), deadline)?;
-        if inspection.state != CredentialLeaseState::Active
-            || inspection.rotation_generation != lease.metadata.rotation_generation
-        {
+        if inspection.state != CredentialLeaseState::Active {
+            self.update_state(
+                &key,
+                &record,
+                inspection.state,
+                CredentialOutcomeCode::Success,
+            )?;
+            return Err(error_for_state(inspection.state));
+        }
+        if Self::is_expired(inspection.expires_at_unix_ms, Self::now_unix_ms()) {
+            self.update_state(
+                &key,
+                &record,
+                CredentialLeaseState::Expired,
+                CredentialOutcomeCode::Success,
+            )?;
+            return Err(expired());
+        }
+        if inspection.rotation_generation < record.metadata.rotation_generation {
             return Err(invariant());
         }
         let grant = Self::poll_client(self.client.refresh_lease(&lease), deadline)?;
-        let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
-        self.leases.lock().map_err(|_| invariant())?.insert(
-            key,
-            LeaseRecord {
-                idempotency_key: request.idempotency_key().to_owned(),
-                metadata: metadata.clone(),
-            },
-        );
+        let metadata =
+            Self::grant_metadata(grant, requested_expiry, record.metadata.rotation_generation)?;
+        self.replace_record(&key, &record, request.idempotency_key(), metadata.clone())?;
         Ok(CredentialResponse::RefreshToken(DeliveryResponse {
             metadata,
             delivery_session_params: delivery,
@@ -128,64 +211,194 @@ impl ManagedIdentityCredentialProvider {
     fn revoke(
         &self,
         request: &CredentialRequest,
+        authorization: &CredentialAuthorization,
     ) -> Result<CredentialResponse, CredentialServiceError> {
+        let session = self.validate_authenticated_session(
+            CredentialMethod::RevokeToken,
+            request,
+            authorization,
+        )?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
-        let mut leases = self.leases.lock().map_err(|_| invariant())?;
-        let record = leases.get_mut(&key).ok_or_else(expired)?;
-        let outcome = if record.metadata.state == CredentialLeaseState::Revoked {
-            CredentialOutcomeCode::AlreadyRevoked
-        } else {
-            let lease = ManagedIdentityLeaseRef {
-                credential_ref: request.credential_ref().clone(),
-                metadata: record.metadata.clone(),
-            };
-            let revocation = Self::poll_client(self.client.revoke_lease(&lease), deadline)?;
-            record.metadata.state = CredentialLeaseState::Revoked;
-            match revocation {
-                crate::ManagedIdentityLeaseRevocation::Revoked => CredentialOutcomeCode::Revoked,
-                crate::ManagedIdentityLeaseRevocation::AlreadyRevoked => {
-                    CredentialOutcomeCode::AlreadyRevoked
-                }
+        let now = Self::now_unix_ms();
+        let record = {
+            let mut leases = self.leases.lock().map_err(|_| invariant())?;
+            Self::mark_expired_locked(&mut leases, now);
+            let records = leases.get(&key).ok_or_else(expired)?;
+            let record = records
+                .iter()
+                .find(|record| {
+                    Self::same_owner(
+                        &record.authenticated_subject,
+                        session.authenticated_subject(),
+                    )
+                })
+                .ok_or_else(operation_denied)?;
+            if !Self::same_session(
+                &record.authenticated_subject,
+                session.authenticated_subject(),
+            ) {
+                return Err(operation_denied());
+            }
+            record.clone()
+        };
+        if record.metadata.state == CredentialLeaseState::Revoked {
+            return Ok(CredentialResponse::RevokeToken(MetadataResponse {
+                metadata: record.metadata,
+            }));
+        }
+        ensure_active(&record)?;
+        let lease = ManagedIdentityLeaseRef {
+            credential_ref: request.credential_ref().clone(),
+            metadata: record.metadata.clone(),
+        };
+        let revocation = Self::poll_client(self.client.revoke_lease(&lease), deadline)?;
+        let outcome = match revocation {
+            crate::ManagedIdentityLeaseRevocation::Revoked => CredentialOutcomeCode::Revoked,
+            crate::ManagedIdentityLeaseRevocation::AlreadyRevoked => {
+                CredentialOutcomeCode::AlreadyRevoked
             }
         };
-        record.metadata.outcome = outcome;
+        let mut metadata = record.metadata.clone();
+        metadata.state = CredentialLeaseState::Revoked;
+        metadata.outcome = outcome;
+        self.replace_record(&key, &record, request.idempotency_key(), metadata.clone())?;
         Ok(CredentialResponse::RevokeToken(MetadataResponse {
-            metadata: record.metadata.clone(),
+            metadata,
         }))
     }
 
     fn inspect(
         &self,
         request: &CredentialRequest,
+        authorization: &CredentialAuthorization,
     ) -> Result<CredentialResponse, CredentialServiceError> {
+        let session = self.validate_authenticated_session(
+            CredentialMethod::InspectMetadata,
+            request,
+            authorization,
+        )?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
-        let record = self
-            .leases
-            .lock()
-            .map_err(|_| invariant())?
-            .get(&request.credential_ref().to_canonical_string())
-            .cloned()
-            .ok_or_else(expired)?;
+        let _mutation = self.mutation_guard()?;
+        let key = request.credential_ref().to_canonical_string();
+        let now = Self::now_unix_ms();
+        let record = {
+            let mut leases = self.leases.lock().map_err(|_| invariant())?;
+            Self::mark_expired_locked(&mut leases, now);
+            let records = leases.get(&key).ok_or_else(expired)?;
+            let record = records
+                .iter()
+                .find(|record| {
+                    Self::same_owner(
+                        &record.authenticated_subject,
+                        session.authenticated_subject(),
+                    )
+                })
+                .ok_or_else(operation_denied)?;
+            if !Self::same_session(
+                &record.authenticated_subject,
+                session.authenticated_subject(),
+            ) {
+                return Err(operation_denied());
+            }
+            ensure_active_or_observable(record)?;
+            record.clone()
+        };
         let lease = ManagedIdentityLeaseRef {
             credential_ref: request.credential_ref().clone(),
-            metadata: record.metadata,
+            metadata: record.metadata.clone(),
         };
         let inspection = Self::poll_client(self.client.inspect_lease(&lease), deadline)?;
-        let mut metadata = lease.metadata;
+        let mut metadata = record.metadata.clone();
         metadata.state = inspection.state;
         metadata.source_version = inspection.source_version;
-        metadata.rotation_generation = inspection.rotation_generation;
+        metadata.rotation_generation = inspection
+            .rotation_generation
+            .max(metadata.rotation_generation);
         metadata.expires_at_unix_ms = inspection.expires_at_unix_ms;
+        if Self::is_expired(metadata.expires_at_unix_ms, Self::now_unix_ms())
+            && metadata.state == CredentialLeaseState::Active
+        {
+            metadata.state = CredentialLeaseState::Expired;
+        }
+        self.replace_record(&key, &record, request.idempotency_key(), metadata.clone())?;
+        if metadata.state == CredentialLeaseState::Expired {
+            return Err(expired());
+        }
+        if metadata.state == CredentialLeaseState::Revoked {
+            return Err(error_for_state(metadata.state));
+        }
         Ok(CredentialResponse::InspectMetadata(MetadataResponse {
             metadata,
         }))
+    }
+
+    fn update_state(
+        &self,
+        key: &str,
+        record: &LeaseRecord,
+        state: CredentialLeaseState,
+        outcome: CredentialOutcomeCode,
+    ) -> Result<(), CredentialServiceError> {
+        let mut metadata = record.metadata.clone();
+        metadata.state = state;
+        metadata.outcome = outcome;
+        self.replace_record(key, record, &record.idempotency_key, metadata)
+    }
+
+    fn replace_record(
+        &self,
+        key: &str,
+        old: &LeaseRecord,
+        idempotency_key: &str,
+        metadata: d2b_contracts::v3::credential::CredentialMetadata,
+    ) -> Result<(), CredentialServiceError> {
+        let mut leases = self.leases.lock().map_err(|_| invariant())?;
+        let records = leases.get_mut(key).ok_or_else(invariant)?;
+        let record = records
+            .iter_mut()
+            .find(|record| {
+                record.metadata == old.metadata
+                    && record.authenticated_subject == old.authenticated_subject
+            })
+            .ok_or_else(invariant)?;
+        record.idempotency_key = idempotency_key.to_owned();
+        record.metadata = metadata;
+        Ok(())
+    }
+}
+
+fn ensure_active(record: &LeaseRecord) -> Result<(), CredentialServiceError> {
+    match record.metadata.state {
+        CredentialLeaseState::Active => Ok(()),
+        state => Err(error_for_state(state)),
+    }
+}
+
+fn ensure_active_or_observable(record: &LeaseRecord) -> Result<(), CredentialServiceError> {
+    match record.metadata.state {
+        CredentialLeaseState::Active => Ok(()),
+        state => Err(error_for_state(state)),
+    }
+}
+
+fn error_for_state(state: CredentialLeaseState) -> CredentialServiceError {
+    match state {
+        CredentialLeaseState::Expired => expired(),
+        CredentialLeaseState::Revoked => {
+            CredentialServiceError::new(CredentialServiceErrorCode::LeaseRevoked)
+        }
+        CredentialLeaseState::Active | CredentialLeaseState::Unknown => invariant(),
     }
 }
 
 fn invariant() -> CredentialServiceError {
     CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+}
+
+fn operation_denied() -> CredentialServiceError {
+    CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
 }
 
 fn expired() -> CredentialServiceError {

--- a/packages/d2b-provider-credential-managed-identity/src/service.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/service.rs
@@ -58,31 +58,35 @@ impl ManagedIdentityCredentialProvider {
             let mut leases = self.leases.lock().map_err(|_| invariant())?;
             Self::mark_expired_locked(&mut leases, now);
             let records = leases.get(&key);
-            if let Some(records) = records {
-                if records.iter().any(|record| {
-                    Self::same_owner(
-                        &record.authenticated_subject,
-                        session.authenticated_subject(),
-                    )
-                }) {
-                    if let Some(existing) = records.iter().find(|record| {
-                        record.metadata.state == CredentialLeaseState::Active
-                            && record.idempotency_key == request.idempotency_key()
-                            && Self::same_owner(
-                                &record.authenticated_subject,
-                                session.authenticated_subject(),
-                            )
-                    }) {
-                        return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
-                            metadata: existing.metadata.clone(),
-                            delivery_session_params: delivery,
-                        }));
-                    }
-                } else if !records.is_empty() {
-                    return Err(operation_denied());
-                }
+            if let Some(records) = records
+                && let Some(existing) = records.iter().find(|record| {
+                    record.metadata.state == CredentialLeaseState::Active
+                        && record.idempotency_key == request.idempotency_key()
+                        && Self::same_session(
+                            &record.authenticated_subject,
+                            session.authenticated_subject(),
+                        )
+                })
+            {
+                return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
+                    metadata: existing.metadata.clone(),
+                    delivery_session_params: delivery,
+                }));
             }
-            if Self::active_lease_count(&leases) >= self.config.max_leases() as usize {
+            let active_for_owner = records
+                .into_iter()
+                .flatten()
+                .filter(|record| {
+                    record.metadata.state == CredentialLeaseState::Active
+                        && Self::same_owner(
+                            &record.authenticated_subject,
+                            session.authenticated_subject(),
+                        )
+                })
+                .count();
+            if Self::active_lease_count(&leases).saturating_sub(active_for_owner)
+                >= self.config.max_leases() as usize
+            {
                 return Err(CredentialServiceError::new(
                     CredentialServiceErrorCode::ProviderUnavailable,
                 ));
@@ -99,7 +103,7 @@ impl ManagedIdentityCredentialProvider {
                 .map(|record| record.metadata.rotation_generation)
                 .max()
                 .unwrap_or(0);
-            prior_generation.checked_add(1).ok_or_else(|| invariant())?
+            prior_generation.checked_add(1).ok_or_else(invariant)?
         };
         let client_request = ManagedIdentityLeaseRequest {
             credential_ref: request.credential_ref().clone(),
@@ -110,17 +114,20 @@ impl ManagedIdentityCredentialProvider {
         };
         let grant = Self::poll_client(self.client.issue_lease(&client_request), deadline)?;
         let metadata = Self::grant_metadata(grant, requested_expiry, rotation_generation)?;
-        self.leases
-            .lock()
-            .map_err(|_| invariant())?
-            .entry(key)
-            .or_default()
-            .push(LeaseRecord {
-                idempotency_key: request.idempotency_key().to_owned(),
-                metadata: metadata.clone(),
-                authenticated_subject: session.authenticated_subject().clone(),
-                session_expires_at_unix_ms: session.expires_at_unix_ms(),
-            });
+        let mut leases = self.leases.lock().map_err(|_| invariant())?;
+        let records = leases.entry(key).or_default();
+        records.retain(|record| {
+            !Self::same_owner(
+                &record.authenticated_subject,
+                session.authenticated_subject(),
+            )
+        });
+        records.push(LeaseRecord {
+            idempotency_key: request.idempotency_key().to_owned(),
+            metadata: metadata.clone(),
+            authenticated_subject: session.authenticated_subject().clone(),
+            session_expires_at_unix_ms: session.expires_at_unix_ms(),
+        });
         Ok(CredentialResponse::AcquireToken(DeliveryResponse {
             metadata,
             delivery_session_params: delivery,
@@ -157,18 +164,12 @@ impl ManagedIdentityCredentialProvider {
             let record = records
                 .iter()
                 .find(|record| {
-                    Self::same_owner(
+                    Self::same_session(
                         &record.authenticated_subject,
                         session.authenticated_subject(),
                     )
                 })
                 .ok_or_else(operation_denied)?;
-            if !Self::same_session(
-                &record.authenticated_subject,
-                session.authenticated_subject(),
-            ) {
-                return Err(operation_denied());
-            }
             ensure_active(record)?;
             record.clone()
         };
@@ -195,7 +196,7 @@ impl ManagedIdentityCredentialProvider {
             )?;
             return Err(expired());
         }
-        if inspection.rotation_generation < record.metadata.rotation_generation {
+        if inspection.rotation_generation != record.metadata.rotation_generation {
             return Err(invariant());
         }
         let grant = Self::poll_client(self.client.refresh_lease(&lease), deadline)?;
@@ -229,18 +230,12 @@ impl ManagedIdentityCredentialProvider {
             let record = records
                 .iter()
                 .find(|record| {
-                    Self::same_owner(
+                    Self::same_session(
                         &record.authenticated_subject,
                         session.authenticated_subject(),
                     )
                 })
                 .ok_or_else(operation_denied)?;
-            if !Self::same_session(
-                &record.authenticated_subject,
-                session.authenticated_subject(),
-            ) {
-                return Err(operation_denied());
-            }
             record.clone()
         };
         if record.metadata.state == CredentialLeaseState::Revoked {
@@ -290,18 +285,12 @@ impl ManagedIdentityCredentialProvider {
             let record = records
                 .iter()
                 .find(|record| {
-                    Self::same_owner(
+                    Self::same_session(
                         &record.authenticated_subject,
                         session.authenticated_subject(),
                     )
                 })
                 .ok_or_else(operation_denied)?;
-            if !Self::same_session(
-                &record.authenticated_subject,
-                session.authenticated_subject(),
-            ) {
-                return Err(operation_denied());
-            }
             ensure_active_or_observable(record)?;
             record.clone()
         };
@@ -313,9 +302,10 @@ impl ManagedIdentityCredentialProvider {
         let mut metadata = record.metadata.clone();
         metadata.state = inspection.state;
         metadata.source_version = inspection.source_version;
-        metadata.rotation_generation = inspection
-            .rotation_generation
-            .max(metadata.rotation_generation);
+        if inspection.rotation_generation < metadata.rotation_generation {
+            return Err(invariant());
+        }
+        metadata.rotation_generation = inspection.rotation_generation;
         metadata.expires_at_unix_ms = inspection.expires_at_unix_ms;
         if Self::is_expired(metadata.expires_at_unix_ms, Self::now_unix_ms())
             && metadata.state == CredentialLeaseState::Active

--- a/packages/d2b-provider-credential-managed-identity/tests/binding.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/binding.rs
@@ -1,0 +1,387 @@
+mod common;
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use d2b_contracts::v3::ResourceRef;
+use d2b_contracts::v3::credential::{
+    CredentialAuthorization, CredentialMethod, CredentialRequest, CredentialResponse,
+    CredentialServiceErrorCode, CredentialSessionBinding, MAX_PROVIDER_LEASE_LIFETIME_MS,
+    dispatch_authorized_provider,
+};
+use d2b_provider_credential_managed_identity::{
+    ManagedIdentityCredentialProvider, ManagedIdentityCredentialProviderFactory,
+};
+
+use common::{
+    authenticated_session, authenticated_session_with_expiry, authorization_for,
+    delivery_for_timing, request, setup,
+};
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+fn dispatch(
+    provider: &ManagedIdentityCredentialProvider,
+    method: CredentialMethod,
+    request: &CredentialRequest,
+    session: CredentialSessionBinding,
+) -> Result<CredentialResponse, d2b_contracts::v3::credential::CredentialServiceError> {
+    let authorization = authorization_for(method, session, request.credential_ref().clone())?;
+    dispatch_authorized_provider(provider, method, request, &authorization)
+}
+
+fn dispatch_without_session(
+    provider: &ManagedIdentityCredentialProvider,
+    method: CredentialMethod,
+    request: &CredentialRequest,
+) -> Result<CredentialResponse, d2b_contracts::v3::credential::CredentialServiceError> {
+    let delivery = method
+        .requires_delivery()
+        .then(|| common::delivery_for(method, 1, request.credential_ref().clone()));
+    let authorization = CredentialAuthorization::new(method, delivery)?;
+    dispatch_authorized_provider(provider, method, request, &authorization)
+}
+
+fn restart_provider(
+    provider: &ManagedIdentityCredentialProvider,
+    client: Arc<common::FakeClient>,
+) -> ManagedIdentityCredentialProvider {
+    ManagedIdentityCredentialProviderFactory::new(
+        provider.config().clone(),
+        provider.placement().clone(),
+        provider.consumer_ref().clone(),
+        client,
+    )
+    .unwrap()
+    .construct()
+}
+
+#[test]
+fn lease_operations_bind_to_authenticated_zone_workload_subject_and_session() {
+    let (provider, client) = setup();
+    let acquire_request = request("binding-acquire");
+    let good_session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &acquire_request,
+        good_session.clone(),
+    )
+    .unwrap();
+
+    let mismatches = [
+        authenticated_session(
+            "Provider/workload-b",
+            "Zone/dev",
+            "Guest/aca-sandbox",
+            "Provider/runtime-azure-container-apps",
+            1,
+            1,
+        ),
+        authenticated_session(
+            "Provider/workload-a",
+            "Zone/other",
+            "Guest/aca-sandbox",
+            "Provider/runtime-azure-container-apps",
+            1,
+            1,
+        ),
+        authenticated_session(
+            "Provider/workload-a",
+            "Zone/dev",
+            "Guest/other",
+            "Provider/runtime-azure-container-apps",
+            1,
+            1,
+        ),
+        authenticated_session(
+            "Provider/workload-a",
+            "Zone/dev",
+            "Guest/aca-sandbox",
+            "Provider/runtime-azure-container-apps",
+            2,
+            1,
+        ),
+        authenticated_session(
+            "Provider/workload-a",
+            "Zone/dev",
+            "Guest/aca-sandbox",
+            "Provider/runtime-azure-container-apps",
+            1,
+            2,
+        ),
+    ];
+    for session in mismatches {
+        assert_eq!(
+            dispatch(
+                &provider,
+                CredentialMethod::RefreshToken,
+                &request("binding-refresh"),
+                session,
+            )
+            .unwrap_err()
+            .code(),
+            CredentialServiceErrorCode::OperationDenied
+        );
+    }
+    assert_eq!(
+        client
+            .refresh_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+    assert_eq!(
+        dispatch_without_session(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &request("binding-no-session"),
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+}
+
+#[test]
+fn expired_sessions_and_leases_fail_closed() {
+    let (provider, client) = setup();
+    let expired_session = authenticated_session_with_expiry(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+        now_unix_ms().saturating_sub(1),
+    );
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("expired-session"),
+            expired_session,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::DeadlineExceeded
+    );
+    assert_eq!(
+        client.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+
+    let expires_soon = now_unix_ms() + 5;
+    let lease_request = CredentialRequest::new(
+        ResourceRef::parse("Credential/aca-relay-mi").unwrap(),
+        "operation-expiring",
+        "expiring-lease",
+        expires_soon,
+        expires_soon.saturating_sub(1),
+    )
+    .unwrap();
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &lease_request,
+        session.clone(),
+    )
+    .unwrap();
+    thread::sleep(Duration::from_millis(10));
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &request("expired-lease-refresh"),
+            session,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::LeaseExpired
+    );
+}
+
+#[test]
+fn lease_lifetime_is_capped_by_provider_maximum() {
+    let (provider, _) = setup();
+    let now = now_unix_ms();
+    let requested_expiry = now + MAX_PROVIDER_LEASE_LIFETIME_MS * 2;
+    let request = CredentialRequest::new(
+        ResourceRef::parse("Credential/aca-relay-mi").unwrap(),
+        "operation-capped",
+        "capped-lease",
+        requested_expiry,
+        requested_expiry - 1,
+    )
+    .unwrap();
+    let session_expiry = requested_expiry;
+    let session = authenticated_session_with_expiry(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+        session_expiry,
+    );
+    let delivery = delivery_for_timing(
+        CredentialMethod::AcquireToken,
+        1,
+        request.credential_ref().clone(),
+        requested_expiry,
+        requested_expiry - 1,
+    );
+    let authorization =
+        CredentialAuthorization::new(CredentialMethod::AcquireToken, Some(delivery))
+            .unwrap()
+            .with_authenticated_session(session)
+            .unwrap();
+    let CredentialResponse::AcquireToken(response) = dispatch_authorized_provider(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request,
+        &authorization,
+    )
+    .unwrap() else {
+        panic!("acquire response");
+    };
+    assert!(response.metadata.expires_at_unix_ms <= now + MAX_PROVIDER_LEASE_LIFETIME_MS);
+}
+
+#[test]
+fn checkpoints_restore_and_refresh_without_secret_material() {
+    let (provider, client) = setup();
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("checkpoint-acquire"),
+        session.clone(),
+    )
+    .unwrap();
+    let checkpoints = provider.export_checkpoints().unwrap();
+    assert_eq!(checkpoints.len(), 1);
+    let checkpoint_debug = format!("{checkpoints:?}");
+    assert!(!checkpoint_debug.contains(client.token_canary.as_str()));
+    assert!(!checkpoint_debug.contains(client.endpoint_canary.as_str()));
+
+    let restored = restart_provider(&provider, client.clone());
+    restored.restore_checkpoints(checkpoints).unwrap();
+    assert!(matches!(
+        dispatch(
+            &restored,
+            CredentialMethod::RefreshToken,
+            &request("checkpoint-refresh"),
+            session,
+        )
+        .unwrap(),
+        CredentialResponse::RefreshToken(_)
+    ));
+    assert_eq!(
+        client
+            .refresh_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
+#[test]
+fn finalization_revokes_only_the_callers_owned_handles() {
+    let (provider, client) = setup();
+    let owner_a = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    let owner_b = authenticated_session(
+        "Provider/workload-b",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &CredentialRequest::new(
+            ResourceRef::parse("Credential/owned-a").unwrap(),
+            "operation-owner-a",
+            "owner-a",
+            common::EXPIRY,
+            15_000,
+        )
+        .unwrap(),
+        owner_a.clone(),
+    )
+    .unwrap();
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &CredentialRequest::new(
+            ResourceRef::parse("Credential/owned-b").unwrap(),
+            "operation-owner-b",
+            "owner-b",
+            common::EXPIRY,
+            15_000,
+        )
+        .unwrap(),
+        owner_b,
+    )
+    .unwrap();
+
+    assert_eq!(provider.revoke_owned_handles(&owner_a, 15_000).unwrap(), 1);
+    assert_eq!(
+        client
+            .revoke_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    let checkpoints = provider.export_checkpoints().unwrap();
+    assert_eq!(
+        checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.metadata().state
+                == d2b_contracts::v3::credential::CredentialLeaseState::Revoked)
+            .count(),
+        1
+    );
+    assert_eq!(
+        checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.metadata().state
+                == d2b_contracts::v3::credential::CredentialLeaseState::Active)
+            .count(),
+        1
+    );
+}

--- a/packages/d2b-provider-credential-managed-identity/tests/binding.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/binding.rs
@@ -156,6 +156,34 @@ fn lease_operations_bind_to_authenticated_zone_workload_subject_and_session() {
 }
 
 #[test]
+fn wrong_zone_acquire_is_denied_before_first_client_call() {
+    let (provider, client) = setup();
+    let wrong_zone = authenticated_session(
+        "Provider/workload-a",
+        "Zone/other",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("wrong-zone-first"),
+            wrong_zone,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(
+        client.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+}
+
+#[test]
 fn expired_sessions_and_leases_fail_closed() {
     let (provider, client) = setup();
     let expired_session = authenticated_session_with_expiry(
@@ -222,6 +250,228 @@ fn expired_sessions_and_leases_fail_closed() {
 }
 
 #[test]
+fn expired_lease_reacquire_replaces_predecessor_before_refresh() {
+    let (provider, client) = setup();
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    let expiry = now_unix_ms() + 5;
+    let first_request = CredentialRequest::new(
+        ResourceRef::parse("Credential/aca-relay-mi").unwrap(),
+        "expire-reacquire-first",
+        "expire-reacquire-first",
+        expiry,
+        expiry - 1,
+    )
+    .unwrap();
+    let first = dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &first_request,
+        session.clone(),
+    )
+    .unwrap();
+    let CredentialResponse::AcquireToken(first) = first else {
+        panic!("acquire response");
+    };
+    assert_eq!(first.metadata.rotation_generation, 1);
+
+    thread::sleep(Duration::from_millis(20));
+    let reacquired = dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("expire-reacquire-second"),
+        session.clone(),
+    )
+    .unwrap();
+    let CredentialResponse::AcquireToken(reacquired) = reacquired else {
+        panic!("reacquire response");
+    };
+    assert_eq!(reacquired.metadata.rotation_generation, 2);
+
+    let refreshed = dispatch(
+        &provider,
+        CredentialMethod::RefreshToken,
+        &request("expire-reacquire-refresh"),
+        session,
+    )
+    .unwrap();
+    let CredentialResponse::RefreshToken(refreshed) = refreshed else {
+        panic!("refresh response");
+    };
+    assert_eq!(refreshed.metadata.rotation_generation, 3);
+    assert_eq!(
+        client.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+        2
+    );
+    assert_eq!(
+        client
+            .refresh_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
+#[test]
+fn revoked_lease_reacquire_targets_only_the_current_record() {
+    let (provider, client) = setup();
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("revoke-reacquire-first"),
+        session.clone(),
+    )
+    .unwrap();
+    dispatch(
+        &provider,
+        CredentialMethod::RevokeToken,
+        &request("revoke-reacquire-revoke-first"),
+        session.clone(),
+    )
+    .unwrap();
+    let reacquired = dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("revoke-reacquire-second"),
+        session.clone(),
+    )
+    .unwrap();
+    let CredentialResponse::AcquireToken(reacquired) = reacquired else {
+        panic!("reacquire response");
+    };
+    assert_eq!(reacquired.metadata.rotation_generation, 2);
+
+    dispatch(
+        &provider,
+        CredentialMethod::RevokeToken,
+        &request("revoke-reacquire-revoke-second"),
+        session.clone(),
+    )
+    .unwrap();
+    assert_eq!(
+        client
+            .revoke_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        2
+    );
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &request("revoke-reacquire-refresh"),
+            session,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::LeaseRevoked
+    );
+    assert_eq!(
+        client
+            .refresh_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+}
+
+#[test]
+fn reconnect_reacquire_replaces_stale_session_before_refresh() {
+    let (provider, client) = setup();
+    let first_session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    let reconnected_session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        2,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("reconnect-first"),
+        first_session.clone(),
+    )
+    .unwrap();
+    let reacquired = dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("reconnect-second"),
+        reconnected_session.clone(),
+    )
+    .unwrap();
+    let CredentialResponse::AcquireToken(reacquired) = reacquired else {
+        panic!("reacquire response");
+    };
+    assert_eq!(reacquired.metadata.rotation_generation, 2);
+
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &request("reconnect-stale-refresh"),
+            first_session.clone(),
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::InspectMetadata,
+            &request("reconnect-stale-inspect"),
+            first_session,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    let refreshed = dispatch(
+        &provider,
+        CredentialMethod::RefreshToken,
+        &request("reconnect-current-refresh"),
+        reconnected_session,
+    )
+    .unwrap();
+    let CredentialResponse::RefreshToken(refreshed) = refreshed else {
+        panic!("refresh response");
+    };
+    assert_eq!(refreshed.metadata.rotation_generation, 3);
+    assert_eq!(
+        client
+            .inspect_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    assert_eq!(
+        client
+            .refresh_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
+#[test]
 fn lease_lifetime_is_capped_by_provider_maximum() {
     let (provider, _) = setup();
     let now = now_unix_ms();
@@ -269,7 +519,7 @@ fn lease_lifetime_is_capped_by_provider_maximum() {
 }
 
 #[test]
-fn checkpoints_restore_and_refresh_without_secret_material() {
+fn checkpoints_restore_is_idempotent_and_refreshes_without_secret_material() {
     let (provider, client) = setup();
     let session = authenticated_session(
         "Provider/workload-a",
@@ -293,7 +543,9 @@ fn checkpoints_restore_and_refresh_without_secret_material() {
     assert!(!checkpoint_debug.contains(client.endpoint_canary.as_str()));
 
     let restored = restart_provider(&provider, client.clone());
+    restored.restore_checkpoints(checkpoints.clone()).unwrap();
     restored.restore_checkpoints(checkpoints).unwrap();
+    assert_eq!(restored.export_checkpoints().unwrap().len(), 1);
     assert!(matches!(
         dispatch(
             &restored,
@@ -335,7 +587,7 @@ fn finalization_revokes_only_the_callers_owned_handles() {
         &provider,
         CredentialMethod::AcquireToken,
         &CredentialRequest::new(
-            ResourceRef::parse("Credential/owned-a").unwrap(),
+            ResourceRef::parse("Credential/shared").unwrap(),
             "operation-owner-a",
             "owner-a",
             common::EXPIRY,
@@ -349,14 +601,14 @@ fn finalization_revokes_only_the_callers_owned_handles() {
         &provider,
         CredentialMethod::AcquireToken,
         &CredentialRequest::new(
-            ResourceRef::parse("Credential/owned-b").unwrap(),
+            ResourceRef::parse("Credential/shared").unwrap(),
             "operation-owner-b",
             "owner-b",
             common::EXPIRY,
             15_000,
         )
         .unwrap(),
-        owner_b,
+        owner_b.clone(),
     )
     .unwrap();
 
@@ -384,4 +636,21 @@ fn finalization_revokes_only_the_callers_owned_handles() {
             .count(),
         1
     );
+    assert!(matches!(
+        dispatch(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &CredentialRequest::new(
+                ResourceRef::parse("Credential/shared").unwrap(),
+                "operation-owner-b-refresh",
+                "owner-b-refresh",
+                common::EXPIRY,
+                15_000,
+            )
+            .unwrap(),
+            owner_b,
+        )
+        .unwrap(),
+        CredentialResponse::RefreshToken(_)
+    ));
 }

--- a/packages/d2b-provider-credential-managed-identity/tests/canary.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/canary.rs
@@ -141,7 +141,6 @@ fn process_unique_managed_identity_canaries_are_absent_from_rendered_surfaces() 
         config_debug,
         request_debug,
         format!("{response:?}"),
-        String::from_utf8_lossy(&encode_outer(delivery).unwrap()).into_owned(),
         format!("{:?}", delivery.metadata.lease_handle),
         delivery.metadata.lease_handle.to_string(),
         format!("{:?}", delivery.metadata.source_version),
@@ -162,23 +161,36 @@ fn process_unique_managed_identity_canaries_are_absent_from_rendered_surfaces() 
         format!("{telemetry_error:?}"),
         telemetry_error.to_string(),
     ];
-    let markers = [
+    let secret_markers = [
         client.token_canary.as_str(),
         client.endpoint_canary.as_str(),
         client.response_canary.as_str(),
         provider_client_id_marker(),
+    ];
+    let identity_markers = [
         credential_name.as_str(),
         credential_ref.as_str(),
         credential_uid.as_str(),
         credential_digest.as_str(),
     ];
-    for surface in surfaces {
-        for marker in markers {
+    for (surface_index, surface) in surfaces.into_iter().enumerate() {
+        for (marker_index, marker) in secret_markers
+            .into_iter()
+            .chain(identity_markers)
+            .enumerate()
+        {
             assert!(
                 !surface.contains(marker),
-                "managed identity canary reached a rendered surface"
+                "managed identity canary reached rendered surface {surface_index} marker {marker_index}"
             );
         }
+    }
+    let delivery_wire = String::from_utf8_lossy(&encode_outer(delivery).unwrap()).into_owned();
+    for marker in secret_markers {
+        assert!(
+            !delivery_wire.contains(marker),
+            "managed identity secret canary reached the authorized delivery binding"
+        );
     }
 }
 

--- a/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
@@ -82,6 +82,7 @@ impl ManagedIdentityCredentialClient for FakeClient {
         let error = *self.issue_error.lock().unwrap();
         let state = *self.state.lock().unwrap();
         let expiry = request.requested_expiry_unix_ms();
+        let rotation_generation = request.rotation_generation();
         let token = self.token_canary.clone();
         let endpoint = self.endpoint_canary.clone();
         *self.observed_request.lock().unwrap() = Some((
@@ -100,7 +101,7 @@ impl ManagedIdentityCredentialClient for FakeClient {
             let grant = ManagedIdentityLeaseGrant {
                 lease_handle: CredentialLeaseHandle::parse(&token).unwrap(),
                 source_version: CredentialSourceVersion::parse(&endpoint).unwrap(),
-                rotation_generation: 1,
+                rotation_generation,
                 expires_at_unix_ms: expiry,
             };
             *inspection.lock().unwrap() = Some(ManagedIdentityLeaseInspection {
@@ -128,13 +129,14 @@ impl ManagedIdentityCredentialClient for FakeClient {
     ) -> ManagedIdentityFuture<'_, ManagedIdentityLeaseRenewal> {
         self.refresh_calls.fetch_add(1, Ordering::SeqCst);
         let expiry = lease.metadata().expires_at_unix_ms;
+        let rotation_generation = lease.metadata().rotation_generation;
         let inspection = &self.inspection;
         Box::pin(async move {
             let grant = ManagedIdentityLeaseGrant {
                 lease_handle: CredentialLeaseHandle::parse("managed-identity-lease").unwrap(),
                 source_version: CredentialSourceVersion::parse("managed-identity-source-2")
                     .unwrap(),
-                rotation_generation: 2,
+                rotation_generation: rotation_generation + 1,
                 expires_at_unix_ms: expiry,
             };
             *inspection.lock().unwrap() = Some(ManagedIdentityLeaseInspection {
@@ -162,9 +164,8 @@ pub fn setup() -> (ManagedIdentityCredentialProvider, Arc<FakeClient>) {
     let placement = ManagedIdentityPlacement::new(
         PlacementBinding::GuestAgent,
         ResourceRef::parse("Guest/aca-sandbox").unwrap(),
+        ResourceRef::parse("Zone/dev").unwrap(),
     )
-    .unwrap()
-    .with_zone_ref(ResourceRef::parse("Zone/dev").unwrap())
     .unwrap();
     let factory = ManagedIdentityCredentialProviderFactory::new(
         config,

--- a/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
@@ -2,14 +2,20 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use d2b_contracts::v3::credential::{
     AudienceToken, CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState,
     CredentialMethod, CredentialProvider, CredentialRequest, CredentialResponse,
-    CredentialServiceError, CredentialServiceErrorCode, CredentialSourceVersion,
-    DeliveryRouteDigest, DeliverySessionParams, PlacementBinding, dispatch_authorized_provider,
+    CredentialServiceError, CredentialServiceErrorCode, CredentialSessionBinding,
+    CredentialSourceVersion, DeliveryRouteDigest, DeliverySessionParams, PlacementBinding,
+    dispatch_authorized_provider,
 };
-use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid};
+use d2b_contracts::v3::{
+    AuthenticatedSubjectContext, BindingDigest, EvidenceClass, Locality, ReconnectGeneration,
+    ResourceGeneration, ResourceRef, ResourceUid, SchemaFingerprint, ServiceName, SessionBinding,
+    SessionPurpose, TranscriptHash, TransportBinding,
+};
 use d2b_provider_credential_managed_identity::{
     ManagedIdentityClientConfig, ManagedIdentityClientError, ManagedIdentityClientState,
     ManagedIdentityCredentialClient, ManagedIdentityCredentialProvider,
@@ -19,6 +25,15 @@ use d2b_provider_credential_managed_identity::{
 };
 
 pub const EXPIRY: u64 = 20_000;
+
+pub fn session_expiry() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+        + 20_000
+}
 
 pub struct FakeClient {
     pub state: Mutex<ManagedIdentityClientState>,
@@ -148,6 +163,8 @@ pub fn setup() -> (ManagedIdentityCredentialProvider, Arc<FakeClient>) {
         PlacementBinding::GuestAgent,
         ResourceRef::parse("Guest/aca-sandbox").unwrap(),
     )
+    .unwrap()
+    .with_zone_ref(ResourceRef::parse("Zone/dev").unwrap())
     .unwrap();
     let factory = ManagedIdentityCredentialProviderFactory::new(
         config,
@@ -171,21 +188,120 @@ pub fn request(idempotency: &str) -> CredentialRequest {
 }
 
 pub fn delivery(method: CredentialMethod, sequence: u64) -> DeliverySessionParams {
-    DeliverySessionParams::new(
+    delivery_for(
+        method,
+        sequence,
         ResourceRef::parse("Credential/aca-relay-mi").unwrap(),
+    )
+}
+
+pub fn delivery_for(
+    method: CredentialMethod,
+    sequence: u64,
+    credential_ref: ResourceRef,
+) -> DeliverySessionParams {
+    delivery_for_timing(method, sequence, credential_ref, EXPIRY, 15_000)
+}
+
+pub fn delivery_for_timing(
+    method: CredentialMethod,
+    sequence: u64,
+    credential_ref: ResourceRef,
+    expiry_unix_ms: u64,
+    deadline_unix_ms: u64,
+) -> DeliverySessionParams {
+    DeliverySessionParams::new(
+        credential_ref,
         ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),
         ResourceGeneration::new(1).unwrap(),
         ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
         ResourceGeneration::new(1).unwrap(),
         AudienceToken::parse("azure-resource-manager").unwrap(),
         method.operation_class(),
-        EXPIRY,
-        15_000,
+        expiry_unix_ms,
+        deadline_unix_ms,
         DeliveryRouteDigest::parse(format!("sha256:{}", "d".repeat(64))).unwrap(),
         4_096,
         sequence,
     )
     .unwrap()
+}
+
+pub fn authenticated_session(
+    subject_ref: &str,
+    zone_ref: &str,
+    execution_ref: &str,
+    provider_ref: &str,
+    provider_generation: u64,
+    reconnect_generation: u64,
+) -> CredentialSessionBinding {
+    authenticated_session_with_expiry(
+        subject_ref,
+        zone_ref,
+        execution_ref,
+        provider_ref,
+        provider_generation,
+        reconnect_generation,
+        session_expiry(),
+    )
+}
+
+pub fn authenticated_session_with_expiry(
+    subject_ref: &str,
+    zone_ref: &str,
+    execution_ref: &str,
+    provider_ref: &str,
+    provider_generation: u64,
+    reconnect_generation: u64,
+    expires_at_unix_ms: u64,
+) -> CredentialSessionBinding {
+    let subject = AuthenticatedSubjectContext::new(
+        ResourceRef::parse(subject_ref).unwrap(),
+        ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),
+        ResourceRef::parse(zone_ref).unwrap(),
+        EvidenceClass::EnrolledKk,
+        SessionPurpose::parse("credential-delivery").unwrap(),
+        ServiceName::parse("d2b.credential.v3").unwrap(),
+        SessionBinding::new(
+            SchemaFingerprint::parse(format!("sha256:{}", "a".repeat(64))).unwrap(),
+            TransportBinding::new(
+                Locality::Local,
+                BindingDigest::parse(format!("sha256:{}", "b".repeat(64))).unwrap(),
+            ),
+            ReconnectGeneration::new(reconnect_generation).unwrap(),
+            TranscriptHash::from_bytes([7; 32]),
+        ),
+    )
+    .with_execution_ref(ResourceRef::parse(execution_ref).unwrap())
+    .with_provider_ref(ResourceRef::parse(provider_ref).unwrap())
+    .with_process_ref(ResourceRef::parse("Process/mi-agent-aca-relay-mi").unwrap())
+    .with_provider_generation(ResourceGeneration::new(provider_generation).unwrap());
+    CredentialSessionBinding::new(subject, expires_at_unix_ms).unwrap()
+}
+
+pub fn authorization(
+    method: CredentialMethod,
+    session: CredentialSessionBinding,
+) -> Result<CredentialAuthorization, CredentialServiceError> {
+    authorization_for(
+        method,
+        session,
+        ResourceRef::parse("Credential/aca-relay-mi").unwrap(),
+    )
+}
+
+pub fn authorization_for(
+    method: CredentialMethod,
+    session: CredentialSessionBinding,
+    credential_ref: ResourceRef,
+) -> Result<CredentialAuthorization, CredentialServiceError> {
+    CredentialAuthorization::new(
+        method,
+        method
+            .requires_delivery()
+            .then(|| delivery_for(method, 1, credential_ref)),
+    )?
+    .with_authenticated_session(session)
 }
 
 #[derive(Clone)]
@@ -214,9 +330,17 @@ impl TestAdmission for Admission {
                 CredentialServiceErrorCode::OperationDenied,
             ));
         }
-        CredentialAuthorization::new(
+        authorization_for(
             method,
-            method.requires_delivery().then(|| delivery(method, 1)),
+            authenticated_session(
+                "Provider/runtime-azure-container-apps",
+                "Zone/dev",
+                "Guest/aca-sandbox",
+                "Provider/runtime-azure-container-apps",
+                1,
+                1,
+            ),
+            _request.credential_ref().clone(),
         )
     }
 }

--- a/packages/d2b-provider-credential-managed-identity/tests/delivery.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/delivery.rs
@@ -7,7 +7,9 @@ use d2b_contracts::v3::credential::{
 };
 use d2b_provider_credential_managed_identity::ManagedIdentityCredentialProvider;
 
-use common::{ProviderHarness, TestAdmission, admitted, delivery, request, setup};
+use common::{
+    ProviderHarness, TestAdmission, admitted, authenticated_session, delivery, request, setup,
+};
 
 #[test]
 fn provider_returns_the_adapter_supplied_binding_unchanged() {
@@ -44,7 +46,15 @@ impl TestAdmission for FixedAdmission {
         method: CredentialMethod,
         _request: &CredentialRequest,
     ) -> Result<CredentialAuthorization, CredentialServiceError> {
-        CredentialAuthorization::new(method, Some(self.authorized.clone()))
+        CredentialAuthorization::new(method, Some(self.authorized.clone()))?
+            .with_authenticated_session(authenticated_session(
+                "Provider/runtime-azure-container-apps",
+                "Zone/dev",
+                "Guest/aca-sandbox",
+                "Provider/runtime-azure-container-apps",
+                1,
+                1,
+            ))
     }
 }
 

--- a/packages/d2b-provider-credential-managed-identity/tests/faults.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/faults.rs
@@ -77,6 +77,7 @@ fn client_call_stops_at_request_deadline() {
         ManagedIdentityPlacement::new(
             PlacementBinding::GuestAgent,
             ResourceRef::parse("Guest/aca-sandbox").unwrap(),
+            ResourceRef::parse("Zone/dev").unwrap(),
         )
         .unwrap(),
         ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),

--- a/packages/d2b-provider-credential-managed-identity/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/lifecycle.rs
@@ -238,6 +238,7 @@ fn provider_with_client(
         ManagedIdentityPlacement::new(
             PlacementBinding::GuestAgent,
             ResourceRef::parse("Guest/aca-sandbox").unwrap(),
+            ResourceRef::parse("Zone/dev").unwrap(),
         )
         .unwrap(),
         ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),

--- a/packages/d2b-provider-credential-managed-identity/tests/placement.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/placement.rs
@@ -10,6 +10,7 @@ fn machine_placements_are_accepted_and_user_agent_is_rejected() {
         ManagedIdentityPlacement::new(
             PlacementBinding::HostSystem,
             ResourceRef::parse("Host/azure-vm").unwrap(),
+            ResourceRef::parse("Zone/dev").unwrap(),
         )
         .is_ok()
     );
@@ -17,6 +18,7 @@ fn machine_placements_are_accepted_and_user_agent_is_rejected() {
         ManagedIdentityPlacement::new(
             PlacementBinding::GuestAgent,
             ResourceRef::parse("Guest/aca-sandbox").unwrap(),
+            ResourceRef::parse("Zone/dev").unwrap(),
         )
         .is_ok()
     );
@@ -24,6 +26,19 @@ fn machine_placements_are_accepted_and_user_agent_is_rejected() {
         ManagedIdentityPlacement::new(
             PlacementBinding::UserAgent,
             ResourceRef::parse("Host/azure-vm").unwrap(),
+            ResourceRef::parse("Zone/dev").unwrap(),
+        ),
+        Err(ManagedIdentityProviderError::InvalidPlacement)
+    );
+}
+
+#[test]
+fn unbound_or_non_zone_placements_are_rejected() {
+    assert_eq!(
+        ManagedIdentityPlacement::new(
+            PlacementBinding::GuestAgent,
+            ResourceRef::parse("Guest/aca-sandbox").unwrap(),
+            ResourceRef::parse("Host/workstation").unwrap(),
         ),
         Err(ManagedIdentityProviderError::InvalidPlacement)
     );

--- a/packages/d2b-provider-credential-managed-identity/tests/topology.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/topology.rs
@@ -7,7 +7,12 @@ use d2b_provider_credential_managed_identity::{
 
 fn controller(binding: PlacementBinding, execution: &str) -> ManagedIdentityController {
     ManagedIdentityController::new(
-        ManagedIdentityPlacement::new(binding, ResourceRef::parse(execution).unwrap()).unwrap(),
+        ManagedIdentityPlacement::new(
+            binding,
+            ResourceRef::parse(execution).unwrap(),
+            ResourceRef::parse("Zone/dev").unwrap(),
+        )
+        .unwrap(),
     )
 }
 


### PR DESCRIPTION
## Summary
- Require authenticated subject, Zone, workload, and Provider session bindings for managed-identity operations.
- Bound lease expiry and restart checkpoints without persisting token material.
- Revoke only handles owned by the finalizing workload.

## Verification
- `cargo test -p d2b-provider-credential-managed-identity --lib --test binding --test lifecycle --test conformance --test faults --test canary --test delivery --test placement --test topology`
- `cargo test -p d2b-credential-service --test redaction --test server`
- `cargo fmt --all -- --check`