### PR TITLE
provider: remove dead RelayProvider trait

### DIFF
--- a/changelog.d/chore-provider-dead-code.md
+++ b/changelog.d/chore-provider-dead-code.md
@@ -1,0 +1,4 @@
+### Removed
+
+- Removed the unimplemented `RelayProvider` trait; relay implementations use
+  the live `TransportProvider` surface.

--- a/packages/d2b-realm-provider/src/lib.rs
+++ b/packages/d2b-realm-provider/src/lib.rs
@@ -30,7 +30,7 @@ pub use provider::{
     CredentialProvider, CredentialStatus, DaemonAccessApi, DaemonAccessTransport, DisplayProvider,
     DurableExecutionProvider, GuestControlEndpointProvider, HostSubstrateProvider,
     InfrastructureProvider, NodeProvider, ObservabilitySinkProvider, PersistentShellProvider,
-    ProtocolCodec, RelayProvider, RuntimeProvider, StreamMux, TransportListener, TransportProvider,
+    ProtocolCodec, RuntimeProvider, StreamMux, TransportListener, TransportProvider,
     WorkloadProvider,
 };
 pub use rate_limit::{CircuitBreakerConfig, CircuitBreakerSnapshot, ProviderCircuitBreaker};

--- a/packages/d2b-realm-provider/src/provider.rs
+++ b/packages/d2b-realm-provider/src/provider.rs
@@ -318,16 +318,6 @@ pub trait ObservabilitySinkProvider: Send + Sync {
     async fn healthy(&self) -> ProviderResult<bool>;
 }
 
-/// Rendezvous/listener/sender mechanics (e.g. Azure Relay Hybrid
-/// Connections).
-#[async_trait]
-pub trait RelayProvider: Send + Sync {
-    /// Provider id.
-    fn provider_id(&self) -> ProviderId;
-    /// Open the listener side (outbound-only).
-    async fn open_listener(&self, node: NodeId) -> ProviderResult<Box<dyn TransportListener>>;
-}
-
 /// A registered node that dispatches operations.
 #[async_trait]
 pub trait NodeProvider: Send + Sync {


### PR DESCRIPTION
## Summary

- Remove the unimplemented `RelayProvider` trait and its `d2b-realm-provider` reexport.
- Preserve credential.rs/reexports, old CredentialProvider, and parity-bound provider traits/mocks because current ADR-046 provider dossiers and migration evidence still treat them as active or future-wave anchors.
- Leave host posture, labs, Spec 001 later-wave pre-work, and Gas City contributor surfaces unchanged.

## Verification

- `cargo fmt --package d2b-realm-provider -- --check`
- `cargo test -p d2b-realm-provider --all-targets` (46 passed)
- `cargo clippy -p d2b-realm-provider --all-targets -- -D warnings`
- Focused policy tests: provider crates, host/realm relay, changelog gate
- `cargo check` for direct dependent crates
- `cargo run -q -p xtask -- process-marker-pin`
- `cargo run -q -p xtask -- changelog-fold --check`

No merge or review performed.