### PR TITLE
credential: harden Secret Service lease recovery

### DIFF
--- a/changelog.d/feat-spec001-u21-credential-secret-service.md
+++ b/changelog.d/feat-spec001-u21-credential-secret-service.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Hardened Secret Service credential lease state, idempotency, timeout, and
+  disconnect/finalization recovery while keeping credential material opaque.

--- a/packages/d2b-provider-credential-secret-service/README.md
+++ b/packages/d2b-provider-credential-secret-service/README.md
@@ -66,7 +66,13 @@ The port retains credential bytes and Secret Service object paths. Outer
 responses contain only opaque digests and metadata; raw values use a dedicated
 adapter-authorized Noise KK delivery session. The Provider receives that
 binding read-only and cannot select its consumer, audience, route, or limits.
-There is no ambient D-Bus or path fallback.
+There is no ambient D-Bus or path fallback. Mutating completions that are
+unknown at the service boundary, including deadline expiry, are fenced by
+idempotency key and recovered through the adapter during disconnect or
+finalization without replaying issuance or refresh. An unknown lease or
+ambiguous operation cannot be made live again by inspection. Request deadlines
+are interpreted as absolute Unix milliseconds; small relative budgets remain
+accepted for compatibility with hermetic callers.
 
 ## State and telemetry
 

--- a/packages/d2b-provider-credential-secret-service/src/lib.rs
+++ b/packages/d2b-provider-credential-secret-service/src/lib.rs
@@ -10,7 +10,7 @@
 mod controller;
 mod service;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread::{self, Thread};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialLeaseHandle, CredentialLeaseState, CredentialMetadata,
@@ -37,6 +37,7 @@ pub const PROVIDER_REF: &str = "Provider/credential-secret-service";
 pub const MAX_LOCAL_LEASES: u32 = 256;
 /// Maximum bytes in a Secret Service collection alias.
 pub const MAX_COLLECTION_ALIAS_BYTES: usize = 128;
+const ABSOLUTE_UNIX_MS_THRESHOLD: u64 = 1_000_000_000_000;
 
 /// A boxed asynchronous result returned by the injected port.
 pub type SecretServiceFuture<'a, T> =
@@ -47,6 +48,23 @@ pub type SecretServiceFuture<'a, T> =
 pub enum SecretServiceOwner {
     /// The authenticated user-domain process.
     Userd,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum OperationKind {
+    Acquire,
+    Inspect,
+    Refresh,
+    Revoke,
+}
+
+pub(crate) enum SecretServicePollError {
+    Port(SecretServicePortError),
+    Deadline,
+}
+
+fn invariant_error() -> CredentialServiceError {
+    CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure)
 }
 
 /// Locked-keyring behavior.
@@ -380,6 +398,25 @@ pub trait Oo7SecretServicePort: Send + Sync {
         &self,
         lease: &SecretServiceLeaseRef,
     ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation>;
+    /// Revoke a lease whose issue completion was ambiguous, using the
+    /// original idempotency key instead of replaying issuance.
+    fn revoke_ambiguous_lease(
+        &self,
+        _request: &SecretServiceLeaseRequest,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
+        Box::pin(async { Err(SecretServicePortError::Unavailable) })
+    }
+    /// Revoke the prior and any rotated lease associated with a refresh whose
+    /// completion was ambiguous, using the operation identity without
+    /// replaying refresh.
+    fn revoke_ambiguous_refresh(
+        &self,
+        _lease: &SecretServiceLeaseRef,
+        _operation_id: &str,
+        _idempotency_key: &str,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
+        Box::pin(async { Err(SecretServicePortError::Unavailable) })
+    }
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -677,6 +714,9 @@ impl SecretServiceCredentialProviderFactory {
             authority: SessionAuthority::new()?,
             sessions: Mutex::new(BTreeMap::new()),
             leases: Mutex::new(BTreeMap::new()),
+            ambiguous_operations: Mutex::new(BTreeSet::new()),
+            ambiguous_acquires: Mutex::new(BTreeMap::new()),
+            ambiguous_refreshes: Mutex::new(BTreeMap::new()),
             mutation_gate: Mutex::new(()),
             finalized: AtomicBool::new(false),
         })
@@ -691,8 +731,15 @@ impl fmt::Debug for SecretServiceCredentialProviderFactory {
 
 #[derive(Clone)]
 struct LeaseRecord {
-    idempotency_key: String,
+    refresh_results: BTreeMap<String, CredentialMetadata>,
     metadata: CredentialMetadata,
+}
+
+#[derive(Clone)]
+struct AmbiguousRefreshRecord {
+    lease: SecretServiceLeaseRef,
+    operation_id: String,
+    idempotency_key: String,
 }
 
 /// Secret Service implementation of the prepared Credential service.
@@ -705,6 +752,9 @@ pub struct SecretServiceCredentialProvider {
     authority: SessionAuthority,
     sessions: Mutex<BTreeMap<SessionKey, ()>>,
     leases: Mutex<BTreeMap<(SessionKey, String), LeaseRecord>>,
+    ambiguous_operations: Mutex<BTreeSet<(SessionKey, String, String, OperationKind)>>,
+    ambiguous_acquires: Mutex<BTreeMap<(SessionKey, String, String), SecretServiceLeaseRequest>>,
+    ambiguous_refreshes: Mutex<BTreeMap<(SessionKey, String, String), AmbiguousRefreshRecord>>,
     mutation_gate: Mutex<()>,
     finalized: AtomicBool,
 }
@@ -855,18 +905,51 @@ impl SecretServiceCredentialProvider {
             .map_err(|_| CredentialServiceError::new(CredentialServiceErrorCode::InvariantFailure))
     }
 
+    pub(crate) fn now_unix_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+            .unwrap_or(0)
+    }
+
+    pub(crate) const fn is_absolute_unix_ms(value: u64) -> bool {
+        value >= ABSOLUTE_UNIX_MS_THRESHOLD
+    }
+
     pub(crate) fn operation_deadline(deadline_ms: u64) -> Result<Instant, CredentialServiceError> {
+        let duration_ms = if Self::is_absolute_unix_ms(deadline_ms) {
+            deadline_ms.saturating_sub(Self::now_unix_ms())
+        } else {
+            deadline_ms
+        };
+        if duration_ms == 0 {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::DeadlineExceeded,
+            ));
+        }
         Instant::now()
-            .checked_add(Duration::from_millis(deadline_ms))
+            .checked_add(Duration::from_millis(duration_ms))
             .ok_or_else(|| {
                 CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
             })
     }
 
     pub(crate) fn poll_port<T>(
-        mut future: SecretServiceFuture<'_, T>,
+        future: SecretServiceFuture<'_, T>,
         deadline: Instant,
     ) -> Result<T, CredentialServiceError> {
+        Self::poll_port_raw(future, deadline).map_err(|error| match error {
+            SecretServicePollError::Port(error) => Self::map_port_error(error),
+            SecretServicePollError::Deadline => {
+                CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+            }
+        })
+    }
+
+    pub(crate) fn poll_port_raw<T>(
+        mut future: SecretServiceFuture<'_, T>,
+        deadline: Instant,
+    ) -> Result<T, SecretServicePollError> {
         struct ThreadWake(Thread);
         impl Wake for ThreadWake {
             fn wake(self: Arc<Self>) {
@@ -881,24 +964,311 @@ impl SecretServiceCredentialProvider {
         let mut context = Context::from_waker(&waker);
         loop {
             if Instant::now() >= deadline {
-                return Err(CredentialServiceError::new(
-                    CredentialServiceErrorCode::DeadlineExceeded,
-                ));
+                return Err(SecretServicePollError::Deadline);
             }
             match future.as_mut().poll(&mut context) {
-                Poll::Ready(result) => return result.map_err(Self::map_port_error),
+                Poll::Ready(result) => {
+                    return result.map_err(SecretServicePollError::Port);
+                }
                 Poll::Pending => {
-                    let remaining =
-                        deadline
-                            .checked_duration_since(Instant::now())
-                            .ok_or_else(|| {
-                                CredentialServiceError::new(
-                                    CredentialServiceErrorCode::DeadlineExceeded,
-                                )
-                            })?;
+                    let remaining = deadline
+                        .checked_duration_since(Instant::now())
+                        .ok_or(SecretServicePollError::Deadline)?;
+                    if remaining.is_zero() {
+                        return Err(SecretServicePollError::Deadline);
+                    }
                     thread::park_timeout(remaining);
                 }
             }
+        }
+    }
+
+    pub(crate) fn ensure_unlocked(&self, deadline: Instant) -> Result<(), CredentialServiceError> {
+        if Self::poll_port(self.port.state(), deadline)? == SecretServiceState::Locked {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            ));
+        }
+        Self::deadline_remaining(deadline)
+    }
+
+    pub(crate) fn deadline_remaining(deadline: Instant) -> Result<(), CredentialServiceError> {
+        if Instant::now() >= deadline {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::DeadlineExceeded,
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn has_ambiguous_credential(
+        &self,
+        session_key: SessionKey,
+        credential: &str,
+    ) -> Result<bool, CredentialServiceError> {
+        Ok(self
+            .ambiguous_operations
+            .lock()
+            .map_err(|_| invariant_error())?
+            .iter()
+            .any(|(key, candidate, _, _)| *key == session_key && candidate == credential))
+    }
+
+    pub(crate) fn ambiguous_lease_count(&self) -> Result<usize, CredentialServiceError> {
+        let tracked = self
+            .leases
+            .lock()
+            .map_err(|_| invariant_error())?
+            .values()
+            .filter(|record| {
+                matches!(
+                    record.metadata.state,
+                    CredentialLeaseState::Active | CredentialLeaseState::Unknown
+                )
+            })
+            .count();
+        let pending = self
+            .ambiguous_acquires
+            .lock()
+            .map_err(|_| invariant_error())?
+            .len();
+        Ok(tracked.saturating_add(pending))
+    }
+
+    pub(crate) fn mark_ambiguous(
+        &self,
+        session_key: SessionKey,
+        credential: &str,
+        idempotency_key: &str,
+        operation: OperationKind,
+    ) -> Result<(), CredentialServiceError> {
+        self.ambiguous_operations
+            .lock()
+            .map_err(|_| invariant_error())?
+            .insert((
+                session_key,
+                credential.to_owned(),
+                idempotency_key.to_owned(),
+                operation,
+            ));
+        Ok(())
+    }
+
+    pub(crate) fn remember_ambiguous_acquire(
+        &self,
+        session_key: SessionKey,
+        request: SecretServiceLeaseRequest,
+    ) -> Result<(), CredentialServiceError> {
+        let credential = request.credential_ref().to_canonical_string();
+        self.mark_ambiguous(
+            session_key,
+            &credential,
+            request.idempotency_key(),
+            OperationKind::Acquire,
+        )?;
+        self.ambiguous_acquires
+            .lock()
+            .map_err(|_| invariant_error())?
+            .insert(
+                (
+                    session_key,
+                    credential,
+                    request.idempotency_key().to_owned(),
+                ),
+                request,
+            );
+        Ok(())
+    }
+
+    pub(crate) fn remember_ambiguous_refresh(
+        &self,
+        session_key: SessionKey,
+        request: &d2b_contracts::v3::credential::CredentialRequest,
+        lease: SecretServiceLeaseRef,
+    ) -> Result<(), CredentialServiceError> {
+        let credential = request.credential_ref().to_canonical_string();
+        self.mark_ambiguous(
+            session_key,
+            &credential,
+            request.idempotency_key(),
+            OperationKind::Refresh,
+        )?;
+        self.ambiguous_refreshes
+            .lock()
+            .map_err(|_| invariant_error())?
+            .insert(
+                (
+                    session_key,
+                    credential,
+                    request.idempotency_key().to_owned(),
+                ),
+                AmbiguousRefreshRecord {
+                    lease,
+                    operation_id: request.operation_id().to_owned(),
+                    idempotency_key: request.idempotency_key().to_owned(),
+                },
+            );
+        Ok(())
+    }
+
+    pub(crate) fn ambiguous_acquires(
+        &self,
+        session_key: SessionKey,
+    ) -> Result<Vec<(String, String, SecretServiceLeaseRequest)>, CredentialServiceError> {
+        Ok(self
+            .ambiguous_acquires
+            .lock()
+            .map_err(|_| invariant_error())?
+            .iter()
+            .filter(|((key, _, _), _)| *key == session_key)
+            .map(|((_, credential, idempotency), request)| {
+                (credential.clone(), idempotency.clone(), request.clone())
+            })
+            .collect())
+    }
+
+    pub(crate) fn ambiguous_refreshes(
+        &self,
+        session_key: SessionKey,
+    ) -> Result<Vec<(String, String, AmbiguousRefreshRecord)>, CredentialServiceError> {
+        Ok(self
+            .ambiguous_refreshes
+            .lock()
+            .map_err(|_| invariant_error())?
+            .iter()
+            .filter(|((key, _, _), _)| *key == session_key)
+            .map(|((_, credential, idempotency), record)| {
+                (credential.clone(), idempotency.clone(), record.clone())
+            })
+            .collect())
+    }
+
+    pub(crate) fn clear_ambiguous_operation(
+        &self,
+        session_key: SessionKey,
+        credential: &str,
+        idempotency_key: &str,
+        operation: OperationKind,
+    ) -> Result<(), CredentialServiceError> {
+        self.ambiguous_operations
+            .lock()
+            .map_err(|_| invariant_error())?
+            .retain(|(key, candidate, candidate_key, candidate_operation)| {
+                *key != session_key
+                    || candidate != credential
+                    || candidate_key != idempotency_key
+                    || *candidate_operation != operation
+            });
+        Ok(())
+    }
+
+    pub(crate) fn clear_ambiguous_acquire(
+        &self,
+        session_key: SessionKey,
+        credential: &str,
+        idempotency_key: &str,
+    ) -> Result<(), CredentialServiceError> {
+        self.ambiguous_acquires
+            .lock()
+            .map_err(|_| invariant_error())?
+            .remove(&(
+                session_key,
+                credential.to_owned(),
+                idempotency_key.to_owned(),
+            ));
+        self.clear_ambiguous_operation(
+            session_key,
+            credential,
+            idempotency_key,
+            OperationKind::Acquire,
+        )
+    }
+
+    pub(crate) fn clear_ambiguous_refresh(
+        &self,
+        session_key: SessionKey,
+        credential: &str,
+        idempotency_key: &str,
+    ) -> Result<(), CredentialServiceError> {
+        self.ambiguous_refreshes
+            .lock()
+            .map_err(|_| invariant_error())?
+            .remove(&(
+                session_key,
+                credential.to_owned(),
+                idempotency_key.to_owned(),
+            ));
+        self.clear_ambiguous_operation(
+            session_key,
+            credential,
+            idempotency_key,
+            OperationKind::Refresh,
+        )
+    }
+
+    pub(crate) fn clear_ambiguous_session(
+        &self,
+        session_key: SessionKey,
+    ) -> Result<(), CredentialServiceError> {
+        self.ambiguous_operations
+            .lock()
+            .map_err(|_| invariant_error())?
+            .retain(|(key, _, _, _)| *key != session_key);
+        self.ambiguous_acquires
+            .lock()
+            .map_err(|_| invariant_error())?
+            .retain(|(key, _, _), _| *key != session_key);
+        self.ambiguous_refreshes
+            .lock()
+            .map_err(|_| invariant_error())?
+            .retain(|(key, _, _), _| *key != session_key);
+        Ok(())
+    }
+
+    pub(crate) fn clear_ambiguous_for_credential(
+        &self,
+        session_key: SessionKey,
+        credential: &str,
+    ) -> Result<(), CredentialServiceError> {
+        self.ambiguous_operations
+            .lock()
+            .map_err(|_| invariant_error())?
+            .retain(|(key, candidate, _, _)| *key != session_key || candidate != credential);
+        self.ambiguous_acquires
+            .lock()
+            .map_err(|_| invariant_error())?
+            .retain(|(key, candidate, _), _| *key != session_key || candidate != credential);
+        self.ambiguous_refreshes
+            .lock()
+            .map_err(|_| invariant_error())?
+            .retain(|(key, candidate, _), _| *key != session_key || candidate != credential);
+        Ok(())
+    }
+
+    pub(crate) fn has_ambiguous_session(
+        &self,
+        session_key: SessionKey,
+    ) -> Result<bool, CredentialServiceError> {
+        Ok(self
+            .ambiguous_operations
+            .lock()
+            .map_err(|_| invariant_error())?
+            .iter()
+            .any(|(key, _, _, _)| *key == session_key))
+    }
+
+    fn metadata_from_grant(
+        grant: &SecretServiceLeaseGrant,
+        state: CredentialLeaseState,
+        outcome: CredentialOutcomeCode,
+    ) -> CredentialMetadata {
+        CredentialMetadata {
+            lease_handle: grant.lease_handle.clone(),
+            rotation_generation: grant.rotation_generation,
+            source_version: grant.source_version.clone(),
+            expires_at_unix_ms: grant.expires_at_unix_ms,
+            state,
+            outcome,
         }
     }
 
@@ -914,14 +1284,19 @@ impl SecretServiceCredentialProvider {
                 CredentialServiceErrorCode::InvariantFailure,
             ));
         }
-        Ok(CredentialMetadata {
-            lease_handle: grant.lease_handle,
-            rotation_generation: grant.rotation_generation,
-            source_version: grant.source_version,
-            expires_at_unix_ms: grant.expires_at_unix_ms,
-            state: CredentialLeaseState::Active,
-            outcome: CredentialOutcomeCode::Success,
-        })
+        Ok(Self::metadata_from_grant(
+            &grant,
+            CredentialLeaseState::Active,
+            CredentialOutcomeCode::Success,
+        ))
+    }
+
+    pub(crate) fn unknown_metadata(grant: &SecretServiceLeaseGrant) -> CredentialMetadata {
+        Self::metadata_from_grant(
+            grant,
+            CredentialLeaseState::Unknown,
+            CredentialOutcomeCode::Success,
+        )
     }
 }
 
@@ -1064,5 +1439,25 @@ mod tests {
             next_counter(&counter),
             Err(SessionAuthorityError::Exhausted)
         );
+    }
+
+    #[test]
+    fn absolute_deadlines_use_unix_milliseconds() {
+        let now = SecretServiceCredentialProvider::now_unix_ms();
+        let deadline = SecretServiceCredentialProvider::operation_deadline(now + 100);
+        assert!(deadline.is_ok());
+        assert!(
+            SecretServiceCredentialProvider::operation_deadline(now.saturating_sub(1)).is_err()
+        );
+    }
+
+    #[test]
+    fn poll_port_raw_does_not_start_after_deadline() {
+        let deadline = Instant::now();
+        let result = SecretServiceCredentialProvider::poll_port_raw(
+            Box::pin(async { Ok::<_, SecretServicePortError>(SecretServiceState::Unlocked) }),
+            deadline,
+        );
+        assert!(matches!(result, Err(SecretServicePollError::Deadline)));
     }
 }

--- a/packages/d2b-provider-credential-secret-service/src/service.rs
+++ b/packages/d2b-provider-credential-secret-service/src/service.rs
@@ -1,5 +1,7 @@
 //! Credential service dispatch for Secret Service.
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use d2b_contracts::v3::credential::{
     CredentialAuthorization, CredentialLeaseState, CredentialMethod, CredentialOutcomeCode,
     CredentialProvider, CredentialRequest, CredentialResponse, CredentialServiceError,
@@ -7,8 +9,8 @@ use d2b_contracts::v3::credential::{
 };
 
 use crate::{
-    LeaseRecord, SecretServiceCredentialProvider, SecretServiceLeaseRef, SecretServiceLeaseRequest,
-    SessionKey,
+    LeaseRecord, OperationKind, SecretServiceCredentialProvider, SecretServiceLeaseRef,
+    SecretServiceLeaseRequest, SecretServicePollError, SecretServicePortError, SessionKey,
 };
 
 impl CredentialProvider for SecretServiceCredentialProvider {
@@ -45,23 +47,32 @@ impl SecretServiceCredentialProvider {
             .ok_or_else(invariant)?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let key = request.credential_ref().to_canonical_string();
+        self.ensure_unlocked(deadline)?;
+        if self.has_ambiguous_credential(session_key, &key)? {
+            return Err(invariant());
+        }
         let lease_key = (session_key, key.clone());
         {
             let mut leases = self.leases.lock().map_err(|_| invariant())?;
-            leases.retain(|_, record| record.metadata.state == CredentialLeaseState::Active);
-            if let Some(existing) = leases.get(&lease_key)
-                && existing.idempotency_key == request.idempotency_key()
-            {
-                return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
-                    metadata: existing.metadata.clone(),
-                    delivery_session_params: delivery,
-                }));
+            if let Some(existing) = leases.get(&lease_key) {
+                match existing.metadata.state {
+                    CredentialLeaseState::Active => {
+                        return Ok(CredentialResponse::AcquireToken(DeliveryResponse {
+                            metadata: existing.metadata.clone(),
+                            delivery_session_params: delivery,
+                        }));
+                    }
+                    CredentialLeaseState::Unknown => return Err(invariant()),
+                    CredentialLeaseState::Expired | CredentialLeaseState::Revoked => {
+                        leases.remove(&lease_key);
+                    }
+                }
             }
-            if leases.len() >= self.config.max_leases() as usize {
-                return Err(CredentialServiceError::new(
-                    CredentialServiceErrorCode::ProviderUnavailable,
-                ));
-            }
+        }
+        if self.ambiguous_lease_count()? >= self.config.max_leases() as usize {
+            return Err(CredentialServiceError::new(
+                CredentialServiceErrorCode::ProviderUnavailable,
+            ));
         }
         let port_request = SecretServiceLeaseRequest {
             credential_ref: request.credential_ref().clone(),
@@ -69,12 +80,45 @@ impl SecretServiceCredentialProvider {
             idempotency_key: request.idempotency_key().to_owned(),
             requested_expiry_unix_ms: request.requested_expiry_unix_ms(),
         };
-        let grant = Self::poll_port(self.port.issue_lease(&port_request), deadline)?;
-        let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
+        Self::deadline_remaining(deadline)?;
+        let grant = match Self::poll_port_raw(self.port.issue_lease(&port_request), deadline) {
+            Ok(grant) => grant,
+            Err(SecretServicePollError::Port(SecretServicePortError::CompletionUnknown)) => {
+                self.remember_ambiguous_acquire(session_key, port_request.clone())?;
+                return Err(invariant());
+            }
+            Err(SecretServicePollError::Deadline) => {
+                self.remember_ambiguous_acquire(session_key, port_request.clone())?;
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::DeadlineExceeded,
+                ));
+            }
+            Err(error) => return Err(map_poll_error(error)),
+        };
+        let metadata = match Self::grant_metadata(grant.clone(), request.requested_expiry_unix_ms())
+        {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                self.leases.lock().map_err(|_| invariant())?.insert(
+                    lease_key,
+                    LeaseRecord {
+                        refresh_results: BTreeMap::new(),
+                        metadata: Self::unknown_metadata(&grant),
+                    },
+                );
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Acquire,
+                )?;
+                return Err(error);
+            }
+        };
         self.leases.lock().map_err(|_| invariant())?.insert(
             lease_key,
             LeaseRecord {
-                idempotency_key: request.idempotency_key().to_owned(),
+                refresh_results: BTreeMap::new(),
                 metadata: metadata.clone(),
             },
         );
@@ -96,7 +140,11 @@ impl SecretServiceCredentialProvider {
             .ok_or_else(invariant)?;
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let key = request.credential_ref().to_canonical_string();
-        let lease_key = (session_key, key);
+        self.ensure_unlocked(deadline)?;
+        if self.has_ambiguous_credential(session_key, &key)? {
+            return Err(invariant());
+        }
+        let lease_key = (session_key, key.clone());
         let current = self
             .leases
             .lock()
@@ -104,28 +152,164 @@ impl SecretServiceCredentialProvider {
             .get(&lease_key)
             .cloned()
             .ok_or_else(expired)?;
-        if current.metadata.state != CredentialLeaseState::Active {
-            return Err(expired());
+        match current.metadata.state {
+            CredentialLeaseState::Active => {
+                if let Some(metadata) = current.refresh_results.get(request.idempotency_key()) {
+                    return Ok(CredentialResponse::RefreshToken(DeliveryResponse {
+                        metadata: metadata.clone(),
+                        delivery_session_params: delivery,
+                    }));
+                }
+            }
+            CredentialLeaseState::Expired => return Err(expired()),
+            CredentialLeaseState::Revoked => return Err(revoked()),
+            CredentialLeaseState::Unknown => return Err(invariant()),
         }
         let lease = SecretServiceLeaseRef {
             credential_ref: request.credential_ref().clone(),
-            metadata: current.metadata,
+            metadata: current.metadata.clone(),
         };
-        let inspected = Self::poll_port(self.port.inspect_lease(&lease), deadline)?;
-        if inspected.state != CredentialLeaseState::Active
-            || inspected.rotation_generation != lease.metadata.rotation_generation
-        {
-            return Err(invariant());
+        let inspected = match Self::poll_port_raw(self.port.inspect_lease(&lease), deadline) {
+            Ok(inspected) => inspected,
+            Err(SecretServicePollError::Port(SecretServicePortError::CompletionUnknown)) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Inspect,
+                )?;
+                return Err(invariant());
+            }
+            Err(SecretServicePollError::Deadline) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Inspect,
+                )?;
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::DeadlineExceeded,
+                ));
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseExpired)) => {
+                self.set_lease_state(&lease_key, CredentialLeaseState::Expired)?;
+                return Err(expired());
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseRevoked)) => {
+                self.set_lease_state(&lease_key, CredentialLeaseState::Revoked)?;
+                return Err(revoked());
+            }
+            Err(error) => return Err(map_poll_error(error)),
+        };
+        let mut inspected_metadata = lease.metadata.clone();
+        inspected_metadata.state = inspected.state;
+        inspected_metadata.source_version = inspected.source_version;
+        inspected_metadata.rotation_generation = inspected.rotation_generation;
+        inspected_metadata.expires_at_unix_ms = inspected.expires_at_unix_ms;
+        match inspected_metadata.state {
+            CredentialLeaseState::Active => {
+                if inspected_metadata.rotation_generation != lease.metadata.rotation_generation {
+                    self.mark_metadata_unknown(&lease_key)?;
+                    self.mark_ambiguous(
+                        session_key,
+                        &key,
+                        request.idempotency_key(),
+                        OperationKind::Inspect,
+                    )?;
+                    return Err(invariant());
+                }
+            }
+            CredentialLeaseState::Expired => {
+                self.leases
+                    .lock()
+                    .map_err(|_| invariant())?
+                    .get_mut(&lease_key)
+                    .ok_or_else(expired)?
+                    .metadata = inspected_metadata;
+                return Err(expired());
+            }
+            CredentialLeaseState::Revoked => {
+                self.leases
+                    .lock()
+                    .map_err(|_| invariant())?
+                    .get_mut(&lease_key)
+                    .ok_or_else(expired)?
+                    .metadata = inspected_metadata;
+                return Err(revoked());
+            }
+            CredentialLeaseState::Unknown => {
+                self.leases
+                    .lock()
+                    .map_err(|_| invariant())?
+                    .get_mut(&lease_key)
+                    .ok_or_else(expired)?
+                    .metadata = inspected_metadata;
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Inspect,
+                )?;
+                return Err(invariant());
+            }
         }
-        let grant = Self::poll_port(self.port.refresh_lease(&lease), deadline)?;
-        let metadata = Self::grant_metadata(grant, request.requested_expiry_unix_ms())?;
-        self.leases.lock().map_err(|_| invariant())?.insert(
-            lease_key,
-            LeaseRecord {
-                idempotency_key: request.idempotency_key().to_owned(),
-                metadata: metadata.clone(),
-            },
-        );
+        self.leases
+            .lock()
+            .map_err(|_| invariant())?
+            .get_mut(&lease_key)
+            .ok_or_else(expired)?
+            .metadata = inspected_metadata.clone();
+        let lease = SecretServiceLeaseRef {
+            credential_ref: request.credential_ref().clone(),
+            metadata: inspected_metadata,
+        };
+        let recovery_lease = lease.clone();
+        let grant = match Self::poll_port_raw(self.port.refresh_lease(&lease), deadline) {
+            Ok(grant) => grant,
+            Err(SecretServicePollError::Port(SecretServicePortError::CompletionUnknown)) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.remember_ambiguous_refresh(session_key, request, recovery_lease)?;
+                return Err(invariant());
+            }
+            Err(SecretServicePollError::Deadline) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.remember_ambiguous_refresh(session_key, request, recovery_lease)?;
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::DeadlineExceeded,
+                ));
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseExpired)) => {
+                self.set_lease_state(&lease_key, CredentialLeaseState::Expired)?;
+                return Err(expired());
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseRevoked)) => {
+                self.set_lease_state(&lease_key, CredentialLeaseState::Revoked)?;
+                return Err(revoked());
+            }
+            Err(error) => return Err(map_poll_error(error)),
+        };
+        let metadata = match Self::grant_metadata(grant.clone(), request.requested_expiry_unix_ms())
+        {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                let mut leases = self.leases.lock().map_err(|_| invariant())?;
+                let record = leases.get_mut(&lease_key).ok_or_else(expired)?;
+                record.metadata = Self::unknown_metadata(&grant);
+                self.remember_ambiguous_refresh(session_key, request, recovery_lease)?;
+                return Err(error);
+            }
+        };
+        let mut record = current;
+        record.metadata = metadata.clone();
+        record
+            .refresh_results
+            .insert(request.idempotency_key().to_owned(), metadata.clone());
+        self.leases
+            .lock()
+            .map_err(|_| invariant())?
+            .insert(lease_key, record);
         Ok(CredentialResponse::RefreshToken(DeliveryResponse {
             metadata,
             delivery_session_params: delivery,
@@ -139,25 +323,83 @@ impl SecretServiceCredentialProvider {
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let key = request.credential_ref().to_canonical_string();
-        let lease_key = (session_key, key);
-        let mut leases = self.leases.lock().map_err(|_| invariant())?;
-        let record = leases.get_mut(&lease_key).ok_or_else(expired)?;
-        let outcome = if record.metadata.state == CredentialLeaseState::Revoked {
-            CredentialOutcomeCode::AlreadyRevoked
-        } else {
-            let lease = SecretServiceLeaseRef {
-                credential_ref: request.credential_ref().clone(),
-                metadata: record.metadata.clone(),
-            };
-            let result = Self::poll_port(self.port.revoke_lease(&lease), deadline)?;
-            record.metadata.state = CredentialLeaseState::Revoked;
-            match result {
-                crate::SecretServiceLeaseRevocation::Revoked => CredentialOutcomeCode::Revoked,
-                crate::SecretServiceLeaseRevocation::AlreadyRevoked => {
-                    CredentialOutcomeCode::AlreadyRevoked
-                }
+        self.ensure_unlocked(deadline)?;
+        if self.has_ambiguous_credential(session_key, &key)? {
+            return Err(invariant());
+        }
+        let lease_key = (session_key, key.clone());
+        let current = self
+            .leases
+            .lock()
+            .map_err(|_| invariant())?
+            .get(&lease_key)
+            .cloned()
+            .ok_or_else(expired)?;
+        match current.metadata.state {
+            CredentialLeaseState::Revoked => {
+                let mut metadata = current.metadata;
+                metadata.outcome = CredentialOutcomeCode::AlreadyRevoked;
+                self.leases
+                    .lock()
+                    .map_err(|_| invariant())?
+                    .get_mut(&lease_key)
+                    .ok_or_else(expired)?
+                    .metadata = metadata.clone();
+                return Ok(CredentialResponse::RevokeToken(MetadataResponse {
+                    metadata,
+                }));
+            }
+            CredentialLeaseState::Expired => return Err(expired()),
+            CredentialLeaseState::Unknown => return Err(invariant()),
+            CredentialLeaseState::Active => {}
+        }
+
+        let lease = SecretServiceLeaseRef {
+            credential_ref: request.credential_ref().clone(),
+            metadata: current.metadata,
+        };
+        let result = match Self::poll_port_raw(self.port.revoke_lease(&lease), deadline) {
+            Ok(result) => result,
+            Err(SecretServicePollError::Port(SecretServicePortError::CompletionUnknown)) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Revoke,
+                )?;
+                return Err(invariant());
+            }
+            Err(SecretServicePollError::Deadline) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Revoke,
+                )?;
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::DeadlineExceeded,
+                ));
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseExpired)) => {
+                self.set_lease_state(&lease_key, CredentialLeaseState::Expired)?;
+                return Err(expired());
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseRevoked)) => {
+                crate::SecretServiceLeaseRevocation::AlreadyRevoked
+            }
+            Err(error) => return Err(map_poll_error(error)),
+        };
+        let outcome = match result {
+            crate::SecretServiceLeaseRevocation::Revoked => CredentialOutcomeCode::Revoked,
+            crate::SecretServiceLeaseRevocation::AlreadyRevoked => {
+                CredentialOutcomeCode::AlreadyRevoked
             }
         };
+        let mut leases = self.leases.lock().map_err(|_| invariant())?;
+        let record = leases.get_mut(&lease_key).ok_or_else(expired)?;
+        record.metadata.state = CredentialLeaseState::Revoked;
         record.metadata.outcome = outcome;
         Ok(CredentialResponse::RevokeToken(MetadataResponse {
             metadata: record.metadata.clone(),
@@ -171,7 +413,11 @@ impl SecretServiceCredentialProvider {
     ) -> Result<CredentialResponse, CredentialServiceError> {
         let deadline = Self::operation_deadline(request.deadline_unix_ms())?;
         let key = request.credential_ref().to_canonical_string();
-        let lease_key = (session_key, key);
+        self.ensure_unlocked(deadline)?;
+        if self.has_ambiguous_credential(session_key, &key)? {
+            return Err(invariant());
+        }
+        let lease_key = (session_key, key.clone());
         let record = self
             .leases
             .lock()
@@ -179,19 +425,107 @@ impl SecretServiceCredentialProvider {
             .get(&lease_key)
             .cloned()
             .ok_or_else(expired)?;
+        match record.metadata.state {
+            CredentialLeaseState::Active => {}
+            CredentialLeaseState::Expired => return Err(expired()),
+            CredentialLeaseState::Revoked => return Err(revoked()),
+            CredentialLeaseState::Unknown => return Err(invariant()),
+        }
         let lease = SecretServiceLeaseRef {
             credential_ref: request.credential_ref().clone(),
-            metadata: record.metadata,
+            metadata: record.metadata.clone(),
         };
-        let inspection = Self::poll_port(self.port.inspect_lease(&lease), deadline)?;
+        let inspection = match Self::poll_port_raw(self.port.inspect_lease(&lease), deadline) {
+            Ok(inspection) => inspection,
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseExpired)) => {
+                self.leases
+                    .lock()
+                    .map_err(|_| invariant())?
+                    .get_mut(&lease_key)
+                    .ok_or_else(expired)?
+                    .metadata
+                    .state = CredentialLeaseState::Expired;
+                return Err(expired());
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::LeaseRevoked)) => {
+                self.leases
+                    .lock()
+                    .map_err(|_| invariant())?
+                    .get_mut(&lease_key)
+                    .ok_or_else(expired)?
+                    .metadata
+                    .state = CredentialLeaseState::Revoked;
+                return Err(revoked());
+            }
+            Err(SecretServicePollError::Port(SecretServicePortError::CompletionUnknown)) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Inspect,
+                )?;
+                return Err(invariant());
+            }
+            Err(SecretServicePollError::Deadline) => {
+                self.mark_metadata_unknown(&lease_key)?;
+                self.mark_ambiguous(
+                    session_key,
+                    &key,
+                    request.idempotency_key(),
+                    OperationKind::Inspect,
+                )?;
+                return Err(CredentialServiceError::new(
+                    CredentialServiceErrorCode::DeadlineExceeded,
+                ));
+            }
+            Err(error) => return Err(map_poll_error(error)),
+        };
         let mut metadata = lease.metadata;
         metadata.state = inspection.state;
         metadata.source_version = inspection.source_version;
         metadata.rotation_generation = inspection.rotation_generation;
         metadata.expires_at_unix_ms = inspection.expires_at_unix_ms;
+        self.leases
+            .lock()
+            .map_err(|_| invariant())?
+            .get_mut(&lease_key)
+            .ok_or_else(expired)?
+            .metadata = metadata.clone();
+        if metadata.state == CredentialLeaseState::Unknown {
+            self.mark_ambiguous(
+                session_key,
+                &key,
+                request.idempotency_key(),
+                OperationKind::Inspect,
+            )?;
+            return Err(invariant());
+        }
         Ok(CredentialResponse::InspectMetadata(MetadataResponse {
             metadata,
         }))
+    }
+
+    fn mark_metadata_unknown(
+        &self,
+        lease_key: &(SessionKey, String),
+    ) -> Result<(), CredentialServiceError> {
+        self.set_lease_state(lease_key, CredentialLeaseState::Unknown)
+    }
+
+    fn set_lease_state(
+        &self,
+        lease_key: &(SessionKey, String),
+        state: CredentialLeaseState,
+    ) -> Result<(), CredentialServiceError> {
+        self.leases
+            .lock()
+            .map_err(|_| invariant())?
+            .get_mut(lease_key)
+            .ok_or_else(expired)?
+            .metadata
+            .state = state;
+        Ok(())
     }
 
     /// Revoke every active lease owned by one admitted session and release its
@@ -235,17 +569,8 @@ impl SecretServiceCredentialProvider {
         let _mutation = self.blocking_mutation_guard()?;
         self.finalized
             .store(true, std::sync::atomic::Ordering::Release);
-        let keys = self
-            .sessions
-            .lock()
-            .map_err(|_| invariant())?
-            .keys()
-            .copied()
-            .collect::<Vec<_>>();
         let deadline = Self::operation_deadline(1_000)?;
-        for session_key in keys {
-            self.close_session_locked(session_key, deadline)?;
-        }
+        self.close_all_sessions_locked(deadline)?;
         self.authority.clear().map_err(|_| invariant())?;
         Ok(())
     }
@@ -261,10 +586,13 @@ impl SecretServiceCredentialProvider {
             .keys()
             .copied()
             .collect::<Vec<_>>();
+        let mut first_error = None;
         for session_key in keys {
-            self.close_session_locked(session_key, deadline)?;
+            if let Err(error) = self.close_session_locked(session_key, deadline) {
+                first_error.get_or_insert(error);
+            }
         }
-        Ok(())
+        first_error.map_or(Ok(()), Err)
     }
 
     fn close_session_locked(
@@ -272,30 +600,134 @@ impl SecretServiceCredentialProvider {
         session_key: SessionKey,
         deadline: std::time::Instant,
     ) -> Result<(), CredentialServiceError> {
+        let pending_acquires = self.ambiguous_acquires(session_key)?;
+        let mut first_error = None;
+        for (credential, idempotency_key, request) in pending_acquires {
+            match Self::poll_port_raw(self.port.revoke_ambiguous_lease(&request), deadline) {
+                Ok(_)
+                | Err(SecretServicePollError::Port(SecretServicePortError::LeaseExpired))
+                | Err(SecretServicePollError::Port(SecretServicePortError::LeaseRevoked)) => {
+                    self.clear_ambiguous_acquire(session_key, &credential, &idempotency_key)?;
+                }
+                Err(SecretServicePollError::Deadline) => {
+                    first_error.get_or_insert_with(|| {
+                        CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+                    });
+                }
+                Err(error) => {
+                    first_error.get_or_insert_with(|| map_poll_error(error));
+                }
+            }
+        }
+
+        let pending_refreshes = self.ambiguous_refreshes(session_key)?;
+        let pending_refresh_credentials = pending_refreshes
+            .iter()
+            .map(|(credential, _, _)| credential.clone())
+            .collect::<BTreeSet<_>>();
+        for (credential, idempotency_key, refresh) in pending_refreshes {
+            match Self::poll_port_raw(
+                self.port.revoke_ambiguous_refresh(
+                    &refresh.lease,
+                    &refresh.operation_id,
+                    &refresh.idempotency_key,
+                ),
+                deadline,
+            ) {
+                Ok(_)
+                | Err(SecretServicePollError::Port(SecretServicePortError::LeaseExpired))
+                | Err(SecretServicePollError::Port(SecretServicePortError::LeaseRevoked)) => {
+                    self.leases
+                        .lock()
+                        .map_err(|_| invariant())?
+                        .remove(&(session_key, credential.clone()));
+                    self.clear_ambiguous_refresh(session_key, &credential, &idempotency_key)?;
+                }
+                Err(SecretServicePollError::Deadline) => {
+                    first_error.get_or_insert_with(|| {
+                        CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+                    });
+                }
+                Err(error) => {
+                    first_error.get_or_insert_with(|| map_poll_error(error));
+                }
+            }
+        }
+
         let records = self
             .leases
             .lock()
             .map_err(|_| invariant())?
             .iter()
-            .filter(|((key, _), record)| {
-                *key == session_key && record.metadata.state == CredentialLeaseState::Active
+            .filter(|((key, credential), record)| {
+                *key == session_key
+                    && matches!(
+                        record.metadata.state,
+                        CredentialLeaseState::Active | CredentialLeaseState::Unknown
+                    )
+                    && !pending_refresh_credentials.contains(credential)
             })
             .map(|((_, credential), record)| (credential.clone(), record.clone()))
             .collect::<Vec<_>>();
 
         for (credential, record) in records {
+            let lease_key = (session_key, credential.clone());
             let lease = SecretServiceLeaseRef {
                 credential_ref: d2b_contracts::v3::ResourceRef::parse(&credential)
                     .map_err(|_| invariant())?,
                 metadata: record.metadata,
             };
-            Self::poll_port(self.port.revoke_lease(&lease), deadline)?;
+            match Self::poll_port_raw(self.port.revoke_lease(&lease), deadline) {
+                Ok(_)
+                | Err(SecretServicePollError::Port(SecretServicePortError::LeaseExpired))
+                | Err(SecretServicePollError::Port(SecretServicePortError::LeaseRevoked)) => {
+                    self.leases
+                        .lock()
+                        .map_err(|_| invariant())?
+                        .remove(&lease_key);
+                    self.clear_ambiguous_for_credential(session_key, &credential)?;
+                }
+                Err(SecretServicePollError::Port(SecretServicePortError::CompletionUnknown)) => {
+                    self.mark_metadata_unknown(&lease_key)?;
+                    first_error.get_or_insert_with(invariant);
+                }
+                Err(SecretServicePollError::Deadline) => {
+                    self.mark_metadata_unknown(&lease_key)?;
+                    first_error.get_or_insert_with(|| {
+                        CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+                    });
+                }
+                Err(error) => {
+                    first_error.get_or_insert_with(|| map_poll_error(error));
+                }
+            }
+        }
+
+        let unresolved_leases =
+            self.leases
+                .lock()
+                .map_err(|_| invariant())?
+                .iter()
+                .any(|((key, _), record)| {
+                    *key == session_key
+                        && matches!(
+                            record.metadata.state,
+                            CredentialLeaseState::Active | CredentialLeaseState::Unknown
+                        )
+                });
+        let unresolved_operations = self.has_ambiguous_session(session_key)?;
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        if unresolved_leases || unresolved_operations {
+            return Err(invariant());
         }
 
         self.leases
             .lock()
             .map_err(|_| invariant())?
             .retain(|(key, _), _| *key != session_key);
+        self.clear_ambiguous_session(session_key)?;
         self.release_session_key(session_key)?;
         self.sessions
             .lock()
@@ -311,4 +743,19 @@ fn invariant() -> CredentialServiceError {
 
 fn expired() -> CredentialServiceError {
     CredentialServiceError::new(CredentialServiceErrorCode::LeaseExpired)
+}
+
+fn revoked() -> CredentialServiceError {
+    CredentialServiceError::new(CredentialServiceErrorCode::LeaseRevoked)
+}
+
+fn map_poll_error(error: SecretServicePollError) -> CredentialServiceError {
+    match error {
+        SecretServicePollError::Port(error) => {
+            SecretServiceCredentialProvider::map_port_error(error)
+        }
+        SecretServicePollError::Deadline => {
+            CredentialServiceError::new(CredentialServiceErrorCode::DeadlineExceeded)
+        }
+    }
 }

--- a/packages/d2b-provider-credential-secret-service/tests/common/mod.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/common/mod.rs
@@ -27,7 +27,11 @@ pub struct FakeOo7Port {
     pub inspect_calls: AtomicUsize,
     pub refresh_calls: AtomicUsize,
     pub revoke_calls: AtomicUsize,
+    pub ambiguous_revoke_calls: AtomicUsize,
+    pub ambiguous_refresh_revoke_calls: AtomicUsize,
     pub issue_error: Mutex<Option<SecretServicePortError>>,
+    pub refresh_error: Mutex<Option<SecretServicePortError>>,
+    pub issue_rotation_generation: Mutex<u64>,
     pub observed_request: Mutex<Option<(String, String, String)>>,
     pub credential_canary: String,
     pub object_path_canary: String,
@@ -43,7 +47,11 @@ impl FakeOo7Port {
             inspect_calls: AtomicUsize::new(0),
             refresh_calls: AtomicUsize::new(0),
             revoke_calls: AtomicUsize::new(0),
+            ambiguous_revoke_calls: AtomicUsize::new(0),
+            ambiguous_refresh_revoke_calls: AtomicUsize::new(0),
             issue_error: Mutex::new(None),
+            refresh_error: Mutex::new(None),
+            issue_rotation_generation: Mutex::new(1),
             observed_request: Mutex::new(None),
             credential_canary: format!("secret-service-value-canary-{nonce}"),
             object_path_canary: format!("secret-service-object-path-canary-{nonce}"),
@@ -64,6 +72,7 @@ impl Oo7SecretServicePort for FakeOo7Port {
         self.issue_calls.fetch_add(1, Ordering::SeqCst);
         let error = *self.issue_error.lock().unwrap();
         let expiry = request.requested_expiry_unix_ms();
+        let rotation_generation = *self.issue_rotation_generation.lock().unwrap();
         let secret = self.credential_canary.clone();
         let object_path = self.object_path_canary.clone();
         *self.observed_request.lock().unwrap() = Some((
@@ -79,7 +88,7 @@ impl Oo7SecretServicePort for FakeOo7Port {
             let grant = SecretServiceLeaseGrant {
                 lease_handle: CredentialLeaseHandle::parse(&secret).unwrap(),
                 source_version: CredentialSourceVersion::parse(&object_path).unwrap(),
-                rotation_generation: 1,
+                rotation_generation,
                 expires_at_unix_ms: expiry,
             };
             *inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
@@ -106,9 +115,13 @@ impl Oo7SecretServicePort for FakeOo7Port {
         lease: &SecretServiceLeaseRef,
     ) -> SecretServiceFuture<'_, SecretServiceLeaseRenewal> {
         self.refresh_calls.fetch_add(1, Ordering::SeqCst);
+        let error = *self.refresh_error.lock().unwrap();
         let expiry = lease.metadata().expires_at_unix_ms;
         let inspection = &self.inspection;
         Box::pin(async move {
+            if let Some(error) = error {
+                return Err(error);
+            }
             let grant = SecretServiceLeaseGrant {
                 lease_handle: CredentialLeaseHandle::parse("secret-service-lease").unwrap(),
                 source_version: CredentialSourceVersion::parse("secret-service-source-2").unwrap(),
@@ -130,6 +143,25 @@ impl Oo7SecretServicePort for FakeOo7Port {
         _lease: &SecretServiceLeaseRef,
     ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
         self.revoke_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(SecretServiceLeaseRevocation::Revoked) })
+    }
+
+    fn revoke_ambiguous_lease(
+        &self,
+        _request: &SecretServiceLeaseRequest,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
+        self.ambiguous_revoke_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(SecretServiceLeaseRevocation::Revoked) })
+    }
+
+    fn revoke_ambiguous_refresh(
+        &self,
+        _lease: &SecretServiceLeaseRef,
+        _operation_id: &str,
+        _idempotency_key: &str,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
+        self.ambiguous_refresh_revoke_calls
+            .fetch_add(1, Ordering::SeqCst);
         Box::pin(async { Ok(SecretServiceLeaseRevocation::Revoked) })
     }
 }

--- a/packages/d2b-provider-credential-secret-service/tests/faults.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/faults.rs
@@ -6,15 +6,16 @@ use std::thread;
 use std::time::Duration;
 
 use d2b_contracts::v3::credential::{
-    CredentialMethod, CredentialRequest, CredentialServiceErrorCode, PlacementBinding,
+    CredentialAuthorization, CredentialMethod, CredentialProvider, CredentialRequest,
+    CredentialServiceErrorCode, PlacementBinding,
 };
-use d2b_contracts::v3::{ResourceRef, ZoneId};
+use d2b_contracts::v3::{ResourceGeneration, ResourceRef, ZoneId};
 use d2b_provider_credential_secret_service::{
-    LockPolicy, Oo7SecretServicePort, SecretServiceConfig, SecretServiceCredentialProviderFactory,
-    SecretServiceFuture, SecretServiceLeaseGrant, SecretServiceLeaseInspection,
-    SecretServiceLeaseRef, SecretServiceLeaseRenewal, SecretServiceLeaseRequest,
-    SecretServiceLeaseRevocation, SecretServicePlacement, SecretServicePortError,
-    SecretServiceState,
+    LockPolicy, Oo7SecretServicePort, SecretServiceConfig, SecretServiceCredentialProvider,
+    SecretServiceCredentialProviderFactory, SecretServiceFuture, SecretServiceLeaseGrant,
+    SecretServiceLeaseInspection, SecretServiceLeaseRef, SecretServiceLeaseRenewal,
+    SecretServiceLeaseRequest, SecretServiceLeaseRevocation, SecretServicePlacement,
+    SecretServicePortError, SecretServiceState,
 };
 
 use common::{Admission, ProviderHarness, request, setup};
@@ -38,6 +39,195 @@ fn locked_and_unavailable_map_to_provider_unavailable() {
         );
         assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
     }
+}
+
+#[test]
+fn locked_state_is_checked_before_issuing_a_lease() {
+    let (provider, port) = setup(64);
+    *port.state.lock().unwrap() = SecretServiceState::Locked;
+    let server = ProviderHarness::new(provider, Admission);
+
+    assert_eq!(
+        server
+            .call(CredentialMethod::AcquireToken, request("idem-locked-state"))
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn completion_unknown_is_not_replayed_with_the_same_idempotency_key() {
+    let (provider, port) = setup(64);
+    *port.issue_error.lock().unwrap() = Some(SecretServicePortError::CompletionUnknown);
+    let server = ProviderHarness::new(provider, Admission);
+    let request = request("idem-unknown");
+
+    assert_eq!(
+        server
+            .call(CredentialMethod::AcquireToken, request.clone())
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(
+        server
+            .call(CredentialMethod::AcquireToken, request)
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn remembered_ambiguous_acquire_consumes_capacity() {
+    let (provider, port) = setup(1);
+    let server = ProviderHarness::new(provider, Admission);
+    *port.issue_error.lock().unwrap() = Some(SecretServicePortError::CompletionUnknown);
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-capacity-unknown")
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+
+    *port.issue_error.lock().unwrap() = None;
+    let other = CredentialRequest::new(
+        ResourceRef::parse("Credential/other-keyring").unwrap(),
+        "operation-capacity-other",
+        "idem-capacity-other",
+        common::EXPIRY,
+        15_000,
+    )
+    .unwrap();
+    assert_eq!(
+        server
+            .call(CredentialMethod::AcquireToken, other)
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn unknown_lease_record_consumes_capacity() {
+    let (provider, port) = setup(1);
+    let server = ProviderHarness::new(provider, Admission);
+    *port.issue_rotation_generation.lock().unwrap() = 0;
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-capacity-record")
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+
+    *port.issue_rotation_generation.lock().unwrap() = 1;
+    let other = CredentialRequest::new(
+        ResourceRef::parse("Credential/other-keyring").unwrap(),
+        "operation-capacity-record-other",
+        "idem-capacity-record-other",
+        common::EXPIRY,
+        15_000,
+    )
+    .unwrap();
+    assert_eq!(
+        server
+            .call(CredentialMethod::AcquireToken, other)
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::ProviderUnavailable
+    );
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn ambiguous_refresh_uses_adapter_recovery_without_revoking_only_the_old_lease() {
+    let (provider, port) = setup(64);
+    let capability = Arc::new(
+        provider
+            .issue_session_capability(ResourceGeneration::new(1).unwrap())
+            .unwrap(),
+    );
+    let acquire_authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(common::delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_shared_session_proof(capability.clone());
+    let refresh_authorization = CredentialAuthorization::new(
+        CredentialMethod::RefreshToken,
+        Some(common::delivery(CredentialMethod::RefreshToken, 1)),
+    )
+    .unwrap()
+    .with_shared_session_proof(capability);
+
+    provider
+        .dispatch(
+            CredentialMethod::AcquireToken,
+            &request("idem-refresh-recovery-acquire"),
+            &acquire_authorization,
+        )
+        .unwrap();
+    *port.refresh_error.lock().unwrap() = Some(SecretServicePortError::CompletionUnknown);
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::RefreshToken,
+                &request("idem-refresh-recovery"),
+                &refresh_authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+
+    provider.disconnect(&acquire_authorization).unwrap();
+    assert_eq!(
+        port.ambiguous_refresh_revoke_calls.load(Ordering::SeqCst),
+        1
+    );
+    assert_eq!(port.revoke_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn disconnect_recovers_an_ambiguous_acquire_without_replaying_issue() {
+    let (provider, port) = setup(64);
+    *port.issue_error.lock().unwrap() = Some(SecretServicePortError::CompletionUnknown);
+    let capability = provider
+        .issue_session_capability(ResourceGeneration::new(1).unwrap())
+        .unwrap();
+    let authorization = CredentialAuthorization::new(
+        CredentialMethod::AcquireToken,
+        Some(common::delivery(CredentialMethod::AcquireToken, 1)),
+    )
+    .unwrap()
+    .with_session_proof(capability);
+
+    assert_eq!(
+        provider
+            .dispatch(
+                CredentialMethod::AcquireToken,
+                &request("idem-ambiguous-disconnect"),
+                &authorization,
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    provider.disconnect(&authorization).unwrap();
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(port.ambiguous_revoke_calls.load(Ordering::SeqCst), 1);
 }
 
 #[test]
@@ -129,8 +319,183 @@ fn port_call_stops_at_request_deadline() {
     assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
 }
 
+#[test]
+fn deadline_fences_issue_retry() {
+    let (server, port) = never_server();
+    let first = CredentialRequest::new(
+        ResourceRef::parse("Credential/local-keyring").unwrap(),
+        "operation-deadline-first",
+        "idem-deadline-first",
+        common::EXPIRY,
+        10,
+    )
+    .unwrap();
+    assert_eq!(
+        server
+            .call(CredentialMethod::AcquireToken, first)
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::DeadlineExceeded
+    );
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::AcquireToken,
+                request("idem-deadline-second")
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn late_unlock_does_not_start_or_fence_issue() {
+    let (server, port) = delayed_unlock_server(Duration::from_millis(40));
+    let first = CredentialRequest::new(
+        ResourceRef::parse("Credential/local-keyring").unwrap(),
+        "operation-late-unlock-first",
+        "idem-late-unlock-first",
+        common::EXPIRY,
+        10,
+    )
+    .unwrap();
+    assert_eq!(
+        server
+            .call(CredentialMethod::AcquireToken, first)
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::DeadlineExceeded
+    );
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 0);
+
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-late-unlock-second"),
+        )
+        .unwrap();
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
+}
+
+struct DelayedUnlockPort {
+    issue_calls: AtomicUsize,
+    ready_at: std::time::Instant,
+}
+
+fn delayed_unlock_server(
+    delay: Duration,
+) -> (
+    ProviderHarness<SecretServiceCredentialProvider, Admission>,
+    Arc<DelayedUnlockPort>,
+) {
+    let port = Arc::new(DelayedUnlockPort {
+        issue_calls: AtomicUsize::new(0),
+        ready_at: std::time::Instant::now() + delay,
+    });
+    let provider = SecretServiceCredentialProviderFactory::new(
+        SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
+        SecretServicePlacement::new(
+            ZoneId::parse("user-zone").unwrap(),
+            PlacementBinding::UserAgent,
+            ResourceRef::parse("Host/workstation").unwrap(),
+            ResourceRef::parse("User/alice").unwrap(),
+        )
+        .unwrap(),
+        Some(ResourceRef::parse("Provider/shell-terminal").unwrap()),
+        port.clone(),
+    )
+    .unwrap()
+    .construct()
+    .expect("test provider authority must be constructible");
+    (ProviderHarness::new(provider, Admission), port)
+}
+
+impl Oo7SecretServicePort for DelayedUnlockPort {
+    fn state(&self) -> SecretServiceFuture<'_, SecretServiceState> {
+        let ready_at = self.ready_at;
+        Box::pin(std::future::poll_fn(move |context| {
+            if std::time::Instant::now() >= ready_at {
+                std::task::Poll::Ready(Ok(SecretServiceState::Unlocked))
+            } else {
+                context.waker().wake_by_ref();
+                std::task::Poll::Pending
+            }
+        }))
+    }
+
+    fn issue_lease(
+        &self,
+        request: &SecretServiceLeaseRequest,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseGrant> {
+        self.issue_calls.fetch_add(1, Ordering::SeqCst);
+        let expiry = request.requested_expiry_unix_ms();
+        Box::pin(async move {
+            Ok(SecretServiceLeaseGrant {
+                lease_handle: d2b_contracts::v3::credential::CredentialLeaseHandle::parse(
+                    "secret-service-lease",
+                )
+                .unwrap(),
+                source_version: d2b_contracts::v3::credential::CredentialSourceVersion::parse(
+                    "secret-service-source",
+                )
+                .unwrap(),
+                rotation_generation: 1,
+                expires_at_unix_ms: expiry,
+            })
+        })
+    }
+
+    fn inspect_lease(
+        &self,
+        _lease: &SecretServiceLeaseRef,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseInspection> {
+        Box::pin(async { panic!("unexpected inspect") })
+    }
+
+    fn refresh_lease(
+        &self,
+        _lease: &SecretServiceLeaseRef,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRenewal> {
+        Box::pin(async { panic!("unexpected refresh") })
+    }
+
+    fn revoke_lease(
+        &self,
+        _lease: &SecretServiceLeaseRef,
+    ) -> SecretServiceFuture<'_, SecretServiceLeaseRevocation> {
+        Box::pin(async { panic!("unexpected revoke") })
+    }
+}
+
 struct NeverPort {
     issue_calls: AtomicUsize,
+}
+
+fn never_server() -> (
+    ProviderHarness<SecretServiceCredentialProvider, Admission>,
+    Arc<NeverPort>,
+) {
+    let port = Arc::new(NeverPort {
+        issue_calls: AtomicUsize::new(0),
+    });
+    let provider = SecretServiceCredentialProviderFactory::new(
+        SecretServiceConfig::new("login collection", 64, LockPolicy::FailClosed).unwrap(),
+        SecretServicePlacement::new(
+            ZoneId::parse("user-zone").unwrap(),
+            PlacementBinding::UserAgent,
+            ResourceRef::parse("Host/workstation").unwrap(),
+            ResourceRef::parse("User/alice").unwrap(),
+        )
+        .unwrap(),
+        Some(ResourceRef::parse("Provider/shell-terminal").unwrap()),
+        port.clone(),
+    )
+    .unwrap()
+    .construct()
+    .expect("test provider authority must be constructible");
+    (ProviderHarness::new(provider, Admission), port)
 }
 
 impl Oo7SecretServicePort for NeverPort {

--- a/packages/d2b-provider-credential-secret-service/tests/lifecycle.rs
+++ b/packages/d2b-provider-credential-secret-service/tests/lifecycle.rs
@@ -79,6 +79,287 @@ fn duplicate_acquire_is_idempotent() {
 }
 
 #[test]
+fn acquire_with_a_new_key_does_not_orphan_the_existing_lease() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    let first = server
+        .call(CredentialMethod::AcquireToken, request("first-key"))
+        .unwrap();
+    let second = server
+        .call(CredentialMethod::AcquireToken, request("second-key"))
+        .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(port.issue_calls.load(Ordering::SeqCst), 1);
+    server
+        .call(CredentialMethod::RevokeToken, request("revoke-key"))
+        .unwrap();
+    assert_eq!(port.revoke_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn duplicate_refresh_is_idempotent() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-acquire-refresh"),
+        )
+        .unwrap();
+
+    let first = server
+        .call(CredentialMethod::RefreshToken, request("same-refresh-key"))
+        .unwrap();
+    let second = server
+        .call(CredentialMethod::RefreshToken, request("same-refresh-key"))
+        .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(port.refresh_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn an_older_refresh_key_replays_its_original_result() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-acquire-old-refresh"),
+        )
+        .unwrap();
+
+    let first = server
+        .call(CredentialMethod::RefreshToken, request("first-refresh-key"))
+        .unwrap();
+    server
+        .call(
+            CredentialMethod::RefreshToken,
+            request("second-refresh-key"),
+        )
+        .unwrap();
+    let replay = server
+        .call(CredentialMethod::RefreshToken, request("first-refresh-key"))
+        .unwrap();
+
+    assert_eq!(replay, first);
+    assert_eq!(port.refresh_calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn inspect_persists_terminal_state_for_later_revoke() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-inspect-terminal"),
+        )
+        .unwrap();
+    *port.inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
+        state: CredentialLeaseState::Revoked,
+        source_version: CredentialSourceVersion::parse("terminal-source").unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+
+    let inspected = server
+        .call(
+            CredentialMethod::InspectMetadata,
+            request("idem-inspect-terminal-read"),
+        )
+        .unwrap();
+    let CredentialResponse::InspectMetadata(inspected) = inspected else {
+        panic!("inspect response");
+    };
+    assert_eq!(inspected.metadata.state, CredentialLeaseState::Revoked);
+
+    let revoked = server
+        .call(
+            CredentialMethod::RevokeToken,
+            request("idem-inspect-terminal-revoke"),
+        )
+        .unwrap();
+    let CredentialResponse::RevokeToken(revoked) = revoked else {
+        panic!("revoke response");
+    };
+    assert_eq!(
+        revoked.metadata.outcome,
+        CredentialOutcomeCode::AlreadyRevoked
+    );
+    assert_eq!(port.revoke_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn inspect_unknown_state_is_fenced_and_cannot_restore_active_metadata() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-inspect-unknown"),
+        )
+        .unwrap();
+    *port.inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
+        state: CredentialLeaseState::Unknown,
+        source_version: CredentialSourceVersion::parse("unknown-source").unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-inspect-unknown-read"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    *port.inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
+        state: CredentialLeaseState::Active,
+        source_version: CredentialSourceVersion::parse("restored-source").unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-inspect-unknown-retry"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(port.inspect_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn inspect_cannot_restore_a_revoked_lease() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-inspect-revoked"),
+        )
+        .unwrap();
+    server
+        .call(
+            CredentialMethod::RevokeToken,
+            request("idem-inspect-revoked-revoke"),
+        )
+        .unwrap();
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-inspect-revoked-read"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseRevoked
+    );
+    assert_eq!(port.inspect_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn refresh_preflight_terminal_state_is_sticky() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-refresh-terminal"),
+        )
+        .unwrap();
+    *port.inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
+        state: CredentialLeaseState::Revoked,
+        source_version: CredentialSourceVersion::parse("refresh-terminal-source").unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::RefreshToken,
+                request("idem-refresh-terminal-call"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseRevoked
+    );
+    *port.inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
+        state: CredentialLeaseState::Active,
+        source_version: CredentialSourceVersion::parse("refresh-restored-source").unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-refresh-terminal-read"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::LeaseRevoked
+    );
+    assert_eq!(port.inspect_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn refresh_rotation_mismatch_fences_the_lease() {
+    let (provider, port) = setup(64);
+    let server = ProviderHarness::new(provider, Admission);
+    server
+        .call(
+            CredentialMethod::AcquireToken,
+            request("idem-refresh-generation"),
+        )
+        .unwrap();
+    *port.inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
+        state: CredentialLeaseState::Active,
+        source_version: CredentialSourceVersion::parse("mismatch-source").unwrap(),
+        rotation_generation: 2,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::RefreshToken,
+                request("idem-refresh-generation-call"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    *port.inspection.lock().unwrap() = Some(SecretServiceLeaseInspection {
+        state: CredentialLeaseState::Active,
+        source_version: CredentialSourceVersion::parse("mismatch-restored-source").unwrap(),
+        rotation_generation: 1,
+        expires_at_unix_ms: common::EXPIRY,
+    });
+    assert_eq!(
+        server
+            .call(
+                CredentialMethod::InspectMetadata,
+                request("idem-refresh-generation-read"),
+            )
+            .unwrap_err()
+            .code(),
+        CredentialServiceErrorCode::InvariantFailure
+    );
+    assert_eq!(port.inspect_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
 fn concurrent_acquires_issue_once() {
     let (entered_tx, entered_rx) = mpsc::channel();
     let port = Arc::new(BlockingPort::new(entered_tx));


### PR DESCRIPTION
## Summary

Secret Service leases can now recover from ambiguous Secret Service completions without replaying `issue` or `refresh`. Deadline, `CompletionUnknown`, and disconnect/finalize paths fence the credential and recover through adapter revoke hooks. Session and Zone binding stay exact. Credential bytes stay opaque in provider responses.

Expired request deadlines now fail before a port poll or `issue_lease` starts. A late unlock that becomes ready after the Instant expires no longer starts or fences a lease.

This continues Spec 001 credential work after the sealed one-shot Secret Service capability already on `v3`. Process-restart adoption remains out of scope: recovery state is in-memory only.

## Validation evidence

- [x] **Focused tests for the changed components** were run; list exact
      commands and results.
      `cd packages && cargo test -p d2b-provider-credential-secret-service --lib --test faults --test lifecycle`
      after rebase onto `origin/v3` (`e00e535a`): 10 lib, 12 faults, and 14 lifecycle tests passed.
- [x] **Wider lanes are conditional.** Run the applicable public lane when the
      changed surface needs it, and explain any deliberate omission:
      crate-local Secret Service lease state only. No container, NixOS, daemon,
      or host behavior change, so `make test-integration` and
      `make test-host-integration` were not run.
- [x] **Hardware checks are conditional:** not applicable. No graphics/GPU,
      video decode, USBIP/YubiKey, hardware-TPM, or microVM-boot surface.
- [x] **Changed tests are inventoried:** Layer-1 type 2/3 coverage lives in
      this crate's `--lib`, `tests/faults.rs`, and `tests/lifecycle.rs`. No
      migration-ledger retirement or inventory row.
- [x] **Changelog updated** for code or user-visible behavior, using
      `changelog.d/feat-spec001-u21-credential-secret-service.md`.
- [x] **Docs + CI updated in lockstep** where applicable: crate README
      updated. No `AGENTS.md`, `tests/README.md`, or workflow change.

## Notes

Rebased onto current `origin/v3` (`e00e535a`) with no conflicts. Residual risks: adapters that omit `revoke_ambiguous_*` fail closed; an older refresh idempotency key still replays its original metadata.
