### PR TITLE
credential: bind Secret Service leases to authenticated sessions

### DIFF
--- a/changelog.d/feat-spec001-credential-secret-service.md
+++ b/changelog.d/feat-spec001-credential-secret-service.md
@@ -5,3 +5,4 @@
 ### Fixed
 
 - Kept missing-secret, outage, timeout, status, audit, log, and telemetry outcomes stable and free of credential material or identifiers.
+- Sealed session capability minting behind one provider-owned, non-Clone authority with exact consumer and generation checks; lifecycle fencing now makes admission, inspect, disconnect, and finalization race-safe and drains admitted leases.

--- a/changelog.d/feat-spec001-credential-secret-service.md
+++ b/changelog.d/feat-spec001-credential-secret-service.md
@@ -1,0 +1,7 @@
+### Added
+
+- Added authenticated, Zone- and workload-bound Secret Service Credential sessions with opaque lease ownership and disconnect/finalization revocation.
+
+### Fixed
+
+- Kept missing-secret, outage, timeout, status, audit, log, and telemetry outcomes stable and free of credential material or identifiers.

--- a/packages/d2b-contracts/src/v3/credential/service.rs
+++ b/packages/d2b-contracts/src/v3/credential/service.rs
@@ -1,16 +1,16 @@
 //! Neutral provider-facing DTO and sensitive-record contracts.
 
 use core::fmt;
-use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use super::{
     AudienceToken, CredentialLeaseHandle, CredentialLeaseState, CredentialSourceVersion,
     OperationClass,
 };
 use crate::v3::component_session::MAX_PROTECTED_PLAINTEXT_BYTES;
-use crate::v3::{ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash, ZoneId};
+use crate::v3::{ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash};
 
 /// Canonical service package routed by the Zone bus.
 pub const CREDENTIAL_SERVICE_NAME: &str = "d2b.credential.v3";
@@ -587,350 +587,42 @@ impl fmt::Debug for CredentialResponse {
     }
 }
 
-/// Stable failure returned while admitting a Credential session capability.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CredentialSessionError {
-    /// The capability is unknown or its binding was altered.
-    InvalidCapability,
-    /// The one-shot capability was already consumed by another presentation.
-    CapabilityAlreadyConsumed,
-    /// The capability was released and cannot be admitted again.
-    CapabilityReleased,
-    /// The authority exhausted its process-local capability counter.
-    CapabilityExhausted,
-    /// One of the authority-issued resource bindings is not admissible.
-    InvalidBinding,
-}
-
-impl fmt::Display for CredentialSessionError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(match self {
-            Self::InvalidCapability => "credential session capability is invalid",
-            Self::CapabilityAlreadyConsumed => "credential session capability was replayed",
-            Self::CapabilityReleased => "credential session capability was released",
-            Self::CapabilityExhausted => "credential session capability space is exhausted",
-            Self::InvalidBinding => "credential session capability binding is invalid",
-        })
-    }
-}
-
-impl std::error::Error for CredentialSessionError {}
-
-/// Exact Zone, workload, subject, consumer, and generation binding issued for
-/// one Credential session.
-#[derive(Clone, PartialEq, Eq)]
-pub struct CredentialSessionBinding {
-    zone: ZoneId,
-    workload: ResourceRef,
-    subject: ResourceRef,
-    consumer: ResourceRef,
-    generation: ResourceGeneration,
-}
-
-impl CredentialSessionBinding {
-    /// Borrow the exact Zone binding.
-    pub const fn zone(&self) -> &ZoneId {
-        &self.zone
-    }
-
-    /// Borrow the exact workload binding.
-    pub const fn workload(&self) -> &ResourceRef {
-        &self.workload
-    }
-
-    /// Borrow the authenticated subject binding.
-    pub const fn subject(&self) -> &ResourceRef {
-        &self.subject
-    }
-
-    /// Borrow the exact consumer Provider binding.
-    pub const fn consumer(&self) -> &ResourceRef {
-        &self.consumer
-    }
-
-    /// Return the authority-issued session generation.
-    pub const fn generation(&self) -> ResourceGeneration {
-        self.generation
-    }
-}
-
-impl fmt::Debug for CredentialSessionBinding {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("CredentialSessionBinding(<redacted>)")
-    }
-}
-
-#[derive(Clone)]
-struct CredentialSessionRecord {
-    binding: CredentialSessionBinding,
-    consumed_presentation: Option<u64>,
-    active: bool,
-}
-
-struct CredentialSessionAuthorityState {
-    next_capability: AtomicU64,
-    next_presentation: AtomicU64,
-    sessions: Mutex<BTreeMap<u64, CredentialSessionRecord>>,
-}
-
-impl fmt::Debug for CredentialSessionAuthorityState {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("CredentialSessionAuthorityState")
-            .field("sessions", &"<redacted>")
-            .finish()
-    }
-}
-
-/// Authority that mints one-shot, process-local Credential session
-/// capabilities.
-#[derive(Clone)]
-pub struct CredentialSessionAuthority {
-    state: Arc<CredentialSessionAuthorityState>,
-}
-
-impl CredentialSessionAuthority {
-    /// Construct an empty capability authority.
-    pub fn new() -> Self {
-        Self {
-            state: Arc::new(CredentialSessionAuthorityState {
-                next_capability: AtomicU64::new(0),
-                next_presentation: AtomicU64::new(0),
-                sessions: Mutex::new(BTreeMap::new()),
-            }),
-        }
-    }
-
-    /// Issue one exact session capability.
-    pub fn issue(
-        &self,
-        zone: ZoneId,
-        workload: ResourceRef,
-        subject: ResourceRef,
-        consumer: ResourceRef,
-        generation: ResourceGeneration,
-    ) -> Result<CredentialSessionCapability, CredentialSessionError> {
-        if !matches!(workload.resource_type().as_str(), "Host" | "Guest")
-            || subject.resource_type().as_str() != "User"
-            || consumer.resource_type().as_str() != "Provider"
-        {
-            return Err(CredentialSessionError::InvalidBinding);
-        }
-        let capability_id = next_counter(&self.state.next_capability)?;
-        let presentation = next_counter(&self.state.next_presentation)?;
-        let binding = CredentialSessionBinding {
-            zone,
-            workload,
-            subject,
-            consumer,
-            generation,
-        };
-        self.state
-            .sessions
-            .lock()
-            .map_err(|_| CredentialSessionError::InvalidCapability)?
-            .insert(
-                capability_id,
-                CredentialSessionRecord {
-                    binding: binding.clone(),
-                    consumed_presentation: None,
-                    active: true,
-                },
-            );
-        Ok(CredentialSessionCapability {
-            authority: self.clone(),
-            capability_id,
-            presentation,
-            binding,
-        })
-    }
-
-    fn consume(
-        &self,
-        capability: &CredentialSessionCapability,
-    ) -> Result<(), CredentialSessionError> {
-        let mut sessions = self
-            .state
-            .sessions
-            .lock()
-            .map_err(|_| CredentialSessionError::InvalidCapability)?;
-        let record = sessions
-            .get_mut(&capability.capability_id)
-            .ok_or(CredentialSessionError::InvalidCapability)?;
-        if record.binding != capability.binding {
-            return Err(CredentialSessionError::InvalidCapability);
-        }
-        if !record.active {
-            return Err(CredentialSessionError::CapabilityReleased);
-        }
-        if record.consumed_presentation.is_some() {
-            return Err(CredentialSessionError::CapabilityAlreadyConsumed);
-        }
-        record.consumed_presentation = Some(capability.presentation);
-        Ok(())
-    }
-
-    fn release(
-        &self,
-        capability: &CredentialSessionCapability,
-    ) -> Result<(), CredentialSessionError> {
-        let mut sessions = self
-            .state
-            .sessions
-            .lock()
-            .map_err(|_| CredentialSessionError::InvalidCapability)?;
-        let record = sessions
-            .get_mut(&capability.capability_id)
-            .ok_or(CredentialSessionError::InvalidCapability)?;
-        if record.binding != capability.binding {
-            return Err(CredentialSessionError::InvalidCapability);
-        }
-        if record.consumed_presentation != Some(capability.presentation) {
-            return Err(CredentialSessionError::CapabilityAlreadyConsumed);
-        }
-        record.active = false;
-        Ok(())
-    }
-}
-
-impl Default for CredentialSessionAuthority {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl fmt::Debug for CredentialSessionAuthority {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("CredentialSessionAuthority(<redacted>)")
-    }
-}
-
-fn next_counter(counter: &AtomicU64) -> Result<u64, CredentialSessionError> {
-    let mut current = counter.load(Ordering::Relaxed);
-    loop {
-        let next = current
-            .checked_add(1)
-            .ok_or(CredentialSessionError::CapabilityExhausted)?;
-        match counter.compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed) {
-            Ok(_) => return Ok(next),
-            Err(observed) => current = observed,
-        }
-    }
-}
-
-/// Opaque process-local key for one authenticated Credential session.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CredentialSessionKey {
-    authority: usize,
-    capability_id: u64,
-    presentation: u64,
-}
-
-impl fmt::Debug for CredentialSessionKey {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("CredentialSessionKey(<redacted>)")
-    }
-}
-
-impl fmt::Display for CredentialSessionKey {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("CredentialSessionKey(<redacted>)")
-    }
-}
-
-/// One authority-issued, one-shot Credential session capability.
-pub struct CredentialSessionCapability {
-    authority: CredentialSessionAuthority,
-    capability_id: u64,
-    presentation: u64,
-    binding: CredentialSessionBinding,
-}
-
-impl Clone for CredentialSessionCapability {
-    fn clone(&self) -> Self {
-        let presentation = next_counter(&self.authority.state.next_presentation)
-            .expect("Credential session presentation space exhausted");
-        Self {
-            authority: self.authority.clone(),
-            capability_id: self.capability_id,
-            presentation,
-            binding: self.binding.clone(),
-        }
-    }
-}
-
-impl PartialEq for CredentialSessionCapability {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.authority.state, &other.authority.state)
-            && self.capability_id == other.capability_id
-            && self.presentation == other.presentation
-            && self.binding == other.binding
-    }
-}
-
-impl Eq for CredentialSessionCapability {}
-
-impl CredentialSessionCapability {
-    /// Borrow the exact Zone binding.
-    pub const fn zone(&self) -> &ZoneId {
-        self.binding.zone()
-    }
-
-    /// Borrow the exact workload binding.
-    pub const fn workload(&self) -> &ResourceRef {
-        self.binding.workload()
-    }
-
-    /// Borrow the authenticated subject binding.
-    pub const fn subject(&self) -> &ResourceRef {
-        self.binding.subject()
-    }
-
-    /// Borrow the exact consumer Provider binding.
-    pub const fn consumer(&self) -> &ResourceRef {
-        self.binding.consumer()
-    }
-
-    /// Return the authority-issued generation.
-    pub const fn generation(&self) -> ResourceGeneration {
-        self.binding.generation()
-    }
-
-    /// Return the opaque process-local lookup key.
-    pub fn session_key(&self) -> CredentialSessionKey {
-        CredentialSessionKey {
-            authority: Arc::as_ptr(&self.authority.state) as usize,
-            capability_id: self.capability_id,
-            presentation: self.presentation,
-        }
-    }
-
-    /// Consume this capability's one-shot admission claim.
-    pub fn consume(&self) -> Result<(), CredentialSessionError> {
-        self.authority.consume(self)
-    }
-
-    /// Release all authority owned by this exact admitted presentation.
-    pub fn release(&self) -> Result<(), CredentialSessionError> {
-        self.authority.release(self)
-    }
-}
-
-impl fmt::Debug for CredentialSessionCapability {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("CredentialSessionCapability(<redacted>)")
-    }
-}
-
 /// Authorization result derived by the authenticated service adapter.
 ///
 /// For sensitive-output methods this carries the complete delivery binding
 /// constructed during route authorization. The Provider may use it but cannot
 /// replace any of its authority-bearing fields.
-#[derive(Clone, PartialEq, Eq)]
 pub struct CredentialAuthorization {
     delivery_session_params: Option<DeliverySessionParams>,
-    session_capability: Option<Arc<CredentialSessionCapability>>,
+    session_proof: Option<Arc<dyn Any + Send + Sync>>,
+}
+
+impl Clone for CredentialAuthorization {
+    fn clone(&self) -> Self {
+        Self {
+            delivery_session_params: self.delivery_session_params.clone(),
+            session_proof: self.session_proof.clone(),
+        }
+    }
+}
+
+impl PartialEq for CredentialAuthorization {
+    fn eq(&self, other: &Self) -> bool {
+        self.delivery_session_params == other.delivery_session_params
+            && match (&self.session_proof, &other.session_proof) {
+                (None, None) => true,
+                (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+                _ => false,
+            }
+    }
+}
+
+impl Eq for CredentialAuthorization {}
+
+impl fmt::Debug for CredentialAuthorization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CredentialAuthorization(<redacted>)")
+    }
 }
 
 impl CredentialAuthorization {
@@ -950,7 +642,7 @@ impl CredentialAuthorization {
         }
         Ok(Self {
             delivery_session_params,
-            session_capability: None,
+            session_proof: None,
         })
     }
 
@@ -959,30 +651,36 @@ impl CredentialAuthorization {
         self.delivery_session_params.as_ref()
     }
 
-    /// Attach one authority-issued authenticated session capability.
-    pub fn with_session_capability(mut self, capability: CredentialSessionCapability) -> Self {
-        self.session_capability = Some(Arc::new(capability));
+    /// Attach one provider-owned authenticated session proof.
+    ///
+    /// The proof is intentionally erased at this contract boundary. Each
+    /// Provider downcasts it to its own private proof type and authenticates
+    /// that proof against its retained authority.
+    pub fn with_session_proof<T>(mut self, proof: T) -> Self
+    where
+        T: Any + Send + Sync,
+    {
+        self.session_proof = Some(Arc::new(proof));
         self
     }
 
-    /// Attach a shared capability presentation to another method authorization.
-    pub fn with_shared_session_capability(
-        mut self,
-        capability: Arc<CredentialSessionCapability>,
-    ) -> Self {
-        self.session_capability = Some(capability);
+    /// Attach a shared provider-owned session proof to another authorization.
+    pub fn with_shared_session_proof<T>(mut self, proof: Arc<T>) -> Self
+    where
+        T: Any + Send + Sync,
+    {
+        self.session_proof = Some(proof);
         self
     }
 
-    /// Borrow the authenticated session capability, when present.
-    pub fn session_capability(&self) -> Option<&CredentialSessionCapability> {
-        self.session_capability.as_deref()
-    }
-}
-
-impl fmt::Debug for CredentialAuthorization {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("CredentialAuthorization(<redacted>)")
+    /// Borrow a provider-owned session proof of the requested concrete type.
+    pub fn session_proof<T>(&self) -> Option<&T>
+    where
+        T: Any + Send + Sync,
+    {
+        self.session_proof
+            .as_deref()
+            .and_then(|proof| proof.downcast_ref::<T>())
     }
 }
 

--- a/packages/d2b-contracts/src/v3/credential/service.rs
+++ b/packages/d2b-contracts/src/v3/credential/service.rs
@@ -1,14 +1,16 @@
 //! Neutral provider-facing DTO and sensitive-record contracts.
 
 use core::fmt;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use super::{
     AudienceToken, CredentialLeaseHandle, CredentialLeaseState, CredentialSourceVersion,
     OperationClass,
 };
 use crate::v3::component_session::MAX_PROTECTED_PLAINTEXT_BYTES;
-use crate::v3::{ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash};
+use crate::v3::{ResourceGeneration, ResourceRef, ResourceUid, TranscriptHash, ZoneId};
 
 /// Canonical service package routed by the Zone bus.
 pub const CREDENTIAL_SERVICE_NAME: &str = "d2b.credential.v3";
@@ -585,6 +587,341 @@ impl fmt::Debug for CredentialResponse {
     }
 }
 
+/// Stable failure returned while admitting a Credential session capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialSessionError {
+    /// The capability is unknown or its binding was altered.
+    InvalidCapability,
+    /// The one-shot capability was already consumed by another presentation.
+    CapabilityAlreadyConsumed,
+    /// The capability was released and cannot be admitted again.
+    CapabilityReleased,
+    /// The authority exhausted its process-local capability counter.
+    CapabilityExhausted,
+    /// One of the authority-issued resource bindings is not admissible.
+    InvalidBinding,
+}
+
+impl fmt::Display for CredentialSessionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidCapability => "credential session capability is invalid",
+            Self::CapabilityAlreadyConsumed => "credential session capability was replayed",
+            Self::CapabilityReleased => "credential session capability was released",
+            Self::CapabilityExhausted => "credential session capability space is exhausted",
+            Self::InvalidBinding => "credential session capability binding is invalid",
+        })
+    }
+}
+
+impl std::error::Error for CredentialSessionError {}
+
+/// Exact Zone, workload, subject, consumer, and generation binding issued for
+/// one Credential session.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CredentialSessionBinding {
+    zone: ZoneId,
+    workload: ResourceRef,
+    subject: ResourceRef,
+    consumer: ResourceRef,
+    generation: ResourceGeneration,
+}
+
+impl CredentialSessionBinding {
+    /// Borrow the exact Zone binding.
+    pub const fn zone(&self) -> &ZoneId {
+        &self.zone
+    }
+
+    /// Borrow the exact workload binding.
+    pub const fn workload(&self) -> &ResourceRef {
+        &self.workload
+    }
+
+    /// Borrow the authenticated subject binding.
+    pub const fn subject(&self) -> &ResourceRef {
+        &self.subject
+    }
+
+    /// Borrow the exact consumer Provider binding.
+    pub const fn consumer(&self) -> &ResourceRef {
+        &self.consumer
+    }
+
+    /// Return the authority-issued session generation.
+    pub const fn generation(&self) -> ResourceGeneration {
+        self.generation
+    }
+}
+
+impl fmt::Debug for CredentialSessionBinding {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialSessionBinding(<redacted>)")
+    }
+}
+
+#[derive(Clone)]
+struct CredentialSessionRecord {
+    binding: CredentialSessionBinding,
+    consumed_presentation: Option<u64>,
+    active: bool,
+}
+
+struct CredentialSessionAuthorityState {
+    next_capability: AtomicU64,
+    next_presentation: AtomicU64,
+    sessions: Mutex<BTreeMap<u64, CredentialSessionRecord>>,
+}
+
+impl fmt::Debug for CredentialSessionAuthorityState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CredentialSessionAuthorityState")
+            .field("sessions", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Authority that mints one-shot, process-local Credential session
+/// capabilities.
+#[derive(Clone)]
+pub struct CredentialSessionAuthority {
+    state: Arc<CredentialSessionAuthorityState>,
+}
+
+impl CredentialSessionAuthority {
+    /// Construct an empty capability authority.
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(CredentialSessionAuthorityState {
+                next_capability: AtomicU64::new(0),
+                next_presentation: AtomicU64::new(0),
+                sessions: Mutex::new(BTreeMap::new()),
+            }),
+        }
+    }
+
+    /// Issue one exact session capability.
+    pub fn issue(
+        &self,
+        zone: ZoneId,
+        workload: ResourceRef,
+        subject: ResourceRef,
+        consumer: ResourceRef,
+        generation: ResourceGeneration,
+    ) -> Result<CredentialSessionCapability, CredentialSessionError> {
+        if !matches!(workload.resource_type().as_str(), "Host" | "Guest")
+            || subject.resource_type().as_str() != "User"
+            || consumer.resource_type().as_str() != "Provider"
+        {
+            return Err(CredentialSessionError::InvalidBinding);
+        }
+        let capability_id = next_counter(&self.state.next_capability)?;
+        let presentation = next_counter(&self.state.next_presentation)?;
+        let binding = CredentialSessionBinding {
+            zone,
+            workload,
+            subject,
+            consumer,
+            generation,
+        };
+        self.state
+            .sessions
+            .lock()
+            .map_err(|_| CredentialSessionError::InvalidCapability)?
+            .insert(
+                capability_id,
+                CredentialSessionRecord {
+                    binding: binding.clone(),
+                    consumed_presentation: None,
+                    active: true,
+                },
+            );
+        Ok(CredentialSessionCapability {
+            authority: self.clone(),
+            capability_id,
+            presentation,
+            binding,
+        })
+    }
+
+    fn consume(
+        &self,
+        capability: &CredentialSessionCapability,
+    ) -> Result<(), CredentialSessionError> {
+        let mut sessions = self
+            .state
+            .sessions
+            .lock()
+            .map_err(|_| CredentialSessionError::InvalidCapability)?;
+        let record = sessions
+            .get_mut(&capability.capability_id)
+            .ok_or(CredentialSessionError::InvalidCapability)?;
+        if record.binding != capability.binding {
+            return Err(CredentialSessionError::InvalidCapability);
+        }
+        if !record.active {
+            return Err(CredentialSessionError::CapabilityReleased);
+        }
+        if record.consumed_presentation.is_some() {
+            return Err(CredentialSessionError::CapabilityAlreadyConsumed);
+        }
+        record.consumed_presentation = Some(capability.presentation);
+        Ok(())
+    }
+
+    fn release(
+        &self,
+        capability: &CredentialSessionCapability,
+    ) -> Result<(), CredentialSessionError> {
+        let mut sessions = self
+            .state
+            .sessions
+            .lock()
+            .map_err(|_| CredentialSessionError::InvalidCapability)?;
+        let record = sessions
+            .get_mut(&capability.capability_id)
+            .ok_or(CredentialSessionError::InvalidCapability)?;
+        if record.binding != capability.binding {
+            return Err(CredentialSessionError::InvalidCapability);
+        }
+        if record.consumed_presentation != Some(capability.presentation) {
+            return Err(CredentialSessionError::CapabilityAlreadyConsumed);
+        }
+        record.active = false;
+        Ok(())
+    }
+}
+
+impl Default for CredentialSessionAuthority {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for CredentialSessionAuthority {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialSessionAuthority(<redacted>)")
+    }
+}
+
+fn next_counter(counter: &AtomicU64) -> Result<u64, CredentialSessionError> {
+    let mut current = counter.load(Ordering::Relaxed);
+    loop {
+        let next = current
+            .checked_add(1)
+            .ok_or(CredentialSessionError::CapabilityExhausted)?;
+        match counter.compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed) {
+            Ok(_) => return Ok(next),
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+/// Opaque process-local key for one authenticated Credential session.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CredentialSessionKey {
+    authority: usize,
+    capability_id: u64,
+    presentation: u64,
+}
+
+impl fmt::Debug for CredentialSessionKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialSessionKey(<redacted>)")
+    }
+}
+
+impl fmt::Display for CredentialSessionKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialSessionKey(<redacted>)")
+    }
+}
+
+/// One authority-issued, one-shot Credential session capability.
+pub struct CredentialSessionCapability {
+    authority: CredentialSessionAuthority,
+    capability_id: u64,
+    presentation: u64,
+    binding: CredentialSessionBinding,
+}
+
+impl Clone for CredentialSessionCapability {
+    fn clone(&self) -> Self {
+        let presentation = next_counter(&self.authority.state.next_presentation)
+            .expect("Credential session presentation space exhausted");
+        Self {
+            authority: self.authority.clone(),
+            capability_id: self.capability_id,
+            presentation,
+            binding: self.binding.clone(),
+        }
+    }
+}
+
+impl PartialEq for CredentialSessionCapability {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.authority.state, &other.authority.state)
+            && self.capability_id == other.capability_id
+            && self.presentation == other.presentation
+            && self.binding == other.binding
+    }
+}
+
+impl Eq for CredentialSessionCapability {}
+
+impl CredentialSessionCapability {
+    /// Borrow the exact Zone binding.
+    pub const fn zone(&self) -> &ZoneId {
+        self.binding.zone()
+    }
+
+    /// Borrow the exact workload binding.
+    pub const fn workload(&self) -> &ResourceRef {
+        self.binding.workload()
+    }
+
+    /// Borrow the authenticated subject binding.
+    pub const fn subject(&self) -> &ResourceRef {
+        self.binding.subject()
+    }
+
+    /// Borrow the exact consumer Provider binding.
+    pub const fn consumer(&self) -> &ResourceRef {
+        self.binding.consumer()
+    }
+
+    /// Return the authority-issued generation.
+    pub const fn generation(&self) -> ResourceGeneration {
+        self.binding.generation()
+    }
+
+    /// Return the opaque process-local lookup key.
+    pub fn session_key(&self) -> CredentialSessionKey {
+        CredentialSessionKey {
+            authority: Arc::as_ptr(&self.authority.state) as usize,
+            capability_id: self.capability_id,
+            presentation: self.presentation,
+        }
+    }
+
+    /// Consume this capability's one-shot admission claim.
+    pub fn consume(&self) -> Result<(), CredentialSessionError> {
+        self.authority.consume(self)
+    }
+
+    /// Release all authority owned by this exact admitted presentation.
+    pub fn release(&self) -> Result<(), CredentialSessionError> {
+        self.authority.release(self)
+    }
+}
+
+impl fmt::Debug for CredentialSessionCapability {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialSessionCapability(<redacted>)")
+    }
+}
+
 /// Authorization result derived by the authenticated service adapter.
 ///
 /// For sensitive-output methods this carries the complete delivery binding
@@ -593,6 +930,7 @@ impl fmt::Debug for CredentialResponse {
 #[derive(Clone, PartialEq, Eq)]
 pub struct CredentialAuthorization {
     delivery_session_params: Option<DeliverySessionParams>,
+    session_capability: Option<Arc<CredentialSessionCapability>>,
 }
 
 impl CredentialAuthorization {
@@ -612,12 +950,33 @@ impl CredentialAuthorization {
         }
         Ok(Self {
             delivery_session_params,
+            session_capability: None,
         })
     }
 
     /// Borrow the adapter-authorized delivery binding, when the method needs one.
     pub const fn delivery_session_params(&self) -> Option<&DeliverySessionParams> {
         self.delivery_session_params.as_ref()
+    }
+
+    /// Attach one authority-issued authenticated session capability.
+    pub fn with_session_capability(mut self, capability: CredentialSessionCapability) -> Self {
+        self.session_capability = Some(Arc::new(capability));
+        self
+    }
+
+    /// Attach a shared capability presentation to another method authorization.
+    pub fn with_shared_session_capability(
+        mut self,
+        capability: Arc<CredentialSessionCapability>,
+    ) -> Self {
+        self.session_capability = Some(capability);
+        self
+    }
+
+    /// Borrow the authenticated session capability, when present.
+    pub fn session_capability(&self) -> Option<&CredentialSessionCapability> {
+        self.session_capability.as_deref()
     }
 }
 

--- a/packages/d2b-provider-credential-secret-service/README.md
+++ b/packages/d2b-provider-credential-secret-service/README.md
@@ -48,7 +48,9 @@ The `d2b-provider-credential-secret-service` binary hosts the user-domain
 Only `user-agent` is accepted, on a same-Zone `Host` or `Guest` with an exact
 `User` reference. `host-system` and system-domain `guest-agent` fail with
 `credential placement mismatch`. The execution context and user must be Ready
-before acquisition. An optional `consumerRef` must name a Provider.
+before acquisition. An optional `consumerRef` must name a Provider; when it is
+absent, the canonical `Provider/credential-secret-service` reference is used
+and no other Provider is accepted.
 
 ## RBAC requirements
 
@@ -68,10 +70,14 @@ There is no ambient D-Bus or path fallback.
 
 ## State and telemetry
 
-There is no Provider state Volume. Bounded observations live in Credential
-status and the core operation ledger. Audit permits only authorized bounded
-identity digests. Logs, errors, status, OTEL attributes, metric labels, and
-Debug output exclude credential and object-path canaries. The test
+There is no Provider state Volume. Session capabilities are issued by one
+provider-owned, non-Clone authority and are bound to the exact Zone, workload,
+subject, consumer, and Provider generation. Every operation, inspect, and
+disconnect/finalize path uses the same lifecycle gate; finalization drains
+leases and prevents later capability minting. Bounded observations live in
+Credential status and the core operation ledger. Audit permits only authorized
+bounded identity digests. Logs, errors, status, OTEL attributes, metric labels,
+and Debug output exclude credential and object-path canaries. The test
 `process_unique_secret_service_canaries_are_absent_from_every_rendered_surface`
 enforces this.
 

--- a/packages/d2b-provider-credential-secret-service/src/lib.rs
+++ b/packages/d2b-provider-credential-secret-service/src/lib.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread::{self, Thread};
@@ -22,7 +23,6 @@ use std::time::{Duration, Instant};
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState, CredentialMetadata,
     CredentialOutcomeCode, CredentialServiceError, CredentialServiceErrorCode,
-    CredentialSessionAuthority, CredentialSessionCapability, CredentialSessionKey,
     CredentialSourceVersion, PlacementBinding,
 };
 use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ZoneId};
@@ -171,6 +171,8 @@ pub enum SecretServiceProviderError {
     InvalidScope,
     /// The declared consumer is not a Provider reference.
     InvalidConsumer,
+    /// The provider-owned session authority could not allocate an identity.
+    AuthorityUnavailable,
 }
 
 impl fmt::Display for SecretServiceProviderError {
@@ -179,6 +181,7 @@ impl fmt::Display for SecretServiceProviderError {
             Self::InvalidConfig => "credential schema is invalid",
             Self::InvalidPlacement | Self::InvalidScope => "credential placement mismatch",
             Self::InvalidConsumer => "credential consumer mismatch",
+            Self::AuthorityUnavailable => "credential provider unavailable",
         })
     }
 }
@@ -379,47 +382,304 @@ pub trait Oo7SecretServicePort: Send + Sync {
     ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation>;
 }
 
-/// Factory fixed to one user placement and optional exact consumer.
+#[derive(Clone, PartialEq, Eq)]
+struct SessionBinding {
+    zone: ZoneId,
+    workload: ResourceRef,
+    subject: ResourceRef,
+    consumer: ResourceRef,
+    generation: ResourceGeneration,
+}
+
+#[derive(Clone)]
+struct AuthoritySession {
+    binding: SessionBinding,
+    consumed_presentation: Option<u64>,
+}
+
+struct SessionAuthorityState {
+    next_capability: AtomicU64,
+    next_presentation: AtomicU64,
+    sessions: Mutex<BTreeMap<u64, AuthoritySession>>,
+}
+
+#[derive(Clone)]
+struct SessionAuthority {
+    identity: u64,
+    state: Arc<SessionAuthorityState>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionAuthorityError {
+    Invalid,
+    AlreadyConsumed,
+    Released,
+    Exhausted,
+    InvalidBinding,
+}
+
+impl SessionAuthority {
+    fn new() -> Result<Self, SecretServiceProviderError> {
+        let identity = next_counter(&NEXT_AUTHORITY_ID)
+            .map_err(|_| SecretServiceProviderError::AuthorityUnavailable)?;
+        Ok(Self {
+            identity,
+            state: Arc::new(SessionAuthorityState {
+                next_capability: AtomicU64::new(0),
+                next_presentation: AtomicU64::new(0),
+                sessions: Mutex::new(BTreeMap::new()),
+            }),
+        })
+    }
+
+    fn issue(
+        &self,
+        binding: SessionBinding,
+    ) -> Result<SecretServiceSessionCapability, SessionAuthorityError> {
+        if !matches!(binding.workload.resource_type().as_str(), "Host" | "Guest")
+            || binding.subject.resource_type().as_str() != "User"
+            || binding.consumer.resource_type().as_str() != "Provider"
+        {
+            return Err(SessionAuthorityError::InvalidBinding);
+        }
+        let capability_id = next_counter(&self.state.next_capability)
+            .map_err(|_| SessionAuthorityError::Exhausted)?;
+        let presentation = next_counter(&self.state.next_presentation)
+            .map_err(|_| SessionAuthorityError::Exhausted)?;
+        self.state
+            .sessions
+            .lock()
+            .map_err(|_| SessionAuthorityError::Invalid)?
+            .insert(
+                capability_id,
+                AuthoritySession {
+                    binding: binding.clone(),
+                    consumed_presentation: None,
+                },
+            );
+        Ok(SecretServiceSessionCapability {
+            authority: self.clone(),
+            capability_id,
+            presentation,
+            binding,
+        })
+    }
+
+    fn consume(
+        &self,
+        capability: &SecretServiceSessionCapability,
+    ) -> Result<(), SessionAuthorityError> {
+        if capability.authority.identity != self.identity {
+            return Err(SessionAuthorityError::Invalid);
+        }
+        let mut sessions = self
+            .state
+            .sessions
+            .lock()
+            .map_err(|_| SessionAuthorityError::Invalid)?;
+        let record = sessions
+            .get_mut(&capability.capability_id)
+            .ok_or(SessionAuthorityError::Released)?;
+        if record.binding != capability.binding {
+            return Err(SessionAuthorityError::Invalid);
+        }
+        if record.consumed_presentation.is_some() {
+            return Err(SessionAuthorityError::AlreadyConsumed);
+        }
+        record.consumed_presentation = Some(capability.presentation);
+        Ok(())
+    }
+
+    fn release_key(&self, key: SessionKey) -> Result<(), SessionAuthorityError> {
+        if key.authority != self.identity {
+            return Err(SessionAuthorityError::Invalid);
+        }
+        let mut sessions = self
+            .state
+            .sessions
+            .lock()
+            .map_err(|_| SessionAuthorityError::Invalid)?;
+        let record = sessions
+            .get(&key.capability_id)
+            .ok_or(SessionAuthorityError::Released)?;
+        if record.consumed_presentation != Some(key.presentation) {
+            return Err(SessionAuthorityError::Invalid);
+        }
+        sessions.remove(&key.capability_id);
+        Ok(())
+    }
+
+    fn discard_unconsumed(&self, capability: &SecretServiceSessionCapability) {
+        if capability.authority.identity != self.identity {
+            return;
+        }
+        if let Ok(mut sessions) = self.state.sessions.lock()
+            && sessions
+                .get(&capability.capability_id)
+                .is_some_and(|record| record.consumed_presentation.is_none())
+        {
+            sessions.remove(&capability.capability_id);
+        }
+    }
+
+    fn clear(&self) -> Result<(), SessionAuthorityError> {
+        self.state
+            .sessions
+            .lock()
+            .map_err(|_| SessionAuthorityError::Invalid)?
+            .clear();
+        Ok(())
+    }
+
+    fn discard_key(&self, key: SessionKey) -> Result<(), SessionAuthorityError> {
+        if key.authority != self.identity {
+            return Err(SessionAuthorityError::Invalid);
+        }
+        let mut sessions = self
+            .state
+            .sessions
+            .lock()
+            .map_err(|_| SessionAuthorityError::Invalid)?;
+        let Some(record) = sessions.get(&key.capability_id) else {
+            return Ok(());
+        };
+        if record.consumed_presentation.is_some() {
+            return Err(SessionAuthorityError::Invalid);
+        }
+        sessions.remove(&key.capability_id);
+        Ok(())
+    }
+}
+
+static NEXT_AUTHORITY_ID: AtomicU64 = AtomicU64::new(0);
+
+fn next_counter(counter: &AtomicU64) -> Result<u64, SessionAuthorityError> {
+    let mut current = counter.load(Ordering::Relaxed);
+    loop {
+        let next = current
+            .checked_add(1)
+            .ok_or(SessionAuthorityError::Exhausted)?;
+        match counter.compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed) {
+            Ok(_) => return Ok(next),
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SessionKey {
+    authority: u64,
+    capability_id: u64,
+    presentation: u64,
+}
+
+impl fmt::Debug for SessionKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SessionKey(<redacted>)")
+    }
+}
+
+/// Provider-owned, non-Clone session capability.
+///
+/// The capability has no public constructor. It is issued only by the
+/// provider that retains its authority, and the provider authenticates the
+/// authority identity before admitting it.
+///
+/// ```compile_fail
+/// # use d2b_provider_credential_secret_service::SecretServiceSessionCapability;
+/// fn cannot_clone(capability: SecretServiceSessionCapability) {
+///     let _ = capability.clone();
+/// }
+/// ```
+pub struct SecretServiceSessionCapability {
+    authority: SessionAuthority,
+    capability_id: u64,
+    presentation: u64,
+    binding: SessionBinding,
+}
+
+impl SecretServiceSessionCapability {
+    fn session_key(&self) -> SessionKey {
+        SessionKey {
+            authority: self.authority.identity,
+            capability_id: self.capability_id,
+            presentation: self.presentation,
+        }
+    }
+
+    fn binding(&self) -> &SessionBinding {
+        &self.binding
+    }
+}
+
+impl Drop for SecretServiceSessionCapability {
+    fn drop(&mut self) {
+        self.authority.discard_unconsumed(self);
+    }
+}
+
+impl fmt::Debug for SecretServiceSessionCapability {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SecretServiceSessionCapability(<redacted>)")
+    }
+}
+
+/// Factory fixed to one user placement and exact consumer.
 pub struct SecretServiceCredentialProviderFactory {
     config: SecretServiceConfig,
     placement: SecretServicePlacement,
-    consumer_ref: Option<ResourceRef>,
+    consumer_ref: ResourceRef,
+    generation: ResourceGeneration,
     port: Arc<dyn Oo7SecretServicePort>,
 }
 
 impl SecretServiceCredentialProviderFactory {
-    /// Build a factory. A present consumer must be a Provider reference.
+    /// Build a factory. A present consumer must be a Provider reference;
+    /// absence selects this Provider's canonical reference.
     pub fn new(
         config: SecretServiceConfig,
         placement: SecretServicePlacement,
         consumer_ref: Option<ResourceRef>,
         port: Arc<dyn Oo7SecretServicePort>,
     ) -> Result<Self, SecretServiceProviderError> {
-        if consumer_ref
-            .as_ref()
-            .is_some_and(|reference| reference.resource_type().as_str() != "Provider")
-        {
+        let consumer_ref = match consumer_ref {
+            Some(reference) => reference,
+            None => ResourceRef::parse(PROVIDER_REF)
+                .map_err(|_| SecretServiceProviderError::InvalidConsumer)?,
+        };
+        if consumer_ref.resource_type().as_str() != "Provider" {
             return Err(SecretServiceProviderError::InvalidConsumer);
         }
         Ok(Self {
             config,
             placement,
             consumer_ref,
+            generation: ResourceGeneration::new(1)
+                .map_err(|_| SecretServiceProviderError::InvalidScope)?,
             port,
         })
     }
 
+    /// Pin the authority-issued session generation for this Provider.
+    pub fn with_generation(mut self, generation: ResourceGeneration) -> Self {
+        self.generation = generation;
+        self
+    }
+
     /// Construct the service Provider.
-    pub fn construct(self) -> SecretServiceCredentialProvider {
-        SecretServiceCredentialProvider {
+    pub fn construct(self) -> Result<SecretServiceCredentialProvider, SecretServiceProviderError> {
+        Ok(SecretServiceCredentialProvider {
             config: self.config,
             placement: self.placement,
             consumer_ref: self.consumer_ref,
+            generation: self.generation,
             port: self.port,
+            authority: SessionAuthority::new()?,
             sessions: Mutex::new(BTreeMap::new()),
             leases: Mutex::new(BTreeMap::new()),
             mutation_gate: Mutex::new(()),
-        }
+            finalized: AtomicBool::new(false),
+        })
     }
 }
 
@@ -439,11 +699,14 @@ struct LeaseRecord {
 pub struct SecretServiceCredentialProvider {
     config: SecretServiceConfig,
     placement: SecretServicePlacement,
-    consumer_ref: Option<ResourceRef>,
+    consumer_ref: ResourceRef,
+    generation: ResourceGeneration,
     port: Arc<dyn Oo7SecretServicePort>,
-    sessions: Mutex<BTreeMap<CredentialSessionKey, ()>>,
-    leases: Mutex<BTreeMap<(CredentialSessionKey, String), LeaseRecord>>,
+    authority: SessionAuthority,
+    sessions: Mutex<BTreeMap<SessionKey, ()>>,
+    leases: Mutex<BTreeMap<(SessionKey, String), LeaseRecord>>,
     mutation_gate: Mutex<()>,
+    finalized: AtomicBool,
 }
 
 impl SecretServiceCredentialProvider {
@@ -452,9 +715,9 @@ impl SecretServiceCredentialProvider {
         SecretServiceOwner::Userd
     }
 
-    /// Borrow the optional exact consumer expected by authenticated admission.
-    pub const fn consumer_ref(&self) -> Option<&ResourceRef> {
-        self.consumer_ref.as_ref()
+    /// Borrow the exact consumer expected by authenticated admission.
+    pub const fn consumer_ref(&self) -> &ResourceRef {
+        &self.consumer_ref
     }
 
     /// Borrow the fixed placement.
@@ -472,42 +735,34 @@ impl SecretServiceCredentialProvider {
     pub fn issue_session_capability(
         &self,
         generation: ResourceGeneration,
-    ) -> Result<CredentialSessionCapability, SecretServiceProviderError> {
-        let consumer = self.consumer_ref.clone().unwrap_or_else(|| {
-            ResourceRef::parse(PROVIDER_REF)
-                .expect("the canonical Provider reference is a validated constant")
-        });
-        CredentialSessionAuthority::new()
-            .issue(
-                self.placement.zone().clone(),
-                self.placement.execution_ref().clone(),
-                self.placement.user_ref().clone(),
-                consumer,
+    ) -> Result<SecretServiceSessionCapability, SecretServiceProviderError> {
+        let _lifecycle = self
+            .blocking_mutation_guard()
+            .map_err(|_| SecretServiceProviderError::AuthorityUnavailable)?;
+        if self.finalized.load(Ordering::Acquire) || generation != self.generation {
+            return Err(SecretServiceProviderError::InvalidScope);
+        }
+        self.authority
+            .issue(SessionBinding {
+                zone: self.placement.zone().clone(),
+                workload: self.placement.execution_ref().clone(),
+                subject: self.placement.user_ref().clone(),
+                consumer: self.consumer_ref.clone(),
                 generation,
-            )
-            .map_err(|_| SecretServiceProviderError::InvalidScope)
+            })
+            .map_err(|_| SecretServiceProviderError::AuthorityUnavailable)
     }
 
-    pub(crate) fn authorize_session(
+    pub(crate) fn authorize_session_locked(
         &self,
         authorization: &CredentialAuthorization,
-    ) -> Result<CredentialSessionKey, CredentialServiceError> {
-        let capability = authorization.session_capability().ok_or_else(|| {
-            CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
-        })?;
-        if capability.zone() != self.placement.zone()
-            || capability.workload() != self.placement.execution_ref()
-            || capability.subject() != self.placement.user_ref()
-            || self
-                .consumer_ref
-                .as_ref()
-                .is_some_and(|expected| capability.consumer() != expected)
-            || capability.consumer().resource_type().as_str() != "Provider"
-        {
+    ) -> Result<SessionKey, CredentialServiceError> {
+        if self.finalized.load(Ordering::Acquire) {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::OperationDenied,
             ));
         }
+        let capability = self.session_capability(authorization)?;
         let key = capability.session_key();
         let mut sessions = self.sessions.lock().map_err(|_| {
             CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
@@ -515,11 +770,34 @@ impl SecretServiceCredentialProvider {
         if sessions.contains_key(&key) {
             return Ok(key);
         }
-        capability.consume().map_err(|_| {
+        self.authority.consume(capability).map_err(|_| {
             CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
         })?;
         sessions.insert(key, ());
         Ok(key)
+    }
+
+    pub(crate) fn session_capability<'a>(
+        &self,
+        authorization: &'a CredentialAuthorization,
+    ) -> Result<&'a SecretServiceSessionCapability, CredentialServiceError> {
+        let capability = authorization
+            .session_proof::<SecretServiceSessionCapability>()
+            .ok_or_else(|| {
+                CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
+            })?;
+        if capability.authority.identity != self.authority.identity
+            || &capability.binding().zone != self.placement.zone()
+            || &capability.binding().workload != self.placement.execution_ref()
+            || &capability.binding().subject != self.placement.user_ref()
+            || capability.binding().consumer != self.consumer_ref
+            || capability.binding().generation != self.generation
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::OperationDenied,
+            ));
+        }
+        Ok(capability)
     }
 
     pub(crate) fn map_port_error(error: SecretServicePortError) -> CredentialServiceError {
@@ -549,6 +827,32 @@ impl SecretServiceCredentialProvider {
                 CredentialServiceErrorCode::InvariantFailure,
             )),
         }
+    }
+
+    pub(crate) fn blocking_mutation_guard(
+        &self,
+    ) -> Result<MutexGuard<'_, ()>, CredentialServiceError> {
+        self.mutation_gate
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))
+    }
+
+    pub(crate) fn release_session_key(
+        &self,
+        key: SessionKey,
+    ) -> Result<(), CredentialServiceError> {
+        self.authority
+            .release_key(key)
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))
+    }
+
+    pub(crate) fn discard_session_key(
+        &self,
+        key: SessionKey,
+    ) -> Result<(), CredentialServiceError> {
+        self.authority
+            .discard_key(key)
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))
     }
 
     pub(crate) fn operation_deadline(deadline_ms: u64) -> Result<Instant, CredentialServiceError> {
@@ -630,6 +934,9 @@ impl fmt::Debug for SecretServiceCredentialProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use d2b_contracts::v3::credential::CredentialMethod;
+    use std::sync::Arc;
+    use std::thread;
 
     #[test]
     fn collection_alias_accepts_spaces_and_rejects_unsafe_text() {
@@ -669,5 +976,93 @@ mod tests {
         let config = SecretServiceConfig::new(&marker, 64, LockPolicy::FailClosed).unwrap();
         assert!(!format!("{config:?}").contains(&marker));
         assert_eq!(config.collection_alias(), marker);
+    }
+
+    #[test]
+    fn same_presentation_concurrent_first_admission_is_idempotent() {
+        struct NoopPort;
+
+        impl Oo7SecretServicePort for NoopPort {
+            fn state(&self) -> SecretServiceFuture<'_, SecretServiceState> {
+                Box::pin(async { Ok(SecretServiceState::Unlocked) })
+            }
+
+            fn issue_lease(
+                &self,
+                _request: &SecretServiceLeaseRequest,
+            ) -> SecretServiceFuture<'_, SecretServiceLeaseGrant> {
+                Box::pin(async { Err(SecretServicePortError::Unavailable) })
+            }
+
+            fn inspect_lease(
+                &self,
+                _lease: &SecretServiceLeaseRef,
+            ) -> SecretServiceFuture<'_, SecretServiceLeaseInspection> {
+                Box::pin(async { Err(SecretServicePortError::Unavailable) })
+            }
+
+            fn refresh_lease(
+                &self,
+                _lease: &SecretServiceLeaseRef,
+            ) -> SecretServiceFuture<'_, SecretServiceLeaseRenewal> {
+                Box::pin(async { Err(SecretServicePortError::Unavailable) })
+            }
+
+            fn revoke_lease(
+                &self,
+                _lease: &SecretServiceLeaseRef,
+            ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
+                Box::pin(async { Err(SecretServicePortError::Unavailable) })
+            }
+        }
+
+        let provider = SecretServiceCredentialProviderFactory::new(
+            SecretServiceConfig::new("login", 8, LockPolicy::FailClosed).unwrap(),
+            SecretServicePlacement::new(
+                ZoneId::parse("user-zone").unwrap(),
+                PlacementBinding::UserAgent,
+                ResourceRef::parse("Host/workstation").unwrap(),
+                ResourceRef::parse("User/alice").unwrap(),
+            )
+            .unwrap(),
+            None,
+            Arc::new(NoopPort),
+        )
+        .unwrap()
+        .construct()
+        .unwrap();
+        let capability = Arc::new(
+            provider
+                .issue_session_capability(ResourceGeneration::new(1).unwrap())
+                .unwrap(),
+        );
+        let authorization = Arc::new(
+            CredentialAuthorization::new(CredentialMethod::InspectMetadata, None)
+                .unwrap()
+                .with_shared_session_proof(capability),
+        );
+        let provider = Arc::new(provider);
+        let first = {
+            let provider = provider.clone();
+            let authorization = authorization.clone();
+            thread::spawn(move || provider.authorize_session_locked(&authorization))
+        };
+        let second = {
+            let provider = provider.clone();
+            let authorization = authorization.clone();
+            thread::spawn(move || provider.authorize_session_locked(&authorization))
+        };
+        let first = first.join().unwrap().unwrap();
+        let second = second.join().unwrap().unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn counter_exhaustion_is_fallible() {
+        let counter = AtomicU64::new(u64::MAX);
+        assert_eq!(
+            next_counter(&counter),
+            Err(SessionAuthorityError::Exhausted)
+        );
     }
 }

--- a/packages/d2b-provider-credential-secret-service/src/lib.rs
+++ b/packages/d2b-provider-credential-secret-service/src/lib.rs
@@ -19,11 +19,13 @@ use std::task::{Context, Poll, Wake, Waker};
 use std::thread::{self, Thread};
 use std::time::{Duration, Instant};
 
-use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
-    CredentialLeaseHandle, CredentialLeaseState, CredentialMetadata, CredentialOutcomeCode,
-    CredentialServiceError, CredentialServiceErrorCode, CredentialSourceVersion, PlacementBinding,
+    CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState, CredentialMetadata,
+    CredentialOutcomeCode, CredentialServiceError, CredentialServiceErrorCode,
+    CredentialSessionAuthority, CredentialSessionCapability, CredentialSessionKey,
+    CredentialSourceVersion, PlacementBinding,
 };
+use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ZoneId};
 
 pub use controller::{
     SecretServiceController, SecretServiceControllerHealth, SecretServiceStatusProjection,
@@ -70,6 +72,8 @@ pub enum SecretServiceState {
 pub enum SecretServicePortError {
     /// The backing collection is locked.
     Locked,
+    /// The requested secret is absent from the backing collection.
+    Missing,
     /// Backing policy denied the operation.
     Denied,
     /// The backing service is unavailable.
@@ -85,7 +89,7 @@ pub enum SecretServicePortError {
 impl fmt::Display for SecretServicePortError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
-            Self::Locked | Self::Unavailable => "credential-provider-unavailable",
+            Self::Locked | Self::Missing | Self::Unavailable => "credential-provider-unavailable",
             Self::Denied => "credential-operation-denied",
             Self::LeaseExpired => "credential-lease-expired",
             Self::LeaseRevoked => "credential-lease-revoked",
@@ -184,6 +188,7 @@ impl std::error::Error for SecretServiceProviderError {}
 /// User-domain placement fixed by the Provider factory.
 #[derive(Clone, PartialEq, Eq)]
 pub struct SecretServicePlacement {
+    zone: ZoneId,
     execution_ref: ResourceRef,
     user_ref: ResourceRef,
 }
@@ -191,6 +196,7 @@ pub struct SecretServicePlacement {
 impl SecretServicePlacement {
     /// Validate user-agent placement on a Host or Guest execution context.
     pub fn new(
+        zone: ZoneId,
         binding: PlacementBinding,
         execution_ref: ResourceRef,
         user_ref: ResourceRef,
@@ -204,9 +210,15 @@ impl SecretServicePlacement {
             return Err(SecretServiceProviderError::InvalidScope);
         }
         Ok(Self {
+            zone,
             execution_ref,
             user_ref,
         })
+    }
+
+    /// Borrow the fixed Zone binding.
+    pub const fn zone(&self) -> &ZoneId {
+        &self.zone
     }
 
     /// Borrow the fixed execution context.
@@ -404,6 +416,7 @@ impl SecretServiceCredentialProviderFactory {
             placement: self.placement,
             consumer_ref: self.consumer_ref,
             port: self.port,
+            sessions: Mutex::new(BTreeMap::new()),
             leases: Mutex::new(BTreeMap::new()),
             mutation_gate: Mutex::new(()),
         }
@@ -428,7 +441,8 @@ pub struct SecretServiceCredentialProvider {
     placement: SecretServicePlacement,
     consumer_ref: Option<ResourceRef>,
     port: Arc<dyn Oo7SecretServicePort>,
-    leases: Mutex<BTreeMap<String, LeaseRecord>>,
+    sessions: Mutex<BTreeMap<CredentialSessionKey, ()>>,
+    leases: Mutex<BTreeMap<(CredentialSessionKey, String), LeaseRecord>>,
     mutation_gate: Mutex<()>,
 }
 
@@ -453,9 +467,66 @@ impl SecretServiceCredentialProvider {
         &self.config
     }
 
+    /// Issue one authority-backed capability for this exact placement and
+    /// configured consumer.
+    pub fn issue_session_capability(
+        &self,
+        generation: ResourceGeneration,
+    ) -> Result<CredentialSessionCapability, SecretServiceProviderError> {
+        let consumer = self.consumer_ref.clone().unwrap_or_else(|| {
+            ResourceRef::parse(PROVIDER_REF)
+                .expect("the canonical Provider reference is a validated constant")
+        });
+        CredentialSessionAuthority::new()
+            .issue(
+                self.placement.zone().clone(),
+                self.placement.execution_ref().clone(),
+                self.placement.user_ref().clone(),
+                consumer,
+                generation,
+            )
+            .map_err(|_| SecretServiceProviderError::InvalidScope)
+    }
+
+    pub(crate) fn authorize_session(
+        &self,
+        authorization: &CredentialAuthorization,
+    ) -> Result<CredentialSessionKey, CredentialServiceError> {
+        let capability = authorization.session_capability().ok_or_else(|| {
+            CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
+        })?;
+        if capability.zone() != self.placement.zone()
+            || capability.workload() != self.placement.execution_ref()
+            || capability.subject() != self.placement.user_ref()
+            || self
+                .consumer_ref
+                .as_ref()
+                .is_some_and(|expected| capability.consumer() != expected)
+            || capability.consumer().resource_type().as_str() != "Provider"
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::OperationDenied,
+            ));
+        }
+        let key = capability.session_key();
+        let mut sessions = self.sessions.lock().map_err(|_| {
+            CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+        })?;
+        if sessions.contains_key(&key) {
+            return Ok(key);
+        }
+        capability.consume().map_err(|_| {
+            CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
+        })?;
+        sessions.insert(key, ());
+        Ok(key)
+    }
+
     pub(crate) fn map_port_error(error: SecretServicePortError) -> CredentialServiceError {
         let code = match error {
-            SecretServicePortError::Locked | SecretServicePortError::Unavailable => {
+            SecretServicePortError::Locked
+            | SecretServicePortError::Missing
+            | SecretServicePortError::Unavailable => {
                 CredentialServiceErrorCode::ProviderUnavailable
             }
             SecretServicePortError::Denied => CredentialServiceErrorCode::OperationDenied,
@@ -573,11 +644,21 @@ mod tests {
         let host = ResourceRef::parse("Host/workstation").unwrap();
         let user = ResourceRef::parse("User/alice").unwrap();
         assert!(
-            SecretServicePlacement::new(PlacementBinding::UserAgent, host.clone(), user.clone())
-                .is_ok()
+            SecretServicePlacement::new(
+                ZoneId::parse("user-zone").unwrap(),
+                PlacementBinding::UserAgent,
+                host.clone(),
+                user.clone(),
+            )
+            .is_ok()
         );
         assert_eq!(
-            SecretServicePlacement::new(PlacementBinding::HostSystem, host, user),
+            SecretServicePlacement::new(
+                ZoneId::parse("user-zone").unwrap(),
+                PlacementBinding::HostSystem,
+                host,
+                user,
+            ),
             Err(SecretServiceProviderError::InvalidPlacement)
         );
     }

--- a/packages/d2b-provider-credential-secret-service/src/service.rs
+++ b/packages/d2b-provider-credential-secret-service/src/service.rs
@@ -3,7 +3,7 @@
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
     CredentialProvider, CredentialRequest, CredentialResponse, CredentialServiceError,
-    CredentialServiceErrorCode, DeliveryResponse, MetadataResponse,
+    CredentialServiceErrorCode, CredentialSessionKey, DeliveryResponse, MetadataResponse,
 };
 
 use crate::{
@@ -17,11 +17,12 @@ impl CredentialProvider for SecretServiceCredentialProvider {
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
     ) -> Result<CredentialResponse, CredentialServiceError> {
+        let session_key = self.authorize_session(authorization)?;
         match method {
-            CredentialMethod::AcquireToken => self.acquire(request, authorization),
-            CredentialMethod::RefreshToken => self.refresh(request, authorization),
-            CredentialMethod::RevokeToken => self.revoke(request),
-            CredentialMethod::InspectMetadata => self.inspect(request),
+            CredentialMethod::AcquireToken => self.acquire(request, authorization, session_key),
+            CredentialMethod::RefreshToken => self.refresh(request, authorization, session_key),
+            CredentialMethod::RevokeToken => self.revoke(request, session_key),
+            CredentialMethod::InspectMetadata => self.inspect(request, session_key),
             CredentialMethod::SignChallenge => Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::Malformed,
             )),
@@ -34,6 +35,7 @@ impl SecretServiceCredentialProvider {
         &self,
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
+        session_key: CredentialSessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let delivery = authorization
             .delivery_session_params()
@@ -42,10 +44,11 @@ impl SecretServiceCredentialProvider {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
+        let lease_key = (session_key, key.clone());
         {
             let mut leases = self.leases.lock().map_err(|_| invariant())?;
             leases.retain(|_, record| record.metadata.state == CredentialLeaseState::Active);
-            if let Some(existing) = leases.get(&key)
+            if let Some(existing) = leases.get(&lease_key)
                 && existing.idempotency_key == request.idempotency_key()
             {
                 return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
@@ -68,7 +71,7 @@ impl SecretServiceCredentialProvider {
         let grant = Self::poll_port(self.port.issue_lease(&port_request), deadline)?;
         let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
         self.leases.lock().map_err(|_| invariant())?.insert(
-            key,
+            lease_key,
             LeaseRecord {
                 idempotency_key: request.idempotency_key().to_owned(),
                 metadata: metadata.clone(),
@@ -84,6 +87,7 @@ impl SecretServiceCredentialProvider {
         &self,
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
+        session_key: CredentialSessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let delivery = authorization
             .delivery_session_params()
@@ -92,11 +96,12 @@ impl SecretServiceCredentialProvider {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
+        let lease_key = (session_key, key);
         let current = self
             .leases
             .lock()
             .map_err(|_| invariant())?
-            .get(&key)
+            .get(&lease_key)
             .cloned()
             .ok_or_else(expired)?;
         if current.metadata.state != CredentialLeaseState::Active {
@@ -115,7 +120,7 @@ impl SecretServiceCredentialProvider {
         let grant = Self::poll_port(self.port.refresh_lease(&lease), deadline)?;
         let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
         self.leases.lock().map_err(|_| invariant())?.insert(
-            key,
+            lease_key,
             LeaseRecord {
                 idempotency_key: request.idempotency_key().to_owned(),
                 metadata: metadata.clone(),
@@ -130,12 +135,14 @@ impl SecretServiceCredentialProvider {
     fn revoke(
         &self,
         request: &CredentialRequest,
+        session_key: CredentialSessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
+        let lease_key = (session_key, key);
         let mut leases = self.leases.lock().map_err(|_| invariant())?;
-        let record = leases.get_mut(&key).ok_or_else(expired)?;
+        let record = leases.get_mut(&lease_key).ok_or_else(expired)?;
         let outcome = if record.metadata.state == CredentialLeaseState::Revoked {
             CredentialOutcomeCode::AlreadyRevoked
         } else {
@@ -161,14 +168,16 @@ impl SecretServiceCredentialProvider {
     fn inspect(
         &self,
         request: &CredentialRequest,
+        session_key: CredentialSessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let key = request.credential_ref().to_canonical_string();
+        let lease_key = (session_key, key);
         let record = self
             .leases
             .lock()
             .map_err(|_| invariant())?
-            .get(&key)
+            .get(&lease_key)
             .cloned()
             .ok_or_else(expired)?;
         let lease = SecretServiceLeaseRef {
@@ -184,6 +193,64 @@ impl SecretServiceCredentialProvider {
         Ok(CredentialResponse::InspectMetadata(MetadataResponse {
             metadata,
         }))
+    }
+
+    /// Revoke every active lease owned by one admitted session and release its
+    /// capability authority.
+    pub fn disconnect(
+        &self,
+        authorization: &CredentialAuthorization,
+    ) -> Result<(), CredentialServiceError> {
+        let session_key = self.authorize_session(authorization)?;
+        let _mutation = self.mutation_guard()?;
+        let deadline = Self::operation_deadline(1_000)?;
+        let records = self
+            .leases
+            .lock()
+            .map_err(|_| invariant())?
+            .iter()
+            .filter(|((key, _), record)| {
+                *key == session_key && record.metadata.state == CredentialLeaseState::Active
+            })
+            .map(|((_, credential), record)| (credential.clone(), record.clone()))
+            .collect::<Vec<_>>();
+
+        for (credential, record) in records {
+            let lease = SecretServiceLeaseRef {
+                credential_ref: d2b_contracts::v3::ResourceRef::parse(&credential)
+                    .map_err(|_| invariant())?,
+                metadata: record.metadata,
+            };
+            Self::poll_port(self.port.revoke_lease(&lease), deadline)?;
+        }
+
+        let mut leases = self.leases.lock().map_err(|_| invariant())?;
+        for ((key, _), record) in leases.iter_mut() {
+            if *key == session_key && record.metadata.state == CredentialLeaseState::Active {
+                record.metadata.state = CredentialLeaseState::Revoked;
+                record.metadata.outcome = CredentialOutcomeCode::Revoked;
+            }
+        }
+        drop(leases);
+
+        let capability = authorization.session_capability().ok_or_else(|| {
+            CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
+        })?;
+        capability.release().map_err(|_| invariant())?;
+        self.sessions
+            .lock()
+            .map_err(|_| invariant())?
+            .remove(&session_key);
+        Ok(())
+    }
+
+    /// Finalize one admitted session using the same revocation semantics as a
+    /// transport disconnect.
+    pub fn finalize_session(
+        &self,
+        authorization: &CredentialAuthorization,
+    ) -> Result<(), CredentialServiceError> {
+        self.disconnect(authorization)
     }
 }
 

--- a/packages/d2b-provider-credential-secret-service/src/service.rs
+++ b/packages/d2b-provider-credential-secret-service/src/service.rs
@@ -3,11 +3,12 @@
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
     CredentialProvider, CredentialRequest, CredentialResponse, CredentialServiceError,
-    CredentialServiceErrorCode, CredentialSessionKey, DeliveryResponse, MetadataResponse,
+    CredentialServiceErrorCode, DeliveryResponse, MetadataResponse,
 };
 
 use crate::{
     LeaseRecord, SecretServiceCredentialProvider, SecretServiceLeaseRef, SecretServiceLeaseRequest,
+    SessionKey,
 };
 
 impl CredentialProvider for SecretServiceCredentialProvider {
@@ -17,7 +18,8 @@ impl CredentialProvider for SecretServiceCredentialProvider {
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
     ) -> Result<CredentialResponse, CredentialServiceError> {
-        let session_key = self.authorize_session(authorization)?;
+        let _lifecycle = self.mutation_guard()?;
+        let session_key = self.authorize_session_locked(authorization)?;
         match method {
             CredentialMethod::AcquireToken => self.acquire(request, authorization, session_key),
             CredentialMethod::RefreshToken => self.refresh(request, authorization, session_key),
@@ -35,14 +37,13 @@ impl SecretServiceCredentialProvider {
         &self,
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
-        session_key: CredentialSessionKey,
+        session_key: SessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let delivery = authorization
             .delivery_session_params()
             .cloned()
             .ok_or_else(invariant)?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
-        let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
         let lease_key = (session_key, key.clone());
         {
@@ -87,14 +88,13 @@ impl SecretServiceCredentialProvider {
         &self,
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
-        session_key: CredentialSessionKey,
+        session_key: SessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let delivery = authorization
             .delivery_session_params()
             .cloned()
             .ok_or_else(invariant)?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
-        let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
         let lease_key = (session_key, key);
         let current = self
@@ -135,10 +135,9 @@ impl SecretServiceCredentialProvider {
     fn revoke(
         &self,
         request: &CredentialRequest,
-        session_key: CredentialSessionKey,
+        session_key: SessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
-        let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
         let lease_key = (session_key, key);
         let mut leases = self.leases.lock().map_err(|_| invariant())?;
@@ -168,7 +167,7 @@ impl SecretServiceCredentialProvider {
     fn inspect(
         &self,
         request: &CredentialRequest,
-        session_key: CredentialSessionKey,
+        session_key: SessionKey,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let key = request.credential_ref().to_canonical_string();
@@ -201,9 +200,78 @@ impl SecretServiceCredentialProvider {
         &self,
         authorization: &CredentialAuthorization,
     ) -> Result<(), CredentialServiceError> {
-        let session_key = self.authorize_session(authorization)?;
-        let _mutation = self.mutation_guard()?;
+        let _mutation = self.blocking_mutation_guard()?;
+        let session_key = self.session_capability(authorization)?.session_key();
+        if !self
+            .sessions
+            .lock()
+            .map_err(|_| invariant())?
+            .contains_key(&session_key)
+        {
+            self.discard_session_key(session_key)?;
+            return Ok(());
+        }
         let deadline = Self::operation_deadline(1_000)?;
+        self.close_session_locked(session_key, deadline)
+    }
+
+    /// Finalize one admitted session using the same revocation semantics as a
+    /// transport disconnect, then prevent further capability minting.
+    pub fn finalize_session(
+        &self,
+        authorization: &CredentialAuthorization,
+    ) -> Result<(), CredentialServiceError> {
+        let _mutation = self.blocking_mutation_guard()?;
+        self.session_capability(authorization)?;
+        self.finalized
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.close_all_sessions_locked(Self::operation_deadline(1_000)?)?;
+        self.authority.clear().map_err(|_| invariant())?;
+        Ok(())
+    }
+
+    /// Finalize every admitted session and prevent later capability minting.
+    pub fn drain(&self) -> Result<(), CredentialServiceError> {
+        let _mutation = self.blocking_mutation_guard()?;
+        self.finalized
+            .store(true, std::sync::atomic::Ordering::Release);
+        let keys = self
+            .sessions
+            .lock()
+            .map_err(|_| invariant())?
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        let deadline = Self::operation_deadline(1_000)?;
+        for session_key in keys {
+            self.close_session_locked(session_key, deadline)?;
+        }
+        self.authority.clear().map_err(|_| invariant())?;
+        Ok(())
+    }
+
+    fn close_all_sessions_locked(
+        &self,
+        deadline: std::time::Instant,
+    ) -> Result<(), CredentialServiceError> {
+        let keys = self
+            .sessions
+            .lock()
+            .map_err(|_| invariant())?
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        for session_key in keys {
+            self.close_session_locked(session_key, deadline)?;
+        }
+        Ok(())
+    }
+
+    fn close_session_locked(
+        &self,
+        session_key: SessionKey,
+        deadline: std::time::Instant,
+    ) -> Result<(), CredentialServiceError> {
         let records = self
             .leases
             .lock()
@@ -224,33 +292,16 @@ impl SecretServiceCredentialProvider {
             Self::poll_port(self.port.revoke_lease(&lease), deadline)?;
         }
 
-        let mut leases = self.leases.lock().map_err(|_| invariant())?;
-        for ((key, _), record) in leases.iter_mut() {
-            if *key == session_key && record.metadata.state == CredentialLeaseState::Active {
-                record.metadata.state = CredentialLeaseState::Revoked;
-                record.metadata.outcome = CredentialOutcomeCode::Revoked;
-            }
-        }
-        drop(leases);
-
-        let capability = authorization.session_capability().ok_or_else(|| {
-            CredentialServiceError::new(CredentialServiceErrorCode::OperationDenied)
-        })?;
-        capability.release().map_err(|_| invariant())?;
+        self.leases
+            .lock()
+            .map_err(|_| invariant())?
+            .retain(|(key, _), _| *key != session_key);
+        self.release_session_key(session_key)?;
         self.sessions
             .lock()
             .map_err(|_| invariant())?
             .remove(&session_key);
         Ok(())
-    }
-
-    /// Finalize one admitted session using the same revocation semantics as a
-    /// transport disconnect.
-    pub fn finalize_session(
-        &self,
-        authorization: &CredentialAuthorization,
-    ) -> Result<(), CredentialServiceError> {
-        self.disconnect(authorization)
     }
 }
 

--- a/packages/d2b-provider-credential-secret-service/tests/canary.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/canary.rs
@@ -6,6 +6,10 @@ use d2b_contracts::v3::credential::{
     CredentialRequest, CredentialResponse, CredentialServiceErrorCode, CredentialSourceVersion,
     CredentialStatus, PlacementBinding, encode_outer,
 };
+use d2b_contracts::v3::credential_controller::{
+    CredentialAuditOutcome, CredentialTelemetryOperation, CredentialTelemetryOutcome,
+};
+use d2b_provider_credential_secret_service::SecretServiceController;
 
 use common::{Admission, ProviderHarness, setup};
 
@@ -17,6 +21,7 @@ fn process_unique_secret_service_canaries_are_absent_from_every_rendered_surface
     let credential_uid = format!("credential-uid-{nonce}");
     let credential_digest = format!("credential-digest-{nonce}");
     let (provider, port) = setup(64);
+    let controller = SecretServiceController::new(provider.config().clone());
     let operation_id = format!("{}-{credential_uid}", port.object_path_canary);
     let idempotency_key = format!("{}-{credential_digest}", port.credential_canary);
     let request = CredentialRequest::new(
@@ -113,6 +118,32 @@ fn process_unique_secret_service_canaries_are_absent_from_every_rendered_surface
         serde_json::to_string(&status).unwrap(),
         format!("{error:?}"),
         error.to_string(),
+        format!(
+            "{:?}",
+            controller
+                .authorized_service_audit(
+                    true,
+                    "user-zone",
+                    credential_uid.as_bytes(),
+                    credential_name.as_bytes(),
+                    CredentialMethod::AcquireToken,
+                    CredentialAuditOutcome::Success,
+                    1,
+                    Some(credential_digest.as_bytes()),
+                )
+                .unwrap()
+        ),
+        format!(
+            "{:?}",
+            controller
+                .telemetry(
+                    "user-zone",
+                    CredentialTelemetryOperation::AcquireToken,
+                    CredentialTelemetryOutcome::Success,
+                    1,
+                )
+                .unwrap()
+        ),
     ];
     for surface in surfaces {
         for canary in [

--- a/packages/d2b-provider-credential-secret-service/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/common/mod.rs
@@ -6,9 +6,8 @@ use std::sync::{Arc, Mutex};
 use d2b_contracts::v3::credential::{
     AudienceToken, CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState,
     CredentialMethod, CredentialProvider, CredentialRequest, CredentialResponse,
-    CredentialServiceError, CredentialSessionCapability, CredentialSourceVersion,
-    DeliveryRouteDigest, DeliverySessionParams, OperationClass, PlacementBinding,
-    dispatch_authorized_provider,
+    CredentialServiceError, CredentialSourceVersion, DeliveryRouteDigest, DeliverySessionParams,
+    OperationClass, PlacementBinding, dispatch_authorized_provider,
 };
 use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid, ZoneId};
 use d2b_provider_credential_secret_service::{
@@ -16,7 +15,7 @@ use d2b_provider_credential_secret_service::{
     SecretServiceCredentialProviderFactory, SecretServiceFuture, SecretServiceLeaseGrant,
     SecretServiceLeaseInspection, SecretServiceLeaseRef, SecretServiceLeaseRenewal,
     SecretServiceLeaseRequest, SecretServiceLeaseRevocation, SecretServicePlacement,
-    SecretServicePortError, SecretServiceState,
+    SecretServicePortError, SecretServiceSessionCapability, SecretServiceState,
 };
 
 pub const EXPIRY: u64 = 20_000;
@@ -153,7 +152,12 @@ pub fn setup(max_leases: u32) -> (SecretServiceCredentialProvider, Arc<FakeOo7Po
         port.clone(),
     )
     .unwrap();
-    (factory.construct(), port)
+    (
+        factory
+            .construct()
+            .expect("test provider authority must be constructible"),
+        port,
+    )
 }
 
 pub fn request(idempotency: &str) -> CredentialRequest {
@@ -212,11 +216,11 @@ impl TestAdmission for Admission {
 }
 
 pub trait SessionCapabilitySource {
-    fn test_session_capability(&self) -> CredentialSessionCapability;
+    fn test_session_capability(&self) -> SecretServiceSessionCapability;
 }
 
 impl SessionCapabilitySource for SecretServiceCredentialProvider {
-    fn test_session_capability(&self) -> CredentialSessionCapability {
+    fn test_session_capability(&self) -> SecretServiceSessionCapability {
         self.issue_session_capability(ResourceGeneration::new(1).unwrap())
             .expect("test provider must issue its placement-bound capability")
     }
@@ -225,7 +229,7 @@ impl SessionCapabilitySource for SecretServiceCredentialProvider {
 pub struct ProviderHarness<P, A> {
     provider: P,
     admission: A,
-    capability: Arc<CredentialSessionCapability>,
+    capability: Arc<SecretServiceSessionCapability>,
 }
 
 impl<P, A> ProviderHarness<P, A>
@@ -249,7 +253,7 @@ where
         let authorization = self
             .admission
             .authorize(method, &request)?
-            .with_shared_session_capability(self.capability.clone());
+            .with_shared_session_proof(self.capability.clone());
         dispatch_authorized_provider(&self.provider, method, &request, &authorization)
     }
 }

--- a/packages/d2b-provider-credential-secret-service/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/common/mod.rs
@@ -6,10 +6,11 @@ use std::sync::{Arc, Mutex};
 use d2b_contracts::v3::credential::{
     AudienceToken, CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState,
     CredentialMethod, CredentialProvider, CredentialRequest, CredentialResponse,
-    CredentialServiceError, CredentialSourceVersion, DeliveryRouteDigest, DeliverySessionParams,
-    OperationClass, PlacementBinding, dispatch_authorized_provider,
+    CredentialServiceError, CredentialSessionCapability, CredentialSourceVersion,
+    DeliveryRouteDigest, DeliverySessionParams, OperationClass, PlacementBinding,
+    dispatch_authorized_provider,
 };
-use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid};
+use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ResourceUid, ZoneId};
 use d2b_provider_credential_secret_service::{
     LockPolicy, Oo7SecretServicePort, SecretServiceConfig, SecretServiceCredentialProvider,
     SecretServiceCredentialProviderFactory, SecretServiceFuture, SecretServiceLeaseGrant,
@@ -139,6 +140,7 @@ pub fn setup(max_leases: u32) -> (SecretServiceCredentialProvider, Arc<FakeOo7Po
     let config =
         SecretServiceConfig::new("login collection", max_leases, LockPolicy::FailClosed).unwrap();
     let placement = SecretServicePlacement::new(
+        ZoneId::parse("user-zone").unwrap(),
         PlacementBinding::UserAgent,
         ResourceRef::parse("Host/workstation").unwrap(),
         ResourceRef::parse("User/alice").unwrap(),
@@ -209,18 +211,31 @@ impl TestAdmission for Admission {
     }
 }
 
+pub trait SessionCapabilitySource {
+    fn test_session_capability(&self) -> CredentialSessionCapability;
+}
+
+impl SessionCapabilitySource for SecretServiceCredentialProvider {
+    fn test_session_capability(&self) -> CredentialSessionCapability {
+        self.issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .expect("test provider must issue its placement-bound capability")
+    }
+}
+
 pub struct ProviderHarness<P, A> {
     provider: P,
     admission: A,
+    capability: Arc<CredentialSessionCapability>,
 }
 
 impl<P, A> ProviderHarness<P, A>
 where
-    P: CredentialProvider,
+    P: CredentialProvider + SessionCapabilitySource,
     A: TestAdmission,
 {
-    pub const fn new(provider: P, admission: A) -> Self {
+    pub fn new(provider: P, admission: A) -> Self {
         Self {
+            capability: Arc::new(provider.test_session_capability()),
             provider,
             admission,
         }
@@ -231,7 +246,10 @@ where
         method: CredentialMethod,
         request: CredentialRequest,
     ) -> Result<CredentialResponse, CredentialServiceError> {
-        let authorization = self.admission.authorize(method, &request)?;
+        let authorization = self
+            .admission
+            .authorize(method, &request)?
+            .with_shared_session_capability(self.capability.clone());
         dispatch_authorized_provider(&self.provider, method, &request, &authorization)
     }
 }

--- a/packages/d2b-provider-credential-secret-service/tests/delivery.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/delivery.rs
@@ -7,7 +7,7 @@ use d2b_contracts::v3::credential::{
 };
 use d2b_provider_credential_secret_service::SecretServiceCredentialProvider;
 
-use common::{Admission, ProviderHarness, TestAdmission, request, setup};
+use common::{Admission, ProviderHarness, SessionCapabilitySource, TestAdmission, request, setup};
 
 #[test]
 fn response_uses_the_read_only_adapter_binding_and_record_zeroizes() {
@@ -62,6 +62,16 @@ impl CredentialProvider for BindingReplacingProvider {
             delivery.delivery_session_params = self.replacement.clone();
         }
         Ok(response)
+    }
+}
+
+impl SessionCapabilitySource for BindingReplacingProvider {
+    fn test_session_capability(
+        &self,
+    ) -> d2b_contracts::v3::credential::CredentialSessionCapability {
+        self.inner
+            .issue_session_capability(d2b_contracts::v3::ResourceGeneration::new(1).unwrap())
+            .expect("test provider must issue its placement-bound capability")
     }
 }
 

--- a/packages/d2b-provider-credential-secret-service/tests/delivery.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/delivery.rs
@@ -5,7 +5,9 @@ use d2b_contracts::v3::credential::{
     CredentialResponse, CredentialServiceError, CredentialServiceErrorCode, DeliverySessionParams,
     SensitiveDeliveryRecord,
 };
-use d2b_provider_credential_secret_service::SecretServiceCredentialProvider;
+use d2b_provider_credential_secret_service::{
+    SecretServiceCredentialProvider, SecretServiceSessionCapability,
+};
 
 use common::{Admission, ProviderHarness, SessionCapabilitySource, TestAdmission, request, setup};
 
@@ -66,9 +68,7 @@ impl CredentialProvider for BindingReplacingProvider {
 }
 
 impl SessionCapabilitySource for BindingReplacingProvider {
-    fn test_session_capability(
-        &self,
-    ) -> d2b_contracts::v3::credential::CredentialSessionCapability {
+    fn test_session_capability(&self) -> SecretServiceSessionCapability {
         self.inner
             .issue_session_capability(d2b_contracts::v3::ResourceGeneration::new(1).unwrap())
             .expect("test provider must issue its placement-bound capability")

--- a/packages/d2b-provider-credential-secret-service/tests/faults.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/faults.rs
@@ -5,10 +5,10 @@ use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::Duration;
 
-use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
     CredentialMethod, CredentialRequest, CredentialServiceErrorCode, PlacementBinding,
 };
+use d2b_contracts::v3::{ResourceRef, ZoneId};
 use d2b_provider_credential_secret_service::{
     LockPolicy, Oo7SecretServicePort, SecretServiceConfig, SecretServiceCredentialProviderFactory,
     SecretServiceFuture, SecretServiceLeaseGrant, SecretServiceLeaseInspection,
@@ -23,6 +23,7 @@ use common::{Admission, ProviderHarness, request, setup};
 fn locked_and_unavailable_map_to_provider_unavailable() {
     for failure in [
         SecretServicePortError::Locked,
+        SecretServicePortError::Missing,
         SecretServicePortError::Unavailable,
     ] {
         let (provider, port) = setup(64);
@@ -86,6 +87,7 @@ fn port_call_stops_at_request_deadline() {
     let provider = SecretServiceCredentialProviderFactory::new(
         SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
         SecretServicePlacement::new(
+            ZoneId::parse("user-zone").unwrap(),
             PlacementBinding::UserAgent,
             ResourceRef::parse("Host/workstation").unwrap(),
             ResourceRef::parse("User/alice").unwrap(),

--- a/packages/d2b-provider-credential-secret-service/tests/faults.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/faults.rs
@@ -97,7 +97,8 @@ fn port_call_stops_at_request_deadline() {
         port.clone(),
     )
     .unwrap()
-    .construct();
+    .construct()
+    .expect("test provider authority must be constructible");
     let server = ProviderHarness::new(provider, Admission);
     let (result_tx, result_rx) = mpsc::channel();
     thread::spawn(move || {

--- a/packages/d2b-provider-credential-secret-service/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/lifecycle.rs
@@ -8,9 +8,9 @@ use std::thread;
 use std::time::Duration;
 
 use d2b_contracts::v3::credential::{
-    CredentialLeaseHandle, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
-    CredentialRequest, CredentialResponse, CredentialServiceErrorCode, CredentialSourceVersion,
-    PlacementBinding,
+    CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState, CredentialMethod,
+    CredentialOutcomeCode, CredentialProvider, CredentialRequest, CredentialResponse,
+    CredentialServiceErrorCode, CredentialSourceVersion, PlacementBinding,
 };
 use d2b_contracts::v3::{ResourceRef, ZoneId};
 use d2b_provider_credential_secret_service::{
@@ -120,6 +120,156 @@ fn concurrent_acquires_issue_once() {
 }
 
 #[test]
+fn disconnect_waits_for_inflight_acquire_and_fences_the_session() {
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let port = Arc::new(BlockingPort::new(entered_tx));
+    let provider = Arc::new(provider_with_port(64, port.clone()));
+    let capability = Arc::new(
+        provider
+            .issue_session_capability(d2b_contracts::v3::ResourceGeneration::new(1).unwrap())
+            .unwrap(),
+    );
+    let authorization = Arc::new(
+        CredentialAuthorization::new(
+            CredentialMethod::AcquireToken,
+            Some(common::delivery(CredentialMethod::AcquireToken, 1)),
+        )
+        .unwrap()
+        .with_shared_session_proof(capability),
+    );
+
+    let acquire_provider = provider.clone();
+    let acquire_authorization = authorization.clone();
+    let (acquire_tx, acquire_rx) = mpsc::channel();
+    let acquire = thread::spawn(move || {
+        acquire_tx
+            .send(acquire_provider.dispatch(
+                CredentialMethod::AcquireToken,
+                &request("race-acquire"),
+                &acquire_authorization,
+            ))
+            .unwrap();
+    });
+    entered_rx.recv().unwrap();
+
+    let disconnect_provider = provider.clone();
+    let disconnect_authorization = authorization.clone();
+    let (disconnect_tx, disconnect_rx) = mpsc::channel();
+    let disconnect = thread::spawn(move || {
+        disconnect_tx
+            .send(disconnect_provider.disconnect(&disconnect_authorization))
+            .unwrap();
+    });
+    assert!(
+        disconnect_rx
+            .recv_timeout(Duration::from_millis(50))
+            .is_err()
+    );
+
+    port.release();
+    assert!(
+        acquire_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .is_ok()
+    );
+    assert!(
+        disconnect_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .is_ok()
+    );
+    acquire.join().unwrap();
+    disconnect.join().unwrap();
+    assert_eq!(port.revoke_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::InspectMetadata,
+                &request("after-race"),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+}
+
+#[test]
+fn inspect_waits_on_the_lifecycle_gate_before_disconnect() {
+    let (inspect_tx, inspect_rx) = mpsc::channel();
+    let port = Arc::new(InspectBlockingPort::new(inspect_tx));
+    let provider = Arc::new(provider_with_port(64, port.clone()));
+    let capability = Arc::new(
+        provider
+            .issue_session_capability(d2b_contracts::v3::ResourceGeneration::new(1).unwrap())
+            .unwrap(),
+    );
+    let acquire_authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(common::delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_shared_session_proof(capability.clone());
+    provider
+        .dispatch(
+            CredentialMethod::AcquireToken,
+            &request("inspect-fence-acquire"),
+            &acquire_authorization,
+        )
+        .unwrap();
+    let inspect_authorization =
+        CredentialAuthorization::new(CredentialMethod::InspectMetadata, None)
+            .unwrap()
+            .with_shared_session_proof(capability);
+
+    let inspect_provider = provider.clone();
+    let inspect_authorization_for_thread = inspect_authorization.clone();
+    let (inspect_result_tx, inspect_result_rx) = mpsc::channel();
+    let inspect = thread::spawn(move || {
+        inspect_result_tx
+            .send(inspect_provider.dispatch(
+                CredentialMethod::InspectMetadata,
+                &request("inspect-fence"),
+                &inspect_authorization_for_thread,
+            ))
+            .unwrap();
+    });
+    inspect_rx.recv().unwrap();
+
+    let disconnect_provider = provider.clone();
+    let disconnect_authorization = acquire_authorization.clone();
+    let (disconnect_tx, disconnect_rx) = mpsc::channel();
+    let disconnect = thread::spawn(move || {
+        disconnect_tx
+            .send(disconnect_provider.disconnect(&disconnect_authorization))
+            .unwrap();
+    });
+    assert!(
+        disconnect_rx
+            .recv_timeout(Duration::from_millis(50))
+            .is_err()
+    );
+
+    port.release();
+    assert!(
+        inspect_result_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .is_ok()
+    );
+    assert!(
+        disconnect_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .is_ok()
+    );
+    inspect.join().unwrap();
+    disconnect.join().unwrap();
+    assert_eq!(port.revoke_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
 fn revocation_releases_capacity() {
     let (provider, port) = setup(1);
     let server = ProviderHarness::new(provider, Admission);
@@ -149,6 +299,7 @@ struct BlockingPort {
     entered: Mutex<Option<mpsc::Sender<()>>>,
     state: Mutex<BlockingState>,
     issue_calls: AtomicUsize,
+    revoke_calls: AtomicUsize,
 }
 
 struct BlockingState {
@@ -165,6 +316,7 @@ impl BlockingPort {
                 wakers: Vec::new(),
             }),
             issue_calls: AtomicUsize::new(0),
+            revoke_calls: AtomicUsize::new(0),
         }
     }
 
@@ -235,7 +387,102 @@ impl Oo7SecretServicePort for BlockingPort {
         &self,
         _lease: &SecretServiceLeaseRef,
     ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
-        Box::pin(async { panic!("unexpected revoke") })
+        self.revoke_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(SecretServiceLeaseRevocation::Revoked) })
+    }
+}
+
+struct InspectBlockingPort {
+    entered: Mutex<Option<mpsc::Sender<()>>>,
+    state: Mutex<BlockingState>,
+    revoke_calls: AtomicUsize,
+}
+
+impl InspectBlockingPort {
+    fn new(entered: mpsc::Sender<()>) -> Self {
+        Self {
+            entered: Mutex::new(Some(entered)),
+            state: Mutex::new(BlockingState {
+                released: false,
+                wakers: Vec::new(),
+            }),
+            revoke_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn release(&self) {
+        let wakers = {
+            let mut state = self.state.lock().unwrap();
+            state.released = true;
+            std::mem::take(&mut state.wakers)
+        };
+        for waker in wakers {
+            waker.wake();
+        }
+    }
+}
+
+impl Oo7SecretServicePort for InspectBlockingPort {
+    fn state(&self) -> SecretServiceFuture<'_, SecretServiceState> {
+        Box::pin(async { Ok(SecretServiceState::Unlocked) })
+    }
+
+    fn issue_lease(
+        &self,
+        request: &SecretServiceLeaseRequest,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseGrant> {
+        let expiry = request.requested_expiry_unix_ms();
+        Box::pin(async move {
+            Ok(SecretServiceLeaseGrant {
+                lease_handle: CredentialLeaseHandle::parse("inspect-lease").unwrap(),
+                source_version: CredentialSourceVersion::parse("inspect-source").unwrap(),
+                rotation_generation: 1,
+                expires_at_unix_ms: expiry,
+            })
+        })
+    }
+
+    fn inspect_lease(
+        &self,
+        lease: &SecretServiceLeaseRef,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseInspection> {
+        if let Some(entered) = self.entered.lock().unwrap().take() {
+            entered.send(()).unwrap();
+        }
+        let metadata = lease.metadata().clone();
+        Box::pin(async move {
+            poll_fn(|context| {
+                let mut state = self.state.lock().unwrap();
+                if state.released {
+                    Poll::Ready(())
+                } else {
+                    state.wakers.push(context.waker().clone());
+                    Poll::Pending
+                }
+            })
+            .await;
+            Ok(SecretServiceLeaseInspection {
+                state: CredentialLeaseState::Active,
+                source_version: metadata.source_version,
+                rotation_generation: metadata.rotation_generation,
+                expires_at_unix_ms: metadata.expires_at_unix_ms,
+            })
+        })
+    }
+
+    fn refresh_lease(
+        &self,
+        _lease: &SecretServiceLeaseRef,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRenewal> {
+        Box::pin(async { panic!("unexpected refresh") })
+    }
+
+    fn revoke_lease(
+        &self,
+        _lease: &SecretServiceLeaseRef,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
+        self.revoke_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(SecretServiceLeaseRevocation::Revoked) })
     }
 }
 
@@ -257,4 +504,5 @@ fn provider_with_port(
     )
     .unwrap()
     .construct()
+    .expect("test provider authority must be constructible")
 }

--- a/packages/d2b-provider-credential-secret-service/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/lifecycle.rs
@@ -7,12 +7,12 @@ use std::task::{Poll, Waker};
 use std::thread;
 use std::time::Duration;
 
-use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
     CredentialLeaseHandle, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
     CredentialRequest, CredentialResponse, CredentialServiceErrorCode, CredentialSourceVersion,
     PlacementBinding,
 };
+use d2b_contracts::v3::{ResourceRef, ZoneId};
 use d2b_provider_credential_secret_service::{
     LockPolicy, Oo7SecretServicePort, SecretServiceConfig, SecretServiceCredentialProvider,
     SecretServiceCredentialProviderFactory, SecretServiceFuture, SecretServiceLeaseGrant,
@@ -246,6 +246,7 @@ fn provider_with_port(
     SecretServiceCredentialProviderFactory::new(
         SecretServiceConfig::new("login collection", max_leases, LockPolicy::FailClosed).unwrap(),
         SecretServicePlacement::new(
+            ZoneId::parse("user-zone").unwrap(),
             PlacementBinding::UserAgent,
             ResourceRef::parse("Host/workstation").unwrap(),
             ResourceRef::parse("User/alice").unwrap(),

--- a/packages/d2b-provider-credential-secret-service/tests/placement.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/placement.rs
@@ -1,5 +1,5 @@
-use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::PlacementBinding;
+use d2b_contracts::v3::{ResourceRef, ZoneId};
 use d2b_provider_credential_secret_service::{SecretServicePlacement, SecretServiceProviderError};
 
 #[test]
@@ -8,6 +8,7 @@ fn only_user_agent_on_host_or_guest_is_accepted() {
     for execution in ["Host/workstation", "Guest/work-vm"] {
         assert!(
             SecretServicePlacement::new(
+                ZoneId::parse("user-zone").unwrap(),
                 PlacementBinding::UserAgent,
                 ResourceRef::parse(execution).unwrap(),
                 user.clone(),
@@ -18,6 +19,7 @@ fn only_user_agent_on_host_or_guest_is_accepted() {
     for binding in [PlacementBinding::HostSystem, PlacementBinding::GuestAgent] {
         assert_eq!(
             SecretServicePlacement::new(
+                ZoneId::parse("user-zone").unwrap(),
                 binding,
                 ResourceRef::parse("Guest/work-vm").unwrap(),
                 user.clone(),

--- a/packages/d2b-provider-credential-secret-service/tests/session.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/session.rs
@@ -1,0 +1,262 @@
+mod common;
+
+use d2b_contracts::v3::credential::{
+    CredentialAuthorization, CredentialMethod, CredentialProvider, CredentialServiceErrorCode,
+    CredentialSessionAuthority, PlacementBinding, dispatch_authorized_provider,
+};
+use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ZoneId};
+use d2b_provider_credential_secret_service::{
+    LockPolicy, SecretServiceConfig, SecretServiceCredentialProvider,
+    SecretServiceCredentialProviderFactory, SecretServicePlacement,
+};
+
+use common::{FakeOo7Port, delivery, request, setup};
+
+#[test]
+fn unauthenticated_authorization_cannot_reach_the_port() {
+    let (provider, port) = setup(64);
+    let authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap();
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::AcquireToken,
+                &request("unauthenticated"),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(
+        port.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+}
+
+#[test]
+fn one_session_capability_rejects_clone_replay_and_disconnects_owned_lease() {
+    let (provider, port) = setup(64);
+    let capability = provider
+        .issue_session_capability(ResourceGeneration::new(1).unwrap())
+        .unwrap();
+    let cloned_capability = capability.clone();
+    let authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_session_capability(capability);
+    dispatch_authorized_provider(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("session-owned"),
+        &authorization,
+    )
+    .unwrap();
+    dispatch_authorized_provider(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &d2b_contracts::v3::credential::CredentialRequest::new(
+            ResourceRef::parse("Credential/other-keyring").unwrap(),
+            "operation-2",
+            "session-owned-2",
+            common::EXPIRY,
+            15_000,
+        )
+        .unwrap(),
+        &authorization,
+    )
+    .unwrap();
+
+    let cloned_authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 2)),
+    )
+    .unwrap()
+    .with_session_capability(cloned_capability);
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::AcquireToken,
+                &request("clone-replay"),
+                &cloned_authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+
+    provider.disconnect(&authorization).unwrap();
+    assert_eq!(
+        port.revoke_calls.load(std::sync::atomic::Ordering::SeqCst),
+        2
+    );
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::InspectMetadata,
+                &request("after-disconnect"),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+}
+
+#[test]
+fn wrong_zone_and_workload_capabilities_are_refused() {
+    let (provider, _) = setup(64);
+    let authority = CredentialSessionAuthority::new();
+    for (zone, workload, consumer, subject) in [
+        (
+            "other-zone",
+            "Host/workstation",
+            "Provider/shell-terminal",
+            "User/alice",
+        ),
+        (
+            "user-zone",
+            "Host/other-workstation",
+            "Provider/shell-terminal",
+            "User/alice",
+        ),
+        (
+            "user-zone",
+            "Host/workstation",
+            "Provider/other-consumer",
+            "User/alice",
+        ),
+        (
+            "user-zone",
+            "Host/workstation",
+            "Provider/shell-terminal",
+            "User/bob",
+        ),
+    ] {
+        let capability = authority
+            .issue(
+                ZoneId::parse(zone).unwrap(),
+                ResourceRef::parse(workload).unwrap(),
+                ResourceRef::parse(subject).unwrap(),
+                ResourceRef::parse(consumer).unwrap(),
+                ResourceGeneration::new(1).unwrap(),
+            )
+            .unwrap();
+        let authorization = CredentialAuthorization::new(
+            CredentialMethod::AcquireToken,
+            Some(delivery(CredentialMethod::AcquireToken, 1)),
+        )
+        .unwrap()
+        .with_session_capability(capability);
+        assert_eq!(
+            provider
+                .dispatch(
+                    CredentialMethod::AcquireToken,
+                    &request("wrong-binding"),
+                    &authorization,
+                )
+                .unwrap_err()
+                .code(),
+            CredentialServiceErrorCode::OperationDenied
+        );
+    }
+}
+
+#[test]
+fn disconnect_revokes_only_the_owned_workload_leases() {
+    let port = std::sync::Arc::new(FakeOo7Port::new());
+    let first = provider_for(
+        ZoneId::parse("user-zone").unwrap(),
+        ResourceRef::parse("Host/workstation").unwrap(),
+        port.clone(),
+    );
+    let second = provider_for(
+        ZoneId::parse("other-zone").unwrap(),
+        ResourceRef::parse("Host/other-workstation").unwrap(),
+        port.clone(),
+    );
+    let first_capability = std::sync::Arc::new(
+        first
+            .issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .unwrap(),
+    );
+    let second_capability = std::sync::Arc::new(
+        second
+            .issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .unwrap(),
+    );
+    let first_auth = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_shared_session_capability(first_capability.clone());
+    let second_auth = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_shared_session_capability(second_capability.clone());
+
+    dispatch_authorized_provider(
+        &first,
+        CredentialMethod::AcquireToken,
+        &request("first-lease"),
+        &first_auth,
+    )
+    .unwrap();
+    dispatch_authorized_provider(
+        &second,
+        CredentialMethod::AcquireToken,
+        &request("second-lease"),
+        &second_auth,
+    )
+    .unwrap();
+
+    first.disconnect(&first_auth).unwrap();
+    let second_inspect_auth = CredentialAuthorization::new(CredentialMethod::InspectMetadata, None)
+        .unwrap()
+        .with_shared_session_capability(second_capability);
+    dispatch_authorized_provider(
+        &second,
+        CredentialMethod::InspectMetadata,
+        &request("second-inspect"),
+        &second_inspect_auth,
+    )
+    .unwrap();
+    assert_eq!(
+        port.revoke_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    second.finalize_session(&second_auth).unwrap();
+    assert_eq!(
+        port.revoke_calls.load(std::sync::atomic::Ordering::SeqCst),
+        2
+    );
+}
+
+fn provider_for(
+    zone: ZoneId,
+    workload: ResourceRef,
+    port: std::sync::Arc<FakeOo7Port>,
+) -> SecretServiceCredentialProvider {
+    SecretServiceCredentialProviderFactory::new(
+        SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
+        SecretServicePlacement::new(
+            zone,
+            PlacementBinding::UserAgent,
+            workload,
+            ResourceRef::parse("User/alice").unwrap(),
+        )
+        .unwrap(),
+        Some(ResourceRef::parse("Provider/shell-terminal").unwrap()),
+        port,
+    )
+    .unwrap()
+    .construct()
+}

--- a/packages/d2b-provider-credential-secret-service/tests/session.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/session.rs
@@ -2,7 +2,7 @@ mod common;
 
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialMethod, CredentialProvider, CredentialServiceErrorCode,
-    CredentialSessionAuthority, PlacementBinding, dispatch_authorized_provider,
+    PlacementBinding, dispatch_authorized_provider,
 };
 use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ZoneId};
 use d2b_provider_credential_secret_service::{
@@ -43,13 +43,12 @@ fn one_session_capability_rejects_clone_replay_and_disconnects_owned_lease() {
     let capability = provider
         .issue_session_capability(ResourceGeneration::new(1).unwrap())
         .unwrap();
-    let cloned_capability = capability.clone();
     let authorization = CredentialAuthorization::new(
         CredentialMethod::AcquireToken,
         Some(delivery(CredentialMethod::AcquireToken, 1)),
     )
     .unwrap()
-    .with_session_capability(capability);
+    .with_session_proof(capability);
     dispatch_authorized_provider(
         &provider,
         CredentialMethod::AcquireToken,
@@ -72,24 +71,7 @@ fn one_session_capability_rejects_clone_replay_and_disconnects_owned_lease() {
     )
     .unwrap();
 
-    let cloned_authorization = CredentialAuthorization::new(
-        CredentialMethod::AcquireToken,
-        Some(delivery(CredentialMethod::AcquireToken, 2)),
-    )
-    .unwrap()
-    .with_session_capability(cloned_capability);
-    assert_eq!(
-        provider
-            .dispatch(
-                CredentialMethod::AcquireToken,
-                &request("clone-replay"),
-                &cloned_authorization,
-            )
-            .unwrap_err()
-            .code(),
-        CredentialServiceErrorCode::OperationDenied
-    );
-
+    provider.disconnect(&authorization).unwrap();
     provider.disconnect(&authorization).unwrap();
     assert_eq!(
         port.revoke_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -109,9 +91,143 @@ fn one_session_capability_rejects_clone_replay_and_disconnects_owned_lease() {
 }
 
 #[test]
-fn wrong_zone_and_workload_capabilities_are_refused() {
+fn foreign_exact_match_authority_is_refused() {
     let (provider, _) = setup(64);
-    let authority = CredentialSessionAuthority::new();
+    let (foreign_provider, _) = setup(64);
+    let authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_session_proof(
+        foreign_provider
+            .issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .unwrap(),
+    );
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::AcquireToken,
+                &request("foreign-authority"),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+}
+
+#[test]
+fn absent_consumer_uses_only_the_canonical_provider_reference() {
+    let port = std::sync::Arc::new(common::FakeOo7Port::new());
+    let provider = SecretServiceCredentialProviderFactory::new(
+        SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
+        SecretServicePlacement::new(
+            ZoneId::parse("user-zone").unwrap(),
+            PlacementBinding::UserAgent,
+            ResourceRef::parse("Host/workstation").unwrap(),
+            ResourceRef::parse("User/alice").unwrap(),
+        )
+        .unwrap(),
+        None,
+        port,
+    )
+    .unwrap()
+    .construct()
+    .expect("test provider authority must be constructible");
+    assert_eq!(
+        provider.consumer_ref().to_canonical_string(),
+        d2b_provider_credential_secret_service::PROVIDER_REF
+    );
+    let own_authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_session_proof(
+        provider
+            .issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .unwrap(),
+    );
+    provider
+        .dispatch(
+            CredentialMethod::AcquireToken,
+            &request("canonical-consumer"),
+            &own_authorization,
+        )
+        .unwrap();
+    let (_, foreign_port) = setup(64);
+    let authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_session_proof(
+        SecretServiceCredentialProviderFactory::new(
+            SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
+            SecretServicePlacement::new(
+                ZoneId::parse("user-zone").unwrap(),
+                PlacementBinding::UserAgent,
+                ResourceRef::parse("Host/workstation").unwrap(),
+                ResourceRef::parse("User/alice").unwrap(),
+            )
+            .unwrap(),
+            Some(ResourceRef::parse("Provider/shell-terminal").unwrap()),
+            foreign_port,
+        )
+        .unwrap()
+        .construct()
+        .expect("foreign provider authority must be constructible")
+        .issue_session_capability(ResourceGeneration::new(1).unwrap())
+        .unwrap(),
+    );
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::AcquireToken,
+                &request("consumer-none"),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+}
+
+#[test]
+fn provider_generation_is_checked_before_admission() {
+    let port = std::sync::Arc::new(common::FakeOo7Port::new());
+    let provider = SecretServiceCredentialProviderFactory::new(
+        SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
+        SecretServicePlacement::new(
+            ZoneId::parse("user-zone").unwrap(),
+            PlacementBinding::UserAgent,
+            ResourceRef::parse("Host/workstation").unwrap(),
+            ResourceRef::parse("User/alice").unwrap(),
+        )
+        .unwrap(),
+        Some(ResourceRef::parse("Provider/shell-terminal").unwrap()),
+        port,
+    )
+    .unwrap()
+    .with_generation(ResourceGeneration::new(2).unwrap())
+    .construct()
+    .expect("test provider authority must be constructible");
+    assert!(
+        provider
+            .issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .is_err()
+    );
+    assert!(
+        provider
+            .issue_session_capability(ResourceGeneration::new(2).unwrap())
+            .is_ok()
+    );
+}
+
+#[test]
+fn foreign_bindings_are_refused() {
+    let (provider, _) = setup(64);
     for (zone, workload, consumer, subject) in [
         (
             "other-zone",
@@ -138,21 +254,23 @@ fn wrong_zone_and_workload_capabilities_are_refused() {
             "User/bob",
         ),
     ] {
-        let capability = authority
-            .issue(
-                ZoneId::parse(zone).unwrap(),
-                ResourceRef::parse(workload).unwrap(),
-                ResourceRef::parse(subject).unwrap(),
-                ResourceRef::parse(consumer).unwrap(),
-                ResourceGeneration::new(1).unwrap(),
-            )
-            .unwrap();
+        let foreign = provider_for_binding(
+            ZoneId::parse(zone).unwrap(),
+            ResourceRef::parse(workload).unwrap(),
+            ResourceRef::parse(subject).unwrap(),
+            ResourceRef::parse(consumer).unwrap(),
+            std::sync::Arc::new(common::FakeOo7Port::new()),
+        );
         let authorization = CredentialAuthorization::new(
             CredentialMethod::AcquireToken,
             Some(delivery(CredentialMethod::AcquireToken, 1)),
         )
         .unwrap()
-        .with_session_capability(capability);
+        .with_session_proof(
+            foreign
+                .issue_session_capability(ResourceGeneration::new(1).unwrap())
+                .unwrap(),
+        );
         assert_eq!(
             provider
                 .dispatch(
@@ -195,13 +313,13 @@ fn disconnect_revokes_only_the_owned_workload_leases() {
         Some(delivery(CredentialMethod::AcquireToken, 1)),
     )
     .unwrap()
-    .with_shared_session_capability(first_capability.clone());
+    .with_shared_session_proof(first_capability.clone());
     let second_auth = CredentialAuthorization::new(
         CredentialMethod::AcquireToken,
         Some(delivery(CredentialMethod::AcquireToken, 1)),
     )
     .unwrap()
-    .with_shared_session_capability(second_capability.clone());
+    .with_shared_session_proof(second_capability.clone());
 
     dispatch_authorized_provider(
         &first,
@@ -221,7 +339,7 @@ fn disconnect_revokes_only_the_owned_workload_leases() {
     first.disconnect(&first_auth).unwrap();
     let second_inspect_auth = CredentialAuthorization::new(CredentialMethod::InspectMetadata, None)
         .unwrap()
-        .with_shared_session_capability(second_capability);
+        .with_shared_session_proof(second_capability);
     dispatch_authorized_provider(
         &second,
         CredentialMethod::InspectMetadata,
@@ -240,23 +358,77 @@ fn disconnect_revokes_only_the_owned_workload_leases() {
     );
 }
 
+#[test]
+fn finalize_releases_leases_and_prevents_later_minting() {
+    let (provider, port) = setup(64);
+    let capability = provider
+        .issue_session_capability(ResourceGeneration::new(1).unwrap())
+        .unwrap();
+    let authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_session_proof(capability);
+    provider
+        .dispatch(
+            CredentialMethod::AcquireToken,
+            &request("finalize"),
+            &authorization,
+        )
+        .unwrap();
+    provider.finalize_session(&authorization).unwrap();
+    provider.finalize_session(&authorization).unwrap();
+    assert!(
+        provider
+            .issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .is_err()
+    );
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::InspectMetadata,
+                &request("after-finalize"),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(
+        port.revoke_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
 fn provider_for(
     zone: ZoneId,
     workload: ResourceRef,
     port: std::sync::Arc<FakeOo7Port>,
 ) -> SecretServiceCredentialProvider {
+    provider_for_binding(
+        zone,
+        workload,
+        ResourceRef::parse("User/alice").unwrap(),
+        ResourceRef::parse("Provider/shell-terminal").unwrap(),
+        port,
+    )
+}
+
+fn provider_for_binding(
+    zone: ZoneId,
+    workload: ResourceRef,
+    subject: ResourceRef,
+    consumer: ResourceRef,
+    port: std::sync::Arc<FakeOo7Port>,
+) -> SecretServiceCredentialProvider {
     SecretServiceCredentialProviderFactory::new(
         SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
-        SecretServicePlacement::new(
-            zone,
-            PlacementBinding::UserAgent,
-            workload,
-            ResourceRef::parse("User/alice").unwrap(),
-        )
-        .unwrap(),
-        Some(ResourceRef::parse("Provider/shell-terminal").unwrap()),
+        SecretServicePlacement::new(zone, PlacementBinding::UserAgent, workload, subject).unwrap(),
+        Some(consumer),
         port,
     )
     .unwrap()
     .construct()
+    .expect("test provider authority must be constructible")
 }


### PR DESCRIPTION
## Summary
- require one-shot authenticated session capabilities bound to Zone, workload, subject, and consumer Provider
- scope opaque leases to their owning session and revoke all owned leases on disconnect or finalization
- preserve stable non-secret failures and redacted status, audit, log, and telemetry surfaces

## Verification
- `cargo test -p d2b-provider-credential-secret-service --lib --tests`
- `cargo test -p d2b-contracts --lib credential`
- `rustfmt --edition 2024 --check` on changed Rust files
- `git diff --check`