### PR TITLE
credential-entra: bind Guest-only Entra lease lifecycle

### DIFF
--- a/changelog.d/feat-spec001-credential-entra.md
+++ b/changelog.d/feat-spec001-credential-entra.md
@@ -1,0 +1,12 @@
+### Changed
+
+- Bound Entra credential acquisition, refresh, authorization, redacted status,
+  bounded degradation, and finalization cleanup to the owning Guest and Zone.
+- Require exact authenticated Guest, Provider, and Zone bindings before any
+  client effect, preserve committed refresh metadata after post-commit
+  validation failures, and prevent finalized credentials from minting again.
+- Bind every service operation to the authenticated Credential session and
+  delivery context, persist remote lease state, reject generation rollback,
+  accept Unix-millisecond deadlines, and cap projected retry state.
+- Revoke newly issued leases when replacement validation or local commitment
+  fails, retaining degraded cleanup state when remote revocation is ambiguous.

--- a/changelog.d/feat-spec001-credential-entra.md
+++ b/changelog.d/feat-spec001-credential-entra.md
@@ -10,3 +10,5 @@
   accept Unix-millisecond deadlines, and cap projected retry state.
 - Revoke newly issued leases when replacement validation or local commitment
   fails, retaining degraded cleanup state when remote revocation is ambiguous.
+- Keep proactive refresh available during an ambiguous replacement retry, and
+  keep that replacement idempotency key after a successful refresh.

--- a/packages/d2b-provider-credential-entra/src/controller.rs
+++ b/packages/d2b-provider-credential-entra/src/controller.rs
@@ -6,6 +6,7 @@ mod audit;
 mod telemetry;
 
 use d2b_contracts::v3::ResourceRef;
+use d2b_contracts::v3::credential::CREDENTIAL_SERVICE_NAME;
 use d2b_contracts::v3::credential::{
     CredentialInteractionState, CredentialLeaseStatus, CredentialMetadata, CredentialServiceError,
     CredentialServiceErrorCode, CredentialStatus,
@@ -21,7 +22,8 @@ use d2b_contracts::v3::credential_controller::{
 use d2b_contracts::v3::{AuthenticatedSubjectContext, Locality};
 
 use crate::{
-    EntraClientState, EntraPlacement, EntraResourceHealth, LOGIN_ENDPOINT_PURPOSE, PROVIDER_REF,
+    CREDENTIAL_SESSION_PURPOSE, EntraClientState, EntraPlacement, EntraResourceHealth,
+    LOGIN_ENDPOINT_PURPOSE, MAX_REFRESH_ATTEMPTS, PROVIDER_REF,
 };
 
 /// Canonical provider-visible Endpoint policy for the Entrablau service.
@@ -75,6 +77,9 @@ impl EntraEndpointPolicy {
             && subject
                 .provider_ref()
                 .is_some_and(|provider| provider == &self.provider_ref)
+            && subject.provider_generation().is_some()
+            && subject.service().as_str() == CREDENTIAL_SERVICE_NAME
+            && subject.session_purpose().as_str() == CREDENTIAL_SESSION_PURPOSE
     }
 }
 
@@ -135,6 +140,9 @@ impl EntraController {
         resource_health: EntraResourceHealth,
         refresh_attempts: u16,
     ) -> Result<EntraStatusProjection, CredentialServiceError> {
+        if refresh_attempts > MAX_REFRESH_ATTEMPTS {
+            return Err(invariant());
+        }
         let lease = metadata
             .map(|metadata| {
                 CredentialLeaseStatus::new(

--- a/packages/d2b-provider-credential-entra/src/lib.rs
+++ b/packages/d2b-provider-credential-entra/src/lib.rs
@@ -17,7 +17,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread::{self, Thread};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
@@ -32,10 +32,13 @@ pub use controller::{EntraController, EntraEndpointPolicy, EntraStatusProjection
 pub const PROVIDER_REF: &str = "Provider/credential-entra";
 /// Canonical identity-Guest login Endpoint purpose.
 pub const LOGIN_ENDPOINT_PURPOSE: &str = "credential-entra.d2bus.org/entra-login-token";
+/// Authenticated ComponentSession purpose accepted by this Provider.
+pub const CREDENTIAL_SESSION_PURPOSE: &str = "credential";
 /// Maximum active leases per Provider instance.
 pub const MAX_LOCAL_LEASES: u32 = 256;
 /// Maximum refresh failures retained for one Credential before retry stops.
 pub const MAX_REFRESH_ATTEMPTS: u16 = 3;
+const ABSOLUTE_UNIX_MILLIS_THRESHOLD: u64 = 1_000_000_000_000;
 
 /// Boxed asynchronous result returned by the injected identity-Guest client.
 pub type EntraFuture<'a, T> =
@@ -635,7 +638,14 @@ impl EntraCredentialProvider {
             metadata: record.metadata,
             endpoint_generation: self.placement.endpoint_generation(),
         };
-        Self::poll_client(self.client.revoke_lease(&lease), deadline)?;
+        if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
+            && !matches!(
+                error.code(),
+                CredentialServiceErrorCode::LeaseExpired | CredentialServiceErrorCode::LeaseRevoked
+            )
+        {
+            return Err(error);
+        }
         let mut leases = self.leases.lock().map_err(|_| {
             CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
         })?;
@@ -678,11 +688,74 @@ impl EntraCredentialProvider {
     }
 
     pub(crate) fn operation_deadline(deadline_ms: u64) -> Result<Instant, CredentialServiceError> {
-        Instant::now()
-            .checked_add(Duration::from_millis(deadline_ms))
-            .ok_or_else(|| {
+        Self::time_bound_instant(deadline_ms)
+    }
+
+    pub(crate) fn now_unix_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+            .unwrap_or(0)
+    }
+
+    pub(crate) const fn is_absolute_unix_ms(value_ms: u64) -> bool {
+        value_ms >= ABSOLUTE_UNIX_MILLIS_THRESHOLD
+    }
+
+    pub(crate) fn is_expired_unix_ms(value_ms: u64) -> bool {
+        Self::is_absolute_unix_ms(value_ms) && value_ms <= Self::now_unix_ms()
+    }
+
+    pub(crate) fn time_bound_instant(value_ms: u64) -> Result<Instant, CredentialServiceError> {
+        let now = Instant::now();
+        let now_unix_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .as_millis()
+            .try_into()
+            .map_err(|_| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+        Self::time_bound_instant_at(value_ms, now, now_unix_ms)
+    }
+
+    pub(crate) fn time_bounds_not_after(
+        later_ms: u64,
+        earlier_ms: u64,
+    ) -> Result<bool, CredentialServiceError> {
+        let now = Instant::now();
+        let now_unix_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .as_millis()
+            .try_into()
+            .map_err(|_| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+        let later = Self::time_bound_instant_at(later_ms, now, now_unix_ms)?;
+        let earlier = Self::time_bound_instant_at(earlier_ms, now, now_unix_ms)?;
+        Ok(later <= earlier)
+    }
+
+    fn time_bound_instant_at(
+        value_ms: u64,
+        now: Instant,
+        now_unix_ms: u64,
+    ) -> Result<Instant, CredentialServiceError> {
+        if value_ms >= ABSOLUTE_UNIX_MILLIS_THRESHOLD {
+            let remaining_ms = value_ms.checked_sub(now_unix_ms).ok_or_else(|| {
                 CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
-            })
+            })?;
+            now.checked_add(Duration::from_millis(remaining_ms))
+                .ok_or_else(|| {
+                    CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+                })
+        } else {
+            now.checked_add(Duration::from_millis(value_ms))
+                .ok_or_else(|| {
+                    CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+                })
+        }
     }
 
     pub(crate) fn poll_client<T>(
@@ -756,6 +829,11 @@ impl EntraCredentialProvider {
         grant: EntraLeaseGrant,
     ) -> Result<CredentialMetadata, CredentialServiceError> {
         if grant.rotation_generation == 0 || grant.expires_at_unix_ms == 0 {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::InvariantFailure,
+            ));
+        }
+        if Self::is_expired_unix_ms(grant.expires_at_unix_ms) {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::InvariantFailure,
             ));
@@ -854,6 +932,21 @@ mod tests {
                 1,
             ),
             Err(EntraProviderError::InvalidPlacement)
+        );
+    }
+
+    #[test]
+    fn operation_deadline_accepts_absolute_unix_milliseconds() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        assert!(EntraCredentialProvider::operation_deadline(now + 1_000).is_ok());
+        assert_eq!(
+            EntraCredentialProvider::operation_deadline(now - 1)
+                .unwrap_err()
+                .code(),
+            CredentialServiceErrorCode::DeadlineExceeded
         );
     }
 }

--- a/packages/d2b-provider-credential-entra/src/lib.rs
+++ b/packages/d2b-provider-credential-entra/src/lib.rs
@@ -448,6 +448,7 @@ impl EntraCredentialProviderFactory {
             consumer_ref: self.consumer_ref,
             client: self.client,
             leases: Mutex::new(BTreeMap::new()),
+            cleanup_leases: Mutex::new(BTreeMap::new()),
             lifecycle: Mutex::new(BTreeMap::new()),
             mutation_gate: Mutex::new(()),
         }
@@ -463,6 +464,7 @@ impl fmt::Debug for EntraCredentialProviderFactory {
 #[derive(Clone)]
 struct LeaseRecord {
     idempotency_key: String,
+    pending_acquire_idempotency: Option<String>,
     metadata: CredentialMetadata,
     refresh_attempts: u16,
     health: EntraResourceHealth,
@@ -501,6 +503,7 @@ pub struct EntraCredentialProvider {
     consumer_ref: ResourceRef,
     client: Arc<dyn EntraCredentialClient>,
     leases: Mutex<BTreeMap<String, LeaseRecord>>,
+    cleanup_leases: Mutex<BTreeMap<String, Vec<LeaseRecord>>>,
     lifecycle: Mutex<BTreeMap<String, EntraLifecycleState>>,
     mutation_gate: Mutex<()>,
 }
@@ -547,33 +550,69 @@ impl EntraCredentialProvider {
 
     /// Return the active lease count without exposing lease identity.
     pub fn active_lease_count(&self) -> u32 {
-        self.leases
+        let primary = self
+            .leases
             .lock()
             .map(|leases| {
                 leases
                     .values()
                     .filter(|record| record.metadata.state == CredentialLeaseState::Active)
-                    .count() as u32
+                    .count()
             })
-            .unwrap_or(0)
+            .unwrap_or(0);
+        let cleanup = self
+            .cleanup_leases
+            .lock()
+            .map(|leases| {
+                leases
+                    .values()
+                    .flatten()
+                    .filter(|record| record.metadata.state == CredentialLeaseState::Active)
+                    .count()
+            })
+            .unwrap_or(0);
+        (primary + cleanup) as u32
     }
 
     /// Return the typed health of one Credential resource.
     pub fn resource_health(&self, credential_ref: &ResourceRef) -> Option<EntraResourceHealth> {
-        self.leases.lock().ok().and_then(|leases| {
-            leases
-                .get(&credential_ref.to_canonical_string())
-                .map(|record| record.health)
-        })
+        let key = credential_ref.to_canonical_string();
+        self.cleanup_leases
+            .lock()
+            .ok()
+            .and_then(|leases| {
+                leases
+                    .get(&key)
+                    .and_then(|records| records.first())
+                    .map(|record| record.health)
+            })
+            .or_else(|| {
+                self.leases
+                    .lock()
+                    .ok()
+                    .and_then(|leases| leases.get(&key).map(|record| record.health))
+            })
     }
 
     /// Return the bounded refresh retry position for one Credential resource.
     pub fn refresh_retry_state(&self, credential_ref: &ResourceRef) -> Option<(u16, u16)> {
-        self.leases.lock().ok().and_then(|leases| {
-            leases
-                .get(&credential_ref.to_canonical_string())
-                .map(|record| (record.refresh_attempts, MAX_REFRESH_ATTEMPTS))
-        })
+        let key = credential_ref.to_canonical_string();
+        self.cleanup_leases
+            .lock()
+            .ok()
+            .and_then(|leases| {
+                leases
+                    .get(&key)
+                    .and_then(|records| records.first())
+                    .map(|record| (record.refresh_attempts, MAX_REFRESH_ATTEMPTS))
+            })
+            .or_else(|| {
+                self.leases.lock().ok().and_then(|leases| {
+                    leases
+                        .get(&key)
+                        .map(|record| (record.refresh_attempts, MAX_REFRESH_ATTEMPTS))
+                })
+            })
     }
 
     /// Revoke all handles owned by one Credential before finalization clears
@@ -590,66 +629,37 @@ impl EntraCredentialProvider {
         }
         let _mutation = self.mutation_guard()?;
         let key = credential_ref.to_canonical_string();
-        {
-            let mut lifecycle = self.lifecycle.lock().map_err(|_| {
-                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
-            })?;
-            if lifecycle.get(&key) == Some(&EntraLifecycleState::Finalized) {
-                return Ok(EntraOwnedHandleCleanup {
-                    revoked: 0,
-                    remaining: 0,
-                });
-            }
-            lifecycle.insert(key.clone(), EntraLifecycleState::Draining);
-        }
-        let record = self
-            .leases
+        let already_finalized = self
+            .lifecycle
             .lock()
             .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
             .get(&key)
-            .cloned();
-        let Some(record) = record else {
-            self.lifecycle
-                .lock()
-                .map_err(|_| {
-                    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
-                })?
-                .insert(key, EntraLifecycleState::Finalized);
-            return Ok(EntraOwnedHandleCleanup {
-                revoked: 0,
-                remaining: 0,
-            });
-        };
-        if record.metadata.state == CredentialLeaseState::Revoked {
-            self.lifecycle
-                .lock()
-                .map_err(|_| {
-                    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
-                })?
-                .insert(key, EntraLifecycleState::Finalized);
+            == Some(&EntraLifecycleState::Finalized);
+        if already_finalized {
             return Ok(EntraOwnedHandleCleanup {
                 revoked: 0,
                 remaining: 0,
             });
         }
         let deadline = Self::operation_deadline(deadline_ms)?;
-        let lease = EntraLeaseRef {
-            credential_ref: credential_ref.clone(),
-            metadata: record.metadata,
-            endpoint_generation: self.placement.endpoint_generation(),
-        };
-        if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
-            && !matches!(
-                error.code(),
-                CredentialServiceErrorCode::LeaseExpired | CredentialServiceErrorCode::LeaseRevoked
-            )
-        {
-            return Err(error);
-        }
-        let mut leases = self.leases.lock().map_err(|_| {
-            CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
-        })?;
-        let Some(record) = leases.get_mut(&key) else {
+        self.lifecycle
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .insert(key.clone(), EntraLifecycleState::Draining);
+        let primary = self
+            .leases
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .get(&key)
+            .cloned();
+        let cleanup = self
+            .cleanup_leases
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .get(&key)
+            .cloned()
+            .unwrap_or_default();
+        if primary.is_none() && cleanup.is_empty() {
             self.lifecycle
                 .lock()
                 .map_err(|_| {
@@ -657,20 +667,53 @@ impl EntraCredentialProvider {
                 })?
                 .insert(key, EntraLifecycleState::Finalized);
             return Ok(EntraOwnedHandleCleanup {
-                revoked: 1,
+                revoked: 0,
                 remaining: 0,
             });
-        };
-        record.metadata.state = CredentialLeaseState::Revoked;
-        record.metadata.outcome = CredentialOutcomeCode::Revoked;
-        record.health = EntraResourceHealth::Revoked;
-        record.refresh_attempts = 0;
+        }
+        let mut revoked = 0;
+        for record in primary.iter().chain(cleanup.iter()) {
+            if record.metadata.state == CredentialLeaseState::Revoked {
+                continue;
+            }
+            let lease = EntraLeaseRef {
+                credential_ref: credential_ref.clone(),
+                metadata: record.metadata.clone(),
+                endpoint_generation: self.placement.endpoint_generation(),
+            };
+            if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
+                && !matches!(
+                    error.code(),
+                    CredentialServiceErrorCode::LeaseExpired
+                        | CredentialServiceErrorCode::LeaseRevoked
+                )
+            {
+                return Err(error);
+            }
+            revoked += 1;
+        }
+        if primary.is_some() {
+            let mut leases = self.leases.lock().map_err(|_| {
+                CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
+            })?;
+            if let Some(record) = leases.get_mut(&key) {
+                record.metadata.state = CredentialLeaseState::Revoked;
+                record.metadata.outcome = CredentialOutcomeCode::Revoked;
+                record.health = EntraResourceHealth::Revoked;
+                record.refresh_attempts = 0;
+                record.pending_acquire_idempotency = None;
+            }
+        }
+        self.cleanup_leases
+            .lock()
+            .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
+            .remove(&key);
         self.lifecycle
             .lock()
             .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))?
             .insert(key, EntraLifecycleState::Finalized);
         Ok(EntraOwnedHandleCleanup {
-            revoked: 1,
+            revoked,
             remaining: 0,
         })
     }

--- a/packages/d2b-provider-credential-entra/src/service.rs
+++ b/packages/d2b-provider-credential-entra/src/service.rs
@@ -145,6 +145,17 @@ impl EntraCredentialProvider {
         let key = request.credential_ref().to_canonical_string();
         self.ensure_lifecycle_active(&key)?;
         self.ensure_client_ready(deadline)?;
+        if self
+            .cleanup_leases
+            .lock()
+            .map_err(|_| invariant())?
+            .get(&key)
+            .is_some_and(|records| !records.is_empty())
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            ));
+        }
         let existing = {
             let leases = self.leases.lock().map_err(|_| invariant())?;
             leases.get(&key).cloned()
@@ -156,12 +167,19 @@ impl EntraCredentialProvider {
             .values()
             .filter(|record| record.metadata.state == CredentialLeaseState::Active)
             .count();
-        if let Some(existing) = existing {
-            if existing.metadata.state == CredentialLeaseState::Active
+        if let Some(ref existing) = existing {
+            if existing.pending_acquire_idempotency.as_deref() == Some(request.idempotency_key()) {
+                // An explicit retry of an ambiguous replacement may ask the
+                // identity Guest to resolve its idempotency key.
+            } else if existing.pending_acquire_idempotency.is_some() {
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::ProviderUnavailable,
+                ));
+            } else if existing.metadata.state == CredentialLeaseState::Active
                 && existing.idempotency_key == request.idempotency_key()
             {
                 return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
-                    metadata: existing.metadata,
+                    metadata: existing.metadata.clone(),
                     delivery_session_params: delivery,
                 }));
             }
@@ -173,23 +191,6 @@ impl EntraCredentialProvider {
                     CredentialServiceErrorCode::ProviderUnavailable,
                 ));
             }
-            if existing.metadata.state != CredentialLeaseState::Revoked {
-                let lease = EntraLeaseRef {
-                    credential_ref: request.credential_ref().clone(),
-                    metadata: existing.metadata.clone(),
-                    endpoint_generation: self.placement.endpoint_generation(),
-                };
-                if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
-                    && !matches!(
-                        error.code(),
-                        CredentialServiceErrorCode::LeaseExpired
-                            | CredentialServiceErrorCode::LeaseRevoked
-                    )
-                {
-                    return Err(error);
-                }
-            }
-            self.leases.lock().map_err(|_| invariant())?.remove(&key);
         } else if active_leases >= self.config.max_leases() as usize {
             return Err(CredentialServiceError::new(
                 CredentialServiceErrorCode::ProviderUnavailable,
@@ -202,7 +203,22 @@ impl EntraCredentialProvider {
             requested_expiry_unix_ms: request.requested_expiry_unix_ms(),
             endpoint_generation: self.placement.endpoint_generation(),
         };
-        let grant = Self::poll_client(self.client.issue_lease(&client_request), deadline)?;
+        let grant = match Self::poll_client(self.client.issue_lease(&client_request), deadline) {
+            Ok(grant) => grant,
+            Err(error) => {
+                if existing.as_ref().is_some_and(|record| {
+                    record.metadata.state == CredentialLeaseState::Active
+                        && matches!(
+                            error.code(),
+                            CredentialServiceErrorCode::DeadlineExceeded
+                                | CredentialServiceErrorCode::InvariantFailure
+                        )
+                }) {
+                    self.mark_pending_acquire(&key, request.idempotency_key());
+                }
+                return Err(error);
+            }
+        };
         let metadata = match Self::grant_metadata(grant.clone(), request.requested_expiry_unix_ms())
         {
             Ok(metadata) => metadata,
@@ -217,8 +233,34 @@ impl EntraCredentialProvider {
                 return Err(error);
             }
         };
+        if let Some(existing) = existing.as_ref() {
+            if existing.metadata.state != CredentialLeaseState::Revoked {
+                let lease = EntraLeaseRef {
+                    credential_ref: request.credential_ref().clone(),
+                    metadata: existing.metadata.clone(),
+                    endpoint_generation: self.placement.endpoint_generation(),
+                };
+                if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
+                    && !matches!(
+                        error.code(),
+                        CredentialServiceErrorCode::LeaseExpired
+                            | CredentialServiceErrorCode::LeaseRevoked
+                    )
+                {
+                    self.cleanup_uncommitted_grant(
+                        request.credential_ref(),
+                        request.idempotency_key(),
+                        grant,
+                        request.requested_expiry_unix_ms(),
+                        deadline,
+                    );
+                    return Err(error);
+                }
+            }
+        }
         let record = LeaseRecord {
             idempotency_key: request.idempotency_key().to_owned(),
+            pending_acquire_idempotency: None,
             metadata: metadata.clone(),
             refresh_attempts: 0,
             health: crate::EntraResourceHealth::Ready,
@@ -317,10 +359,12 @@ impl EntraCredentialProvider {
                 return Err(error);
             }
         };
+        let pending_acquire_idempotency = record.pending_acquire_idempotency.clone();
         self.leases.lock().map_err(|_| invariant())?.insert(
             key.clone(),
             LeaseRecord {
                 idempotency_key: request.idempotency_key().to_owned(),
+                pending_acquire_idempotency,
                 metadata: metadata.clone(),
                 refresh_attempts: 0,
                 health: crate::EntraResourceHealth::Ready,
@@ -340,49 +384,94 @@ impl EntraCredentialProvider {
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
         self.ensure_client_ready(deadline)?;
-        let record = self
+        let primary = self
             .leases
             .lock()
             .map_err(|_| invariant())?
             .get(&key)
+            .cloned();
+        let cleanup_records = self
+            .cleanup_leases
+            .lock()
+            .map_err(|_| invariant())?
+            .get(&key)
             .cloned()
-            .ok_or_else(expired)?;
-        let (outcome, state) = if record.metadata.state == CredentialLeaseState::Revoked {
-            (
-                CredentialOutcomeCode::AlreadyRevoked,
-                CredentialLeaseState::Revoked,
-            )
-        } else {
+            .unwrap_or_default();
+        if primary.is_none() && cleanup_records.is_empty() {
+            return Err(expired());
+        }
+        let mut outcome = primary
+            .as_ref()
+            .filter(|record| record.metadata.state == CredentialLeaseState::Revoked)
+            .map(|_| CredentialOutcomeCode::AlreadyRevoked);
+        if let Some(record) = primary.as_ref() {
+            if record.metadata.state != CredentialLeaseState::Revoked {
+                let lease = EntraLeaseRef {
+                    credential_ref: request.credential_ref().clone(),
+                    metadata: record.metadata.clone(),
+                    endpoint_generation: self.placement.endpoint_generation(),
+                };
+                outcome = Some(
+                    match Self::poll_client(self.client.revoke_lease(&lease), deadline) {
+                        Ok(crate::EntraLeaseRevocation::Revoked) => CredentialOutcomeCode::Revoked,
+                        Ok(crate::EntraLeaseRevocation::AlreadyRevoked) => {
+                            CredentialOutcomeCode::AlreadyRevoked
+                        }
+                        Err(error)
+                            if matches!(
+                                error.code(),
+                                CredentialServiceErrorCode::LeaseExpired
+                                    | CredentialServiceErrorCode::LeaseRevoked
+                            ) =>
+                        {
+                            CredentialOutcomeCode::AlreadyRevoked
+                        }
+                        Err(error) => return Err(error),
+                    },
+                );
+            }
+        }
+        for record in &cleanup_records {
             let lease = EntraLeaseRef {
                 credential_ref: request.credential_ref().clone(),
                 metadata: record.metadata.clone(),
                 endpoint_generation: self.placement.endpoint_generation(),
             };
-            let outcome = match Self::poll_client(self.client.revoke_lease(&lease), deadline) {
-                Ok(crate::EntraLeaseRevocation::Revoked) => CredentialOutcomeCode::Revoked,
-                Ok(crate::EntraLeaseRevocation::AlreadyRevoked) => {
-                    CredentialOutcomeCode::AlreadyRevoked
-                }
+            match Self::poll_client(self.client.revoke_lease(&lease), deadline) {
+                Ok(crate::EntraLeaseRevocation::Revoked)
+                | Ok(crate::EntraLeaseRevocation::AlreadyRevoked) => {}
                 Err(error)
                     if matches!(
                         error.code(),
                         CredentialServiceErrorCode::LeaseExpired
                             | CredentialServiceErrorCode::LeaseRevoked
-                    ) =>
-                {
-                    CredentialOutcomeCode::AlreadyRevoked
-                }
+                    ) => {}
                 Err(error) => return Err(error),
-            };
-            (outcome, CredentialLeaseState::Revoked)
+            }
+        }
+        let metadata = if primary.is_some() {
+            let mut leases = self.leases.lock().map_err(|_| invariant())?;
+            let record = leases.get_mut(&key).ok_or_else(expired)?;
+            record.metadata.state = CredentialLeaseState::Revoked;
+            record.metadata.outcome = outcome.unwrap_or(CredentialOutcomeCode::Revoked);
+            record.pending_acquire_idempotency = None;
+            record.health = crate::EntraResourceHealth::Revoked;
+            record.metadata.clone()
+        } else {
+            let mut metadata = cleanup_records
+                .first()
+                .map(|record| record.metadata.clone())
+                .ok_or_else(expired)?;
+            metadata.state = CredentialLeaseState::Revoked;
+            metadata.outcome = CredentialOutcomeCode::AlreadyRevoked;
+            metadata
         };
-        let mut leases = self.leases.lock().map_err(|_| invariant())?;
-        let record = leases.get_mut(&key).ok_or_else(expired)?;
-        record.metadata.state = state;
-        record.metadata.outcome = outcome;
-        record.health = crate::EntraResourceHealth::Revoked;
+        self.cleanup_leases
+            .lock()
+            .map_err(|_| invariant())?
+            .remove(&key);
         Ok(CredentialResponse::RevokeToken(MetadataResponse {
-            metadata: record.metadata.clone(),
+            metadata,
         }))
     }
 
@@ -501,6 +590,15 @@ impl EntraCredentialProvider {
         }
     }
 
+    fn mark_pending_acquire(&self, key: &str, idempotency_key: &str) {
+        if let Ok(mut leases) = self.leases.lock()
+            && let Some(record) = leases.get_mut(key)
+        {
+            record.pending_acquire_idempotency = Some(idempotency_key.to_owned());
+            record.health = crate::EntraResourceHealth::Degraded;
+        }
+    }
+
     fn cleanup_uncommitted_grant(
         &self,
         credential_ref: &ResourceRef,
@@ -538,16 +636,17 @@ impl EntraCredentialProvider {
         {
             return;
         }
-        if let Ok(mut leases) = self.leases.lock() {
-            leases.insert(
-                credential_ref.to_canonical_string(),
-                LeaseRecord {
+        if let Ok(mut cleanup_leases) = self.cleanup_leases.lock() {
+            cleanup_leases
+                .entry(credential_ref.to_canonical_string())
+                .or_default()
+                .push(LeaseRecord {
                     idempotency_key: idempotency_key.to_owned(),
+                    pending_acquire_idempotency: None,
                     metadata,
                     refresh_attempts: crate::MAX_REFRESH_ATTEMPTS,
                     health: crate::EntraResourceHealth::Degraded,
-                },
-            );
+                });
         }
     }
 }

--- a/packages/d2b-provider-credential-entra/src/service.rs
+++ b/packages/d2b-provider-credential-entra/src/service.rs
@@ -233,29 +233,29 @@ impl EntraCredentialProvider {
                 return Err(error);
             }
         };
-        if let Some(existing) = existing.as_ref() {
-            if existing.metadata.state != CredentialLeaseState::Revoked {
-                let lease = EntraLeaseRef {
-                    credential_ref: request.credential_ref().clone(),
-                    metadata: existing.metadata.clone(),
-                    endpoint_generation: self.placement.endpoint_generation(),
-                };
-                if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
-                    && !matches!(
-                        error.code(),
-                        CredentialServiceErrorCode::LeaseExpired
-                            | CredentialServiceErrorCode::LeaseRevoked
-                    )
-                {
-                    self.cleanup_uncommitted_grant(
-                        request.credential_ref(),
-                        request.idempotency_key(),
-                        grant,
-                        request.requested_expiry_unix_ms(),
-                        deadline,
-                    );
-                    return Err(error);
-                }
+        if let Some(existing) = existing.as_ref()
+            && existing.metadata.state != CredentialLeaseState::Revoked
+        {
+            let lease = EntraLeaseRef {
+                credential_ref: request.credential_ref().clone(),
+                metadata: existing.metadata.clone(),
+                endpoint_generation: self.placement.endpoint_generation(),
+            };
+            if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
+                && !matches!(
+                    error.code(),
+                    CredentialServiceErrorCode::LeaseExpired
+                        | CredentialServiceErrorCode::LeaseRevoked
+                )
+            {
+                self.cleanup_uncommitted_grant(
+                    request.credential_ref(),
+                    request.idempotency_key(),
+                    grant,
+                    request.requested_expiry_unix_ms(),
+                    deadline,
+                );
+                return Err(error);
             }
         }
         let record = LeaseRecord {
@@ -404,32 +404,32 @@ impl EntraCredentialProvider {
             .as_ref()
             .filter(|record| record.metadata.state == CredentialLeaseState::Revoked)
             .map(|_| CredentialOutcomeCode::AlreadyRevoked);
-        if let Some(record) = primary.as_ref() {
-            if record.metadata.state != CredentialLeaseState::Revoked {
-                let lease = EntraLeaseRef {
-                    credential_ref: request.credential_ref().clone(),
-                    metadata: record.metadata.clone(),
-                    endpoint_generation: self.placement.endpoint_generation(),
-                };
-                outcome = Some(
-                    match Self::poll_client(self.client.revoke_lease(&lease), deadline) {
-                        Ok(crate::EntraLeaseRevocation::Revoked) => CredentialOutcomeCode::Revoked,
-                        Ok(crate::EntraLeaseRevocation::AlreadyRevoked) => {
-                            CredentialOutcomeCode::AlreadyRevoked
-                        }
-                        Err(error)
-                            if matches!(
-                                error.code(),
-                                CredentialServiceErrorCode::LeaseExpired
-                                    | CredentialServiceErrorCode::LeaseRevoked
-                            ) =>
-                        {
-                            CredentialOutcomeCode::AlreadyRevoked
-                        }
-                        Err(error) => return Err(error),
-                    },
-                );
-            }
+        if let Some(record) = primary.as_ref()
+            && record.metadata.state != CredentialLeaseState::Revoked
+        {
+            let lease = EntraLeaseRef {
+                credential_ref: request.credential_ref().clone(),
+                metadata: record.metadata.clone(),
+                endpoint_generation: self.placement.endpoint_generation(),
+            };
+            outcome = Some(
+                match Self::poll_client(self.client.revoke_lease(&lease), deadline) {
+                    Ok(crate::EntraLeaseRevocation::Revoked) => CredentialOutcomeCode::Revoked,
+                    Ok(crate::EntraLeaseRevocation::AlreadyRevoked) => {
+                        CredentialOutcomeCode::AlreadyRevoked
+                    }
+                    Err(error)
+                        if matches!(
+                            error.code(),
+                            CredentialServiceErrorCode::LeaseExpired
+                                | CredentialServiceErrorCode::LeaseRevoked
+                        ) =>
+                    {
+                        CredentialOutcomeCode::AlreadyRevoked
+                    }
+                    Err(error) => return Err(error),
+                },
+            );
         }
         for record in &cleanup_records {
             let lease = EntraLeaseRef {

--- a/packages/d2b-provider-credential-entra/src/service.rs
+++ b/packages/d2b-provider-credential-entra/src/service.rs
@@ -1,13 +1,17 @@
 //! Credential service dispatch for the identity-Guest client.
 
-use d2b_contracts::v3::Locality;
 use d2b_contracts::v3::credential::{
-    CredentialAuthorization, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
-    CredentialProvider, CredentialRequest, CredentialResponse, CredentialServiceError,
-    CredentialServiceErrorCode, DeliveryResponse, MetadataResponse,
+    CREDENTIAL_SERVICE_NAME, CredentialAuthorization, CredentialLeaseState, CredentialMetadata,
+    CredentialMethod, CredentialOutcomeCode, CredentialProvider, CredentialRequest,
+    CredentialResponse, CredentialServiceError, CredentialServiceErrorCode, DeliveryResponse,
+    MetadataResponse,
 };
+use d2b_contracts::v3::{Locality, ResourceRef};
 
-use crate::{EntraCredentialProvider, EntraLeaseRef, EntraLeaseRequest, LeaseRecord};
+use crate::{
+    CREDENTIAL_SESSION_PURPOSE, EntraClientState, EntraCredentialProvider, EntraLeaseInspection,
+    EntraLeaseRef, EntraLeaseRequest, LeaseRecord,
+};
 
 impl CredentialProvider for EntraCredentialProvider {
     fn dispatch(
@@ -16,7 +20,7 @@ impl CredentialProvider for EntraCredentialProvider {
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
     ) -> Result<CredentialResponse, CredentialServiceError> {
-        self.authorize_request(request, authorization)?;
+        self.authorize_request(method, request, authorization)?;
         match method {
             CredentialMethod::AcquireToken => self.acquire(request, authorization),
             CredentialMethod::RefreshToken => self.refresh(request, authorization),
@@ -43,12 +47,17 @@ impl CredentialProvider for &EntraCredentialProvider {
 impl EntraCredentialProvider {
     fn authorize_request(
         &self,
+        method: CredentialMethod,
         request: &CredentialRequest,
         authorization: &CredentialAuthorization,
     ) -> Result<(), CredentialServiceError> {
         let subject = authorization
             .authenticated_subject_context()
             .ok_or_else(denied)?;
+        let session = authorization.authenticated_session().ok_or_else(denied)?;
+        if session.authenticated_subject() != subject {
+            return Err(denied());
+        }
         if subject.transport_binding().locality() != Locality::Local
             || subject.subject_ref() != self.consumer_ref()
             || subject.execution_ref() != Some(self.placement.execution_ref())
@@ -58,6 +67,9 @@ impl EntraCredentialProvider {
             || subject
                 .provider_ref()
                 .is_none_or(|provider| provider.to_canonical_string() != crate::PROVIDER_REF)
+            || subject.provider_generation().is_none()
+            || subject.service().as_str() != CREDENTIAL_SERVICE_NAME
+            || subject.session_purpose().as_str() != CREDENTIAL_SESSION_PURPOSE
         {
             return Err(denied());
         }
@@ -66,6 +78,55 @@ impl EntraCredentialProvider {
             .map_err(|_| denied())?;
         if request.credential_ref().resource_type().as_str() != "Credential" {
             return Err(denied());
+        }
+        Self::time_bound_instant(request.requested_expiry_unix_ms())?;
+        Self::operation_deadline(request.deadline_unix_ms())?;
+        Self::time_bound_instant(session.expires_at_unix_ms()).map_err(|_| denied())?;
+        if !Self::time_bounds_not_after(
+            request.deadline_unix_ms(),
+            request.requested_expiry_unix_ms(),
+        )? || !Self::time_bounds_not_after(
+            request.deadline_unix_ms(),
+            session.expires_at_unix_ms(),
+        )
+        .map_err(|_| denied())?
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::DeadlineExceeded,
+            ));
+        }
+        if method.requires_delivery() {
+            let delivery = authorization
+                .delivery_session_params()
+                .ok_or_else(invariant)?;
+            Self::time_bound_instant(delivery.expiry_unix_ms())?;
+            Self::operation_deadline(delivery.deadline_unix_ms())?;
+            if delivery.credential_ref() != request.credential_ref()
+                || delivery.operation_class() != method.operation_class()
+                || delivery.consumer_provider_ref() != self.consumer_ref()
+                || subject.provider_generation() != Some(delivery.consumer_component_generation())
+                || !Self::time_bounds_not_after(
+                    delivery.deadline_unix_ms(),
+                    delivery.expiry_unix_ms(),
+                )?
+                || !Self::time_bounds_not_after(
+                    delivery.deadline_unix_ms(),
+                    request.deadline_unix_ms(),
+                )?
+                || !Self::time_bounds_not_after(
+                    delivery.expiry_unix_ms(),
+                    request.requested_expiry_unix_ms(),
+                )?
+                || !Self::time_bounds_not_after(
+                    delivery.deadline_unix_ms(),
+                    session.expires_at_unix_ms(),
+                )
+                .map_err(|_| denied())?
+            {
+                return Err(denied());
+            }
+        } else if authorization.delivery_session_params().is_some() {
+            return Err(invariant());
         }
         Ok(())
     }
@@ -83,22 +144,56 @@ impl EntraCredentialProvider {
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
         self.ensure_lifecycle_active(&key)?;
-        {
-            let mut leases = self.leases.lock().map_err(|_| invariant())?;
-            leases.retain(|_, record| record.metadata.state == CredentialLeaseState::Active);
-            if let Some(existing) = leases.get(&key)
+        self.ensure_client_ready(deadline)?;
+        let existing = {
+            let leases = self.leases.lock().map_err(|_| invariant())?;
+            leases.get(&key).cloned()
+        };
+        let active_leases = self
+            .leases
+            .lock()
+            .map_err(|_| invariant())?
+            .values()
+            .filter(|record| record.metadata.state == CredentialLeaseState::Active)
+            .count();
+        if let Some(existing) = existing {
+            if existing.metadata.state == CredentialLeaseState::Active
                 && existing.idempotency_key == request.idempotency_key()
             {
                 return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
-                    metadata: existing.metadata.clone(),
+                    metadata: existing.metadata,
                     delivery_session_params: delivery,
                 }));
             }
-            if leases.len() >= self.config.max_leases() as usize {
+            let active_after_replacement = active_leases.saturating_sub(usize::from(
+                existing.metadata.state == CredentialLeaseState::Active,
+            ));
+            if active_after_replacement >= self.config.max_leases() as usize {
                 return Err(CredentialServiceError::new(
                     CredentialServiceErrorCode::ProviderUnavailable,
                 ));
             }
+            if existing.metadata.state != CredentialLeaseState::Revoked {
+                let lease = EntraLeaseRef {
+                    credential_ref: request.credential_ref().clone(),
+                    metadata: existing.metadata.clone(),
+                    endpoint_generation: self.placement.endpoint_generation(),
+                };
+                if let Err(error) = Self::poll_client(self.client.revoke_lease(&lease), deadline)
+                    && !matches!(
+                        error.code(),
+                        CredentialServiceErrorCode::LeaseExpired
+                            | CredentialServiceErrorCode::LeaseRevoked
+                    )
+                {
+                    return Err(error);
+                }
+            }
+            self.leases.lock().map_err(|_| invariant())?.remove(&key);
+        } else if active_leases >= self.config.max_leases() as usize {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            ));
         }
         let client_request = EntraLeaseRequest {
             credential_ref: request.credential_ref().clone(),
@@ -108,16 +203,43 @@ impl EntraCredentialProvider {
             endpoint_generation: self.placement.endpoint_generation(),
         };
         let grant = Self::poll_client(self.client.issue_lease(&client_request), deadline)?;
-        let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
-        self.leases.lock().map_err(|_| invariant())?.insert(
-            key,
-            LeaseRecord {
-                idempotency_key: request.idempotency_key().to_owned(),
-                metadata: metadata.clone(),
-                refresh_attempts: 0,
-                health: crate::EntraResourceHealth::Ready,
-            },
-        );
+        let metadata = match Self::grant_metadata(grant.clone(), request.requested_expiry_unix_ms())
+        {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                self.cleanup_uncommitted_grant(
+                    request.credential_ref(),
+                    request.idempotency_key(),
+                    grant,
+                    request.requested_expiry_unix_ms(),
+                    deadline,
+                );
+                return Err(error);
+            }
+        };
+        let record = LeaseRecord {
+            idempotency_key: request.idempotency_key().to_owned(),
+            metadata: metadata.clone(),
+            refresh_attempts: 0,
+            health: crate::EntraResourceHealth::Ready,
+        };
+        if let Err(error) = self
+            .leases
+            .lock()
+            .map_err(|_| invariant())
+            .map(|mut leases| {
+                leases.insert(key.clone(), record);
+            })
+        {
+            self.cleanup_uncommitted_grant(
+                request.credential_ref(),
+                request.idempotency_key(),
+                grant,
+                request.requested_expiry_unix_ms(),
+                deadline,
+            );
+            return Err(error);
+        }
         Ok(CredentialResponse::AcquireToken(DeliveryResponse {
             metadata,
             delivery_session_params: delivery,
@@ -137,6 +259,7 @@ impl EntraCredentialProvider {
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
         self.ensure_lifecycle_active(&key)?;
+        self.ensure_client_ready(deadline)?;
         let record = self
             .leases
             .lock()
@@ -145,9 +268,7 @@ impl EntraCredentialProvider {
             .cloned()
             .ok_or_else(expired)?;
         if record.metadata.state != CredentialLeaseState::Active {
-            return Err(CredentialServiceError::new(
-                CredentialServiceErrorCode::LeaseRevoked,
-            ));
+            return Err(error_for_state(record.metadata.state));
         }
         if record.refresh_attempts >= crate::MAX_REFRESH_ATTEMPTS {
             return Err(CredentialServiceError::new(
@@ -166,12 +287,15 @@ impl EntraCredentialProvider {
                 return Err(error);
             }
         };
-        if inspection.state != CredentialLeaseState::Active
-            || inspection.rotation_generation != lease.metadata.rotation_generation
-        {
-            self.record_refresh_failure(&key);
-            return Err(invariant());
+        let inspected_metadata = self.adopt_inspection(&key, inspection, true)?;
+        if inspected_metadata.state != CredentialLeaseState::Active {
+            return Err(error_for_state(inspected_metadata.state));
         }
+        let lease = EntraLeaseRef {
+            credential_ref: request.credential_ref().clone(),
+            metadata: inspected_metadata,
+            endpoint_generation: self.placement.endpoint_generation(),
+        };
         let grant = match Self::poll_client(self.client.refresh_lease(&lease), deadline) {
             Ok(grant) => grant,
             Err(error) => {
@@ -179,6 +303,10 @@ impl EntraCredentialProvider {
                 return Err(error);
             }
         };
+        if grant.rotation_generation < lease.metadata.rotation_generation {
+            self.record_refresh_failure(&key);
+            return Err(invariant());
+        }
         let metadata = match Self::grant_metadata(grant.clone(), request.requested_expiry_unix_ms())
         {
             Ok(metadata) => metadata,
@@ -211,25 +339,46 @@ impl EntraCredentialProvider {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let _mutation = self.mutation_guard()?;
         let key = request.credential_ref().to_canonical_string();
-        let mut leases = self.leases.lock().map_err(|_| invariant())?;
-        let record = leases.get_mut(&key).ok_or_else(expired)?;
-        let outcome = if record.metadata.state == CredentialLeaseState::Revoked {
-            CredentialOutcomeCode::AlreadyRevoked
+        self.ensure_client_ready(deadline)?;
+        let record = self
+            .leases
+            .lock()
+            .map_err(|_| invariant())?
+            .get(&key)
+            .cloned()
+            .ok_or_else(expired)?;
+        let (outcome, state) = if record.metadata.state == CredentialLeaseState::Revoked {
+            (
+                CredentialOutcomeCode::AlreadyRevoked,
+                CredentialLeaseState::Revoked,
+            )
         } else {
             let lease = EntraLeaseRef {
                 credential_ref: request.credential_ref().clone(),
                 metadata: record.metadata.clone(),
                 endpoint_generation: self.placement.endpoint_generation(),
             };
-            let revocation = Self::poll_client(self.client.revoke_lease(&lease), deadline)?;
-            record.metadata.state = CredentialLeaseState::Revoked;
-            match revocation {
-                crate::EntraLeaseRevocation::Revoked => CredentialOutcomeCode::Revoked,
-                crate::EntraLeaseRevocation::AlreadyRevoked => {
+            let outcome = match Self::poll_client(self.client.revoke_lease(&lease), deadline) {
+                Ok(crate::EntraLeaseRevocation::Revoked) => CredentialOutcomeCode::Revoked,
+                Ok(crate::EntraLeaseRevocation::AlreadyRevoked) => {
                     CredentialOutcomeCode::AlreadyRevoked
                 }
-            }
+                Err(error)
+                    if matches!(
+                        error.code(),
+                        CredentialServiceErrorCode::LeaseExpired
+                            | CredentialServiceErrorCode::LeaseRevoked
+                    ) =>
+                {
+                    CredentialOutcomeCode::AlreadyRevoked
+                }
+                Err(error) => return Err(error),
+            };
+            (outcome, CredentialLeaseState::Revoked)
         };
+        let mut leases = self.leases.lock().map_err(|_| invariant())?;
+        let record = leases.get_mut(&key).ok_or_else(expired)?;
+        record.metadata.state = state;
         record.metadata.outcome = outcome;
         record.health = crate::EntraResourceHealth::Revoked;
         Ok(CredentialResponse::RevokeToken(MetadataResponse {
@@ -242,27 +391,164 @@ impl EntraCredentialProvider {
         request: &CredentialRequest,
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
+        let _mutation = self.mutation_guard()?;
+        self.ensure_client_ready(deadline)?;
+        let key = request.credential_ref().to_canonical_string();
         let record = self
             .leases
             .lock()
             .map_err(|_| invariant())?
-            .get(&request.credential_ref().to_canonical_string())
+            .get(&key)
             .cloned()
             .ok_or_else(expired)?;
+        if record.metadata.state == CredentialLeaseState::Revoked {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::LeaseRevoked,
+            ));
+        }
         let lease = EntraLeaseRef {
             credential_ref: request.credential_ref().clone(),
             metadata: record.metadata,
             endpoint_generation: self.placement.endpoint_generation(),
         };
         let inspection = Self::poll_client(self.client.inspect_lease(&lease), deadline)?;
-        let mut metadata = lease.metadata;
-        metadata.state = inspection.state;
-        metadata.source_version = inspection.source_version;
-        metadata.rotation_generation = inspection.rotation_generation;
-        metadata.expires_at_unix_ms = inspection.expires_at_unix_ms;
-        Ok(CredentialResponse::InspectMetadata(MetadataResponse {
-            metadata,
-        }))
+        let metadata = self.adopt_inspection(&key, inspection, false)?;
+        match metadata.state {
+            CredentialLeaseState::Active => {
+                Ok(CredentialResponse::InspectMetadata(MetadataResponse {
+                    metadata,
+                }))
+            }
+            state => Err(error_for_state(state)),
+        }
+    }
+
+    fn adopt_inspection(
+        &self,
+        key: &str,
+        inspection: EntraLeaseInspection,
+        count_refresh_failure: bool,
+    ) -> Result<d2b_contracts::v3::credential::CredentialMetadata, CredentialServiceError> {
+        if inspection.rotation_generation == 0 || inspection.expires_at_unix_ms == 0 {
+            if count_refresh_failure {
+                self.record_refresh_failure(key);
+            }
+            return Err(invariant());
+        }
+        let mut leases = self.leases.lock().map_err(|_| invariant())?;
+        let record = leases.get_mut(key).ok_or_else(expired)?;
+        if record.metadata.state == CredentialLeaseState::Revoked {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::LeaseRevoked,
+            ));
+        }
+        if inspection.rotation_generation < record.metadata.rotation_generation {
+            if count_refresh_failure {
+                record.refresh_attempts = record
+                    .refresh_attempts
+                    .saturating_add(1)
+                    .min(crate::MAX_REFRESH_ATTEMPTS);
+                record.health = crate::EntraResourceHealth::Degraded;
+            }
+            return Err(invariant());
+        }
+        if inspection.state == CredentialLeaseState::Unknown {
+            if count_refresh_failure {
+                record.refresh_attempts = record
+                    .refresh_attempts
+                    .saturating_add(1)
+                    .min(crate::MAX_REFRESH_ATTEMPTS);
+                record.health = crate::EntraResourceHealth::Degraded;
+            }
+            return Err(invariant());
+        }
+        let state = if inspection.state == CredentialLeaseState::Active
+            && crate::EntraCredentialProvider::is_expired_unix_ms(inspection.expires_at_unix_ms)
+        {
+            CredentialLeaseState::Expired
+        } else {
+            inspection.state
+        };
+        record.metadata.state = state;
+        record.metadata.source_version = inspection.source_version;
+        record.metadata.rotation_generation = inspection.rotation_generation;
+        record.metadata.expires_at_unix_ms = inspection.expires_at_unix_ms;
+        match state {
+            CredentialLeaseState::Active => {}
+            CredentialLeaseState::Expired => {
+                record.health = crate::EntraResourceHealth::Degraded;
+            }
+            CredentialLeaseState::Revoked => {
+                record.health = crate::EntraResourceHealth::Revoked;
+                record.refresh_attempts = 0;
+            }
+            CredentialLeaseState::Unknown => {
+                record.health = crate::EntraResourceHealth::Degraded;
+            }
+        }
+        Ok(record.metadata.clone())
+    }
+
+    fn ensure_client_ready(
+        &self,
+        deadline: std::time::Instant,
+    ) -> Result<(), CredentialServiceError> {
+        match Self::poll_client(self.client.state(), deadline)? {
+            EntraClientState::Ready => Ok(()),
+            EntraClientState::InteractionRequired => Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            )),
+        }
+    }
+
+    fn cleanup_uncommitted_grant(
+        &self,
+        credential_ref: &ResourceRef,
+        idempotency_key: &str,
+        grant: crate::EntraLeaseGrant,
+        requested_expiry_unix_ms: u64,
+        deadline: std::time::Instant,
+    ) {
+        let metadata = CredentialMetadata {
+            lease_handle: grant.lease_handle,
+            rotation_generation: grant.rotation_generation.max(1),
+            source_version: grant.source_version,
+            expires_at_unix_ms: if grant.expires_at_unix_ms == 0 {
+                requested_expiry_unix_ms
+            } else {
+                grant.expires_at_unix_ms
+            },
+            state: CredentialLeaseState::Active,
+            outcome: CredentialOutcomeCode::Success,
+        };
+        let lease = EntraLeaseRef {
+            credential_ref: credential_ref.clone(),
+            metadata: metadata.clone(),
+            endpoint_generation: self.placement.endpoint_generation(),
+        };
+        let cleanup = Self::poll_client(self.client.revoke_lease(&lease), deadline);
+        if cleanup.is_ok()
+            || cleanup.as_ref().is_err_and(|error| {
+                matches!(
+                    error.code(),
+                    CredentialServiceErrorCode::LeaseExpired
+                        | CredentialServiceErrorCode::LeaseRevoked
+                )
+            })
+        {
+            return;
+        }
+        if let Ok(mut leases) = self.leases.lock() {
+            leases.insert(
+                credential_ref.to_canonical_string(),
+                LeaseRecord {
+                    idempotency_key: idempotency_key.to_owned(),
+                    metadata,
+                    refresh_attempts: crate::MAX_REFRESH_ATTEMPTS,
+                    health: crate::EntraResourceHealth::Degraded,
+                },
+            );
+        }
     }
 }
 
@@ -276,4 +562,15 @@ fn denied() -> CredentialServiceError {
 
 fn expired() -> CredentialServiceError {
     CredentialServiceError::new(CredentialServiceErrorCode::LeaseExpired)
+}
+
+fn error_for_state(state: CredentialLeaseState) -> CredentialServiceError {
+    match state {
+        CredentialLeaseState::Expired => expired(),
+        CredentialLeaseState::Revoked => {
+            CredentialServiceError::new(CredentialServiceErrorCode::LeaseRevoked)
+        }
+        CredentialLeaseState::Active => invariant(),
+        CredentialLeaseState::Unknown => invariant(),
+    }
 }

--- a/packages/d2b-provider-credential-entra/tests/canary.rs
+++ b/packages/d2b-provider-credential-entra/tests/canary.rs
@@ -2,18 +2,22 @@ mod common;
 
 use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
-    CredentialInteractionState, CredentialLeaseHandle, CredentialLeaseStatus, CredentialMethod,
-    CredentialRequest, CredentialResponse, CredentialServiceErrorCode, CredentialSourceVersion,
-    CredentialStatus, PlacementBinding, encode_outer,
+    CredentialAuthorization, CredentialInteractionState, CredentialLeaseHandle,
+    CredentialLeaseStatus, CredentialMethod, CredentialRequest, CredentialResponse,
+    CredentialServiceErrorCode, CredentialSourceVersion, CredentialStatus, PlacementBinding,
+    dispatch_authorized_provider, encode_outer,
 };
 
-use common::{ProviderHarness, admitted, setup};
+use common::{
+    ProviderHarness, admitted, delivery as test_delivery, session_binding, setup, subject_context,
+};
 
 #[test]
 fn process_unique_entra_secret_and_identity_canaries_are_absent_from_rendered_surfaces() {
     let nonce = format!("{:x}", std::process::id());
     let credential_name = format!("credential-name-{nonce}");
-    let credential_ref = format!("Credential/{credential_name}");
+    let credential_ref = "Credential/work-entra".to_owned();
+    let identity_credential_ref = format!("Credential/{credential_name}");
     let credential_uid = format!("credential-uid-{nonce}");
     let credential_digest = format!("credential-digest-{nonce}");
     let (provider, client) = setup();
@@ -114,12 +118,51 @@ fn process_unique_entra_secret_and_identity_canaries_are_absent_from_rendered_su
         format!("{error:?}"),
         error.to_string(),
     ];
+    let (identity_provider, identity_client) = setup();
+    let identity_request = CredentialRequest::new(
+        ResourceRef::parse(&identity_credential_ref).unwrap(),
+        &operation_id,
+        &idempotency_key,
+        common::EXPIRY,
+        15_000,
+    )
+    .unwrap();
+    let identity_request_debug = format!("{identity_request:?}");
+    let identity_authorization = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(test_delivery(CredentialMethod::AcquireToken, 1)),
+        subject_context(),
+    )
+    .unwrap()
+    .with_authenticated_session(session_binding())
+    .unwrap();
+    let identity_error = dispatch_authorized_provider(
+        &identity_provider,
+        CredentialMethod::AcquireToken,
+        &identity_request,
+        &identity_authorization,
+    )
+    .unwrap_err();
+    assert_eq!(
+        identity_error.code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(
+        identity_client
+            .issue_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+    let surfaces = surfaces
+        .into_iter()
+        .chain([identity_request_debug, format!("{identity_error:?}")])
+        .collect::<Vec<_>>();
     let markers = [
         client.token_canary.as_str(),
         client.endpoint_canary.as_str(),
         client.cookie_canary.as_str(),
         credential_name.as_str(),
-        credential_ref.as_str(),
+        identity_credential_ref.as_str(),
         credential_uid.as_str(),
         credential_digest.as_str(),
     ];

--- a/packages/d2b-provider-credential-entra/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-entra/tests/common/mod.rs
@@ -6,8 +6,9 @@ use std::sync::{Arc, Mutex};
 use d2b_contracts::v3::credential::{
     AudienceToken, CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState,
     CredentialMethod, CredentialProvider, CredentialRequest, CredentialResponse,
-    CredentialServiceError, CredentialServiceErrorCode, CredentialSourceVersion,
-    DeliveryRouteDigest, DeliverySessionParams, PlacementBinding, dispatch_authorized_provider,
+    CredentialServiceError, CredentialServiceErrorCode, CredentialSessionBinding,
+    CredentialSourceVersion, DeliveryRouteDigest, DeliverySessionParams, PlacementBinding,
+    dispatch_authorized_provider,
 };
 use d2b_contracts::v3::{
     AuthenticatedSubjectContext, BindingDigest, EvidenceClass, Locality, ReconnectGeneration,
@@ -30,6 +31,10 @@ pub struct FakeEntraClient {
     pub inspect_calls: AtomicUsize,
     pub refresh_calls: AtomicUsize,
     pub revoke_calls: AtomicUsize,
+    pub refresh_generation: Mutex<u64>,
+    pub issue_generation: Mutex<Option<u64>>,
+    pub issue_expiry: Mutex<Option<u64>>,
+    pub issue_revoke_error: Mutex<Option<EntraClientError>>,
     pub issue_error: Mutex<Option<EntraClientError>>,
     pub refresh_error: Mutex<Option<EntraClientError>>,
     pub revoke_error: Mutex<Option<EntraClientError>>,
@@ -49,6 +54,10 @@ impl FakeEntraClient {
             inspect_calls: AtomicUsize::new(0),
             refresh_calls: AtomicUsize::new(0),
             revoke_calls: AtomicUsize::new(0),
+            refresh_generation: Mutex::new(2),
+            issue_generation: Mutex::new(None),
+            issue_expiry: Mutex::new(None),
+            issue_revoke_error: Mutex::new(None),
             issue_error: Mutex::new(None),
             refresh_error: Mutex::new(None),
             revoke_error: Mutex::new(None),
@@ -70,7 +79,13 @@ impl EntraCredentialClient for FakeEntraClient {
         self.issue_calls.fetch_add(1, Ordering::SeqCst);
         let error = *self.issue_error.lock().unwrap();
         let state = *self.state.lock().unwrap();
-        let expiry = request.requested_expiry_unix_ms();
+        let expiry = self
+            .issue_expiry
+            .lock()
+            .unwrap()
+            .unwrap_or(request.requested_expiry_unix_ms());
+        let generation = self.issue_generation.lock().unwrap().unwrap_or(1);
+        let issue_revoke_error = *self.issue_revoke_error.lock().unwrap();
         let token = self.token_canary.clone();
         let endpoint = self.endpoint_canary.clone();
         *self.observed_request.lock().unwrap() = Some((
@@ -79,6 +94,7 @@ impl EntraCredentialClient for FakeEntraClient {
             request.idempotency_key().to_owned(),
         ));
         let inspection = &self.inspection;
+        let revoke_error_slot = &self.revoke_error;
         Box::pin(async move {
             if state == EntraClientState::InteractionRequired {
                 return Err(EntraClientError::InteractionRequired);
@@ -86,10 +102,13 @@ impl EntraCredentialClient for FakeEntraClient {
             if let Some(error) = error {
                 return Err(error);
             }
+            if let Some(error) = issue_revoke_error {
+                *revoke_error_slot.lock().unwrap() = Some(error);
+            }
             let grant = EntraLeaseGrant {
                 lease_handle: CredentialLeaseHandle::parse(&token).unwrap(),
                 source_version: CredentialSourceVersion::parse(&endpoint).unwrap(),
-                rotation_generation: 1,
+                rotation_generation: generation,
                 expires_at_unix_ms: expiry,
             };
             *inspection.lock().unwrap() = Some(EntraLeaseInspection {
@@ -115,6 +134,7 @@ impl EntraCredentialClient for FakeEntraClient {
         self.refresh_calls.fetch_add(1, Ordering::SeqCst);
         let error = *self.refresh_error.lock().unwrap();
         let expiry = lease.metadata().expires_at_unix_ms;
+        let generation = *self.refresh_generation.lock().unwrap();
         let inspection = &self.inspection;
         Box::pin(async move {
             if let Some(error) = error {
@@ -123,7 +143,7 @@ impl EntraCredentialClient for FakeEntraClient {
             let grant = EntraLeaseGrant {
                 lease_handle: CredentialLeaseHandle::parse("entra-lease").unwrap(),
                 source_version: CredentialSourceVersion::parse("entra-source-2").unwrap(),
-                rotation_generation: 2,
+                rotation_generation: generation,
                 expires_at_unix_ms: expiry,
             };
             *inspection.lock().unwrap() = Some(EntraLeaseInspection {
@@ -221,7 +241,11 @@ pub fn subject_context_with_bindings(
     if let Some(provider) = provider_ref {
         context = context.with_provider_ref(provider);
     }
-    context
+    context.with_provider_generation(ResourceGeneration::new(1).unwrap())
+}
+
+pub fn session_binding() -> CredentialSessionBinding {
+    CredentialSessionBinding::new(subject_context(), EXPIRY).unwrap()
 }
 
 pub fn request(idempotency: &str) -> CredentialRequest {
@@ -236,16 +260,63 @@ pub fn request(idempotency: &str) -> CredentialRequest {
 }
 
 pub fn delivery(method: CredentialMethod, sequence: u64) -> DeliverySessionParams {
-    DeliverySessionParams::new(
+    delivery_values(
+        method,
         ResourceRef::parse("Credential/work-entra").unwrap(),
+        EXPIRY,
+        15_000,
+        sequence,
+        1,
+    )
+}
+
+pub fn delivery_for_request(
+    method: CredentialMethod,
+    request: &CredentialRequest,
+) -> DeliverySessionParams {
+    delivery_values(
+        method,
+        request.credential_ref().clone(),
+        request.requested_expiry_unix_ms(),
+        request.deadline_unix_ms(),
+        1,
+        1,
+    )
+}
+
+pub fn delivery_with_component_generation(
+    method: CredentialMethod,
+    sequence: u64,
+    component_generation: u64,
+) -> DeliverySessionParams {
+    delivery_values(
+        method,
+        ResourceRef::parse("Credential/work-entra").unwrap(),
+        EXPIRY,
+        15_000,
+        sequence,
+        component_generation,
+    )
+}
+
+fn delivery_values(
+    method: CredentialMethod,
+    credential_ref: ResourceRef,
+    expiry_unix_ms: u64,
+    deadline_unix_ms: u64,
+    sequence: u64,
+    component_generation: u64,
+) -> DeliverySessionParams {
+    DeliverySessionParams::new(
+        credential_ref,
         ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),
         ResourceGeneration::new(1).unwrap(),
         ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
-        ResourceGeneration::new(1).unwrap(),
+        ResourceGeneration::new(component_generation).unwrap(),
         AudienceToken::parse("azure-resource-manager").unwrap(),
         method.operation_class(),
-        EXPIRY,
-        15_000,
+        expiry_unix_ms,
+        deadline_unix_ms,
         DeliveryRouteDigest::parse(format!("sha256:{}", "b".repeat(64))).unwrap(),
         4_096,
         sequence,
@@ -270,7 +341,7 @@ impl TestAdmission for Admission {
     fn authorize(
         &self,
         method: CredentialMethod,
-        _request: &CredentialRequest,
+        request: &CredentialRequest,
     ) -> Result<CredentialAuthorization, CredentialServiceError> {
         if self.authenticated_consumer
             != ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap()
@@ -281,9 +352,12 @@ impl TestAdmission for Admission {
         }
         CredentialAuthorization::new_for_subject(
             method,
-            method.requires_delivery().then(|| delivery(method, 1)),
+            method
+                .requires_delivery()
+                .then(|| delivery_for_request(method, request)),
             subject_context(),
         )
+        .and_then(|authorization| authorization.with_authenticated_session(session_binding()))
     }
 }
 

--- a/packages/d2b-provider-credential-entra/tests/controller.rs
+++ b/packages/d2b-provider-credential-entra/tests/controller.rs
@@ -135,3 +135,22 @@ fn status_projection_requires_the_committed_guest_execution() {
         CredentialServiceErrorCode::OperationDenied
     );
 }
+
+#[test]
+fn status_projection_rejects_retry_counts_above_the_provider_ceiling() {
+    let (controller, policy) = controller();
+    assert_eq!(
+        controller
+            .project_for_subject(
+                &policy,
+                &subject_context(),
+                EntraClientState::Ready,
+                None,
+                EntraResourceHealth::Degraded,
+                d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS + 1,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+}

--- a/packages/d2b-provider-credential-entra/tests/delivery.rs
+++ b/packages/d2b-provider-credential-entra/tests/delivery.rs
@@ -7,7 +7,10 @@ use d2b_contracts::v3::credential::{
 };
 use d2b_provider_credential_entra::EntraCredentialProvider;
 
-use common::{ProviderHarness, TestAdmission, admitted, delivery, request, setup, subject_context};
+use common::{
+    ProviderHarness, TestAdmission, admitted, delivery, request, session_binding, setup,
+    subject_context,
+};
 
 #[test]
 fn provider_returns_exactly_the_read_only_adapter_binding() {
@@ -49,6 +52,7 @@ impl TestAdmission for FixedAdmission {
             Some(self.authorized.clone()),
             subject_context(),
         )
+        .and_then(|authorization| authorization.with_authenticated_session(session_binding()))
     }
 }
 

--- a/packages/d2b-provider-credential-entra/tests/faults.rs
+++ b/packages/d2b-provider-credential-entra/tests/faults.rs
@@ -3,13 +3,14 @@ mod common;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use d2b_contracts::v3::Locality;
 use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialMethod, CredentialRequest, CredentialResponse,
-    CredentialServiceErrorCode, PlacementBinding, dispatch_authorized_provider,
+    CredentialServiceErrorCode, CredentialSessionBinding, PlacementBinding,
+    dispatch_authorized_provider,
 };
 use d2b_provider_credential_entra::{
     EntraClientError, EntraClientState, EntraConfig, EntraCredentialClient,
@@ -18,8 +19,8 @@ use d2b_provider_credential_entra::{
 };
 
 use common::{
-    Admission, ProviderHarness, admitted, delivery, request, setup, subject_context_for,
-    subject_context_with_bindings,
+    Admission, ProviderHarness, admitted, delivery, delivery_with_component_generation, request,
+    session_binding, setup, subject_context, subject_context_for, subject_context_with_bindings,
 };
 
 #[test]
@@ -34,6 +35,7 @@ fn interaction_required_is_unavailable_not_denied() {
             .code(),
         CredentialServiceErrorCode::ProviderUnavailable
     );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
 }
 
 #[test]
@@ -49,6 +51,130 @@ fn exact_consumer_mismatch_is_denied_before_client_dispatch() {
             .call(CredentialMethod::AcquireToken, request("idem-mismatch"))
             .unwrap_err()
             .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn missing_authenticated_session_is_denied_before_client_dispatch() {
+    let (provider, client) = setup();
+    let authorization = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+        subject_context(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("idem-missing-session"),
+            &authorization,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn request_and_session_delivery_bindings_must_match_exactly() {
+    let (provider, client) = setup();
+    let authorization = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+        subject_context(),
+    )
+    .unwrap()
+    .with_authenticated_session(session_binding())
+    .unwrap();
+    let other_request = CredentialRequest::new(
+        ResourceRef::parse("Credential/other-entra").unwrap(),
+        "operation-other",
+        "idem-other-binding",
+        common::EXPIRY,
+        15_000,
+    )
+    .unwrap();
+
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &other_request,
+            &authorization,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn provider_generation_must_match_the_delivery_component_generation() {
+    let (provider, client) = setup();
+    let authorization = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(delivery_with_component_generation(
+            CredentialMethod::AcquireToken,
+            1,
+            2,
+        )),
+        subject_context(),
+    )
+    .unwrap()
+    .with_authenticated_session(session_binding())
+    .unwrap();
+
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("idem-generation-binding"),
+            &authorization,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn authenticated_session_subject_must_match_the_authorized_subject() {
+    let (provider, client) = setup();
+    let authorization = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(delivery(CredentialMethod::AcquireToken, 1)),
+        subject_context(),
+    )
+    .unwrap()
+    .with_authenticated_session(
+        CredentialSessionBinding::new(
+            subject_context_for(
+                ResourceRef::parse("Provider/other").unwrap(),
+                ResourceRef::parse("Zone/work").unwrap(),
+                Locality::Local,
+            ),
+            common::EXPIRY,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("idem-session-subject"),
+            &authorization,
+        )
+        .unwrap_err()
+        .code(),
         CredentialServiceErrorCode::OperationDenied
     );
     assert_eq!(client.issue_calls.load(Ordering::SeqCst), 0);
@@ -198,18 +324,24 @@ fn missing_or_mismatched_authenticated_claims_are_denied_before_client_dispatch(
 
     for (index, (label, execution_ref, provider_ref)) in cases.into_iter().enumerate() {
         let (provider, client) = setup();
+        let authenticated_subject = subject_context_with_bindings(
+            ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+            ResourceRef::parse("Zone/work").unwrap(),
+            Locality::Local,
+            execution_ref,
+            provider_ref,
+        );
         let authorization = CredentialAuthorization::new_for_subject(
             CredentialMethod::AcquireToken,
             Some(delivery(CredentialMethod::AcquireToken, 1)),
-            subject_context_with_bindings(
-                ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
-                ResourceRef::parse("Zone/work").unwrap(),
-                Locality::Local,
-                execution_ref,
-                provider_ref,
-            ),
+            authenticated_subject.clone(),
         )
         .unwrap();
+        let authorization = authorization
+            .with_authenticated_session(
+                CredentialSessionBinding::new(authenticated_subject, common::EXPIRY).unwrap(),
+            )
+            .unwrap();
 
         assert_eq!(
             dispatch_authorized_provider(
@@ -230,18 +362,24 @@ fn missing_or_mismatched_authenticated_claims_are_denied_before_client_dispatch(
 #[test]
 fn same_credential_name_from_another_zone_is_denied_before_client_dispatch() {
     let (provider, client) = setup();
+    let authenticated_subject = subject_context_with_bindings(
+        ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
+        ResourceRef::parse("Zone/personal").unwrap(),
+        Locality::Local,
+        Some(ResourceRef::parse("Guest/consumer").unwrap()),
+        Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
+    );
     let authorization = CredentialAuthorization::new_for_subject(
         CredentialMethod::AcquireToken,
         Some(delivery(CredentialMethod::AcquireToken, 1)),
-        subject_context_with_bindings(
-            ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
-            ResourceRef::parse("Zone/personal").unwrap(),
-            Locality::Local,
-            Some(ResourceRef::parse("Guest/consumer").unwrap()),
-            Some(ResourceRef::parse("Provider/credential-entra").unwrap()),
-        ),
+        authenticated_subject.clone(),
     )
     .unwrap();
+    let authorization = authorization
+        .with_authenticated_session(
+            CredentialSessionBinding::new(authenticated_subject, common::EXPIRY).unwrap(),
+        )
+        .unwrap();
 
     assert_eq!(
         dispatch_authorized_provider(
@@ -424,6 +562,256 @@ fn committed_remote_refresh_metadata_is_adopted_for_later_recovery() {
 }
 
 #[test]
+fn refresh_rejects_remote_generation_rollback() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-generation-rollback"),
+        )
+        .unwrap();
+    server
+        .call(
+            CredentialMethod::RefreshToken,
+            request("idem-generation-rollback-first-refresh"),
+        )
+        .unwrap();
+    *client.refresh_generation.lock().unwrap() = 1;
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::RefreshToken,
+                request("idem-generation-rollback-refresh"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(
+        provider.resource_health(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some(d2b_provider_credential_entra::EntraResourceHealth::Degraded)
+    );
+}
+
+#[test]
+fn inspect_persists_remote_revocation_and_degrades_only_that_resource() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-inspect-revoked"),
+        )
+        .unwrap();
+    *client.inspection.lock().unwrap() = Some(EntraLeaseInspection {
+        state: d2b_contracts::v3::credential::CredentialLeaseState::Revoked,
+        source_version: d2b_contracts::v3::credential::CredentialSourceVersion::parse(
+            "entra-source-revoked",
+        )
+        .unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-inspect-revoked-read"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseRevoked
+    );
+    assert_eq!(
+        provider.resource_health(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some(d2b_provider_credential_entra::EntraResourceHealth::Revoked)
+    );
+}
+
+#[test]
+fn unknown_inspection_is_transient_and_acquire_revokes_before_replacement() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(CredentialMethod::AcquireToken, request("idem-unknown-base"))
+        .unwrap();
+    *client.inspection.lock().unwrap() = Some(EntraLeaseInspection {
+        state: d2b_contracts::v3::credential::CredentialLeaseState::Unknown,
+        source_version: d2b_contracts::v3::credential::CredentialSourceVersion::parse(
+            "entra-source-unknown",
+        )
+        .unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-unknown-inspect"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(
+        provider.refresh_retry_state(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some((0, d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS))
+    );
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-unknown-replacement"),
+        )
+        .unwrap();
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn clock_expired_inspection_is_reclaimed_before_acquire_replacement() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(CredentialMethod::AcquireToken, request("idem-expired-base"))
+        .unwrap();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    *client.inspection.lock().unwrap() = Some(EntraLeaseInspection {
+        state: d2b_contracts::v3::credential::CredentialLeaseState::Active,
+        source_version: d2b_contracts::v3::credential::CredentialSourceVersion::parse(
+            "entra-source-expired",
+        )
+        .unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: now - 1,
+    });
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-expired-inspect"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseExpired
+    );
+    assert_eq!(
+        provider.resource_health(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some(d2b_provider_credential_entra::EntraResourceHealth::Degraded)
+    );
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-expired-replacement"),
+        )
+        .unwrap();
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn expired_remote_revoke_is_idempotent_for_explicit_revoke() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-expired-revoke"),
+        )
+        .unwrap();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    *client.inspection.lock().unwrap() = Some(EntraLeaseInspection {
+        state: d2b_contracts::v3::credential::CredentialLeaseState::Active,
+        source_version: d2b_contracts::v3::credential::CredentialSourceVersion::parse(
+            "entra-source-expired-revoke",
+        )
+        .unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: now - 1,
+    });
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-expired-revoke-inspect"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseExpired
+    );
+    *client.revoke_error.lock().unwrap() = Some(EntraClientError::LeaseExpired);
+
+    let response = server
+        .call(
+            CredentialMethod::RevokeToken,
+            request("idem-expired-revoke-finalize"),
+        )
+        .unwrap();
+    let CredentialResponse::RevokeToken(response) = response else {
+        panic!("expected revoke response");
+    };
+    assert_eq!(
+        response.metadata.state,
+        d2b_contracts::v3::credential::CredentialLeaseState::Revoked
+    );
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn local_revocation_is_terminal_even_when_remote_inspection_is_stale() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-local-revoked"),
+        )
+        .unwrap();
+    server
+        .call(
+            CredentialMethod::RevokeToken,
+            request("idem-local-revoked-revoke"),
+        )
+        .unwrap();
+    let inspect_calls = client.inspect_calls.load(Ordering::SeqCst);
+    let refresh_calls = client.refresh_calls.load(Ordering::SeqCst);
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-local-revoked-inspect"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseRevoked
+    );
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::RefreshToken,
+                request("idem-local-revoked-refresh"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseRevoked
+    );
+    assert_eq!(client.inspect_calls.load(Ordering::SeqCst), inspect_calls);
+    assert_eq!(client.refresh_calls.load(Ordering::SeqCst), refresh_calls);
+}
+
+#[test]
 fn client_call_stops_at_request_deadline() {
     let client = Arc::new(NeverClient {
         issue_calls: AtomicUsize::new(0),
@@ -471,6 +859,29 @@ fn client_call_stops_at_request_deadline() {
             .code(),
         CredentialServiceErrorCode::DeadlineExceeded
     );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn absolute_request_bounds_are_ordered_against_legacy_relative_session_values() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(provider, admitted());
+    let request = CredentialRequest::new(
+        ResourceRef::parse("Credential/work-entra").unwrap(),
+        "operation-absolute",
+        "idem-absolute",
+        now + 10_000,
+        now + 5_000,
+    )
+    .unwrap();
+
+    server
+        .call(CredentialMethod::AcquireToken, request)
+        .unwrap();
     assert_eq!(client.issue_calls.load(Ordering::SeqCst), 1);
 }
 

--- a/packages/d2b-provider-credential-entra/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-entra/tests/lifecycle.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::task::{Poll, Waker};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
@@ -144,6 +144,62 @@ fn finalization_revokes_owned_handles_before_clearing_provider_state() {
         0,
         "finalization must not clear state before owned revocation"
     );
+    let stale_deadline = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+        - 1;
+    let retry = provider
+        .revoke_owned_handles(
+            &ResourceRef::parse("Credential/work-entra").unwrap(),
+            stale_deadline,
+        )
+        .unwrap();
+    assert_eq!(retry.revoked, 0);
+    assert_eq!(retry.remaining, 0);
+}
+
+#[test]
+fn finalization_accepts_a_remote_lease_that_already_expired() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-expired-finalize"),
+        )
+        .unwrap();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    *client.inspection.lock().unwrap() = Some(EntraLeaseInspection {
+        state: d2b_contracts::v3::credential::CredentialLeaseState::Active,
+        source_version: CredentialSourceVersion::parse("entra-source-expired-finalize").unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: now - 1,
+    });
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-expired-finalize-inspect"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseExpired
+    );
+    *client.revoke_error.lock().unwrap() = Some(EntraClientError::LeaseExpired);
+
+    let cleanup = provider
+        .revoke_owned_handles(
+            &ResourceRef::parse("Credential/work-entra").unwrap(),
+            15_000,
+        )
+        .unwrap();
+    assert_eq!(cleanup.revoked, 1);
+    assert_eq!(cleanup.remaining, 0);
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
 }
 
 #[test]
@@ -210,6 +266,49 @@ fn draining_credential_cannot_mint_while_revocation_retries() {
     );
     assert_eq!(client.issue_calls.load(Ordering::SeqCst), 1);
     assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn failed_replacement_acquire_tracks_an_uncommitted_grant_until_cleanup() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-before-uncommitted-grant"),
+        )
+        .unwrap();
+    *client.issue_expiry.lock().unwrap() = Some(0);
+    *client.issue_revoke_error.lock().unwrap() = Some(EntraClientError::Unavailable);
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-uncommitted-grant"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(provider.active_lease_count(), 1);
+    assert_eq!(
+        provider.refresh_retry_state(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some((3, 3))
+    );
+
+    *client.revoke_error.lock().unwrap() = None;
+    let cleanup = provider
+        .revoke_owned_handles(
+            &ResourceRef::parse("Credential/work-entra").unwrap(),
+            15_000,
+        )
+        .unwrap();
+    assert_eq!(cleanup.revoked, 1);
+    assert_eq!(cleanup.remaining, 0);
+    assert_eq!(provider.active_lease_count(), 0);
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 3);
 }
 
 struct BlockingClient {

--- a/packages/d2b-provider-credential-entra/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-entra/tests/lifecycle.rs
@@ -129,6 +129,24 @@ fn finalization_revokes_owned_handles_before_clearing_provider_state() {
         .call(CredentialMethod::AcquireToken, request("idem-finalize"))
         .unwrap();
 
+    let stale_deadline = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+        - 1;
+    assert_eq!(
+        provider
+            .revoke_owned_handles(
+                &ResourceRef::parse("Credential/work-entra").unwrap(),
+                stale_deadline,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::DeadlineExceeded
+    );
+    assert_eq!(provider.active_lease_count(), 1);
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 0);
+
     let cleanup = provider
         .revoke_owned_handles(
             &ResourceRef::parse("Credential/work-entra").unwrap(),
@@ -144,11 +162,6 @@ fn finalization_revokes_owned_handles_before_clearing_provider_state() {
         0,
         "finalization must not clear state before owned revocation"
     );
-    let stale_deadline = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64
-        - 1;
     let retry = provider
         .revoke_owned_handles(
             &ResourceRef::parse("Credential/work-entra").unwrap(),
@@ -291,12 +304,23 @@ fn failed_replacement_acquire_tracks_an_uncommitted_grant_until_cleanup() {
             .code(),
         CredentialServiceErrorCode::InvariantFailure
     );
-    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 2);
-    assert_eq!(provider.active_lease_count(), 1);
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.active_lease_count(), 2);
     assert_eq!(
         provider.refresh_retry_state(&ResourceRef::parse("Credential/work-entra").unwrap()),
         Some((3, 3))
     );
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-uncommitted-grant"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 2);
 
     *client.revoke_error.lock().unwrap() = None;
     let cleanup = provider
@@ -305,10 +329,91 @@ fn failed_replacement_acquire_tracks_an_uncommitted_grant_until_cleanup() {
             15_000,
         )
         .unwrap();
-    assert_eq!(cleanup.revoked, 1);
+    assert_eq!(cleanup.revoked, 2);
     assert_eq!(cleanup.remaining, 0);
     assert_eq!(provider.active_lease_count(), 0);
     assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 3);
+}
+
+#[test]
+fn ambiguous_replacement_keeps_the_previous_lease_until_explicit_retry() {
+    let (provider, client) = setup();
+    let server = ProviderHarness::new(&provider, admitted());
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-before-ambiguous-replacement"),
+        )
+        .unwrap();
+    *client.issue_error.lock().unwrap() = Some(EntraClientError::CompletionUnknown);
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-ambiguous-replacement"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(provider.active_lease_count(), 1);
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-other-replacement"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        provider.refresh_retry_state(&ResourceRef::parse("Credential/work-entra").unwrap()),
+        Some((0, d2b_provider_credential_entra::MAX_REFRESH_ATTEMPTS))
+    );
+    assert!(matches!(
+        server
+            .call(
+                CredentialMethod::RefreshToken,
+                request("idem-refresh-during-ambiguous-replacement"),
+            )
+            .unwrap(),
+        CredentialResponse::RefreshToken(_)
+    ));
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-other-after-refresh"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(client.issue_calls.load(Ordering::SeqCst), 2);
+
+    *client.issue_error.lock().unwrap() = None;
+    assert!(matches!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-ambiguous-replacement"),
+            )
+            .unwrap(),
+        CredentialResponse::AcquireToken(_)
+    ));
+    assert_eq!(client.revoke_calls.load(Ordering::SeqCst), 1);
+
+    let cleanup = provider
+        .revoke_owned_handles(
+            &ResourceRef::parse("Credential/work-entra").unwrap(),
+            15_000,
+        )
+        .unwrap();
+    assert_eq!(cleanup.revoked, 1);
 }
 
 struct BlockingClient {


### PR DESCRIPTION
## Summary

Guest-only Entra credentials can now complete a lease lifecycle without
Host custody. Acquisition, refresh, revoke, inspect, and finalization all
require the authenticated Guest, Zone, Provider, and session bindings
before any client effect.

Replacement now issues the new grant first. A failed or ambiguous
replacement keeps the previous lease and records uncommitted grants for
cleanup-only revoke. Finalization refuses a stale deadline before it
marks the credential draining, and a finalized credential cannot mint
again.

Proactive refresh stays available during an ambiguous replacement retry.
The replacement idempotency key survives a successful refresh so a later
rotation cannot drop the same-key retry gate.

## Validation evidence

- [x] **Focused tests for the changed components** were run; list exact
      commands and results.
      `cargo test -p d2b-provider-credential-entra --offline -- --test-threads=1`
      58 passed, 0 failed (unit, canary, conformance, controller,
      delivery, faults, lifecycle, placement).
- [x] **Wider lanes are conditional.** Run the applicable public lane when the
      changed surface needs it, and explain any deliberate omission:
      no container, NixOS host, or device behavior changed. Layer-1 crate
      tests cover the Guest-bound service.
- [x] **Hardware checks are conditional:** not applicable. This slice is
      hermetic Rust lease lifecycle, not GPU, USBIP, TPM, or microVM boot.
- [x] **Changed tests are inventoried:** new coverage is Type 2/3 under
      `packages/d2b-provider-credential-entra/`. No `tests/*.sh` and no
      migration-ledger retirement.
- [x] **Changelog updated** for code or user-visible behavior, using
      `CHANGELOG.md` or a `changelog.d/` fragment.
      `changelog.d/feat-spec001-credential-entra.md`
- [x] **Docs + CI updated in lockstep** where applicable: no AGENTS, workflow,
      or public-doc contract change.

## Notes

No migration-ledger rows. Residual risks left as follow-up, not blockers:
`poll_client` still checks the deadline before a possibly-Ready grant;
first-acquire timeout still has no pending/cleanup record; cleanup grants
do not count toward `max_leases`; in-memory leases are not rehydrated
after process restart.
