### PR TITLE
fix(ci): run nix unit once per PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ D2B_BAZEL_GUEST_TARGETS = //bazel/checks/rust:portable_rust_guest
 D2B_BAZEL_LOCAL_RUST_TARGETS = //bazel/checks/rust:portable_rust_local
 D2B_BAZEL_POLICY_TARGETS = //bazel/checks/policy:policy_tooling
 D2B_BAZEL_NIX_EVAL_TARGETS = //bazel/checks/nix:nix_evaluation
+D2B_BAZEL_NIX_UNIT_TARGETS = //bazel/checks/nix:nix_unit
 D2B_BAZEL_NIX_REALIZED_TARGETS = //bazel/checks/nix:nix_realized
 D2B_BAZEL_NIX_AARCH64_TARGETS = //bazel/checks/nix:nix_aarch64
 D2B_BAZEL_FIXTURE_TARGETS = //bazel/checks/fixtures:fixtures_proofs
@@ -99,6 +100,7 @@ D2B_BAZEL_COMPLETE_TARGETS = \
 	$(D2B_BAZEL_LOCAL_RUST_TARGETS) \
 	$(D2B_BAZEL_POLICY_TARGETS) \
 	$(D2B_BAZEL_NIX_EVAL_TARGETS) \
+	$(D2B_BAZEL_NIX_UNIT_TARGETS) \
 	$(D2B_BAZEL_NIX_REALIZED_TARGETS) \
 	$(D2B_BAZEL_NIX_AARCH64_TARGETS) \
 	$(D2B_BAZEL_FIXTURE_TARGETS) \

--- a/bazel/checks/nix/BUILD.bazel
+++ b/bazel/checks/nix/BUILD.bazel
@@ -373,7 +373,7 @@ nix_native_test(
 
 test_suite(
     name = "nix_evaluation",
-    tests = [":nix_unit", ":flake-eval-x86", ":flake-eval-x86-outputs"],
+    tests = [":flake-eval-x86", ":flake-eval-x86-outputs"],
 )
 
 test_suite(

--- a/changelog.d/fix-issue-456-nix-unit-ci.md
+++ b/changelog.d/fix-issue-456-nix-unit-ci.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Run the Nix-unit suite once per pull request while keeping it part of the
+  stable Layer-1 aggregate and its documented local Make coverage.


### PR DESCRIPTION
## Summary

Nix unit surfaces now run once per pull request instead of being repeated by the Nix evaluation suite. The complete Layer-1 aggregate still owns `nix_unit` explicitly, so the stable required `check` result remains fail-closed.

## Validation

- `make test-nix-unit`
- `make test-flake`
- Independent review found no actionable issues

Fixes #456
