### PR TITLE
host: cache integration Rust builds with sccache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -617,15 +617,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	if [ ! -e /dev/kvm ]; then \
 	echo "test-host-integration: /dev/kvm absent - runNixOSTest will fall back to slow TCG emulation"; \
 	fi; \
-	cache_dir="$${SCCACHE_DIR:-$$HOME/.cache/d2b-sccache}"; \
-	mkdir -p "$$cache_dir"; \
-	chmod 1777 "$$cache_dir"; \
-	cache_dir="$$(cd "$$cache_dir" && pwd -P)"; \
-	export SCCACHE_DIR="$$cache_dir"; \
-	echo "test-host-integration: sccache cache: $$cache_dir"; \
 	root="$$(pwd)"; \
-	export D2B_HOST_RUNTIME_PATH="$$root/.scratch/host-int-sccache/no-host-runtime.json"; \
-	rm -f "$$D2B_HOST_RUNTIME_PATH"; \
 	names="$$(nix eval --raw --impure --no-warn-dirty --expr "builtins.concatStringsSep \" \" (builtins.attrNames (builtins.getFlake \"git+file://$$root\").vmChecks.$$system)")"; \
 	if [ -z "$$names" ]; then \
 	echo "test-host-integration: no vmChecks present"; \
@@ -636,8 +628,20 @@ heavy-lane-host-integration: heavy-lane-guard
 	for name in $$names; do \
 	set -- "$$@" ".#vmChecks.$$system.$$name"; \
 	done; \
+	case "$${D2B_HOST_SCCACHE:-}" in \
+	1|yes|true) \
+	cache_dir="$${SCCACHE_DIR:-$${XDG_CACHE_HOME:-$$HOME/.cache}/d2b-sccache}"; \
+	mkdir -p "$$cache_dir"; \
+	chmod 0700 "$$cache_dir"; \
+	cache_dir="$$(cd "$$cache_dir" && pwd -P)"; \
+	echo "test-host-integration: sccache cache: $$cache_dir -> /var/cache/d2b-sccache"; \
+	echo "==> nix build --option extra-sandbox-paths /var/cache/d2b-sccache=$$cache_dir $$*"; \
+	nix build --option extra-sandbox-paths "/var/cache/d2b-sccache=$$cache_dir" --no-link --print-build-logs "$$@";; \
+	*) \
+	echo "test-host-integration: sccache disabled (set D2B_HOST_SCCACHE=1 to enable)"; \
 	echo "==> nix build $$*"; \
-	nix build --impure --option extra-sandbox-paths "$$cache_dir" --no-link --print-build-logs "$$@"
+	nix build --no-link --print-build-logs "$$@";; \
+	esac
 
 ## test-hardware - G-hw: real GPU/YubiKey/hardware-TPM passthrough + full
 ## microVM boot. NixOS host WITH the devices only; CI cannot run this.

--- a/Makefile
+++ b/Makefile
@@ -619,10 +619,13 @@ heavy-lane-host-integration: heavy-lane-guard
 	fi; \
 	cache_dir="$${SCCACHE_DIR:-$$HOME/.cache/d2b-sccache}"; \
 	mkdir -p "$$cache_dir"; \
+	chmod 1777 "$$cache_dir"; \
 	cache_dir="$$(cd "$$cache_dir" && pwd -P)"; \
 	export SCCACHE_DIR="$$cache_dir"; \
 	echo "test-host-integration: sccache cache: $$cache_dir"; \
 	root="$$(pwd)"; \
+	export D2B_HOST_RUNTIME_PATH="$$root/.scratch/host-int-sccache/no-host-runtime.json"; \
+	rm -f "$$D2B_HOST_RUNTIME_PATH"; \
 	names="$$(nix eval --raw --impure --no-warn-dirty --expr "builtins.concatStringsSep \" \" (builtins.attrNames (builtins.getFlake \"git+file://$$root\").vmChecks.$$system)")"; \
 	if [ -z "$$names" ]; then \
 	echo "test-host-integration: no vmChecks present"; \

--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	set -- "$$@" ".#vmChecks.$$system.$$name"; \
 	done; \
 	echo "==> nix build $$*"; \
-	nix build --option extra-sandbox-paths "$$cache_dir" --no-link --print-build-logs "$$@"
+	nix build --impure --option extra-sandbox-paths "$$cache_dir" --no-link --print-build-logs "$$@"
 
 ## test-hardware - G-hw: real GPU/YubiKey/hardware-TPM passthrough + full
 ## microVM boot. NixOS host WITH the devices only; CI cannot run this.

--- a/Makefile
+++ b/Makefile
@@ -617,6 +617,11 @@ heavy-lane-host-integration: heavy-lane-guard
 	if [ ! -e /dev/kvm ]; then \
 	echo "test-host-integration: /dev/kvm absent - runNixOSTest will fall back to slow TCG emulation"; \
 	fi; \
+	cache_dir="$${SCCACHE_DIR:-$$HOME/.cache/d2b-sccache}"; \
+	mkdir -p "$$cache_dir"; \
+	cache_dir="$$(cd "$$cache_dir" && pwd -P)"; \
+	export SCCACHE_DIR="$$cache_dir"; \
+	echo "test-host-integration: sccache cache: $$cache_dir"; \
 	root="$$(pwd)"; \
 	names="$$(nix eval --raw --impure --no-warn-dirty --expr "builtins.concatStringsSep \" \" (builtins.attrNames (builtins.getFlake \"git+file://$$root\").vmChecks.$$system)")"; \
 	if [ -z "$$names" ]; then \
@@ -629,7 +634,8 @@ heavy-lane-host-integration: heavy-lane-guard
 	set -- "$$@" ".#vmChecks.$$system.$$name"; \
 	done; \
 	echo "==> nix build $$*"; \
-	nix build --no-link --print-build-logs "$$@"
+	nix build --option extra-sandbox-paths "$$cache_dir" --no-link --print-build-logs "$$@"
+
 ## test-hardware - G-hw: real GPU/YubiKey/hardware-TPM passthrough + full
 ## microVM boot. NixOS host WITH the devices only; CI cannot run this.
 ## Public heavy lanes: acquire a slot, then run the raw work behind the gate.

--- a/changelog.d/spec001-host-int-sccache.md
+++ b/changelog.d/spec001-host-int-sccache.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Host-integration Rust tools now use a fallback-safe sccache wrapper with a
+  persistent host cache bind mount, while Crane keeps cargo artifacts and
+  per-package source isolation.

--- a/changelog.d/spec001-host-int-sccache.md
+++ b/changelog.d/spec001-host-int-sccache.md
@@ -1,5 +1,5 @@
-### Fixed
+### Changed
 
-- Host-integration Rust tools now use a fallback-safe sccache wrapper with a
-  persistent host cache bind mount, while Crane keeps cargo artifacts and
-  per-package source isolation.
+- Host-integration Rust tools keep Crane cargo artifacts and per-package
+  source isolation. sccache is opt-in via `D2B_HOST_SCCACHE=1`, uses a
+  constant sandbox path, and never world-writes the host cache.

--- a/nixos-modules/rust-host-tools.nix
+++ b/nixos-modules/rust-host-tools.nix
@@ -126,19 +126,16 @@ let
       && [ -d "''${SCCACHE_DIR}" ] \
       && [ -w "''${SCCACHE_DIR}" ] \
       && command -v sccache >/dev/null 2>&1; then
-      # Keep entries writable across Nix's shared build users.
-      umask 0002
       exec sccache "$@"
     fi
     exec "$@"
   '';
 
-  # The wrapper keeps CI and ordinary sandbox builds hermetic when no cache
-  # bind mount is available, while host-integration builds can opt into the
-  # persistent cache by passing SCCACHE_DIR and extra-sandbox-paths. The
-  # host lane evaluates with --impure so this path becomes a fixed derivation
-  # environment value; pure CI evaluation leaves it empty and falls back.
-  sccacheDir = builtins.getEnv "SCCACHE_DIR";
+  # Constant sandbox path so pure CI and host-int realize the same host-tool
+  # derivations. The directory is absent in the default sandbox, so the
+  # wrapper falls back to rustc. Host-int may bind-mount an owner-private
+  # cache here when D2B_HOST_SCCACHE=1.
+  sccacheDir = "/var/cache/d2b-sccache";
   commonBuildArgs = {
     strictDeps = true;
     cargoExtraArgs = "--locked";

--- a/nixos-modules/rust-host-tools.nix
+++ b/nixos-modules/rust-host-tools.nix
@@ -126,6 +126,8 @@ let
       && [ -d "''${SCCACHE_DIR}" ] \
       && [ -w "''${SCCACHE_DIR}" ] \
       && command -v sccache >/dev/null 2>&1; then
+      # Keep entries writable across Nix's shared build users.
+      umask 0002
       exec sccache "$@"
     fi
     exec "$@"

--- a/nixos-modules/rust-host-tools.nix
+++ b/nixos-modules/rust-host-tools.nix
@@ -25,6 +25,8 @@ let
   dummySource = pkgs.runCommand "d2b-provider-rust-src" { } ''
     mkdir -p "$out/packages"
     cp -r ${dummyPackages}/. "$out/packages/"
+    chmod -R u+w "$out/packages"
+    cp ${../packages/Cargo.toml} "$out/packages/Cargo.toml"
   '';
 
   cratePathName = rel:

--- a/nixos-modules/rust-host-tools.nix
+++ b/nixos-modules/rust-host-tools.nix
@@ -133,7 +133,10 @@ let
 
   # The wrapper keeps CI and ordinary sandbox builds hermetic when no cache
   # bind mount is available, while host-integration builds can opt into the
-  # persistent cache by passing SCCACHE_DIR and extra-sandbox-paths.
+  # persistent cache by passing SCCACHE_DIR and extra-sandbox-paths. The
+  # host lane evaluates with --impure so this path becomes a fixed derivation
+  # environment value; pure CI evaluation leaves it empty and falls back.
+  sccacheDir = builtins.getEnv "SCCACHE_DIR";
   commonBuildArgs = {
     strictDeps = true;
     cargoExtraArgs = "--locked";
@@ -141,7 +144,7 @@ let
     doCheck = false;
     nativeBuildInputs = [ pkgs.protobuf pkgs.sccache ];
     RUSTC_WRAPPER = rustcWrapper;
-    impureEnvVars = [ "SCCACHE_DIR" ];
+    SCCACHE_DIR = sccacheDir;
   };
 
   cargoArtifacts = craneLib.buildDepsOnly (commonBuildArgs // {

--- a/nixos-modules/rust-host-tools.nix
+++ b/nixos-modules/rust-host-tools.nix
@@ -4,15 +4,6 @@ let
   d2bLib = import ./lib.nix { inherit lib; };
   craneLib = inputs.crane.mkLib pkgs;
   packagesSrc = d2bLib.cleanRustPackagesSource ../packages;
-  hostSource = pkgs.runCommand "d2b-provider-rust-src" { } ''
-    mkdir -p "$out/packages"
-    cp -r ${packagesSrc}/. "$out/packages/"
-    mkdir -p "$out/docs/reference/schemas/v3/providers"
-    cp ${../docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json} \
-      "$out/docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json"
-    cp ${../docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json} \
-      "$out/docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json"
-  '';
   cargoLock = ../packages/Cargo.lock;
   # Keep the deps-only derivation keyed to manifests, locks, and Cargo config,
   # not to application source files. Crane still creates the dummy Rust
@@ -27,13 +18,83 @@ let
       || lib.hasSuffix "/Cargo.lock" (toString path)
       || lib.hasSuffix "/.cargo/config.toml" (toString path);
   };
+  dummyPackages = craneLib.mkDummySrc {
+    src = cargoManifestSrc;
+    inherit cargoLock;
+  };
   dummySource = pkgs.runCommand "d2b-provider-rust-src" { } ''
     mkdir -p "$out/packages"
-    cp -r ${craneLib.mkDummySrc {
-      src = cargoManifestSrc;
-      inherit cargoLock;
-    }}/. "$out/packages/"
+    cp -r ${dummyPackages}/. "$out/packages/"
   '';
+
+  cratePathName = rel:
+    let
+      trimmed = lib.removeSuffix "/" (lib.removePrefix "./" rel);
+      name = lib.removePrefix "../" trimmed;
+    in
+    if name == trimmed && lib.hasPrefix "/" trimmed
+    then null
+    else name;
+
+  pathDepNames = cargoToml:
+    let
+      parsed = builtins.fromTOML (builtins.readFile cargoToml);
+      collect = attrs:
+        lib.filter (value: builtins.isAttrs value && value ? path)
+          (lib.attrValues attrs);
+      names = map (value: cratePathName value.path) (
+        collect (parsed.dependencies or { })
+        ++ collect (parsed.build-dependencies or { })
+      );
+    in
+    lib.filter (name: name != null && name != "") names;
+
+  crateClosure = package:
+    let
+      go = seen: queue:
+        if queue == [ ] then seen
+        else
+          let
+            name = builtins.head queue;
+            rest = builtins.tail queue;
+          in
+          if builtins.elem name seen then go seen rest
+          else
+            let
+              toml = ../packages + "/${name}/Cargo.toml";
+              deps = if builtins.pathExists toml then pathDepNames toml else [ ];
+            in
+            go (seen ++ [ name ]) (rest ++ deps);
+    in
+    go [ ] [ package ];
+
+  crateSource = name:
+    d2bLib.cleanRustPackagesSource (../packages + "/${name}");
+
+  # Overlay real sources for one package and its path-dep closure onto the
+  # dummy workspace. Each crate is a separate Nix path input so a d2bd edit
+  # does not rebuild wayland-proxy, the resource compiler, or other host tools.
+  mkPackageSource = package:
+    let
+      crates = lib.filter
+        (name: builtins.pathExists (../packages + "/${name}"))
+        (crateClosure package);
+    in
+    pkgs.runCommand "d2b-provider-rust-src-${package}" { } ''
+      mkdir -p "$out/packages"
+      cp -a ${dummySource}/packages/. "$out/packages/"
+      chmod -R u+w "$out/packages"
+      ${lib.concatMapStringsSep "\n" (name: ''
+        rm -rf "$out/packages/${name}"
+        cp -a ${crateSource name} "$out/packages/${name}"
+      '') crates}
+      mkdir -p "$out/docs/reference/schemas/v3/providers"
+      cp ${../docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json} \
+        "$out/docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json"
+      cp ${../docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json} \
+        "$out/docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json"
+    '';
+
   outputHashes = {
     "git+https://github.com/vicondoa/wl-proxy.git?rev=072945b59fef21a2a8166460454280d543f48772#072945b59fef21a2a8166460454280d543f48772" =
       "sha256-1yO1zgzSyzQ2DnDMpVxcnI5BsTNvXfzIUS+RNlPj4A8=";
@@ -46,17 +107,41 @@ let
     cargoLock = brokerCargoLock;
     inherit outputHashes;
   };
+  hostPackages = [
+    "d2bd"
+    "d2b"
+    "d2b-host"
+    "d2b-host-activation-helper"
+    "d2b-gateway-runtime"
+    "d2b-unsafe-local-helper"
+    "d2b-resource-compiler"
+    "d2b-wayland-proxy"
+  ];
+  hostPackageArgs = lib.concatMapStringsSep " " (package: "--package ${package}") hostPackages;
+
+  rustcWrapper = pkgs.writeShellScript "d2b-sccache-rustc-wrapper" ''
+    if [ -n "''${SCCACHE_DIR:-}" ] \
+      && [ -d "''${SCCACHE_DIR}" ] \
+      && [ -w "''${SCCACHE_DIR}" ] \
+      && command -v sccache >/dev/null 2>&1; then
+      exec sccache "$@"
+    fi
+    exec "$@"
+  '';
+
+  # The wrapper keeps CI and ordinary sandbox builds hermetic when no cache
+  # bind mount is available, while host-integration builds can opt into the
+  # persistent cache by passing SCCACHE_DIR and extra-sandbox-paths.
   commonBuildArgs = {
     strictDeps = true;
     cargoExtraArgs = "--locked";
     inherit cargoVendorDir;
     doCheck = false;
-    nativeBuildInputs = [ pkgs.protobuf ];
-    RUSTC_WRAPPER = "";
-    SCCACHE_DIR = "";
+    nativeBuildInputs = [ pkgs.protobuf pkgs.sccache ];
+    RUSTC_WRAPPER = rustcWrapper;
+    impureEnvVars = [ "SCCACHE_DIR" ];
   };
 
-  # Keep dependency compilation independent of application source changes.
   cargoArtifacts = craneLib.buildDepsOnly (commonBuildArgs // {
     pname = "d2b-host-tools";
     version = "0.0.0-bootstrap";
@@ -64,8 +149,19 @@ let
     sourceRoot = "d2b-provider-rust-src/packages";
     cargoToml = ../packages/Cargo.toml;
     inherit cargoLock outputHashes;
-    cargoCheckExtraArgs = "--package d2bd";
-    cargoBuildExtraArgs = "--package d2bd";
+    cargoCheckExtraArgs = hostPackageArgs;
+    cargoBuildExtraArgs = hostPackageArgs;
+  });
+
+  brokerCargoArtifacts = craneLib.buildDepsOnly (commonBuildArgs // {
+    pname = "d2b-priv-broker";
+    version = "0.0.0-bootstrap";
+    dummySrc = dummySource;
+    sourceRoot = "d2b-provider-rust-src/packages/d2b-priv-broker";
+    cargoToml = ../packages/d2b-priv-broker/Cargo.toml;
+    cargoLock = brokerCargoLock;
+    cargoVendorDir = brokerCargoVendorDir;
+    inherit outputHashes;
   });
 
   installBinaries = binaries:
@@ -84,8 +180,8 @@ let
     craneLib.buildPackage (commonBuildArgs // {
       inherit pname cargoArtifacts cargoLock outputHashes;
       version = "0.0.0-bootstrap";
-      src = hostSource;
-      sourceRoot = "d2b-provider-rust-src/packages";
+      src = mkPackageSource package;
+      sourceRoot = "d2b-provider-rust-src-${package}/packages";
       cargoToml = ../packages + "/${package}/Cargo.toml";
       cargoBuildExtraArgs =
         "--package ${package}"
@@ -96,9 +192,10 @@ let
   broker = craneLib.buildPackage (commonBuildArgs // {
     pname = "d2b-priv-broker";
     version = "0.0.0-bootstrap";
-    inherit cargoArtifacts outputHashes;
-    src = hostSource;
-    sourceRoot = "d2b-provider-rust-src/packages/d2b-priv-broker";
+    cargoArtifacts = brokerCargoArtifacts;
+    inherit outputHashes;
+    src = mkPackageSource "d2b-priv-broker";
+    sourceRoot = "d2b-provider-rust-src-d2b-priv-broker/packages/d2b-priv-broker";
     cargoToml = ../packages/d2b-priv-broker/Cargo.toml;
     cargoLock = brokerCargoLock;
     cargoVendorDir = brokerCargoVendorDir;

--- a/tests/unit/nix/cases/test-infrastructure.nix
+++ b/tests/unit/nix/cases/test-infrastructure.nix
@@ -39,6 +39,8 @@ let
   flakeSource = builtins.readFile (flakeRoot + "/flake.nix");
   rustHostToolsSource =
     builtins.readFile (flakeRoot + "/nixos-modules/rust-host-tools.nix");
+  makefileSource = builtins.readFile (flakeRoot + "/Makefile");
+  sccacheSandboxDir = "/var/cache/d2b-sccache";
   providerSchemaPaths = [
     "docs/reference/schemas/v3/providers/transport-azure-relay.transport-settings.json"
     "docs/reference/schemas/v3/providers/transport-vsock.transport-binding.json"
@@ -111,6 +113,39 @@ in
     expected = {
       flakeSource = true;
       rustHostToolsSource = true;
+    };
+  };
+
+  "test-infrastructure/host-tools-sccache-contract" = {
+    expr = {
+      constantSandboxDir =
+        lib.hasInfix ''sccacheDir = "${sccacheSandboxDir}"'' rustHostToolsSource
+        && lib.hasInfix "SCCACHE_DIR = sccacheDir" rustHostToolsSource;
+      noImpureSccacheEnv =
+        !(lib.hasInfix ''builtins.getEnv "SCCACHE_DIR"'' rustHostToolsSource);
+      wrapperRequiresWritableDir =
+        lib.hasInfix "[ -d \"''\${SCCACHE_DIR}\" ]" rustHostToolsSource
+        && lib.hasInfix "[ -w \"''\${SCCACHE_DIR}\" ]" rustHostToolsSource
+        && lib.hasInfix "exec sccache" rustHostToolsSource
+        && lib.hasInfix ''exec "$@"'' rustHostToolsSource;
+      waylandProxySourceBuilt =
+        lib.hasInfix "waylandProxy = mkMainPackage" rustHostToolsSource;
+      makefileNoWorldWritableCache = !(lib.hasInfix "chmod 1777" makefileSource);
+      makefileCacheOptIn =
+        lib.hasInfix "D2B_HOST_SCCACHE" makefileSource
+        && lib.hasInfix "chmod 0700" makefileSource
+        && lib.hasInfix "${sccacheSandboxDir}=" makefileSource;
+      makefileDefaultBuildIsPure =
+        !(lib.hasInfix "nix build --impure" makefileSource);
+    };
+    expected = {
+      constantSandboxDir = true;
+      noImpureSccacheEnv = true;
+      wrapperRequiresWritableDir = true;
+      waylandProxySourceBuilt = true;
+      makefileNoWorldWritableCache = true;
+      makefileCacheOptIn = true;
+      makefileDefaultBuildIsPure = true;
     };
   };
 }

--- a/tests/unit/nix/pinned/common.txt
+++ b/tests/unit/nix/pinned/common.txt
@@ -855,6 +855,7 @@ store-overlay-emit/first-op-owner-uid-positive
 store-overlay-emit/first-op-size-bytes
 store-overlay-emit/first-op-target-suffix
 store-overlay-emit/planops-count
+test-infrastructure/host-tools-sccache-contract
 test-infrastructure/own-shard-registration-unique
 test-infrastructure/pin-integrity-complete
 test-infrastructure/provider-runtime-schema-is-staged-with-rust-sources


### PR DESCRIPTION
## Summary

Wave 6 U9 already landed Crane host tools on `v3`. Host-integration still rebuilt those crates from scratch on every VM check. This PR isolates each host crate Nix source so a `d2bd` edit does not rebuild `wayland-proxy` or the other host tools, and it adds an opt-in sccache bind mount that does not change derivation hashes.

CI and default host-int stay hermetic. The rustc wrapper falls back to rustc unless `/var/cache/d2b-sccache` exists and is writable. That path is a constant derivation input, so pure and host-int evaluations realize the same host-tool drvs. Set `D2B_HOST_SCCACHE=1` to bind-mount an owner-private (`0700`) host cache onto that path. Default host-int does not pass `--impure` or `extra-sandbox-paths`.

`d2b-wayland-proxy` remains a Crane source build.

## Validation evidence

- [x] **Focused tests for the changed components** were run; list exact
      commands and results.
  - `nix-instantiate --parse nixos-modules/rust-host-tools.nix` — pass
  - Layer-1 `test-infrastructure/host-tools-sccache-contract` — pass (`expr == expected`)
  - Layer-1 `test-infrastructure/provider-runtime-schema-is-staged-with-rust-sources` — pass
  - `nix eval` of `rust-host-tools` attrNames includes `waylandProxy`
  - `make test-changelog` — pass
- [x] **Wider lanes are conditional.** `make test-host-integration` was not run. That lane boots real NixOS VMs and was out of scope for this landing pass. `make test-integration` and `make test-hardware` are not applicable.
- [x] **Hardware checks are conditional:** not applicable.
- [x] **Changed tests are inventoried:** added `test-infrastructure/host-tools-sccache-contract` and pinned it in `tests/unit/nix/pinned/common.txt`.
- [x] **Changelog updated** via `changelog.d/spec001-host-int-sccache.md`.
- [x] **Docs + CI updated in lockstep** where applicable: no workflow change required.

## Notes

Rebased onto current `origin/v3` (`e00e535a`). Review P0/P1 from the first head are resolved on `e80c3cfd`:

- no `chmod 1777`; opt-in cache is `0700`
- default host-int `nix build` is hermetic
- `SCCACHE_DIR` is the constant `/var/cache/d2b-sccache`
- Layer-1 contract covers wrapper fallback, Makefile opt-in, and source-built `waylandProxy`

Residual: a multi-user Nix daemon build user still cannot write a `0700` cache, so opt-in reuse is for the invoking owner. That is intentional; do not reopen world-writable sharing.

Related: #433
