### PR TITLE
fix(credential): bind managed-identity leases to trusted sessions

### DIFF
--- a/changelog.d/spec001-w6-u20-managed-identity.md
+++ b/changelog.d/spec001-w6-u20-managed-identity.md
@@ -7,5 +7,10 @@
   inflating the accepted client rotation generation, and repeated checkpoint
   restore remains occupancy-safe and idempotent.
 - Restricted service admission to local authenticated transports and matching
-  consumer generations, revoked superseded active handles before reacquisition,
-  and kept terminal lease metadata observable without reopening closed leases.
+  consumer generations, revoked superseded active or session-expired handles
+  before reacquisition, ignored cleanup-only records when measuring live
+  occupancy, and kept terminal lease metadata observable without reopening
+  closed leases.
+- Compensated invalid lease grants by revoking the newly issued handle before
+  returning the invariant error, and returned terminal states discovered by a
+  live metadata inspection as observations.

--- a/changelog.d/spec001-w6-u20-managed-identity.md
+++ b/changelog.d/spec001-w6-u20-managed-identity.md
@@ -1,0 +1,11 @@
+### Changed
+
+- Bound managed-identity Credential leases to authenticated subject, Zone,
+  workload, Provider session, and bounded expiry state; restart checkpoints
+  remain secret-free and finalization revokes only the owning workload's
+  handles. Reacquisition replaces terminal or stale-session records without
+  inflating the accepted client rotation generation, and repeated checkpoint
+  restore remains occupancy-safe and idempotent.
+- Restricted service admission to local authenticated transports and matching
+  consumer generations, revoked superseded active handles before reacquisition,
+  and kept terminal lease metadata observable without reopening closed leases.

--- a/packages/d2b-provider-credential-managed-identity/src/lib.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/lib.rs
@@ -28,7 +28,7 @@ use d2b_contracts::v3::credential::{
     CredentialServiceError, CredentialServiceErrorCode, CredentialSessionBinding,
     CredentialSourceVersion, MAX_PROVIDER_LEASE_LIFETIME_MS, OpaqueAzureRef, PlacementBinding,
 };
-use d2b_contracts::v3::{AuthenticatedSubjectContext, ResourceRef};
+use d2b_contracts::v3::{AuthenticatedSubjectContext, Locality, ResourceRef};
 
 pub use agent::ManagedIdentityAgent;
 pub use audit::{
@@ -594,6 +594,7 @@ impl ManagedIdentityCredentialProvider {
         subject.provider_ref() == Some(&self.consumer_ref)
             && subject.execution_ref() == Some(self.placement.execution_ref())
             && subject.zone_ref() == self.placement.zone_ref()
+            && subject.transport_binding().locality() == Locality::Local
             && subject.service().as_str() == CREDENTIAL_SERVICE_NAME
             && subject.session_purpose().as_str() == CREDENTIAL_SESSION_PURPOSE
             && subject.provider_generation().is_some()
@@ -622,6 +623,14 @@ impl ManagedIdentityCredentialProvider {
                 CredentialServiceErrorCode::OperationDenied,
             ));
         }
+        if authorization
+            .authenticated_subject_context()
+            .is_some_and(|authorized_subject| authorized_subject != subject)
+        {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::OperationDenied,
+            ));
+        }
 
         if method.requires_delivery() {
             let delivery = authorization.delivery_session_params().ok_or_else(|| {
@@ -631,6 +640,11 @@ impl ManagedIdentityCredentialProvider {
                 || delivery.consumer_provider_ref() != &self.consumer_ref
                 || delivery.operation_class() != method.operation_class()
             {
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::OperationDenied,
+                ));
+            }
+            if subject.provider_generation() != Some(delivery.consumer_component_generation()) {
                 return Err(CredentialServiceError::new(
                     CredentialServiceErrorCode::OperationDenied,
                 ));

--- a/packages/d2b-provider-credential-managed-identity/src/lib.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/lib.rs
@@ -487,6 +487,7 @@ struct LeaseRecord {
     metadata: CredentialMetadata,
     authenticated_subject: AuthenticatedSubjectContext,
     session_expires_at_unix_ms: u64,
+    cleanup_only: bool,
 }
 
 /// Non-secret restart checkpoint for one managed-identity lease.
@@ -500,6 +501,7 @@ pub struct ManagedIdentityLeaseCheckpoint {
     metadata: CredentialMetadata,
     authenticated_subject: AuthenticatedSubjectContext,
     session_expires_at_unix_ms: u64,
+    cleanup_only: bool,
 }
 
 impl ManagedIdentityLeaseCheckpoint {
@@ -526,6 +528,12 @@ impl ManagedIdentityLeaseCheckpoint {
     /// Return the session expiry captured with this checkpoint.
     pub const fn session_expires_at_unix_ms(&self) -> u64 {
         self.session_expires_at_unix_ms
+    }
+
+    /// Whether this checkpoint exists only to retain an unresolved cleanup
+    /// handle and must not satisfy a caller acquire or lease operation.
+    pub const fn cleanup_only(&self) -> bool {
+        self.cleanup_only
     }
 }
 
@@ -700,7 +708,8 @@ impl ManagedIdentityCredentialProvider {
     ) {
         for records in leases.values_mut() {
             for record in records {
-                if record.metadata.state == CredentialLeaseState::Active
+                if !record.cleanup_only
+                    && record.metadata.state == CredentialLeaseState::Active
                     && (Self::is_expired(record.metadata.expires_at_unix_ms, now_unix_ms)
                         || Self::is_expired(record.session_expires_at_unix_ms, now_unix_ms))
                 {
@@ -715,7 +724,9 @@ impl ManagedIdentityCredentialProvider {
         leases
             .values()
             .flat_map(|records| records.iter())
-            .filter(|record| record.metadata.state == CredentialLeaseState::Active)
+            .filter(|record| {
+                !record.cleanup_only && record.metadata.state == CredentialLeaseState::Active
+            })
             .count()
     }
 
@@ -813,22 +824,13 @@ impl ManagedIdentityCredentialProvider {
         let waker = Waker::from(Arc::new(ThreadWake(thread::current())));
         let mut context = Context::from_waker(&waker);
         loop {
-            if Instant::now() >= deadline {
-                return Err(CredentialServiceError::new(
-                    CredentialServiceErrorCode::DeadlineExceeded,
-                ));
-            }
             match future.as_mut().poll(&mut context) {
                 Poll::Ready(result) => return result.map_err(Self::map_client_error),
                 Poll::Pending => {
-                    let remaining =
-                        deadline
-                            .checked_duration_since(Instant::now())
-                            .ok_or_else(|| {
-                                CredentialServiceError::new(
-                                    CredentialServiceErrorCode::DeadlineExceeded,
-                                )
-                            })?;
+                    let now = Instant::now();
+                    let remaining = deadline.checked_duration_since(now).ok_or_else(|| {
+                        CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+                    })?;
                     thread::park_timeout(remaining);
                 }
             }
@@ -904,6 +906,7 @@ impl ManagedIdentityCredentialProvider {
                     metadata: record.metadata.clone(),
                     authenticated_subject: record.authenticated_subject.clone(),
                     session_expires_at_unix_ms: record.session_expires_at_unix_ms,
+                    cleanup_only: record.cleanup_only,
                 })
             })
             .collect())
@@ -927,11 +930,12 @@ impl ManagedIdentityCredentialProvider {
                 metadata,
                 authenticated_subject,
                 session_expires_at_unix_ms,
+                cleanup_only,
             } = checkpoint;
             if credential_ref.resource_type().as_str() != "Credential"
                 || !self.context_matches_provider(&authenticated_subject)
-                || metadata.rotation_generation == 0
-                || metadata.expires_at_unix_ms == 0
+                || (!cleanup_only
+                    && (metadata.rotation_generation == 0 || metadata.expires_at_unix_ms == 0))
                 || idempotency_key.is_empty()
                 || session_expires_at_unix_ms == 0
             {
@@ -940,7 +944,8 @@ impl ManagedIdentityCredentialProvider {
                 ));
             }
             let mut metadata = metadata;
-            if metadata.state == CredentialLeaseState::Active
+            if !cleanup_only
+                && metadata.state == CredentialLeaseState::Active
                 && (Self::is_expired(metadata.expires_at_unix_ms, now)
                     || Self::is_expired(session_expires_at_unix_ms, now))
             {
@@ -952,13 +957,10 @@ impl ManagedIdentityCredentialProvider {
                 metadata,
                 authenticated_subject,
                 session_expires_at_unix_ms,
+                cleanup_only,
             };
             if let Some((_, existing)) = restored.iter_mut().find(|(existing_key, existing)| {
-                existing_key == &key
-                    && Self::same_owner(
-                        &existing.authenticated_subject,
-                        &record.authenticated_subject,
-                    )
+                existing_key == &key && Self::same_record_identity(existing, &record)
             }) {
                 *existing = record;
             } else {
@@ -976,12 +978,7 @@ impl ManagedIdentityCredentialProvider {
         Self::mark_expired_locked(&mut next, now);
         for (credential_ref, record) in &restored {
             if let Some(records) = next.get_mut(credential_ref) {
-                records.retain(|existing| {
-                    !Self::same_owner(
-                        &existing.authenticated_subject,
-                        &record.authenticated_subject,
-                    )
-                });
+                records.retain(|existing| !Self::same_record_identity(existing, record));
             }
         }
         for (credential_ref, record) in restored {
@@ -1001,10 +998,12 @@ impl ManagedIdentityCredentialProvider {
         let mut deduplicated: Vec<LeaseRecord> = Vec::with_capacity(records.len());
         for record in records.drain(..) {
             if let Some(index) = deduplicated.iter().position(|existing| {
-                Self::same_owner(
-                    &existing.authenticated_subject,
-                    &record.authenticated_subject,
-                )
+                !existing.cleanup_only
+                    && !record.cleanup_only
+                    && Self::same_owner(
+                        &existing.authenticated_subject,
+                        &record.authenticated_subject,
+                    )
             }) {
                 if record.metadata.state == CredentialLeaseState::Active
                     || deduplicated[index].metadata.state != CredentialLeaseState::Active
@@ -1016,6 +1015,17 @@ impl ManagedIdentityCredentialProvider {
             }
         }
         *records = deduplicated;
+    }
+
+    pub(crate) fn same_record_identity(left: &LeaseRecord, right: &LeaseRecord) -> bool {
+        Self::same_owner(&left.authenticated_subject, &right.authenticated_subject)
+            && if left.cleanup_only || right.cleanup_only {
+                left.cleanup_only
+                    && right.cleanup_only
+                    && left.metadata.lease_handle == right.metadata.lease_handle
+            } else {
+                true
+            }
     }
 
     /// Revoke every active handle owned by one authenticated workload.
@@ -1048,11 +1058,13 @@ impl ManagedIdentityCredentialProvider {
                     records
                         .iter()
                         .filter(|record| {
-                            record.metadata.state == CredentialLeaseState::Active
-                                && Self::same_owner(
-                                    &record.authenticated_subject,
-                                    session.authenticated_subject(),
-                                )
+                            matches!(
+                                record.metadata.state,
+                                CredentialLeaseState::Active | CredentialLeaseState::Expired
+                            ) && Self::same_owner(
+                                &record.authenticated_subject,
+                                session.authenticated_subject(),
+                            )
                         })
                         .map(|record| {
                             (
@@ -1134,5 +1146,14 @@ mod tests {
         let config = ManagedIdentityClientConfig::new(&marker, "azure-imds", 64).unwrap();
         assert!(!format!("{config:?}").contains(&marker));
         assert_eq!(config.client_id().as_str(), marker);
+    }
+
+    #[test]
+    fn poll_client_accepts_ready_result_at_deadline() {
+        let future: ManagedIdentityFuture<'_, u8> = Box::pin(async { Ok(7) });
+        assert_eq!(
+            ManagedIdentityCredentialProvider::poll_client(future, Instant::now()).unwrap(),
+            7
+        );
     }
 }

--- a/packages/d2b-provider-credential-managed-identity/src/service.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/service.rs
@@ -1,9 +1,10 @@
 //! Credential service dispatch for the injected managed identity client.
 
 use d2b_contracts::v3::credential::{
-    CredentialAuthorization, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
-    CredentialProvider, CredentialRequest, CredentialResponse, CredentialServiceError,
-    CredentialServiceErrorCode, DeliveryResponse, MetadataResponse,
+    CredentialAuthorization, CredentialLeaseState, CredentialMetadata, CredentialMethod,
+    CredentialOutcomeCode, CredentialProvider, CredentialRequest, CredentialResponse,
+    CredentialServiceError, CredentialServiceErrorCode, CredentialSessionBinding, DeliveryResponse,
+    MetadataResponse,
 };
 
 use crate::{
@@ -60,7 +61,8 @@ impl ManagedIdentityCredentialProvider {
             let records = leases.get(&key);
             if let Some(records) = records
                 && let Some(existing) = records.iter().find(|record| {
-                    record.metadata.state == CredentialLeaseState::Active
+                    !record.cleanup_only
+                        && record.metadata.state == CredentialLeaseState::Active
                         && record.idempotency_key == request.idempotency_key()
                         && Self::same_session(
                             &record.authenticated_subject,
@@ -77,7 +79,8 @@ impl ManagedIdentityCredentialProvider {
                 .into_iter()
                 .flatten()
                 .filter(|record| {
-                    record.metadata.state == CredentialLeaseState::Active
+                    !record.cleanup_only
+                        && record.metadata.state == CredentialLeaseState::Active
                         && Self::same_owner(
                             &record.authenticated_subject,
                             session.authenticated_subject(),
@@ -112,11 +115,13 @@ impl ManagedIdentityCredentialProvider {
                 .into_iter()
                 .flatten()
                 .filter(|record| {
-                    record.metadata.state == CredentialLeaseState::Active
-                        && Self::same_owner(
-                            &record.authenticated_subject,
-                            session.authenticated_subject(),
-                        )
+                    matches!(
+                        record.metadata.state,
+                        CredentialLeaseState::Active | CredentialLeaseState::Expired
+                    ) && Self::same_owner(
+                        &record.authenticated_subject,
+                        session.authenticated_subject(),
+                    )
                 })
                 .cloned()
                 .collect::<Vec<_>>()
@@ -153,8 +158,35 @@ impl ManagedIdentityCredentialProvider {
             rotation_generation,
         };
         let grant = Self::poll_client(self.client.issue_lease(&client_request), deadline)?;
-        let metadata = Self::grant_metadata(grant, requested_expiry, rotation_generation)?;
-        let mut leases = self.leases.lock().map_err(|_| invariant())?;
+        let cleanup_lease = lease_ref_from_grant(request.credential_ref(), &grant);
+        let metadata = match Self::grant_metadata(grant, requested_expiry, rotation_generation) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                return Err(self.cleanup_or_track_issue(
+                    &key,
+                    request,
+                    session,
+                    cleanup_lease.metadata.clone(),
+                    &cleanup_lease,
+                    deadline,
+                    error,
+                ));
+            }
+        };
+        let mut leases = match self.leases.lock() {
+            Ok(leases) => leases,
+            Err(_) => {
+                return Err(self.cleanup_or_track_issue(
+                    &key,
+                    request,
+                    session,
+                    metadata.clone(),
+                    &cleanup_lease,
+                    deadline,
+                    invariant(),
+                ));
+            }
+        };
         let records = leases.entry(key).or_default();
         records.retain(|record| {
             !Self::same_owner(
@@ -167,11 +199,49 @@ impl ManagedIdentityCredentialProvider {
             metadata: metadata.clone(),
             authenticated_subject: session.authenticated_subject().clone(),
             session_expires_at_unix_ms: session.expires_at_unix_ms(),
+            cleanup_only: false,
         });
         Ok(CredentialResponse::AcquireToken(DeliveryResponse {
             metadata,
             delivery_session_params: delivery,
         }))
+    }
+
+    fn cleanup_or_track_issue(
+        &self,
+        key: &str,
+        request: &CredentialRequest,
+        session: &CredentialSessionBinding,
+        metadata: CredentialMetadata,
+        lease: &ManagedIdentityLeaseRef,
+        deadline: std::time::Instant,
+        error: CredentialServiceError,
+    ) -> CredentialServiceError {
+        if Self::poll_client(self.client.revoke_lease(lease), deadline).is_ok() {
+            return error;
+        }
+        let unresolved = LeaseRecord {
+            idempotency_key: request.idempotency_key().to_owned(),
+            metadata,
+            authenticated_subject: session.authenticated_subject().clone(),
+            session_expires_at_unix_ms: session.expires_at_unix_ms(),
+            cleanup_only: true,
+        };
+        match self.leases.lock() {
+            Ok(mut leases) => {
+                let records = leases.entry(key.to_owned()).or_default();
+                if let Some(existing) = records
+                    .iter_mut()
+                    .find(|existing| Self::same_record_identity(existing, &unresolved))
+                {
+                    *existing = unresolved;
+                } else {
+                    records.push(unresolved);
+                }
+                error
+            }
+            Err(_) => invariant(),
+        }
     }
 
     fn refresh(
@@ -204,10 +274,11 @@ impl ManagedIdentityCredentialProvider {
             let record = records
                 .iter()
                 .find(|record| {
-                    Self::same_session(
-                        &record.authenticated_subject,
-                        session.authenticated_subject(),
-                    )
+                    !record.cleanup_only
+                        && Self::same_session(
+                            &record.authenticated_subject,
+                            session.authenticated_subject(),
+                        )
                 })
                 .ok_or_else(operation_denied)?;
             ensure_active(record)?;
@@ -240,9 +311,38 @@ impl ManagedIdentityCredentialProvider {
             return Err(invariant());
         }
         let grant = Self::poll_client(self.client.refresh_lease(&lease), deadline)?;
-        let metadata =
-            Self::grant_metadata(grant, requested_expiry, record.metadata.rotation_generation)?;
-        self.replace_record(&key, &record, request.idempotency_key(), metadata.clone())?;
+        let cleanup_lease = lease_ref_from_grant(request.credential_ref(), &grant);
+        let metadata = match Self::grant_metadata(
+            grant,
+            requested_expiry,
+            record.metadata.rotation_generation,
+        ) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                return Err(self.cleanup_or_track_issue(
+                    &key,
+                    request,
+                    session,
+                    cleanup_lease.metadata.clone(),
+                    &cleanup_lease,
+                    deadline,
+                    error,
+                ));
+            }
+        };
+        if let Err(error) =
+            self.replace_record(&key, &record, request.idempotency_key(), metadata.clone())
+        {
+            return Err(self.cleanup_or_track_issue(
+                &key,
+                request,
+                session,
+                metadata.clone(),
+                &cleanup_lease,
+                deadline,
+                error,
+            ));
+        }
         Ok(CredentialResponse::RefreshToken(DeliveryResponse {
             metadata,
             delivery_session_params: delivery,
@@ -270,10 +370,11 @@ impl ManagedIdentityCredentialProvider {
             let record = records
                 .iter()
                 .find(|record| {
-                    Self::same_session(
-                        &record.authenticated_subject,
-                        session.authenticated_subject(),
-                    )
+                    !record.cleanup_only
+                        && Self::same_session(
+                            &record.authenticated_subject,
+                            session.authenticated_subject(),
+                        )
                 })
                 .ok_or_else(operation_denied)?;
             record.clone()
@@ -325,10 +426,11 @@ impl ManagedIdentityCredentialProvider {
             let record = records
                 .iter()
                 .find(|record| {
-                    Self::same_session(
-                        &record.authenticated_subject,
-                        session.authenticated_subject(),
-                    )
+                    !record.cleanup_only
+                        && Self::same_session(
+                            &record.authenticated_subject,
+                            session.authenticated_subject(),
+                        )
                 })
                 .ok_or_else(operation_denied)?;
             ensure_active_or_observable(record)?;
@@ -358,11 +460,13 @@ impl ManagedIdentityCredentialProvider {
             metadata.state = CredentialLeaseState::Expired;
         }
         self.replace_record(&key, &record, request.idempotency_key(), metadata.clone())?;
-        if metadata.state == CredentialLeaseState::Expired {
-            return Err(expired());
-        }
-        if metadata.state == CredentialLeaseState::Revoked {
-            return Err(error_for_state(metadata.state));
+        if matches!(
+            metadata.state,
+            CredentialLeaseState::Expired | CredentialLeaseState::Revoked
+        ) {
+            return Ok(CredentialResponse::InspectMetadata(MetadataResponse {
+                metadata,
+            }));
         }
         Ok(CredentialResponse::InspectMetadata(MetadataResponse {
             metadata,
@@ -417,6 +521,23 @@ fn ensure_active_or_observable(record: &LeaseRecord) -> Result<(), CredentialSer
         | CredentialLeaseState::Expired
         | CredentialLeaseState::Revoked => Ok(()),
         CredentialLeaseState::Unknown => Err(invariant()),
+    }
+}
+
+fn lease_ref_from_grant(
+    credential_ref: &d2b_contracts::v3::ResourceRef,
+    grant: &crate::ManagedIdentityLeaseGrant,
+) -> ManagedIdentityLeaseRef {
+    ManagedIdentityLeaseRef {
+        credential_ref: credential_ref.clone(),
+        metadata: CredentialMetadata {
+            lease_handle: grant.lease_handle.clone(),
+            rotation_generation: grant.rotation_generation,
+            source_version: grant.source_version.clone(),
+            expires_at_unix_ms: grant.expires_at_unix_ms,
+            state: CredentialLeaseState::Active,
+            outcome: CredentialOutcomeCode::Success,
+        },
     }
 }
 

--- a/packages/d2b-provider-credential-managed-identity/src/service.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/service.rs
@@ -105,6 +105,46 @@ impl ManagedIdentityCredentialProvider {
                 .unwrap_or(0);
             prior_generation.checked_add(1).ok_or_else(invariant)?
         };
+        let stale_records = {
+            let leases = self.leases.lock().map_err(|_| invariant())?;
+            leases
+                .get(&key)
+                .into_iter()
+                .flatten()
+                .filter(|record| {
+                    record.metadata.state == CredentialLeaseState::Active
+                        && Self::same_owner(
+                            &record.authenticated_subject,
+                            session.authenticated_subject(),
+                        )
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        for stale_record in stale_records {
+            let lease = ManagedIdentityLeaseRef {
+                credential_ref: request.credential_ref().clone(),
+                metadata: stale_record.metadata.clone(),
+            };
+            let revocation = Self::poll_client(self.client.revoke_lease(&lease), deadline)?;
+            let outcome = match revocation {
+                crate::ManagedIdentityLeaseRevocation::Revoked => CredentialOutcomeCode::Revoked,
+                crate::ManagedIdentityLeaseRevocation::AlreadyRevoked => {
+                    CredentialOutcomeCode::AlreadyRevoked
+                }
+            };
+            let mut leases = self.leases.lock().map_err(|_| invariant())?;
+            let records = leases.get_mut(&key).ok_or_else(invariant)?;
+            let record = records
+                .iter_mut()
+                .find(|record| {
+                    record.metadata == stale_record.metadata
+                        && record.authenticated_subject == stale_record.authenticated_subject
+                })
+                .ok_or_else(invariant)?;
+            record.metadata.state = CredentialLeaseState::Revoked;
+            record.metadata.outcome = outcome;
+        }
         let client_request = ManagedIdentityLeaseRequest {
             credential_ref: request.credential_ref().clone(),
             operation_id: request.operation_id().to_owned(),
@@ -294,6 +334,11 @@ impl ManagedIdentityCredentialProvider {
             ensure_active_or_observable(record)?;
             record.clone()
         };
+        if record.metadata.state != CredentialLeaseState::Active {
+            return Ok(CredentialResponse::InspectMetadata(MetadataResponse {
+                metadata: record.metadata,
+            }));
+        }
         let lease = ManagedIdentityLeaseRef {
             credential_ref: request.credential_ref().clone(),
             metadata: record.metadata.clone(),
@@ -368,8 +413,10 @@ fn ensure_active(record: &LeaseRecord) -> Result<(), CredentialServiceError> {
 
 fn ensure_active_or_observable(record: &LeaseRecord) -> Result<(), CredentialServiceError> {
     match record.metadata.state {
-        CredentialLeaseState::Active => Ok(()),
-        state => Err(error_for_state(state)),
+        CredentialLeaseState::Active
+        | CredentialLeaseState::Expired
+        | CredentialLeaseState::Revoked => Ok(()),
+        CredentialLeaseState::Unknown => Err(invariant()),
     }
 }
 

--- a/packages/d2b-provider-credential-managed-identity/src/service.rs
+++ b/packages/d2b-provider-credential-managed-identity/src/service.rs
@@ -163,7 +163,6 @@ impl ManagedIdentityCredentialProvider {
             Ok(metadata) => metadata,
             Err(error) => {
                 return Err(self.cleanup_or_track_issue(
-                    &key,
                     request,
                     session,
                     cleanup_lease.metadata.clone(),
@@ -177,7 +176,6 @@ impl ManagedIdentityCredentialProvider {
             Ok(leases) => leases,
             Err(_) => {
                 return Err(self.cleanup_or_track_issue(
-                    &key,
                     request,
                     session,
                     metadata.clone(),
@@ -209,7 +207,6 @@ impl ManagedIdentityCredentialProvider {
 
     fn cleanup_or_track_issue(
         &self,
-        key: &str,
         request: &CredentialRequest,
         session: &CredentialSessionBinding,
         metadata: CredentialMetadata,
@@ -229,7 +226,9 @@ impl ManagedIdentityCredentialProvider {
         };
         match self.leases.lock() {
             Ok(mut leases) => {
-                let records = leases.entry(key.to_owned()).or_default();
+                let records = leases
+                    .entry(request.credential_ref().to_canonical_string())
+                    .or_default();
                 if let Some(existing) = records
                     .iter_mut()
                     .find(|existing| Self::same_record_identity(existing, &unresolved))
@@ -320,7 +319,6 @@ impl ManagedIdentityCredentialProvider {
             Ok(metadata) => metadata,
             Err(error) => {
                 return Err(self.cleanup_or_track_issue(
-                    &key,
                     request,
                     session,
                     cleanup_lease.metadata.clone(),
@@ -334,7 +332,6 @@ impl ManagedIdentityCredentialProvider {
             self.replace_record(&key, &record, request.idempotency_key(), metadata.clone())
         {
             return Err(self.cleanup_or_track_issue(
-                &key,
                 request,
                 session,
                 metadata.clone(),

--- a/packages/d2b-provider-credential-managed-identity/tests/binding.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/binding.rs
@@ -5,9 +5,9 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use d2b_contracts::v3::credential::{
-    CredentialAuthorization, CredentialMethod, CredentialRequest, CredentialResponse,
-    CredentialServiceErrorCode, CredentialSessionBinding, MAX_PROVIDER_LEASE_LIFETIME_MS,
-    dispatch_authorized_provider,
+    CredentialAuthorization, CredentialLeaseState, CredentialMethod, CredentialRequest,
+    CredentialResponse, CredentialServiceErrorCode, CredentialSessionBinding,
+    MAX_PROVIDER_LEASE_LIFETIME_MS, dispatch_authorized_provider,
 };
 use d2b_contracts::v3::{Locality, ResourceRef};
 use d2b_provider_credential_managed_identity::{
@@ -17,7 +17,7 @@ use d2b_provider_credential_managed_identity::{
 use common::{
     authenticated_session, authenticated_session_with_expiry, authenticated_session_with_locality,
     authorization_for, delivery_for_timing, delivery_for_timing_with_provider_generation, request,
-    setup,
+    setup, setup_with_max_leases,
 };
 
 fn now_unix_ms() -> u64 {
@@ -650,6 +650,323 @@ fn inspect_returns_terminal_metadata_without_reopening_a_revoked_lease() {
             .inspect_calls
             .load(std::sync::atomic::Ordering::SeqCst),
         inspect_calls_before
+    );
+}
+
+#[test]
+fn inspect_returns_client_discovered_terminal_metadata() {
+    let (provider, client) = setup();
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("client-terminal-inspect-acquire"),
+        session.clone(),
+    )
+    .unwrap();
+    client.inspection.lock().unwrap().as_mut().unwrap().state = CredentialLeaseState::Revoked;
+    let response = dispatch(
+        &provider,
+        CredentialMethod::InspectMetadata,
+        &request("client-terminal-inspect"),
+        session,
+    )
+    .unwrap();
+    let CredentialResponse::InspectMetadata(response) = response else {
+        panic!("inspect response");
+    };
+    assert_eq!(response.metadata.state, CredentialLeaseState::Revoked);
+}
+
+#[test]
+fn invalid_issue_grant_is_revoked_before_acquire_returns_error() {
+    let (provider, client) = setup();
+    *client.issue_expiry_override.lock().unwrap() = Some(0);
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("invalid-issue-grant"),
+            session,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(
+        client.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    assert_eq!(
+        client
+            .revoke_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    assert!(provider.export_checkpoints().unwrap().is_empty());
+}
+
+#[test]
+fn unresolved_issue_cleanup_is_checkpointed_without_shadowing_reacquire() {
+    let (provider, client) = setup();
+    *client.issue_expiry_override.lock().unwrap() = Some(0);
+    *client.revoke_error.lock().unwrap() =
+        Some(d2b_provider_credential_managed_identity::ManagedIdentityClientError::Unavailable);
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("unresolved-issue-cleanup"),
+            session.clone(),
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    let checkpoints = provider.export_checkpoints().unwrap();
+    assert_eq!(checkpoints.len(), 1);
+    assert_eq!(
+        checkpoints[0].metadata().state,
+        CredentialLeaseState::Active
+    );
+
+    let restored = restart_provider(&provider, client.clone());
+    restored.restore_checkpoints(checkpoints.clone()).unwrap();
+    restored.restore_checkpoints(checkpoints).unwrap();
+    assert_eq!(restored.export_checkpoints().unwrap().len(), 1);
+
+    *client.issue_expiry_override.lock().unwrap() = None;
+    *client.revoke_error.lock().unwrap() = None;
+    assert!(matches!(
+        dispatch(
+            &restored,
+            CredentialMethod::AcquireToken,
+            &request("unresolved-issue-reacquire"),
+            session,
+        )
+        .unwrap(),
+        CredentialResponse::AcquireToken(_)
+    ));
+    assert_eq!(restored.export_checkpoints().unwrap().len(), 1);
+}
+
+#[test]
+fn unresolved_refresh_cleanup_is_checkpointed_and_finalized() {
+    let (provider, client) = setup();
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("unresolved-refresh-acquire"),
+        session.clone(),
+    )
+    .unwrap();
+    *client.refresh_expiry_override.lock().unwrap() = Some(0);
+    *client.revoke_error.lock().unwrap() =
+        Some(d2b_provider_credential_managed_identity::ManagedIdentityClientError::Unavailable);
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &request("unresolved-refresh"),
+            session.clone(),
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    let checkpoints = provider.export_checkpoints().unwrap();
+    assert_eq!(checkpoints.len(), 2);
+
+    let restored = restart_provider(&provider, client.clone());
+    restored.restore_checkpoints(checkpoints.clone()).unwrap();
+    restored.restore_checkpoints(checkpoints).unwrap();
+    assert_eq!(restored.export_checkpoints().unwrap().len(), 2);
+
+    *client.refresh_expiry_override.lock().unwrap() = None;
+    *client.revoke_error.lock().unwrap() = None;
+    assert_eq!(restored.revoke_owned_handles(&session, 15_000).unwrap(), 2);
+    assert_eq!(
+        restored
+            .export_checkpoints()
+            .unwrap()
+            .iter()
+            .filter(|checkpoint| checkpoint.metadata().state == CredentialLeaseState::Revoked)
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn cleanup_only_records_do_not_consume_restore_capacity() {
+    let (provider, client) = setup_with_max_leases(1);
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("capacity-cleanup-acquire"),
+        session.clone(),
+    )
+    .unwrap();
+    *client.refresh_expiry_override.lock().unwrap() = Some(0);
+    *client.revoke_error.lock().unwrap() =
+        Some(d2b_provider_credential_managed_identity::ManagedIdentityClientError::Unavailable);
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::RefreshToken,
+            &request("capacity-cleanup-refresh"),
+            session.clone(),
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    let checkpoints = provider.export_checkpoints().unwrap();
+    assert_eq!(checkpoints.len(), 2);
+    let restored = restart_provider(&provider, client);
+    restored.restore_checkpoints(checkpoints).unwrap();
+    assert_eq!(restored.export_checkpoints().unwrap().len(), 2);
+}
+
+#[test]
+fn cleanup_only_records_do_not_open_a_spare_live_lease_slot() {
+    let (provider, client) = setup_with_max_leases(1);
+    *client.issue_expiry_override.lock().unwrap() = Some(0);
+    *client.revoke_error.lock().unwrap() =
+        Some(d2b_provider_credential_managed_identity::ManagedIdentityClientError::Unavailable);
+    let owner_a = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("capacity-cleanup-slot-a"),
+            owner_a.clone(),
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    *client.issue_expiry_override.lock().unwrap() = None;
+    *client.revoke_error.lock().unwrap() = None;
+    let owner_b = authenticated_session(
+        "Provider/workload-b",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    assert!(matches!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("capacity-cleanup-slot-b"),
+            owner_b,
+        )
+        .unwrap(),
+        CredentialResponse::AcquireToken(_)
+    ));
+    assert_eq!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("capacity-cleanup-slot-a-retry"),
+            owner_a,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+}
+
+#[test]
+fn session_expiry_reacquire_revokes_the_previous_handle() {
+    let (provider, client) = setup();
+    let first_session = authenticated_session_with_expiry(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+        now_unix_ms() + 80,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("session-expiry-first"),
+        first_session,
+    )
+    .unwrap();
+    thread::sleep(Duration::from_millis(120));
+    let successor = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        2,
+    );
+    assert!(matches!(
+        dispatch(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request("session-expiry-reacquire"),
+            successor,
+        )
+        .unwrap(),
+        CredentialResponse::AcquireToken(_)
+    ));
+    assert_eq!(
+        client
+            .revoke_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
     );
 }
 

--- a/packages/d2b-provider-credential-managed-identity/tests/binding.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/binding.rs
@@ -4,19 +4,20 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use d2b_contracts::v3::ResourceRef;
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialMethod, CredentialRequest, CredentialResponse,
     CredentialServiceErrorCode, CredentialSessionBinding, MAX_PROVIDER_LEASE_LIFETIME_MS,
     dispatch_authorized_provider,
 };
+use d2b_contracts::v3::{Locality, ResourceRef};
 use d2b_provider_credential_managed_identity::{
     ManagedIdentityCredentialProvider, ManagedIdentityCredentialProviderFactory,
 };
 
 use common::{
-    authenticated_session, authenticated_session_with_expiry, authorization_for,
-    delivery_for_timing, request, setup,
+    authenticated_session, authenticated_session_with_expiry, authenticated_session_with_locality,
+    authorization_for, delivery_for_timing, delivery_for_timing_with_provider_generation, request,
+    setup,
 };
 
 fn now_unix_ms() -> u64 {
@@ -172,6 +173,131 @@ fn wrong_zone_acquire_is_denied_before_first_client_call() {
             CredentialMethod::AcquireToken,
             &request("wrong-zone-first"),
             wrong_zone,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(
+        client.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+}
+
+#[test]
+fn non_local_sessions_are_denied_before_first_client_call() {
+    for locality in [Locality::AdjacentZone, Locality::Remote] {
+        let (provider, client) = setup();
+        let session = authenticated_session_with_locality(
+            "Provider/workload-a",
+            "Zone/dev",
+            "Guest/aca-sandbox",
+            "Provider/runtime-azure-container-apps",
+            1,
+            1,
+            common::session_expiry(),
+            locality,
+        );
+        assert_eq!(
+            dispatch(
+                &provider,
+                CredentialMethod::AcquireToken,
+                &request("non-local-session"),
+                session,
+            )
+            .unwrap_err()
+            .code(),
+            CredentialServiceErrorCode::OperationDenied
+        );
+        assert_eq!(
+            client.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+}
+
+#[test]
+fn delivery_session_provider_generation_must_match_authenticated_subject() {
+    let (provider, client) = setup();
+    let request = request("delivery-generation-mismatch");
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    let delivery = delivery_for_timing_with_provider_generation(
+        CredentialMethod::AcquireToken,
+        1,
+        request.credential_ref().clone(),
+        common::EXPIRY,
+        15_000,
+        2,
+    );
+    let authorization =
+        CredentialAuthorization::new(CredentialMethod::AcquireToken, Some(delivery))
+            .unwrap()
+            .with_authenticated_session(session)
+            .unwrap();
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request,
+            &authorization,
+        )
+        .unwrap_err()
+        .code(),
+        CredentialServiceErrorCode::OperationDenied
+    );
+    assert_eq!(
+        client.issue_calls.load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+}
+
+#[test]
+fn authorization_subject_must_match_authenticated_session() {
+    let (provider, client) = setup();
+    let request = request("authorization-subject-mismatch");
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    let mismatched_subject = authenticated_session(
+        "Provider/workload-b",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    )
+    .authenticated_subject()
+    .clone();
+    let authorization = CredentialAuthorization::new_for_subject(
+        CredentialMethod::AcquireToken,
+        Some(common::delivery_for(
+            CredentialMethod::AcquireToken,
+            1,
+            request.credential_ref().clone(),
+        )),
+        mismatched_subject,
+    )
+    .unwrap()
+    .with_authenticated_session(session)
+    .unwrap();
+    assert_eq!(
+        dispatch_authorized_provider(
+            &provider,
+            CredentialMethod::AcquireToken,
+            &request,
+            &authorization,
         )
         .unwrap_err()
         .code(),
@@ -423,6 +549,12 @@ fn reconnect_reacquire_replaces_stale_session_before_refresh() {
         panic!("reacquire response");
     };
     assert_eq!(reacquired.metadata.rotation_generation, 2);
+    assert_eq!(
+        client
+            .revoke_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
 
     assert_eq!(
         dispatch(
@@ -472,6 +604,56 @@ fn reconnect_reacquire_replaces_stale_session_before_refresh() {
 }
 
 #[test]
+fn inspect_returns_terminal_metadata_without_reopening_a_revoked_lease() {
+    let (provider, client) = setup();
+    let session = authenticated_session(
+        "Provider/workload-a",
+        "Zone/dev",
+        "Guest/aca-sandbox",
+        "Provider/runtime-azure-container-apps",
+        1,
+        1,
+    );
+    dispatch(
+        &provider,
+        CredentialMethod::AcquireToken,
+        &request("terminal-inspect-acquire"),
+        session.clone(),
+    )
+    .unwrap();
+    dispatch(
+        &provider,
+        CredentialMethod::RevokeToken,
+        &request("terminal-inspect-revoke"),
+        session.clone(),
+    )
+    .unwrap();
+    let inspect_calls_before = client
+        .inspect_calls
+        .load(std::sync::atomic::Ordering::SeqCst);
+    let response = dispatch(
+        &provider,
+        CredentialMethod::InspectMetadata,
+        &request("terminal-inspect"),
+        session,
+    )
+    .unwrap();
+    let CredentialResponse::InspectMetadata(response) = response else {
+        panic!("inspect response");
+    };
+    assert_eq!(
+        response.metadata.state,
+        d2b_contracts::v3::credential::CredentialLeaseState::Revoked
+    );
+    assert_eq!(
+        client
+            .inspect_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        inspect_calls_before
+    );
+}
+
+#[test]
 fn lease_lifetime_is_capped_by_provider_maximum() {
     let (provider, _) = setup();
     let now = now_unix_ms();
@@ -515,7 +697,8 @@ fn lease_lifetime_is_capped_by_provider_maximum() {
     .unwrap() else {
         panic!("acquire response");
     };
-    assert!(response.metadata.expires_at_unix_ms <= now + MAX_PROVIDER_LEASE_LIFETIME_MS);
+    let completed_at = now_unix_ms();
+    assert!(response.metadata.expires_at_unix_ms <= completed_at + MAX_PROVIDER_LEASE_LIFETIME_MS);
 }
 
 #[test]

--- a/packages/d2b-provider-credential-managed-identity/tests/binding.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/binding.rs
@@ -193,8 +193,7 @@ fn non_local_sessions_are_denied_before_first_client_call() {
             "Zone/dev",
             "Guest/aca-sandbox",
             "Provider/runtime-azure-container-apps",
-            1,
-            1,
+            (1, 1),
             common::session_expiry(),
             locality,
         );

--- a/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
@@ -306,8 +306,7 @@ pub fn authenticated_session_with_expiry(
         zone_ref,
         execution_ref,
         provider_ref,
-        provider_generation,
-        reconnect_generation,
+        (provider_generation, reconnect_generation),
         expires_at_unix_ms,
         Locality::Local,
     )
@@ -318,11 +317,11 @@ pub fn authenticated_session_with_locality(
     zone_ref: &str,
     execution_ref: &str,
     provider_ref: &str,
-    provider_generation: u64,
-    reconnect_generation: u64,
+    generations: (u64, u64),
     expires_at_unix_ms: u64,
     locality: Locality,
 ) -> CredentialSessionBinding {
+    let (provider_generation, reconnect_generation) = generations;
     let subject = AuthenticatedSubjectContext::new(
         ResourceRef::parse(subject_ref).unwrap(),
         ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),

--- a/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
@@ -43,6 +43,9 @@ pub struct FakeClient {
     pub refresh_calls: AtomicUsize,
     pub revoke_calls: AtomicUsize,
     pub issue_error: Mutex<Option<ManagedIdentityClientError>>,
+    pub issue_expiry_override: Mutex<Option<u64>>,
+    pub refresh_expiry_override: Mutex<Option<u64>>,
+    pub revoke_error: Mutex<Option<ManagedIdentityClientError>>,
     pub observed_request: Mutex<Option<(String, String, String)>>,
     pub token_canary: String,
     pub endpoint_canary: String,
@@ -60,6 +63,9 @@ impl FakeClient {
             refresh_calls: AtomicUsize::new(0),
             revoke_calls: AtomicUsize::new(0),
             issue_error: Mutex::new(None),
+            issue_expiry_override: Mutex::new(None),
+            refresh_expiry_override: Mutex::new(None),
+            revoke_error: Mutex::new(None),
             observed_request: Mutex::new(None),
             token_canary: format!("managed-identity-token-canary-{nonce}"),
             endpoint_canary: format!("managed-identity-endpoint-canary-{nonce}"),
@@ -81,7 +87,11 @@ impl ManagedIdentityCredentialClient for FakeClient {
         self.issue_calls.fetch_add(1, Ordering::SeqCst);
         let error = *self.issue_error.lock().unwrap();
         let state = *self.state.lock().unwrap();
-        let expiry = request.requested_expiry_unix_ms();
+        let expiry = self
+            .issue_expiry_override
+            .lock()
+            .unwrap()
+            .unwrap_or(request.requested_expiry_unix_ms());
         let rotation_generation = request.rotation_generation();
         let token = self.token_canary.clone();
         let endpoint = self.endpoint_canary.clone();
@@ -128,7 +138,11 @@ impl ManagedIdentityCredentialClient for FakeClient {
         lease: &ManagedIdentityLeaseRef,
     ) -> ManagedIdentityFuture<'_, ManagedIdentityLeaseRenewal> {
         self.refresh_calls.fetch_add(1, Ordering::SeqCst);
-        let expiry = lease.metadata().expires_at_unix_ms;
+        let expiry = self
+            .refresh_expiry_override
+            .lock()
+            .unwrap()
+            .unwrap_or(lease.metadata().expires_at_unix_ms);
         let rotation_generation = lease.metadata().rotation_generation;
         let inspection = &self.inspection;
         Box::pin(async move {
@@ -154,13 +168,26 @@ impl ManagedIdentityCredentialClient for FakeClient {
         _lease: &ManagedIdentityLeaseRef,
     ) -> ManagedIdentityFuture<'_, ManagedIdentityLeaseRevocation> {
         self.revoke_calls.fetch_add(1, Ordering::SeqCst);
-        Box::pin(async { Ok(ManagedIdentityLeaseRevocation::Revoked) })
+        let error = *self.revoke_error.lock().unwrap();
+        Box::pin(async move {
+            if let Some(error) = error {
+                return Err(error);
+            }
+            Ok(ManagedIdentityLeaseRevocation::Revoked)
+        })
     }
 }
 
 pub fn setup() -> (ManagedIdentityCredentialProvider, Arc<FakeClient>) {
+    setup_with_max_leases(64)
+}
+
+pub fn setup_with_max_leases(
+    max_leases: u32,
+) -> (ManagedIdentityCredentialProvider, Arc<FakeClient>) {
     let client = Arc::new(FakeClient::new());
-    let config = ManagedIdentityClientConfig::new("client-1234", "azure-imds-aca", 64).unwrap();
+    let config =
+        ManagedIdentityClientConfig::new("client-1234", "azure-imds-aca", max_leases).unwrap();
     let placement = ManagedIdentityPlacement::new(
         PlacementBinding::GuestAgent,
         ResourceRef::parse("Guest/aca-sandbox").unwrap(),

--- a/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-managed-identity/tests/common/mod.rs
@@ -211,12 +211,30 @@ pub fn delivery_for_timing(
     expiry_unix_ms: u64,
     deadline_unix_ms: u64,
 ) -> DeliverySessionParams {
+    delivery_for_timing_with_provider_generation(
+        method,
+        sequence,
+        credential_ref,
+        expiry_unix_ms,
+        deadline_unix_ms,
+        1,
+    )
+}
+
+pub fn delivery_for_timing_with_provider_generation(
+    method: CredentialMethod,
+    sequence: u64,
+    credential_ref: ResourceRef,
+    expiry_unix_ms: u64,
+    deadline_unix_ms: u64,
+    provider_generation: u64,
+) -> DeliverySessionParams {
     DeliverySessionParams::new(
         credential_ref,
         ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),
         ResourceGeneration::new(1).unwrap(),
         ResourceRef::parse("Provider/runtime-azure-container-apps").unwrap(),
-        ResourceGeneration::new(1).unwrap(),
+        ResourceGeneration::new(provider_generation).unwrap(),
         AudienceToken::parse("azure-resource-manager").unwrap(),
         method.operation_class(),
         expiry_unix_ms,
@@ -256,6 +274,28 @@ pub fn authenticated_session_with_expiry(
     reconnect_generation: u64,
     expires_at_unix_ms: u64,
 ) -> CredentialSessionBinding {
+    authenticated_session_with_locality(
+        subject_ref,
+        zone_ref,
+        execution_ref,
+        provider_ref,
+        provider_generation,
+        reconnect_generation,
+        expires_at_unix_ms,
+        Locality::Local,
+    )
+}
+
+pub fn authenticated_session_with_locality(
+    subject_ref: &str,
+    zone_ref: &str,
+    execution_ref: &str,
+    provider_ref: &str,
+    provider_generation: u64,
+    reconnect_generation: u64,
+    expires_at_unix_ms: u64,
+    locality: Locality,
+) -> CredentialSessionBinding {
     let subject = AuthenticatedSubjectContext::new(
         ResourceRef::parse(subject_ref).unwrap(),
         ResourceUid::parse("123e4567-e89b-42d3-a456-426614174000").unwrap(),
@@ -266,7 +306,7 @@ pub fn authenticated_session_with_expiry(
         SessionBinding::new(
             SchemaFingerprint::parse(format!("sha256:{}", "a".repeat(64))).unwrap(),
             TransportBinding::new(
-                Locality::Local,
+                locality,
                 BindingDigest::parse(format!("sha256:{}", "b".repeat(64))).unwrap(),
             ),
             ReconnectGeneration::new(reconnect_generation).unwrap(),


### PR DESCRIPTION
## Summary

Managed-identity Credential leases now bind to the authenticated subject, Zone, workload, and local Provider session. Reacquire revokes superseded and session-expired handles first. Invalid grants are revoked or tracked as cleanup-only without opening a spare live occupancy slot. Terminal inspect returns observation metadata without reopening a closed lease.

This is Spec 001 Wave 6 U20 on the managed-identity provider.

## Validation evidence

- [x] **Focused tests for the changed components** were run:
      `cd packages && cargo test -p d2b-provider-credential-managed-identity --offline --lib --test binding -- --test-threads=1`
      Result: 8 lib + 20 binding tests passed.
- [x] **Wider lanes are conditional.** Omitted: crate-local lease logic only; no container, NixOS host, or hardware surface.
- [x] **Hardware checks are conditional:** not applicable — no GPU, USBIP/YubiKey, hardware-TPM, or microVM boot path.
- [x] **Changed tests are inventoried:** new coverage lives in crate `tests/binding.rs` and `src/lib.rs` unit tests. No `tests/migration-ledger.toml` row.
- [x] **Changelog updated** via `changelog.d/spec001-w6-u20-managed-identity.md`.
- [x] **Docs + CI updated in lockstep** where applicable: no daemon, API, schema, or workflow contract change.

## Notes

Checkpoints stay secret-free. First client revoke failure still aborts the remaining batch without marking leftover handles cleanup-only. Inspect still persists client-reported expiry without re-bounding it to the provider cap.
