### PR TITLE
fix(host): restore generation and Zone storage posture

### DIFF
--- a/changelog.d/fix-host-integration.md
+++ b/changelog.d/fix-host-integration.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Provisioned dedicated d2bd-owned Zone audit and telemetry directories beneath
+  broker-owned Zone storage parents, preserving the parent ownership boundary
+  while allowing the production resource plane to open its durable sinks.

--- a/docs/reference/schemas/v3/zone-storage.json
+++ b/docs/reference/schemas/v3/zone-storage.json
@@ -4,6 +4,7 @@
   "description": "Complete closed storage row for one Zone resource store.",
   "type": "object",
   "required": [
+    "auxiliaryDirectories",
     "filesystem",
     "fsync",
     "locking",
@@ -16,6 +17,14 @@
     "zoneStoreId"
   ],
   "properties": {
+    "auxiliaryDirectories": {
+      "description": "Explicit d2bd-owned audit and telemetry directory posture.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ZoneStoreAuxiliaryDirectories"
+        }
+      ]
+    },
     "filesystem": {
       "description": "Required filesystem capability and path-resolution posture.",
       "allOf": [
@@ -99,6 +108,87 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "ZoneStoreAuxiliaryDirectories": {
+      "description": "Broker-resolved directories used by the Zone runtime's audit and telemetry ports.",
+      "type": "object",
+      "required": [
+        "audit",
+        "telemetry"
+      ],
+      "properties": {
+        "audit": {
+          "description": "Durable authoritative audit directory.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZoneStoreAuxiliaryDirectory"
+            }
+          ]
+        },
+        "telemetry": {
+          "description": "Best-effort telemetry receiver directory.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZoneStoreAuxiliaryDirectory"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ZoneStoreAuxiliaryDirectory": {
+      "description": "Exact ownership and repair requirements for one Zone auxiliary directory.",
+      "type": "object",
+      "required": [
+        "directoryId",
+        "group",
+        "mode",
+        "owner",
+        "repairOwner"
+      ],
+      "properties": {
+        "directoryId": {
+          "description": "Opaque identifier for the broker-resolved directory.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZoneStoreDirectoryId"
+            }
+          ]
+        },
+        "group": {
+          "description": "Required directory group.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZoneStorePrincipal"
+            }
+          ]
+        },
+        "mode": {
+          "description": "Required directory mode.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZoneStoreFileMode"
+            }
+          ]
+        },
+        "owner": {
+          "description": "Required directory owner.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZoneStorePrincipal"
+            }
+          ]
+        },
+        "repairOwner": {
+          "description": "Sole authority allowed to provision or repair this directory.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZoneStoreDirectoryRepairOwner"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "ZoneStoreDescriptorPublicationRequirement": {
       "description": "Required descriptor publication posture.",
       "oneOf": [
@@ -107,6 +197,25 @@
           "type": "string",
           "enum": [
             "owned-descriptor-close-on-exec-verified-before-concurrency"
+          ]
+        }
+      ]
+    },
+    "ZoneStoreDirectoryId": {
+      "description": "Opaque auxiliary Zone-directory identifier resolved only by the storage owner.",
+      "type": "string",
+      "maxLength": 160,
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9-]{0,159}$"
+    },
+    "ZoneStoreDirectoryRepairOwner": {
+      "description": "The sole privileged repair authority for broker-provisioned Zone directories.",
+      "oneOf": [
+        {
+          "description": "The privileged broker is the only component allowed to create or repair the declared directory posture.",
+          "type": "string",
+          "enum": [
+            "privileged-broker"
           ]
         }
       ]

--- a/nixos-modules/zone-storage-json.nix
+++ b/nixos-modules/zone-storage-json.nix
@@ -20,6 +20,22 @@ let
       mode = "0640";
       linkCount = 1;
     };
+    auxiliaryDirectories = {
+      audit = {
+        directoryId = "zone-store-audit-${zoneName}";
+        owner = "d2bd";
+        group = "d2bd";
+        mode = "0700";
+        repairOwner = "privileged-broker";
+      };
+      telemetry = {
+        directoryId = "zone-store-telemetry-${zoneName}";
+        owner = "d2bd";
+        group = "d2bd";
+        mode = "0700";
+        repairOwner = "privileged-broker";
+      };
+    };
     filesystem = "regular-file-anchored-fd-relative-no-follow";
     locking = "ofd-close-on-exec";
     marker.identityMarkerId = "zone-store-marker-${zoneName}";

--- a/packages/d2b-contract-tests/tests/zone_storage_contract.rs
+++ b/packages/d2b-contract-tests/tests/zone_storage_contract.rs
@@ -17,6 +17,22 @@ fn canonical_row() -> Value {
             "mode": "0640",
             "linkCount": 1
         },
+        "auxiliaryDirectories": {
+            "audit": {
+                "directoryId": "zone-store-audit-local-root",
+                "owner": "d2bd",
+                "group": "d2bd",
+                "mode": "0700",
+                "repairOwner": "privileged-broker"
+            },
+            "telemetry": {
+                "directoryId": "zone-store-telemetry-local-root",
+                "owner": "d2bd",
+                "group": "d2bd",
+                "mode": "0700",
+                "repairOwner": "privileged-broker"
+            }
+        },
         "filesystem": "regular-file-anchored-fd-relative-no-follow",
         "locking": "ofd-close-on-exec",
         "marker": {
@@ -55,6 +71,7 @@ fn source_row_rejects_paths_missing_invariants_and_unknown_fields() {
         "storageOwnerPrincipal",
         "parentDirectoryId",
         "ownership",
+        "auxiliaryDirectories",
         "filesystem",
         "locking",
         "marker",
@@ -79,6 +96,18 @@ fn source_row_rejects_paths_missing_invariants_and_unknown_fields() {
         assert!(
             serde_json::from_value::<ZoneStoreStorageRow>(candidate).is_err(),
             "missing ownership invariant {field} must be rejected"
+        );
+    }
+
+    for field in ["audit", "telemetry"] {
+        let mut candidate = canonical_row();
+        candidate["auxiliaryDirectories"][field]
+            .as_object_mut()
+            .unwrap()
+            .remove("repairOwner");
+        assert!(
+            serde_json::from_value::<ZoneStoreStorageRow>(candidate).is_err(),
+            "missing auxiliary directory repair owner must be rejected"
         );
     }
 
@@ -121,6 +150,7 @@ fn generated_schema_is_closed_required_and_path_free() {
         "storageOwnerPrincipal",
         "parentDirectoryId",
         "ownership",
+        "auxiliaryDirectories",
         "filesystem",
         "locking",
         "marker",
@@ -140,6 +170,8 @@ fn generated_schema_is_closed_required_and_path_free() {
     }
     for definition in [
         "ZoneStoreOwnershipInvariant",
+        "ZoneStoreAuxiliaryDirectories",
+        "ZoneStoreAuxiliaryDirectory",
         "ZoneStoreMarkerInvariant",
         "ZoneStorePublicationInvariant",
     ] {

--- a/packages/d2b-contracts/src/v3/storage.rs
+++ b/packages/d2b-contracts/src/v3/storage.rs
@@ -130,6 +130,10 @@ opaque_storage_id!(
     "Opaque identity-marker identifier resolved only by the storage owner."
 );
 opaque_storage_id!(
+    ZoneStoreDirectoryId,
+    "Opaque auxiliary Zone-directory identifier resolved only by the storage owner."
+);
+opaque_storage_id!(
     ZoneStorePrincipal,
     "Validated local storage-owner, file-owner, or file-group principal."
 );
@@ -200,6 +204,42 @@ impl JsonSchema for ZoneStoreFileMode {
             ..Default::default()
         })
     }
+}
+
+/// The sole privileged repair authority for broker-provisioned Zone directories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ZoneStoreDirectoryRepairOwner {
+    /// The privileged broker is the only component allowed to create or repair
+    /// the declared directory posture.
+    PrivilegedBroker,
+}
+
+/// Exact ownership and repair requirements for one Zone auxiliary directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ZoneStoreAuxiliaryDirectory {
+    /// Opaque identifier for the broker-resolved directory.
+    pub directory_id: ZoneStoreDirectoryId,
+    /// Required directory owner.
+    pub owner: ZoneStorePrincipal,
+    /// Required directory group.
+    pub group: ZoneStorePrincipal,
+    /// Required directory mode.
+    pub mode: ZoneStoreFileMode,
+    /// Sole authority allowed to provision or repair this directory.
+    pub repair_owner: ZoneStoreDirectoryRepairOwner,
+}
+
+/// Broker-resolved directories used by the Zone runtime's audit and telemetry
+/// ports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ZoneStoreAuxiliaryDirectories {
+    /// Durable authoritative audit directory.
+    pub audit: ZoneStoreAuxiliaryDirectory,
+    /// Best-effort telemetry receiver directory.
+    pub telemetry: ZoneStoreAuxiliaryDirectory,
 }
 
 /// Exact one-link requirement for the database inode.
@@ -329,6 +369,8 @@ pub struct ZoneStoreStorageRow {
     pub parent_directory_id: ZoneStoreParentDirectoryId,
     /// Required owner, group, mode, and link-count posture.
     pub ownership: ZoneStoreOwnershipInvariant,
+    /// Explicit d2bd-owned audit and telemetry directory posture.
+    pub auxiliary_directories: ZoneStoreAuxiliaryDirectories,
     /// Required filesystem capability and path-resolution posture.
     pub filesystem: ZoneStoreFilesystemRequirement,
     /// Required locking capability.
@@ -357,6 +399,22 @@ mod tests {
                 "group": "d2b-zonert",
                 "mode": "0640",
                 "linkCount": 1
+            },
+            "auxiliaryDirectories": {
+                "audit": {
+                    "directoryId": "zone-store-audit-local-root",
+                    "owner": "d2bd",
+                    "group": "d2bd",
+                    "mode": "0700",
+                    "repairOwner": "privileged-broker"
+                },
+                "telemetry": {
+                    "directoryId": "zone-store-telemetry-local-root",
+                    "owner": "d2bd",
+                    "group": "d2bd",
+                    "mode": "0700",
+                    "repairOwner": "privileged-broker"
+                }
             },
             "filesystem": "regular-file-anchored-fd-relative-no-follow",
             "locking": "ofd-close-on-exec",
@@ -406,6 +464,7 @@ mod tests {
             "storageOwnerPrincipal",
             "parentDirectoryId",
             "ownership",
+            "auxiliaryDirectories",
             "filesystem",
             "locking",
             "marker",
@@ -430,6 +489,18 @@ mod tests {
             assert!(
                 serde_json::from_value::<ZoneStoreStorageRow>(candidate).is_err(),
                 "missing ownership invariant {field} must be rejected"
+            );
+        }
+
+        for directory in ["audit", "telemetry"] {
+            let mut candidate = valid_row();
+            candidate["auxiliaryDirectories"][directory]
+                .as_object_mut()
+                .expect("auxiliary directory object")
+                .remove("repairOwner");
+            assert!(
+                serde_json::from_value::<ZoneStoreStorageRow>(candidate).is_err(),
+                "missing auxiliary directory repair owner {directory} must be rejected"
             );
         }
 

--- a/packages/d2b-priv-broker/src/ops/zone_store.rs
+++ b/packages/d2b-priv-broker/src/ops/zone_store.rs
@@ -17,9 +17,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use d2b_contracts::broker_wire::{OpenZoneStoreResponse, ZoneStoreDisposition};
 use d2b_contracts::v3::storage::{
-    ZoneStoreDescriptorPublicationRequirement, ZoneStoreFilesystemRequirement,
-    ZoneStoreFsyncRequirement, ZoneStoreId, ZoneStoreLockingRequirement, ZoneStorePrincipal,
-    ZoneStoreReplacementDetection, ZoneStoreReplacementPublicationRequirement, ZoneStoreStorageRow,
+    ZoneStoreAuxiliaryDirectory, ZoneStoreDescriptorPublicationRequirement,
+    ZoneStoreDirectoryRepairOwner, ZoneStoreFilesystemRequirement, ZoneStoreFsyncRequirement,
+    ZoneStoreId, ZoneStoreLockingRequirement, ZoneStorePrincipal, ZoneStoreReplacementDetection,
+    ZoneStoreReplacementPublicationRequirement, ZoneStoreStorageRow,
 };
 use d2b_core::bundle_resolver::BundleResolver;
 use nix::fcntl::{FcntlArg, FdFlag, fcntl};
@@ -38,6 +39,8 @@ const ZONE_STORE_PARENT_PREFIX: &str = "zone-store-parent-";
 const ZONE_STORE_MARKER_PREFIX: &str = "zone-store-marker-";
 const DATABASE_NAME: &str = "store.redb";
 const MARKER_NAME: &str = ".d2b-store-marker";
+const AUDIT_DIRECTORY_NAME: &str = "audit";
+const TELEMETRY_DIRECTORY_NAME: &str = "telemetry";
 const MARKER_VERSION: u32 = 1;
 const PARENT_MODE: u32 = 0o750;
 const MARKER_MODE: u32 = 0o640;
@@ -101,6 +104,16 @@ struct ResolvedZoneStoreRow {
     database_name: &'static str,
     marker_name: &'static str,
     identity_marker_id: String,
+    owner_uid: u32,
+    group_gid: u32,
+    mode: u32,
+    audit_directory: ResolvedZoneAuxiliaryDirectory,
+    telemetry_directory: ResolvedZoneAuxiliaryDirectory,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedZoneAuxiliaryDirectory {
+    name: &'static str,
     owner_uid: u32,
     group_gid: u32,
     mode: u32,
@@ -172,6 +185,16 @@ fn resolve_signed_row(
     let owner_uid = resolve_user(&row.ownership.owner)?;
     let group_gid = resolve_group(&row.ownership.group)?;
     let mode = parse_mode(row.ownership.mode.as_str())?;
+    let audit_directory = resolve_auxiliary_directory(
+        &row.auxiliary_directories.audit,
+        &format!("zone-store-audit-{zone}"),
+        AUDIT_DIRECTORY_NAME,
+    )?;
+    let telemetry_directory = resolve_auxiliary_directory(
+        &row.auxiliary_directories.telemetry,
+        &format!("zone-store-telemetry-{zone}"),
+        TELEMETRY_DIRECTORY_NAME,
+    )?;
 
     let state_root = resolver
         .find_storage_path_spec(STATE_ROOT_STORAGE_ID)
@@ -197,6 +220,31 @@ fn resolve_signed_row(
         owner_uid,
         group_gid,
         mode,
+        audit_directory,
+        telemetry_directory,
+    })
+}
+
+fn resolve_auxiliary_directory(
+    directory: &ZoneStoreAuxiliaryDirectory,
+    expected_id: &str,
+    name: &'static str,
+) -> Result<ResolvedZoneAuxiliaryDirectory, ZoneStoreError> {
+    if directory.directory_id.as_str() != expected_id
+        || directory.owner.as_str() != "d2bd"
+        || directory.group.as_str() != "d2bd"
+        || directory.mode.as_str() != "0700"
+        || directory.repair_owner != ZoneStoreDirectoryRepairOwner::PrivilegedBroker
+    {
+        return Err(ZoneStoreError::InvalidStorageRow(
+            "auxiliary-directory-invariant",
+        ));
+    }
+    Ok(ResolvedZoneAuxiliaryDirectory {
+        name,
+        owner_uid: resolve_user(&directory.owner)?,
+        group_gid: resolve_group(&directory.group)?,
+        mode: parse_mode(directory.mode.as_str())?,
     })
 }
 
@@ -296,6 +344,8 @@ fn open_resolved_row(row: &ResolvedZoneStoreRow) -> Result<ZoneStoreOutcome, Zon
         .ok_or(ZoneStoreError::PathSafetyViolation("state-root-missing"))?;
     let _state_root_fd = open_anchored_directory(state_root, false)?;
     let parent_fd = open_anchored_directory(&row.parent_directory, true)?;
+    provision_auxiliary_directory(&parent_fd, &row.audit_directory)?;
+    provision_auxiliary_directory(&parent_fd, &row.telemetry_directory)?;
     let marker_present = marker_exists(&parent_fd, row.marker_name)?;
     let database_present = database_exists(&parent_fd, row.database_name)?;
 
@@ -305,6 +355,54 @@ fn open_resolved_row(row: &ResolvedZoneStoreRow) -> Result<ZoneStoreOutcome, Zon
         } else {
             ZoneStoreError::DatabaseMissing
         });
+    }
+
+    fn provision_auxiliary_directory(
+        parent: &OwnedFd,
+        directory: &ResolvedZoneAuxiliaryDirectory,
+    ) -> Result<(), ZoneStoreError> {
+        let flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC;
+        let fd = match openat(parent, directory.name, flags, Mode::empty()) {
+            Ok(fd) => fd,
+            Err(error) if error == rustix::io::Errno::NOENT => {
+                mkdirat(parent, directory.name, Mode::from_raw_mode(directory.mode))
+                    .map_err(|_| ZoneStoreError::Io("auxiliary-directory-create-failed"))?;
+                fsync(parent).map_err(|_| ZoneStoreError::Io("parent-directory-fsync-failed"))?;
+                openat(parent, directory.name, flags, Mode::empty()).map_err(|error| {
+                    if error == rustix::io::Errno::LOOP || error == rustix::io::Errno::NOTDIR {
+                        ZoneStoreError::PathSafetyViolation("auxiliary-directory-symlink-refused")
+                    } else {
+                        ZoneStoreError::Io("auxiliary-directory-open-failed")
+                    }
+                })?
+            }
+            Err(error)
+                if error == rustix::io::Errno::LOOP || error == rustix::io::Errno::NOTDIR =>
+            {
+                return Err(ZoneStoreError::PathSafetyViolation(
+                    "auxiliary-directory-symlink-refused",
+                ));
+            }
+            Err(_) => return Err(ZoneStoreError::Io("auxiliary-directory-open-failed")),
+        };
+        let stat =
+            fstat(&fd).map_err(|_| ZoneStoreError::Io("auxiliary-directory-fstat-failed"))?;
+        if FileType::from_raw_mode(stat.st_mode) != FileType::Directory {
+            return Err(ZoneStoreError::PathSafetyViolation(
+                "auxiliary-directory-not-directory",
+            ));
+        }
+        fchmod(&fd, Mode::from_raw_mode(directory.mode))
+            .map_err(|_| ZoneStoreError::Io("auxiliary-directory-chmod-failed"))?;
+        nix_fchown(
+            fd.as_raw_fd(),
+            Some(Uid::from_raw(directory.owner_uid)),
+            Some(Gid::from_raw(directory.group_gid)),
+        )
+        .map_err(|_| ZoneStoreError::Io("auxiliary-directory-chown-failed"))?;
+        fsync(&fd).map_err(|_| ZoneStoreError::Io("auxiliary-directory-fsync-failed"))?;
+        fsync(parent).map_err(|_| ZoneStoreError::Io("parent-directory-fsync-failed"))?;
+        Ok(())
     }
 
     let (database_fd, disposition) = if database_present {
@@ -836,6 +934,18 @@ mod tests {
                 owner_uid: owner,
                 group_gid: group,
                 mode: 0o640,
+                audit_directory: ResolvedZoneAuxiliaryDirectory {
+                    name: AUDIT_DIRECTORY_NAME,
+                    owner_uid: owner,
+                    group_gid: group,
+                    mode: 0o700,
+                },
+                telemetry_directory: ResolvedZoneAuxiliaryDirectory {
+                    name: TELEMETRY_DIRECTORY_NAME,
+                    owner_uid: owner,
+                    group_gid: group,
+                    mode: 0o700,
+                },
             },
         )
     }
@@ -850,6 +960,22 @@ mod tests {
                 "group": "d2b-zonert",
                 "mode": "0640",
                 "linkCount": 1
+            },
+            "auxiliaryDirectories": {
+                "audit": {
+                    "directoryId": "zone-store-audit-local-root",
+                    "owner": "d2bd",
+                    "group": "d2bd",
+                    "mode": "0700",
+                    "repairOwner": "privileged-broker"
+                },
+                "telemetry": {
+                    "directoryId": "zone-store-telemetry-local-root",
+                    "owner": "d2bd",
+                    "group": "d2bd",
+                    "mode": "0700",
+                    "repairOwner": "privileged-broker"
+                }
             },
             "filesystem": "regular-file-anchored-fd-relative-no-follow",
             "locking": "ofd-close-on-exec",
@@ -918,7 +1044,17 @@ mod tests {
 
     #[test]
     fn provision_and_reopen_are_idempotent_and_owned() {
-        let (_temp, row) = fixture();
+        let (temp, row) = fixture();
+        fs::set_permissions(
+            temp.path().join("zones/local-root"),
+            fs::Permissions::from_mode(0o750),
+        )
+        .expect("parent mode");
+        let parent_mode = fs::metadata(temp.path().join("zones/local-root"))
+            .expect("parent metadata")
+            .permissions()
+            .mode()
+            & 0o777;
         let first = open_resolved_row(&row).expect("provision");
         assert_eq!(
             first.response.disposition,
@@ -933,6 +1069,22 @@ mod tests {
         let identity = first.response.store_identity.clone();
         let first_stat = fstat(&first.database_fd).expect("database stat");
         drop(first);
+        for name in [AUDIT_DIRECTORY_NAME, TELEMETRY_DIRECTORY_NAME] {
+            let metadata = fs::metadata(temp.path().join("zones/local-root").join(name))
+                .expect("auxiliary directory metadata");
+            assert!(metadata.is_dir());
+            assert_eq!(metadata.uid(), NixUid::current().as_raw());
+            assert_eq!(metadata.gid(), NixGid::current().as_raw());
+            assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+        }
+        assert_eq!(
+            fs::metadata(temp.path().join("zones/local-root"))
+                .expect("parent metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            parent_mode
+        );
 
         let second = open_resolved_row(&row).expect("reopen");
         assert_eq!(second.response.disposition, ZoneStoreDisposition::Opened);

--- a/tests/host-integration/gas-city-contributor.nix
+++ b/tests/host-integration/gas-city-contributor.nix
@@ -118,8 +118,6 @@ let
   };
   testPackagePython = "${testPackage}/bin/python3";
   testPackageScripts = "${testPackage}/share/gas-city-contributor/pack/scripts";
-  generation =
-    builtins.substring 0 32 (builtins.hashString "sha256" (toString testPackage));
 
   credentialProbe = pkgs.writeShellScript "gascity-host-credential-probe" ''
     set -eu
@@ -477,7 +475,7 @@ let
       TERMINAL_ROOT = pathlib.Path(
           os.environ.get("GC_TERMINAL_STATE_ROOT", str(AGENT_STATE / "terminal"))
       )
-      GENERATION = os.environ.get("GC_CITY_GENERATION", "${generation}")
+      GENERATION = os.environ.get("GC_CITY_GENERATION", "fixture-generation")
       PUBLIC_SOCKET = os.environ.get(
           "GC_AGENT_LAUNCHER_SOCKET", "/run/gascity-agent/agent.sock"
       )
@@ -918,7 +916,10 @@ let
           context.write_text(
               json.dumps(
                   {
-                      "generation": os.environ.get("GC_CITY_GENERATION", "${generation}"),
+                      "generation": os.environ.get(
+                          "GC_CITY_GENERATION",
+                          "fixture-generation",
+                      ),
                       "state_schema": "1",
                       "worktree": str(FIXTURE),
                       "next_action": "continue",
@@ -1352,7 +1353,7 @@ let
       )
       module.publish_reserve_breach(
           status,
-          generation="${generation}",
+          generation="reserve-breach-fixture",
           state_schema="1",
       )
       raise SystemExit(1)
@@ -1621,13 +1622,13 @@ pkgs.testers.runNixOSTest {
 
   testScript = ''
     import json
+    import shlex
 
     package = "${testPackage}"
     python = "${testPackagePython}"
     fdproxy = "${testPackage.passthru.runtimeScripts}/bin/gascity-fdproxy"
     envoy = "${testPackage}/bin/envoy"
     ca_bundle = "${testPackage}/etc/ssl/certs/ca-bundle.crt"
-    generation = "${generation}"
     auth = "${relayAuth}"
     launcher_probe = "${launcherProbe}"
     proxy_fixture = "${proxyFixture}"
@@ -1684,6 +1685,22 @@ pkgs.testers.runNixOSTest {
         "/var/lib/gascity-contributor/state/worktrees/planning-run/docs/plans/acp-observation-planning-run.json",
     ]:
         machine.wait_for_file(path)
+
+    generation_entries = [
+        entry.split("=", 1)[1]
+        for entry in shlex.split(
+            machine.succeed(
+                "systemctl show -P Environment gas-city-contributor.service"
+            )
+        )
+        if entry.startswith("GC_CITY_GENERATION=")
+    ]
+    assert len(generation_entries) == 1, (
+        "expected exactly one GC_CITY_GENERATION in the rendered "
+        f"service environment, got {len(generation_entries)}"
+    )
+    generation = generation_entries[0]
+    assert generation, "GC_CITY_GENERATION must be nonempty"
 
     machine.succeed(
         "systemctl start gascity-buildbuddy-envoy-syscall-smoke.service"

--- a/tests/host-integration/unsafe-local-helper.nix
+++ b/tests/host-integration/unsafe-local-helper.nix
@@ -91,6 +91,20 @@ if True:
     )
     machine.succeed("systemctl restart d2bd.service")
     machine.wait_for_unit("d2bd.service")
+    machine.wait_until_succeeds(
+        "journalctl -u d2bd.service --no-pager | grep -Eq "
+        "'interaction_runtime_ready[=: ]+true'",
+        timeout=60,
+    )
+    for zone in ["local-root", "other"]:
+        machine.succeed(
+            f"test \"$(stat -c '%U:%G %a' /var/lib/d2b/zones/{zone})\" = "
+            "\"root:d2bd 750\" && "
+            f"test \"$(stat -c '%U:%G %a' /var/lib/d2b/zones/{zone}/audit)\" = "
+            "\"d2bd:d2bd 700\" && "
+            f"test \"$(stat -c '%U:%G %a' /var/lib/d2b/zones/{zone}/telemetry)\" = "
+            "\"d2bd:d2bd 700\""
+        )
     machine.succeed(
         "test -f /etc/d2b/zones/local-root/storage.json && "
         "test -f /etc/d2b/zones/work/storage.json && "

--- a/tests/unit/nix/cases/bundle-artifacts-envelope.nix
+++ b/tests/unit/nix/cases/bundle-artifacts-envelope.nix
@@ -108,6 +108,22 @@ in
           mode = "0640";
           linkCount = 1;
         };
+        auxiliaryDirectories = {
+          audit = {
+            directoryId = "zone-store-audit-work";
+            owner = "d2bd";
+            group = "d2bd";
+            mode = "0700";
+            repairOwner = "privileged-broker";
+          };
+          telemetry = {
+            directoryId = "zone-store-telemetry-work";
+            owner = "d2bd";
+            group = "d2bd";
+            mode = "0700";
+            repairOwner = "privileged-broker";
+          };
+        };
         filesystem = "regular-file-anchored-fd-relative-no-follow";
         locking = "ofd-close-on-exec";
         marker.identityMarkerId = "zone-store-marker-work";

--- a/tests/unit/nix/helpers/bundle-artifacts.nix
+++ b/tests/unit/nix/helpers/bundle-artifacts.nix
@@ -122,6 +122,22 @@ let
       mode = "0640";
       linkCount = 1;
     };
+    auxiliaryDirectories = {
+      audit = {
+        directoryId = "zone-store-audit-local-root";
+        owner = "d2bd";
+        group = "d2bd";
+        mode = "0700";
+        repairOwner = "privileged-broker";
+      };
+      telemetry = {
+        directoryId = "zone-store-telemetry-local-root";
+        owner = "d2bd";
+        group = "d2bd";
+        mode = "0700";
+        repairOwner = "privileged-broker";
+      };
+    };
     filesystem = "regular-file-anchored-fd-relative-no-follow";
     locking = "ofd-close-on-exec";
     marker.identityMarkerId = "zone-store-marker-local-root";


### PR DESCRIPTION
## Summary

This restores two host-integration paths without weakening fail-closed fencing. Gas City launcher probes now use the live `GC_CITY_GENERATION` rendered by `gascity-agent.service`, and Zone storage now provisions dedicated d2bd-owned audit and telemetry directories beneath the broker-owned parent. The storage change removes the audit `EACCES` failure while preserving the parent ownership boundary and single repair owner.

## Validation evidence

- [x] **Focused tests for the changed components** were run:
  - `nix build --no-link --print-build-logs .#vmChecks.x86_64-linux.gas-city-contributor` - passed.
  - `nix build --no-link --print-build-logs .#checks.x86_64-linux.nix-unit-daemon` - passed (`195 cases passed`).
  - `cargo test -p d2b-contracts --lib` - passed (`417 passed`).
  - `cargo test -p d2b-contract-tests --test zone_storage_contract` - passed (`3 passed`).
  - `cargo test zone_store` in `packages/d2b-priv-broker` - passed (`8 passed`).
  - Workspace and broker `cargo fmt --all -- --check`, `git diff --check`, and `bash scripts/changelog-check.sh` - passed.
- [ ] **Wider lanes are conditional.** `make test-host-integration` was run and is dependency-blocked at `unsafe-local-helper`: d2bd logs `resource-runtime-policy-unavailable` and `interaction_runtime_ready=false` while the VM waits for `interaction_runtime_ready=true`. The original Zone audit/telemetry `EACCES` does not recur. The policy-startup dependency is owned by U9 PR #433; no policy/runtime fix is included here.
- [x] **Hardware checks are conditional:** not applicable; this change does not require graphics, GPU, video decode, USBIP/YubiKey, hardware TPM, or a full device boot.
- [x] **Changed tests are inventoried:** existing host and Nix-unit tests were strengthened; no test retirement or migration-ledger row was required.
- [x] **Changelog updated** with `changelog.d/fix-host-integration.md`.
- [x] **Docs + CI updated in lockstep** where applicable: the Zone storage schema and its Nix emitter were updated together; no CI workflow change was needed.

## Notes

- `origin/v3` at `d851094a0d51d566a3bed55c128705c531b15cf0` was merged conflict-free before validation.
- The branch contains no changes to `labs/**`, managed Gas City runtime authority, or later-wave pre-work.
