### PR TITLE
ci: run PR suites concurrently

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -35,7 +35,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make check-tier0
 
   policy-tooling:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -54,7 +53,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-policy
 
   rust-main:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -74,7 +72,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-rust-main
 
   rust-broker:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -93,7 +90,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-rust-broker
 
   rust-guest:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -112,7 +108,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-rust-guest-shell-runner
 
   rust-local:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -131,7 +126,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-rust-local
 
   nix-eval:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -150,7 +144,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-flake
 
   nix-unit:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -169,7 +162,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-nix-unit
 
   nix-realized:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -188,7 +180,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-flake-realized
 
   nix-aarch64:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -207,7 +198,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-flake-aarch64
 
   fixtures-proofs:
-    needs: [tier0]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -226,7 +216,6 @@ jobs:
         run: nix develop --no-write-lock-file .#bazel -c make test-fixture-contracts
 
   test-performance-budgets:
-    needs: [tier0]
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 10

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,6 +58,7 @@ exports_files([
     "flake.lock",
     "flake.nix",
     ".github/PULL_REQUEST_TEMPLATE.md",
+    ".github/workflows/pr-l1-static-fast.yml",
     "scripts/changelog-check.sh",
     "BUILD.bazel",
     "tests/golden/bazel/cache-policy.json",

--- a/bazel/checks/policy/BUILD.bazel
+++ b/bazel/checks/policy/BUILD.bazel
@@ -79,5 +79,6 @@ test_suite(
         ":changelog",
         ":drift",
         ":policy",
+        "//packages/xtask:pr_workflow",
     ],
 )

--- a/changelog.d/fix-461-concurrent-pr-jobs.md
+++ b/changelog.d/fix-461-concurrent-pr-jobs.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Start independent PR Layer-1 test suites concurrently instead of waiting for tier0.

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -258,6 +258,13 @@ rust_test(
 )
 
 rust_test(
+    name = "pr_workflow",
+    srcs = ["tests/pr_workflow.rs"],
+    data = ["//:.github/workflows/pr-l1-static-fast.yml"],
+    visibility = ["//visibility:public"],
+)
+
+rust_test(
     name = "policy_production_closure",
     srcs = [
         "tests/common/mod.rs",

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -1,0 +1,113 @@
+#![forbid(unsafe_code)]
+
+use std::path::PathBuf;
+
+const REQUIRED_AGGREGATE_JOBS: &[&str] = &[
+    "tier0",
+    "policy-tooling",
+    "rust-main",
+    "rust-broker",
+    "rust-guest",
+    "rust-local",
+    "nix-eval",
+    "nix-unit",
+    "nix-realized",
+    "nix-aarch64",
+    "fixtures-proofs",
+];
+
+fn workflow() -> String {
+    let relative = ".github/workflows/pr-l1-static-fast.yml";
+    let mut candidates = Vec::new();
+    for variable in ["TEST_SRCDIR", "RUNFILES_DIR"] {
+        if let Some(base) = std::env::var_os(variable).map(PathBuf::from) {
+            if let Some(workspace) = std::env::var_os("TEST_WORKSPACE") {
+                candidates.push(base.join(workspace).join(relative));
+            }
+            candidates.push(base.join("_main").join(relative));
+        }
+    }
+    if let Ok(current_dir) = std::env::current_dir() {
+        candidates.push(current_dir.join(relative));
+    }
+    for path in candidates {
+        if let Ok(workflow) = std::fs::read_to_string(&path) {
+            return workflow;
+        }
+    }
+    panic!("PR workflow is not discoverable through Bazel runfiles")
+}
+
+fn job_block<'a>(workflow: &'a str, job: &str) -> &'a str {
+    let header = format!("  {job}:\n");
+    let start = workflow
+        .find(&header)
+        .unwrap_or_else(|| panic!("workflow job is missing: {job}"));
+    let body = &workflow[start + header.len()..];
+    let mut offset = 0;
+    for line in body.split_inclusive('\n') {
+        if line.starts_with("  ") && !line.starts_with("    ") {
+            return &body[..offset];
+        }
+        offset += line.len();
+    }
+    body
+}
+
+fn job_names(workflow: &str) -> Vec<&str> {
+    workflow
+        .lines()
+        .skip_while(|line| *line != "jobs:")
+        .skip(1)
+        .filter_map(|line| {
+            let name = line.strip_prefix("  ")?.strip_suffix(':')?;
+            (!name.starts_with(' ')).then_some(name)
+        })
+        .collect()
+}
+
+fn needs_entries(block: &str) -> Vec<&str> {
+    let value = block
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("needs:"))
+        .expect("aggregate job needs a dependency list")
+        .trim()
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .expect("aggregate dependencies use an inline list");
+    value.split(',').map(str::trim).collect()
+}
+
+#[test]
+fn pr_suites_start_concurrently_and_aggregate_preserves_required_failures() {
+    let workflow = workflow();
+
+    for job in job_names(&workflow)
+        .into_iter()
+        .filter(|job| *job != "check")
+    {
+        let block = job_block(&workflow, job);
+        assert!(
+            !block.lines().any(|line| line.trim().starts_with("needs:")),
+            "{job} must not wait for another workflow job"
+        );
+    }
+
+    let performance = job_block(&workflow, "test-performance-budgets");
+    assert!(
+        performance.contains("continue-on-error: true"),
+        "performance budgets must remain advisory"
+    );
+
+    let aggregate = job_block(&workflow, "check");
+    assert_eq!(needs_entries(aggregate), REQUIRED_AGGREGATE_JOBS);
+    assert!(aggregate.contains("if: ${{ always() }}"));
+    assert!(aggregate.contains("!contains(needs.*.result, 'failure')"));
+    assert!(aggregate.contains("!contains(needs.*.result, 'cancelled')"));
+    assert!(aggregate.contains("!contains(needs.*.result, 'skipped')"));
+    assert!(aggregate.contains(r#"run: test "$SUITES_OK" = true"#));
+    assert!(
+        !needs_entries(aggregate).contains(&"test-performance-budgets"),
+        "advisory performance budgets must not block the aggregate"
+    );
+}


### PR DESCRIPTION
## Summary

PR validation now starts every independent Layer-1 suite concurrently. The final `check` job remains the only fan-in, preserves failure, cancellation, and skipped-job handling, and excludes the advisory performance-budget job.

## Validation evidence

- [x] **Focused tests for the changed components** passed:
      `D2B_BAZEL_PROFILE=local D2B_BAZEL_UNTRUSTED=1 nix develop --no-write-lock-file .#bazel -c make test-policy`
- [x] **Wider lanes are conditional.** Container and host lanes were omitted because this change only affects the PR workflow contract.
- [x] **Changed tests are owner-local:** `//packages/xtask:pr_workflow` is wired into the existing policy/tooling suite.
- [x] **Changelog updated** in `changelog.d/fix-461-concurrent-pr-jobs.md`.
- [x] **Docs + CI updated in lockstep:** the workflow changed; no contributor documentation changed.

## Notes

Related: #461
