### PR TITLE
fix: harden CI APT mirror setup

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -150,7 +150,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -253,7 +253,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -356,7 +356,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -459,7 +459,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -562,7 +562,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -665,7 +665,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -768,7 +768,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -928,7 +928,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -1106,7 +1106,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Install flake shard diagnostics
-        run: sudo apt-get update && sudo apt-get install -y gdb
+        run: tests/tools/ci-apt-install gdb
       - name: Flake check shard (x86_64-linux)
         # D2B_FLAKE_CHECK is passed via the step environment, NOT interpolated
         # into the shell command: a flake check attr name is PR-controlled, so
@@ -1310,7 +1310,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -1413,7 +1413,7 @@ jobs:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action

--- a/.github/workflows/release-host-binaries.yml
+++ b/.github/workflows/release-host-binaries.yml
@@ -317,7 +317,7 @@ jobs:
           shared-key: "release-${{ runner.os }}"
           save-if: "true"
       - name: Install ripgrep and acl
-        run: sudo apt-get update && sudo apt-get install -y ripgrep acl
+        run: tests/tools/ci-apt-install ripgrep acl
       - name: Build release binaries
         env:
           VERSION: ${{ needs.prepublication-identity.outputs.version }}

--- a/changelog.d/fix-ci-apt-mirror-resilience.md
+++ b/changelog.d/fix-ci-apt-mirror-resilience.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- CI dependency installation now avoids the throttled Azure Ubuntu mirror with
+  bounded HTTPS APT fetches while retaining normal repository metadata
+  authentication.

--- a/docs/plans/2026-08-19-001-fix-apt-mirror-resilience-plan.md
+++ b/docs/plans/2026-08-19-001-fix-apt-mirror-resilience-plan.md
@@ -1,0 +1,246 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+plan_type: fix
+product_contract_source: ce-plan-bootstrap
+---
+
+# fix: Make CI APT setup resilient to runner mirror stalls
+
+## Goal Capsule
+
+GitHub-hosted Ubuntu 24.04 jobs currently run dependency setup through the
+runner-provided `http://azure.archive.ubuntu.com/ubuntu` mirror. Recent logs
+show repeated `Ign:` fetches for `ripgrep` and long/canceled setup jobs while
+the same package succeeds from `https://archive.ubuntu.com/ubuntu`. Make every
+repository-owned CI dependency install use a bounded, canonical HTTPS mirror
+path while retaining APT's normal `InRelease` signature verification.
+
+## Problem Frame and Scope
+
+The workflow generator emits direct `sudo apt-get update && sudo apt-get
+install` commands in the Layer-1 workflow, and the release workflow repeats the
+same pattern. The hosted runner's mirror list selects
+`http://azure.archive.ubuntu.com/ubuntu`; failures are environmental and occur
+before repository tests run. The fix is limited to CI dependency installation,
+its generated workflow source, the release workflow, and a Layer-1 structural
+contract. It does not change package versions, trust keys, Nix supply-chain
+checks, or application runtime behavior.
+
+## Evidence and Requirements
+
+- **R1:** CI dependency installation must not wait indefinitely on the
+  runner-selected Azure mirror.
+- **R2:** APT must continue authenticating repository metadata and packages
+  using the runner's existing keyrings and HTTPS transport.
+- **R3:** All generated Layer-1 and release workflow package setup paths must
+  share one reviewed implementation.
+- **R4:** Layer-1 validation must fail closed if a workflow reintroduces direct
+  unbounded APT setup or drops the resilience options.
+- **R5:** The change must carry a changelog fragment and leave unrelated
+  workflows and PR branches untouched.
+
+Observed evidence:
+
+- Run `32222548689`, job logs from `test-policy` and
+  `test-rust-supply-chain`: `apt-get update` selected
+  `http://azure.archive.ubuntu.com/ubuntu`; package retrieval then retried
+  `ripgrep` with `Ign:` entries.
+- The same logs show successful fallback retrieval from
+  `https://archive.ubuntu.com/ubuntu`.
+- The workflow source of truth is `tests/tools/layer1-jobs.py`; the committed
+  `.github/workflows/pr-l1-static-fast.yml` is generated from it.
+
+## Key Technical Decisions
+
+1. **Use one repository-owned CI APT helper.**
+   (session-settled: user-directed - chosen over repeating inline shell:
+   one helper prevents generated and hand-authored workflows from drifting.)
+   The helper rewrites the runner mirror-list entry from the Azure HTTP mirror
+   to `https://archive.ubuntu.com/ubuntu`, then invokes `apt-get update` and
+   `apt-get install` with finite HTTP/HTTPS timeouts and bounded retries.
+   It leaves APT `Signed-By` configuration and signature checking untouched.
+2. **Keep workflow generation authoritative.**
+   (session-settled: user-directed - chosen over editing generated YAML:
+   generator changes are reproducible and required by the repository workflow.)
+   `tests/tools/layer1-jobs.py` emits the helper invocation, followed by
+   regeneration of `.github/workflows/pr-l1-static-fast.yml`.
+3. **Enforce the contract in the existing Layer-1 CI coverage gate.**
+   (session-settled: user-directed - chosen over a new ad-hoc shell test:
+   `tests/unit/meta/ci-coverage.sh` already owns workflow structural checks.)
+   The gate checks that every repository workflow uses the helper for APT
+   setup and that the helper retains the mirror rewrite, bounded options, and
+   package arguments.
+
+## High-Level Technical Design
+
+```mermaid
+flowchart LR
+  W[Generated or release workflow] --> H[tests/tools/ci-apt-install]
+  H --> M[Rewrite runner mirror-list entry]
+  H --> A[apt-get update/install with bounded options]
+  A --> S[Existing APT keyrings and InRelease verification]
+  M --> U[https://archive.ubuntu.com/ubuntu]
+```
+
+The helper is CI plumbing, not an application dependency. It should fail
+closed when the mirror-list file is unexpectedly absent or the expected Azure
+entry cannot be replaced, rather than silently running against an unknown
+mirror. The helper accepts package names as positional arguments and must
+reject an empty package list.
+
+## Implementation Units
+
+### U1. Add the bounded APT setup helper and Layer-1 contract
+
+**Goal:** Centralize resilient APT setup and protect it with a hermetic
+structural test.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+
+- `tests/tools/ci-apt-install`
+- `tests/unit/meta/ci-coverage.sh`
+
+**Approach:**
+
+1. Add a strict shell helper that rewrites only the runner's
+   `azure.archive.ubuntu.com/ubuntu` mirror-list entry to the HTTPS generic
+   Ubuntu archive.
+2. Run `apt-get update` and `apt-get install -y` with small finite
+   `Acquire::http::Timeout`, `Acquire::https::Timeout`, and
+   `Acquire::Retries` values.
+3. Preserve the system source definitions, keyrings, `Signed-By` behavior, and
+   package metadata authentication.
+4. Extend the existing CI coverage meta gate to reject direct workflow APT
+   commands and to assert the helper's required safety options and package
+   argument handling.
+
+**Patterns to follow:** Existing strict shell tools under `tests/tools/`;
+workflow structural checks in `tests/unit/meta/ci-coverage.sh`.
+
+**Test scenarios:**
+
+- The helper rejects invocation with no package names.
+- The helper fails when the runner mirror-list file is missing or does not
+  contain the expected Azure Ubuntu entry.
+- The helper source contains HTTPS canonical mirror replacement, bounded HTTP
+  and HTTPS timeouts, bounded retries, and no authentication-disabling option.
+- The CI coverage gate passes with the helper-backed workflows and fails for a
+  fixture containing a direct `apt-get update` or missing required option.
+
+**Verification:** The helper is shellcheck-compatible with repository
+conventions, the structural gate exercises the complete workflow set, and no
+APT authentication bypass appears in the diff.
+
+### U2. Route generated and release workflows through the helper
+
+**Goal:** Remove every repository-owned direct APT setup path from hosted CI.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+
+- `tests/tools/layer1-jobs.py`
+- `.github/workflows/pr-l1-static-fast.yml`
+- `.github/workflows/release-host-binaries.yml`
+
+**Approach:**
+
+1. Change the generator's Rust, flake-diagnostics, and other package setup
+   steps to call `tests/tools/ci-apt-install` through the repository's scrubbed
+   workflow shell.
+2. Regenerate the committed Layer-1 workflow; do not hand-edit generated YAML.
+3. Change the release binary workflow's package setup step to use the same
+   helper.
+4. Keep the existing package list (`ripgrep`, `acl`, or `gdb`) unchanged.
+
+**Patterns to follow:** `tests/tools/layer1-jobs.py` rendering functions and
+the generated-workflow drift check.
+
+**Test scenarios:**
+
+- Regeneration produces a workflow with no direct `apt-get update` or
+  `apt-get install` command.
+- Each generated dependency setup step passes its existing package list to the
+  helper.
+- The release workflow uses the same helper and retains its existing
+  permission and checkout protections.
+- Workflow drift validation passes after regeneration.
+
+**Verification:** Generated YAML is byte-for-byte current according to the
+repository renderer, all APT call sites are helper-backed, and no unrelated
+workflow changes are introduced.
+
+### U3. Record the CI resilience change
+
+**Goal:** Document the operational fix in the repository changelog stream.
+
+**Requirements:** R5
+
+**Dependencies:** U2
+
+**Files:**
+
+- `changelog.d/fix-ci-apt-mirror-resilience.md`
+
+**Approach:** Add a concise fragment describing the Azure runner mirror
+  mitigation and preserved APT verification behavior.
+
+**Test scenarios:**
+
+- The changelog policy accepts the fragment's format and placement.
+
+**Verification:** The repository changelog policy recognizes the fragment
+without changing release history.
+
+## Scope Boundaries
+
+### In scope
+
+- Ubuntu-hosted GitHub Actions dependency setup owned by this repository.
+- The generated Layer-1 workflow and the release-host-binaries workflow.
+- A Layer-1 structural contract for the helper and its call sites.
+
+### Out of scope
+
+- Changing GitHub runner images, Ubuntu archive contents, package versions, or
+  repository signing keys.
+- Retrying complete workflows or modifying unrelated PRs.
+- Adding a second package manager, disabling APT authentication, or changing
+  Nix/Cargo supply-chain verification.
+
+## Risks and Mitigations
+
+- **Runner image changes the mirror-list format:** fail closed when the expected
+  file or entry is absent; update the helper deliberately rather than silently
+  using an unknown source.
+- **Canonical archive availability changes:** bounded APT options ensure a
+  finite failure; package metadata remains signature-verified, so a bad or
+  unavailable archive fails the job.
+- **Generated workflow drift:** regenerate from `tests/tools/layer1-jobs.py`
+  and enforce the existing drift gate.
+
+## Verification Contract
+
+- The helper and meta-gate focused checks pass locally.
+- Generated workflow drift and CI coverage checks pass.
+- Targeted changelog validation passes.
+- The PR's required Layer-1 checks pass without full-workflow reruns; any
+  failed-only retry follows the repository's strict CI retry rule.
+
+## Definition of Done
+
+- U1-U3 are implemented on `fix/ci-apt-mirror-resilience`.
+- The branch is rebased onto the latest `origin/v3` before commit and again
+  whenever `v3` moves.
+- Independent review has no actionable findings at the reviewed head.
+- The PR is mergeable CLEAN with all required checks green.
+- The PR is squash-merged with an exact expected-head guard, or the final
+  response records the blocker and current reviewed head.

--- a/tests/tools/ci-apt-install
+++ b/tests/tools/ci-apt-install
@@ -14,7 +14,8 @@ readonly APT_RETRIES=2
 if [ "${1:-}" = "--self-test" ]; then
   fixture="${AZURE_MIRROR}/$(printf '\t')priority:1"
   rewritten=$(printf '%s\n' "$fixture" | sed -E "s#^${AZURE_MIRROR//./\\.}/?#${CANONICAL_MIRROR}#")
-  if ! printf '%s\n' "$rewritten" | grep -Eq "$CANONICAL_MIRROR_REGEX"; then
+  expected="${CANONICAL_MIRROR}$(printf '\t')priority:1"
+  if [ "$rewritten" != "$expected" ]; then
     echo "APT mirror rewrite did not preserve runner metadata" >&2
     exit 1
   fi
@@ -54,11 +55,8 @@ sudo cp -p -- "$MIRROR_LIST" "$backup"
 
 cleanup() {
   status=$?
-  trap - EXIT
-  if ! sudo cp -p -- "$backup" "$MIRROR_LIST"; then
-    status=1
-  fi
-  if ! sudo rm -f -- "$backup"; then
+  trap - EXIT HUP INT TERM
+  if ! sudo mv -f -- "$backup" "$MIRROR_LIST"; then
     status=1
   fi
   exit "$status"

--- a/tests/tools/ci-apt-install
+++ b/tests/tools/ci-apt-install
@@ -6,9 +6,24 @@ set -euo pipefail
 readonly MIRROR_LIST=/etc/apt/apt-mirrors.txt
 readonly AZURE_MIRROR=http://azure.archive.ubuntu.com/ubuntu
 readonly CANONICAL_MIRROR=https://archive.ubuntu.com/ubuntu
-readonly AZURE_MIRROR_REGEX="^${AZURE_MIRROR//./\\.}/?$"
+readonly AZURE_MIRROR_REGEX="^${AZURE_MIRROR//./\\.}/?([[:space:]]+.*)?$"
+readonly CANONICAL_MIRROR_REGEX="^${CANONICAL_MIRROR//./\\.}/?([[:space:]]+.*)?$"
 readonly APT_TIMEOUT=15
 readonly APT_RETRIES=2
+
+if [ "${1:-}" = "--self-test" ]; then
+  fixture="${AZURE_MIRROR}/$(printf '\t')priority:1"
+  rewritten=$(printf '%s\n' "$fixture" | sed -E "s#^${AZURE_MIRROR//./\\.}/?#${CANONICAL_MIRROR}#")
+  if ! printf '%s\n' "$rewritten" | grep -Eq "$CANONICAL_MIRROR_REGEX"; then
+    echo "APT mirror rewrite did not preserve runner metadata" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$rewritten" | grep -Fq "$AZURE_MIRROR"; then
+    echo "APT mirror rewrite left the Azure mirror selected" >&2
+    exit 1
+  fi
+  exit 0
+fi
 
 if [ "$#" -eq 0 ]; then
   echo "usage: $0 PACKAGE [PACKAGE ...]" >&2
@@ -52,10 +67,10 @@ trap cleanup EXIT
 trap 'exit 130' HUP INT TERM
 
 sudo sed -E -i \
-  "s#${AZURE_MIRROR_REGEX}#${CANONICAL_MIRROR}#" \
+  "s#^${AZURE_MIRROR//./\\.}/?#${CANONICAL_MIRROR}#" \
   "$MIRROR_LIST"
 
-if ! sudo grep -Fqx "$CANONICAL_MIRROR" "$MIRROR_LIST"; then
+if ! sudo grep -Eq "$CANONICAL_MIRROR_REGEX" "$MIRROR_LIST"; then
   echo "failed to select the canonical HTTPS Ubuntu mirror" >&2
   exit 1
 fi

--- a/tests/tools/ci-apt-install
+++ b/tests/tools/ci-apt-install
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Install CI packages without waiting indefinitely on the hosted runner mirror.
+
+set -euo pipefail
+
+readonly MIRROR_LIST=/etc/apt/apt-mirrors.txt
+readonly AZURE_MIRROR=http://azure.archive.ubuntu.com/ubuntu
+readonly CANONICAL_MIRROR=https://archive.ubuntu.com/ubuntu
+readonly AZURE_MIRROR_REGEX="^${AZURE_MIRROR//./\\.}/?$"
+readonly APT_TIMEOUT=15
+readonly APT_RETRIES=2
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 PACKAGE [PACKAGE ...]" >&2
+  exit 2
+fi
+
+for package in "$@"; do
+  case "$package" in
+    ""|-*)
+      echo "invalid package name: $package" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -r "$MIRROR_LIST" ]; then
+  echo "missing APT mirror list: $MIRROR_LIST" >&2
+  exit 1
+fi
+
+if ! sudo grep -Eq "$AZURE_MIRROR_REGEX" "$MIRROR_LIST"; then
+  echo "APT mirror list does not contain the expected Azure mirror" >&2
+  exit 1
+fi
+
+backup="$MIRROR_LIST.d2b.$$"
+sudo cp -p -- "$MIRROR_LIST" "$backup"
+
+cleanup() {
+  status=$?
+  trap - EXIT
+  if ! sudo cp -p -- "$backup" "$MIRROR_LIST"; then
+    status=1
+  fi
+  if ! sudo rm -f -- "$backup"; then
+    status=1
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+sudo sed -E -i \
+  "s#${AZURE_MIRROR_REGEX}#${CANONICAL_MIRROR}#" \
+  "$MIRROR_LIST"
+
+if ! sudo grep -Fqx "$CANONICAL_MIRROR" "$MIRROR_LIST"; then
+  echo "failed to select the canonical HTTPS Ubuntu mirror" >&2
+  exit 1
+fi
+
+apt_options=(
+  -o "Acquire::Retries=$APT_RETRIES"
+  -o "Acquire::http::Timeout=$APT_TIMEOUT"
+  -o "Acquire::https::Timeout=$APT_TIMEOUT"
+)
+
+sudo apt-get "${apt_options[@]}" update
+sudo apt-get "${apt_options[@]}" install -y -- "$@"

--- a/tests/tools/ci-apt-install
+++ b/tests/tools/ci-apt-install
@@ -55,7 +55,8 @@ sudo cp -p -- "$MIRROR_LIST" "$backup"
 
 cleanup() {
   status=$?
-  trap - EXIT HUP INT TERM
+  trap '' HUP INT TERM
+  trap - EXIT
   if ! sudo mv -f -- "$backup" "$MIRROR_LIST"; then
     status=1
   fi

--- a/tests/tools/layer1-jobs.py
+++ b/tests/tools/layer1-jobs.py
@@ -405,7 +405,7 @@ def rust_job(job: dict[str, Any]) -> str:
           rustup toolchain install "$PINNED" --profile minimal --component rustfmt --component clippy
           rustup default "$PINNED"
           echo "Rust toolchain: $(rustc --version)"
-          sudo apt-get update && sudo apt-get install -y ripgrep acl
+          tests/tools/ci-apt-install ripgrep acl
       - name: Rust dependency cache (target dirs + cargo registry)
         # Swatinem/rust-cache caches dependency artifacts in target dirs
         # and the cargo registry. It performs all I/O in its own action
@@ -582,7 +582,7 @@ def flake_x86_shards_job(job: dict[str, Any]) -> str:
           sudo swapon "$SWAP"
 {nix_setup_step(job, MATRIX_CHECK_SCOPE)}
       - name: Install flake shard diagnostics
-        run: sudo apt-get update && sudo apt-get install -y gdb
+        run: tests/tools/ci-apt-install gdb
       - name: {job["displayName"]}
         # D2B_FLAKE_CHECK is passed via the step environment, NOT interpolated
         # into the shell command: a flake check attr name is PR-controlled, so

--- a/tests/unit/meta/ci-coverage.sh
+++ b/tests/unit/meta/ci-coverage.sh
@@ -95,8 +95,19 @@ if [ ! -x "$apt_helper" ]; then
 fi
 
 apt_contract_errors=()
+apt_command_pattern='(^|[^[:alnum:]_-])(apt-get|apt)([^[:alnum:]_-]|$)'
+has_direct_apt() {
+  sed -E '/^[[:space:]]*#/d' \
+    | sed ':a;N;$!ba;s/\\\n//g' \
+    | grep -Eq "$apt_command_pattern"
+}
+
+if ! printf '%s\n' 'sudo apt-\' 'get update' | has_direct_apt; then
+  apt_contract_errors+=("CI APT scan: split apt-get command fixture was not detected")
+fi
+
 while IFS= read -r workflow; do
-  if grep -Ev '^[[:space:]]*#' "$workflow" | grep -Eq '(^|[^[:alnum:]_-])(apt-get|apt)([^[:alnum:]_-]|$)'; then
+  if has_direct_apt < "$workflow"; then
     apt_contract_errors+=("${workflow#"$ROOT"/}: contains a direct apt setup")
   fi
 done < <(
@@ -132,9 +143,12 @@ do
   fi
 done
 
-if grep -Eiq \
-  'allow-?unauthenticated|allowinsecure.repositories|allowdowngrade.*insecure|trusted[[:space:]]*=[[:space:]]*yes|verify-(peer|host)[[:space:]]*=[[:space:]]*false|check-valid-until[[:space:]]*=[[:space:]]*false' \
-  "$apt_helper"
+apt_helper_normalized=$(tr -d '[:space:]_:-' < "$apt_helper" | tr '[:upper:]' '[:lower:]')
+if printf '%s\n' "$apt_helper_normalized" \
+  | grep -Eq 'allowunauthenticated|allowinsecurerepositories|allowdowngradetoinsecurerepositories' \
+  || grep -Eiq \
+    'trusted[[:space:]]*=[[:space:]]*yes|verify-(peer|host)[[:space:]]*=[[:space:]]*false|check-valid-until[[:space:]]*=[[:space:]]*false' \
+    "$apt_helper"
 then
   apt_contract_errors+=("tests/tools/ci-apt-install: disables APT authentication or freshness checks")
 fi

--- a/tests/unit/meta/ci-coverage.sh
+++ b/tests/unit/meta/ci-coverage.sh
@@ -96,7 +96,7 @@ fi
 
 apt_contract_errors=()
 while IFS= read -r workflow; do
-  if grep -Ev '^[[:space:]]*#' "$workflow" | grep -Eq '(^|[^[:alnum:]_-])(apt-get|apt)([[:space:]]|$)'; then
+  if grep -Ev '^[[:space:]]*#' "$workflow" | grep -Eq '(^|[^[:alnum:]_-])(apt-get|apt)([^[:alnum:]_-]|$)'; then
     apt_contract_errors+=("${workflow#"$ROOT"/}: contains a direct apt setup")
   fi
 done < <(
@@ -132,7 +132,10 @@ do
   fi
 done
 
-if grep -Eq 'allow-unauthenticated|trusted=yes|Verify-Peer=false|Check-Valid-Until=false' "$apt_helper"; then
+if grep -Eiq \
+  'allow-?unauthenticated|allowinsecure.repositories|allowdowngrade.*insecure|trusted[[:space:]]*=[[:space:]]*yes|verify-(peer|host)[[:space:]]*=[[:space:]]*false|check-valid-until[[:space:]]*=[[:space:]]*false' \
+  "$apt_helper"
+then
   apt_contract_errors+=("tests/tools/ci-apt-install: disables APT authentication or freshness checks")
 fi
 

--- a/tests/unit/meta/ci-coverage.sh
+++ b/tests/unit/meta/ci-coverage.sh
@@ -147,7 +147,7 @@ apt_helper_normalized=$(tr -d '[:space:]_:-' < "$apt_helper" | tr '[:upper:]' '[
 if printf '%s\n' "$apt_helper_normalized" \
   | grep -Eq 'allowunauthenticated|allowinsecurerepositories|allowdowngradetoinsecurerepositories' \
   || grep -Eiq \
-    'trusted[[:space:]]*=[[:space:]]*yes|verify-(peer|host)[[:space:]]*=[[:space:]]*false|check-valid-until[[:space:]]*=[[:space:]]*false' \
+    'trusted[[:space:]]*=[[:space:]]*yes|verify-(peer|host)[[:space:]]*=[[:space:]]*(false|no|0)|check-(valid-until|date)[[:space:]]*=[[:space:]]*(false|no|0)' \
     "$apt_helper"
 then
   apt_contract_errors+=("tests/tools/ci-apt-install: disables APT authentication or freshness checks")

--- a/tests/unit/meta/ci-coverage.sh
+++ b/tests/unit/meta/ci-coverage.sh
@@ -96,8 +96,8 @@ fi
 
 apt_contract_errors=()
 while IFS= read -r workflow; do
-  if grep -Ev '^[[:space:]]*#' "$workflow" | grep -Eq 'apt-get[[:space:]]+(update|install)'; then
-    apt_contract_errors+=("${workflow#"$ROOT"/}: contains a direct apt-get setup")
+  if grep -Ev '^[[:space:]]*#' "$workflow" | grep -Eq '(^|[^[:alnum:]_-])(apt-get|apt)([[:space:]]|$)'; then
+    apt_contract_errors+=("${workflow#"$ROOT"/}: contains a direct apt setup")
   fi
 done < <(
   find "$WORKFLOW_DIR" -maxdepth 1 -type f \
@@ -113,6 +113,10 @@ do
     apt_contract_errors+=("${workflow#"$ROOT"/}: does not use the CI APT helper")
   fi
 done
+
+if ! "$apt_helper" --self-test; then
+  apt_contract_errors+=("tests/tools/ci-apt-install: runner mirror-list fixture failed")
+fi
 
 for required in \
   'AZURE_MIRROR=.*http://azure.archive.ubuntu.com/ubuntu' \

--- a/tests/unit/meta/ci-coverage.sh
+++ b/tests/unit/meta/ci-coverage.sh
@@ -88,6 +88,56 @@ if [ "${#workflow_shell_errors[@]}" -gt 0 ]; then
   exit 1
 fi
 
+apt_helper="$ROOT/tests/tools/ci-apt-install"
+if [ ! -x "$apt_helper" ]; then
+  echo "FAIL: missing executable CI APT helper $apt_helper" >&2
+  exit 1
+fi
+
+apt_contract_errors=()
+while IFS= read -r workflow; do
+  if grep -Ev '^[[:space:]]*#' "$workflow" | grep -Eq 'apt-get[[:space:]]+(update|install)'; then
+    apt_contract_errors+=("${workflow#"$ROOT"/}: contains a direct apt-get setup")
+  fi
+done < <(
+  find "$WORKFLOW_DIR" -maxdepth 1 -type f \
+    \( -name '*.yml' -o -name '*.yaml' \) -print \
+    | LC_ALL=C sort
+)
+
+for workflow in \
+  "$ROOT/.github/workflows/pr-l1-static-fast.yml" \
+  "$ROOT/.github/workflows/release-host-binaries.yml"
+do
+  if ! grep -Eq 'tests/tools/ci-apt-install[[:space:]]' "$workflow"; then
+    apt_contract_errors+=("${workflow#"$ROOT"/}: does not use the CI APT helper")
+  fi
+done
+
+for required in \
+  'AZURE_MIRROR=.*http://azure.archive.ubuntu.com/ubuntu' \
+  'CANONICAL_MIRROR=.*https://archive.ubuntu.com/ubuntu' \
+  'Acquire::Retries=' \
+  'Acquire::http::Timeout=' \
+  'Acquire::https::Timeout=' \
+  'apt-get .* update' \
+  'apt-get .* install'
+do
+  if ! grep -Eq "$required" "$apt_helper"; then
+    apt_contract_errors+=("tests/tools/ci-apt-install: missing $required")
+  fi
+done
+
+if grep -Eq 'allow-unauthenticated|trusted=yes|Verify-Peer=false|Check-Valid-Until=false' "$apt_helper"; then
+  apt_contract_errors+=("tests/tools/ci-apt-install: disables APT authentication or freshness checks")
+fi
+
+if [ "${#apt_contract_errors[@]}" -gt 0 ]; then
+  echo "FAIL: CI APT mirror coverage is incomplete:" >&2
+  printf '  %s\n' "${apt_contract_errors[@]}" >&2
+  exit 1
+fi
+
 bash "$ROOT/tests/tools/layer1-jobs" self-test
 
 mapfile -t local_job_ids < <(


### PR DESCRIPTION
## Summary

CI dependency setup no longer waits on the runner-selected Azure HTTP mirror. A repository-owned helper selects the canonical HTTPS Ubuntu archive, bounds APT network retries and timeouts, and preserves normal repository signature verification. Generated Layer-1 and release workflows use the helper, and the existing CI coverage gate rejects direct APT setup.

## Validation evidence

- [x] **Focused tests for the changed components** were run: `bash tests/tools/ci-apt-install --self-test` passed; `make test-ci-coverage` passed (65 tests); `make layer1-workflow-check` passed; `make test-changelog` passed.
- [x] **Wider lanes are conditional.** Container, NixOS, and host-integration lanes are not applicable to this CI workflow and static-gate change.
- [x] **Hardware checks are conditional:** not applicable; this change does not touch graphics, video, USBIP, TPM, or microVM behavior.
- [x] **Changed tests are inventoried:** the existing CI coverage meta gate was extended; no test retirement or migration-ledger row is needed.
- [x] **Changelog updated** with `changelog.d/fix-ci-apt-mirror-resilience.md`.
- [x] **Docs + CI updated in lockstep** with the implementation plan and generated workflow changes.

## Notes

Session-settled decisions carried from planning: use one repository-owned APT helper (user-directed over repeated inline shell), keep workflow generation authoritative (user-directed over hand-editing generated YAML), and extend the existing Layer-1 coverage gate (user-directed over a new shell gate).

The branch is based on `v3` at `8dc64e23` and contains the existing five-commit mitigation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
