### PR TITLE
fix(ci): isolate shell supervisor test home

### DIFF
--- a/changelog.d/shell-supervisor-test-isolation.md
+++ b/changelog.d/shell-supervisor-test-isolation.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Isolate unsafe-local shell supervisor tests from host login profiles so
+  Layer-1 Rust checks do not flake on user startup hooks.

--- a/packages/d2b-unsafe-local-helper/tests/shell_supervisor.rs
+++ b/packages/d2b-unsafe-local-helper/tests/shell_supervisor.rs
@@ -404,7 +404,7 @@ fn exercise_helper_runtime_reconstruction(scratch: &Scratch, operation_suffix: &
         ),
         (
             "HOME".to_owned(),
-            user.home_dir().to_string_lossy().into_owned(),
+            scratch.path.display().to_string(),
         ),
     ]);
     environment.insert(


### PR DESCRIPTION
## Summary

The merged `v3` Layer-1 run exposed a flaky shell-supervisor integration test that loaded the runner's real login profiles. This isolates the test's `HOME` while preserving the real passwd-selected shell, cwd, helper binary, PTY, reconstruction, missing-socket kill, and ledger cleanup paths.

Related: #458

## Validation

- Reproduced the baseline failure in 1 of 40 and 1 of 80 Bazel stress runs.
- The committed repair passed 100 of 100 Bazel runs.
- `cargo test -p d2b-unsafe-local-helper --test shell_supervisor` passed.
- Bare `make check` passed.
- Independent review reported no actionable findings.

## Post-Deploy Monitoring & Validation

- Watch `rust-main` and the aggregate `check` on this PR and the next `v3` push.
- Healthy: `//packages/d2b-unsafe-local-helper:shell_supervisor` and `check` complete successfully.
- Failure: another interactive-login assertion failure on the isolated test path.
- Mitigation: revert this test-only commit if the isolated path hides a reproducible product defect.
- Window and owner: repository maintainers through the first green `v3` push after merge.
