### PR TITLE
fix(gateway): stop relay pumps before reconnect

### DIFF
--- a/changelog.d/fix-issue-453-relay-pumps.md
+++ b/changelog.d/fix-issue-453-relay-pumps.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Stop authenticated Relay display rendezvous pumps before listener shutdown,
+  cancellation, or reconnect so successive local socket sessions cannot
+  overlap.

--- a/packages/d2b-gateway-runtime/src/display_listener.rs
+++ b/packages/d2b-gateway-runtime/src/display_listener.rs
@@ -361,13 +361,21 @@ mod tests {
             None,
             Arc::new(|| 900),
         );
-        let joined = Arc::new(AtomicBool::new(false));
-        let thread_joined = Arc::clone(&joined);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let thread_cancelled = Arc::clone(&cancelled);
+        let (cancel, mut cancel_rx) = tokio::sync::watch::channel(false);
         let thread = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            thread_joined.store(true, Ordering::SeqCst);
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .unwrap();
+            let saw_cancel = runtime.block_on(async {
+                timeout(Duration::from_millis(250), cancel_rx.changed())
+                    .await
+                    .is_ok_and(|changed| changed.is_ok() && *cancel_rx.borrow())
+            });
+            thread_cancelled.store(saw_cancel, Ordering::SeqCst);
         });
-        let (cancel, _rx) = tokio::sync::watch::channel(false);
         listener.state.lock().unwrap().insert(
             "h1".into(),
             ListenerState {
@@ -381,6 +389,6 @@ mod tests {
 
         listener.close(&ListenerHandle("h1".into())).await.unwrap();
 
-        assert!(joined.load(Ordering::SeqCst));
+        assert!(cancelled.load(Ordering::SeqCst));
     }
 }

--- a/packages/d2b-gateway-runtime/src/display_listener.rs
+++ b/packages/d2b-gateway-runtime/src/display_listener.rs
@@ -7,8 +7,8 @@
 //! with a [`PrologueVerifier`] that verifies the session handshake under the
 //! authorizing binding + secret. Readiness is signalled only after the
 //! authenticated relay has attached to the local display endpoint, so
-//! `await_handshake` resolves exactly when bytes can flow. `close` aborts the
-//! task and drops the listener.
+//! `await_handshake` resolves exactly when bytes can flow. `close` cancels the
+//! listener and joins its runtime thread.
 //!
 //! The verifier-signal composition is a pure helper ([`notifying_verifier`]) so
 //! it is unit-tested with a real handshake frame and no Azure round-trip.
@@ -53,16 +53,10 @@ pub fn notifying_verifier(
 
 struct ListenerState {
     cancel: tokio::sync::watch::Sender<bool>,
-    thread: Option<std::thread::JoinHandle<()>>,
+    thread: std::thread::JoinHandle<()>,
     handshook: Arc<Notify>,
     armed: Arc<AtomicBool>,
     handshake_timeout: Duration,
-}
-
-impl Drop for ListenerState {
-    fn drop(&mut self) {
-        let _ = self.cancel.send(true);
-    }
 }
 
 /// The production host-side display listener.
@@ -197,7 +191,7 @@ impl DisplayListener for RelayDisplayListener {
             id.clone(),
             ListenerState {
                 cancel: task_cancel,
-                thread: Some(thread),
+                thread,
                 handshook,
                 armed,
                 handshake_timeout,
@@ -234,11 +228,9 @@ impl DisplayListener for RelayDisplayListener {
             let mut guard = self.state.lock().map_err(|_| GatewayError::Internal)?;
             guard.remove(&handle.0)
         };
-        if let Some(mut st) = st {
+        if let Some(st) = st {
             let _ = st.cancel.send(true);
-            if let Some(thread) = st.thread.take() {
-                let _ = tokio::task::spawn_blocking(move || thread.join()).await;
-            }
+            let _ = tokio::task::spawn_blocking(move || st.thread.join()).await;
         }
         Ok(())
     }
@@ -317,7 +309,7 @@ mod tests {
             "h1".into(),
             ListenerState {
                 cancel,
-                thread: Some(thread),
+                thread,
                 handshook,
                 armed,
                 handshake_timeout: Duration::from_secs(100),
@@ -380,7 +372,7 @@ mod tests {
             "h1".into(),
             ListenerState {
                 cancel,
-                thread: Some(thread),
+                thread,
                 handshook: Arc::new(Notify::new()),
                 armed: Arc::new(AtomicBool::new(false)),
                 handshake_timeout: Duration::from_secs(100),

--- a/packages/d2b-gateway-runtime/src/display_listener.rs
+++ b/packages/d2b-gateway-runtime/src/display_listener.rs
@@ -53,7 +53,7 @@ pub fn notifying_verifier(
 
 struct ListenerState {
     cancel: tokio::sync::watch::Sender<bool>,
-    _thread: std::thread::JoinHandle<()>,
+    thread: Option<std::thread::JoinHandle<()>>,
     handshook: Arc<Notify>,
     armed: Arc<AtomicBool>,
     handshake_timeout: Duration,
@@ -160,13 +160,8 @@ impl DisplayListener for RelayDisplayListener {
                     // on its own runtime thread so the listener survives the
                     // daemon's synchronous gatewayDisplay request runtime.
                     loop {
-                        tokio::select! {
-                            changed = cancel_rx.changed() => {
-                                if changed.is_err() || *cancel_rx.borrow() {
-                                    break;
-                                }
-                            }
-                            result = crate::relay_bridge::run_listener_verified_with_ready(
+                        let result =
+                            crate::relay_bridge::run_listener_verified_with_ready_and_cancel(
                                 &endpoint,
                                 &credential,
                                 &target,
@@ -174,14 +169,14 @@ impl DisplayListener for RelayDisplayListener {
                                 ca.as_deref(),
                                 inner.clone(),
                                 ready.clone(),
-                            ) => {
-                                if *cancel_rx.borrow() {
-                                    break;
-                                }
-                                if let Err(err) = result {
-                                    tracing::warn!(error = %err, "gateway relay listener ended before close");
-                                }
-                            }
+                                Some(cancel_rx.clone()),
+                            )
+                            .await;
+                        if *cancel_rx.borrow() {
+                            break;
+                        }
+                        if let Err(err) = result {
+                            tracing::warn!(error = %err, "gateway relay listener ended before close");
                         }
                         tokio::select! {
                             changed = cancel_rx.changed() => {
@@ -202,7 +197,7 @@ impl DisplayListener for RelayDisplayListener {
             id.clone(),
             ListenerState {
                 cancel: task_cancel,
-                _thread: thread,
+                thread: Some(thread),
                 handshook,
                 armed,
                 handshake_timeout,
@@ -239,8 +234,11 @@ impl DisplayListener for RelayDisplayListener {
             let mut guard = self.state.lock().map_err(|_| GatewayError::Internal)?;
             guard.remove(&handle.0)
         };
-        if let Some(st) = st {
+        if let Some(mut st) = st {
             let _ = st.cancel.send(true);
+            if let Some(thread) = st.thread.take() {
+                let _ = tokio::task::spawn_blocking(move || thread.join()).await;
+            }
         }
         Ok(())
     }
@@ -319,7 +317,7 @@ mod tests {
             "h1".into(),
             ListenerState {
                 cancel,
-                _thread: thread,
+                thread: Some(thread),
                 handshook,
                 armed,
                 handshake_timeout: Duration::from_secs(100),
@@ -356,5 +354,41 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, GatewayError::Internal));
+    }
+
+    #[tokio::test]
+    async fn close_joins_listener_thread_before_next_bridge_can_arm() {
+        let listener = RelayDisplayListener::new(
+            RelayEndpoint {
+                namespace: "ns".into(),
+                entity: "e".into(),
+            },
+            RelayCredential::EntraBearer("t".into()),
+            LocalTarget::UnixConnect("unused-socket".into()),
+            60,
+            None,
+            Arc::new(|| 900),
+        );
+        let joined = Arc::new(AtomicBool::new(false));
+        let thread_joined = Arc::clone(&joined);
+        let thread = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            thread_joined.store(true, Ordering::SeqCst);
+        });
+        let (cancel, _rx) = tokio::sync::watch::channel(false);
+        listener.state.lock().unwrap().insert(
+            "h1".into(),
+            ListenerState {
+                cancel,
+                thread: Some(thread),
+                handshook: Arc::new(Notify::new()),
+                armed: Arc::new(AtomicBool::new(false)),
+                handshake_timeout: Duration::from_secs(100),
+            },
+        );
+
+        listener.close(&ListenerHandle("h1".into())).await.unwrap();
+
+        assert!(joined.load(Ordering::SeqCst));
     }
 }

--- a/packages/d2b-gateway-runtime/src/relay_bridge.rs
+++ b/packages/d2b-gateway-runtime/src/relay_bridge.rs
@@ -6,6 +6,7 @@
 
 use std::fmt;
 use std::fs::{File, OpenOptions};
+use std::future::Future;
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
@@ -15,13 +16,12 @@ use d2b_provider_transport_azure_relay::auth::{
     RelayCredential, RelayEndpoint, RelayError, RelayRole, build_connect,
 };
 use rustls_pki_types::{CertificateDer, pem::PemObject};
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, watch};
+use tokio::task::JoinSet;
 use tokio::time::{Duration, timeout};
 
 #[cfg(test)]
-use d2b_provider_transport_azure_relay::auth::{
-    DEFAULT_SAS_TTL_SECS, MAX_SAS_TTL_SECS, mint_sas,
-};
+use d2b_provider_transport_azure_relay::auth::{DEFAULT_SAS_TTL_SECS, MAX_SAS_TTL_SECS, mint_sas};
 #[cfg(test)]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -277,6 +277,43 @@ fn validate_connected_unix_peer(
     Ok(())
 }
 
+#[derive(Default)]
+struct RendezvousTasks {
+    tasks: JoinSet<()>,
+}
+
+impl RendezvousTasks {
+    fn spawn<F>(&mut self, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.tasks.spawn(task);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    async fn reap_one(&mut self) {
+        if let Some(Err(err)) = self.tasks.join_next().await
+            && !err.is_cancelled()
+        {
+            tracing::warn!(error = %err, "relay rendezvous task failed");
+        }
+    }
+
+    async fn cancel_and_join(&mut self) {
+        self.tasks.abort_all();
+        while let Some(result) = self.tasks.join_next().await {
+            if let Err(err) = result
+                && !err.is_cancelled()
+            {
+                tracing::warn!(error = %err, "relay rendezvous task failed while stopping");
+            }
+        }
+    }
+}
+
 /// Pump bytes between the relay WebSocket and a local stream until either
 /// side closes. Binary frames carry the tunneled bytes; pings are answered;
 /// text/close end the pump. This is the productionized form of the POC
@@ -434,38 +471,44 @@ pub async fn run_listener(
     let control =
         connect_with_ca(endpoint, RelayRole::Listener, credential, ttl_secs, ca_pem).await?;
     let (mut sink, mut stream) = control.split();
-    while let Some(msg) = stream.next().await {
-        let msg =
-            msg.map_err(|err| RelayConnectError::Handshake(format!("control channel: {err}")))?;
-        match msg {
-            Message::Text(text) => {
-                let v: serde_json::Value = match serde_json::from_str(&text) {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
-                if let Some(addr) = v
-                    .get("accept")
-                    .and_then(|a| a.get("address"))
-                    .and_then(|s| s.as_str())
-                {
-                    let address = addr.to_owned();
-                    let local = local.clone();
-                    let ca = ca_pem.map(|c| c.to_vec());
-                    tokio::spawn(async move {
-                        if let Err(err) = accept_one(&address, &local, ca.as_deref()).await {
-                            tracing::warn!(error = %err, "relay rendezvous ended");
-                        }
-                    });
+    let mut rendezvous_tasks = RendezvousTasks::default();
+    let result = async {
+        while let Some(msg) = stream.next().await {
+            let msg =
+                msg.map_err(|err| RelayConnectError::Handshake(format!("control channel: {err}")))?;
+            match msg {
+                Message::Text(text) => {
+                    let v: serde_json::Value = match serde_json::from_str(&text) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    if let Some(addr) = v
+                        .get("accept")
+                        .and_then(|a| a.get("address"))
+                        .and_then(|s| s.as_str())
+                    {
+                        let address = addr.to_owned();
+                        let local = local.clone();
+                        let ca = ca_pem.map(|c| c.to_vec());
+                        rendezvous_tasks.spawn(async move {
+                            if let Err(err) = accept_one(&address, &local, ca.as_deref()).await {
+                                tracing::warn!(error = %err, "relay rendezvous ended");
+                            }
+                        });
+                    }
                 }
+                Message::Ping(p) => {
+                    let _ = sink.send(Message::Pong(p)).await;
+                }
+                Message::Close(_) => return Ok(()),
+                _ => {}
             }
-            Message::Ping(p) => {
-                let _ = sink.send(Message::Pong(p)).await;
-            }
-            Message::Close(_) => return Ok(()),
-            _ => {}
         }
+        Ok(())
     }
-    Ok(())
+    .await;
+    rendezvous_tasks.cancel_and_join().await;
+    result
 }
 
 async fn accept_one(
@@ -576,55 +619,122 @@ pub async fn run_listener_verified_with_ready(
     verify: PrologueVerifier,
     ready: std::sync::Arc<dyn Fn() + Send + Sync>,
 ) -> Result<(), RelayConnectError> {
+    run_listener_verified_with_ready_and_cancel(
+        endpoint, credential, local, ttl_secs, ca_pem, verify, ready, None,
+    )
+    .await
+}
+
+pub(crate) async fn run_listener_verified_with_ready_and_cancel(
+    endpoint: &RelayEndpoint,
+    credential: &RelayCredential,
+    local: &LocalTarget,
+    ttl_secs: u64,
+    ca_pem: Option<&[u8]>,
+    verify: PrologueVerifier,
+    ready: std::sync::Arc<dyn Fn() + Send + Sync>,
+    mut cancellation: Option<watch::Receiver<bool>>,
+) -> Result<(), RelayConnectError> {
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message;
 
-    let control =
-        connect_with_ca(endpoint, RelayRole::Listener, credential, ttl_secs, ca_pem).await?;
+    if cancellation
+        .as_ref()
+        .is_some_and(|receiver| *receiver.borrow())
+    {
+        return Ok(());
+    }
+    let control = tokio::select! {
+        result = connect_with_ca(endpoint, RelayRole::Listener, credential, ttl_secs, ca_pem) => {
+            result?
+        }
+        _ = wait_for_listener_cancellation(&mut cancellation) => {
+            return Ok(());
+        }
+    };
     let (mut sink, mut stream) = control.split();
     let rendezvous_slots = std::sync::Arc::new(Semaphore::new(MAX_PENDING_RENDEZVOUS));
-    while let Some(msg) = stream.next().await {
-        let msg =
-            msg.map_err(|err| RelayConnectError::Handshake(format!("control channel: {err}")))?;
-        match msg {
-            Message::Text(text) => {
-                let v: serde_json::Value = match serde_json::from_str(&text) {
-                    Ok(v) => v,
-                    Err(_) => continue,
+    let mut rendezvous_tasks = RendezvousTasks::default();
+    let result: Result<(), RelayConnectError> = 'control: loop {
+        tokio::select! {
+            biased;
+            _ = wait_for_listener_cancellation(&mut cancellation) => {
+                break 'control Ok(());
+            }
+            _ = rendezvous_tasks.reap_one(), if !rendezvous_tasks.is_empty() => {
+            }
+            msg = stream.next() => {
+                let Some(msg) = msg else {
+                    break 'control Ok(());
                 };
-                if let Some(addr) = v
-                    .get("accept")
-                    .and_then(|a| a.get("address"))
-                    .and_then(|s| s.as_str())
-                {
-                    let address = addr.to_owned();
-                    let local = local.clone();
-                    let ca = ca_pem.map(|c| c.to_vec());
-                    let verify = verify.clone();
-                    let ready = ready.clone();
-                    let Ok(slot) = rendezvous_slots.clone().try_acquire_owned() else {
-                        tracing::warn!("relay rendezvous concurrency bound reached");
-                        continue;
-                    };
-                    tokio::spawn(async move {
-                        let _slot = slot;
-                        if let Err(err) =
-                            accept_one_verified(&address, &local, ca.as_deref(), verify, ready)
-                                .await
+                let msg = match msg {
+                    Ok(msg) => msg,
+                    Err(err) => {
+                        break 'control Err(RelayConnectError::Handshake(format!(
+                            "control channel: {err}"
+                        )));
+                    }
+                };
+                match msg {
+                    Message::Text(text) => {
+                        let v: serde_json::Value = match serde_json::from_str(&text) {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+                        if let Some(addr) = v
+                            .get("accept")
+                            .and_then(|a| a.get("address"))
+                            .and_then(|s| s.as_str())
                         {
-                            tracing::warn!(error = %err, "verified relay rendezvous ended");
+                            let address = addr.to_owned();
+                            let local = local.clone();
+                            let ca = ca_pem.map(|c| c.to_vec());
+                            let verify = verify.clone();
+                            let ready = ready.clone();
+                            let Ok(slot) = rendezvous_slots.clone().try_acquire_owned() else {
+                                tracing::warn!("relay rendezvous concurrency bound reached");
+                                continue;
+                            };
+                            rendezvous_tasks.spawn(async move {
+                                let _slot = slot;
+                                if let Err(err) =
+                                    accept_one_verified(&address, &local, ca.as_deref(), verify, ready)
+                                        .await
+                                {
+                                    tracing::warn!(error = %err, "verified relay rendezvous ended");
+                                }
+                            });
                         }
-                    });
+                    }
+                    Message::Ping(p) => {
+                        tokio::select! {
+                            _ = wait_for_listener_cancellation(&mut cancellation) => {
+                                break 'control Ok(());
+                            }
+                            _ = sink.send(Message::Pong(p)) => {}
+                        }
+                    }
+                    Message::Close(_) => break 'control Ok(()),
+                    _ => {}
                 }
             }
-            Message::Ping(p) => {
-                let _ = sink.send(Message::Pong(p)).await;
+        }
+    };
+    rendezvous_tasks.cancel_and_join().await;
+    result
+}
+
+async fn wait_for_listener_cancellation(cancellation: &mut Option<watch::Receiver<bool>>) {
+    loop {
+        match cancellation {
+            Some(receiver) => {
+                if receiver.changed().await.is_err() || *receiver.borrow() {
+                    return;
+                }
             }
-            Message::Close(_) => return Ok(()),
-            _ => {}
+            None => std::future::pending::<()>().await,
         }
     }
-    Ok(())
 }
 
 async fn accept_one_verified(
@@ -719,7 +829,90 @@ pub async fn run_sender_with_prologue(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::pending;
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct PumpProbe {
+        active: Arc<AtomicUsize>,
+        stopped: Arc<AtomicUsize>,
+    }
+
+    impl PumpProbe {
+        fn new(active: &Arc<AtomicUsize>, stopped: &Arc<AtomicUsize>) -> Self {
+            active.fetch_add(1, Ordering::SeqCst);
+            Self {
+                active: Arc::clone(active),
+                stopped: Arc::clone(stopped),
+            }
+        }
+    }
+
+    impl Drop for PumpProbe {
+        fn drop(&mut self) {
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            self.stopped.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn parked_pump(probe: PumpProbe) {
+        let _probe = probe;
+        pending::<()>().await;
+    }
+
+    #[tokio::test]
+    async fn close_frame_stops_both_pump_directions_before_reconnect() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let stopped = Arc::new(AtomicUsize::new(0));
+        let mut owner = RendezvousTasks::default();
+        owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+        owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+        tokio::task::yield_now().await;
+        assert_eq!(active.load(Ordering::SeqCst), 2);
+
+        // The control-channel Close path uses this owner teardown before the
+        // listener returns to its reconnect loop.
+        owner.cancel_and_join().await;
+
+        assert!(owner.is_empty());
+        assert_eq!(stopped.load(Ordering::SeqCst), 2);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn session_cancellation_joins_every_rendezvous_task() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let stopped = Arc::new(AtomicUsize::new(0));
+        let mut owner = RendezvousTasks::default();
+        for _ in 0..3 {
+            owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+        }
+        tokio::task::yield_now().await;
+        owner.cancel_and_join().await;
+
+        assert!(owner.is_empty());
+        assert_eq!(stopped.load(Ordering::SeqCst), 3);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn second_bridge_starts_only_after_prior_local_session_stops() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let stopped = Arc::new(AtomicUsize::new(0));
+        let mut owner = RendezvousTasks::default();
+        owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+        tokio::task::yield_now().await;
+        assert_eq!(active.load(Ordering::SeqCst), 1);
+
+        owner.cancel_and_join().await;
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+
+        let second = PumpProbe::new(&active, &stopped);
+        assert_eq!(active.load(Ordering::SeqCst), 1);
+        drop(second);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
 
     #[test]
     fn extract_prologue_needs_full_length_prefix() {

--- a/packages/d2b-gateway-runtime/src/relay_bridge.rs
+++ b/packages/d2b-gateway-runtime/src/relay_bridge.rs
@@ -686,15 +686,15 @@ pub(crate) async fn run_listener_verified_with_ready_and_cancel(
                             .and_then(|a| a.get("address"))
                             .and_then(|s| s.as_str())
                         {
+                            let Ok(slot) = rendezvous_slots.clone().try_acquire_owned() else {
+                                tracing::warn!("relay rendezvous concurrency bound reached");
+                                continue;
+                            };
                             let address = addr.to_owned();
                             let local = local.clone();
                             let ca = ca_pem.map(|c| c.to_vec());
                             let verify = verify.clone();
                             let ready = ready.clone();
-                            let Ok(slot) = rendezvous_slots.clone().try_acquire_owned() else {
-                                tracing::warn!("relay rendezvous concurrency bound reached");
-                                continue;
-                            };
                             rendezvous_tasks.spawn(async move {
                                 let _slot = slot;
                                 if let Err(err) =

--- a/packages/d2b-gateway-runtime/src/relay_bridge.rs
+++ b/packages/d2b-gateway-runtime/src/relay_bridge.rs
@@ -20,11 +20,6 @@ use tokio::sync::{Semaphore, watch};
 use tokio::task::JoinSet;
 use tokio::time::{Duration, timeout};
 
-#[cfg(test)]
-use d2b_provider_transport_azure_relay::auth::{DEFAULT_SAS_TTL_SECS, MAX_SAS_TTL_SECS, mint_sas};
-#[cfg(test)]
-use std::time::{SystemTime, UNIX_EPOCH};
-
 pub type RelayStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
@@ -294,6 +289,11 @@ impl RendezvousTasks {
         self.tasks.is_empty()
     }
 
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.tasks.len()
+    }
+
     async fn reap_one(&mut self) {
         if let Some(Err(err)) = self.tasks.join_next().await
             && !err.is_cancelled()
@@ -312,6 +312,74 @@ impl RendezvousTasks {
             }
         }
     }
+}
+
+async fn run_listener_control_loop<S, K, F, Fut>(
+    stream: S,
+    mut sink: K,
+    mut cancellation: Option<watch::Receiver<bool>>,
+    mut spawn_rendezvous: F,
+) -> Result<(), RelayConnectError>
+where
+    S: futures_util::Stream<
+            Item = Result<tokio_tungstenite::tungstenite::Message, RelayConnectError>,
+        >,
+    K: futures_util::Sink<tokio_tungstenite::tungstenite::Message> + Unpin,
+    F: FnMut(String) -> Option<Fut>,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message;
+
+    let mut stream = Box::pin(stream);
+    let mut rendezvous_tasks = RendezvousTasks::default();
+    let result: Result<(), RelayConnectError> = 'control: loop {
+        tokio::select! {
+            biased;
+            _ = wait_for_listener_cancellation(&mut cancellation) => {
+                break 'control Ok(());
+            }
+            _ = rendezvous_tasks.reap_one(), if !rendezvous_tasks.is_empty() => {
+            }
+            msg = stream.next() => {
+                let Some(msg) = msg else {
+                    break 'control Ok(());
+                };
+                let msg = match msg {
+                    Ok(msg) => msg,
+                    Err(err) => break 'control Err(err),
+                };
+                match msg {
+                    Message::Text(text) => {
+                        let v: serde_json::Value = match serde_json::from_str(&text) {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+                        if let Some(addr) = v
+                            .get("accept")
+                            .and_then(|a| a.get("address"))
+                            .and_then(|s| s.as_str())
+                            && let Some(task) = spawn_rendezvous(addr.to_owned())
+                        {
+                            rendezvous_tasks.spawn(task);
+                        }
+                    }
+                    Message::Ping(p) => {
+                        tokio::select! {
+                            _ = wait_for_listener_cancellation(&mut cancellation) => {
+                                break 'control Ok(());
+                            }
+                            _ = sink.send(Message::Pong(p)) => {}
+                        }
+                    }
+                    Message::Close(_) => break 'control Ok(()),
+                    _ => {}
+                }
+            }
+        }
+    };
+    rendezvous_tasks.cancel_and_join().await;
+    result
 }
 
 /// Pump bytes between the relay WebSocket and a local stream until either
@@ -465,50 +533,24 @@ pub async fn run_listener(
     ttl_secs: u64,
     ca_pem: Option<&[u8]>,
 ) -> Result<(), RelayConnectError> {
-    use futures_util::{SinkExt, StreamExt};
-    use tokio_tungstenite::tungstenite::Message;
+    use futures_util::StreamExt;
 
     let control =
         connect_with_ca(endpoint, RelayRole::Listener, credential, ttl_secs, ca_pem).await?;
-    let (mut sink, mut stream) = control.split();
-    let mut rendezvous_tasks = RendezvousTasks::default();
-    let result = async {
-        while let Some(msg) = stream.next().await {
-            let msg =
-                msg.map_err(|err| RelayConnectError::Handshake(format!("control channel: {err}")))?;
-            match msg {
-                Message::Text(text) => {
-                    let v: serde_json::Value = match serde_json::from_str(&text) {
-                        Ok(v) => v,
-                        Err(_) => continue,
-                    };
-                    if let Some(addr) = v
-                        .get("accept")
-                        .and_then(|a| a.get("address"))
-                        .and_then(|s| s.as_str())
-                    {
-                        let address = addr.to_owned();
-                        let local = local.clone();
-                        let ca = ca_pem.map(|c| c.to_vec());
-                        rendezvous_tasks.spawn(async move {
-                            if let Err(err) = accept_one(&address, &local, ca.as_deref()).await {
-                                tracing::warn!(error = %err, "relay rendezvous ended");
-                            }
-                        });
-                    }
-                }
-                Message::Ping(p) => {
-                    let _ = sink.send(Message::Pong(p)).await;
-                }
-                Message::Close(_) => return Ok(()),
-                _ => {}
+    let (sink, stream) = control.split();
+    let stream = stream.map(|msg| {
+        msg.map_err(|err| RelayConnectError::Handshake(format!("control channel: {err}")))
+    });
+    run_listener_control_loop(stream, sink, None, |address| {
+        let local = local.clone();
+        let ca = ca_pem.map(|c| c.to_vec());
+        Some(async move {
+            if let Err(err) = accept_one(&address, &local, ca.as_deref()).await {
+                tracing::warn!(error = %err, "relay rendezvous ended");
             }
-        }
-        Ok(())
-    }
-    .await;
-    rendezvous_tasks.cancel_and_join().await;
-    result
+        })
+    })
+    .await
 }
 
 async fn accept_one(
@@ -635,8 +677,7 @@ pub(crate) async fn run_listener_verified_with_ready_and_cancel(
     ready: std::sync::Arc<dyn Fn() + Send + Sync>,
     mut cancellation: Option<watch::Receiver<bool>>,
 ) -> Result<(), RelayConnectError> {
-    use futures_util::{SinkExt, StreamExt};
-    use tokio_tungstenite::tungstenite::Message;
+    use futures_util::StreamExt;
 
     if cancellation
         .as_ref()
@@ -652,76 +693,30 @@ pub(crate) async fn run_listener_verified_with_ready_and_cancel(
             return Ok(());
         }
     };
-    let (mut sink, mut stream) = control.split();
+    let (sink, stream) = control.split();
     let rendezvous_slots = std::sync::Arc::new(Semaphore::new(MAX_PENDING_RENDEZVOUS));
-    let mut rendezvous_tasks = RendezvousTasks::default();
-    let result: Result<(), RelayConnectError> = 'control: loop {
-        tokio::select! {
-            biased;
-            _ = wait_for_listener_cancellation(&mut cancellation) => {
-                break 'control Ok(());
+    let stream = stream.map(|msg| {
+        msg.map_err(|err| RelayConnectError::Handshake(format!("control channel: {err}")))
+    });
+    run_listener_control_loop(stream, sink, cancellation, |address| {
+        let Ok(slot) = rendezvous_slots.clone().try_acquire_owned() else {
+            tracing::warn!("relay rendezvous concurrency bound reached");
+            return None;
+        };
+        let local = local.clone();
+        let ca = ca_pem.map(|c| c.to_vec());
+        let verify = verify.clone();
+        let ready = ready.clone();
+        Some(async move {
+            let _slot = slot;
+            if let Err(err) =
+                accept_one_verified(&address, &local, ca.as_deref(), verify, ready).await
+            {
+                tracing::warn!(error = %err, "verified relay rendezvous ended");
             }
-            _ = rendezvous_tasks.reap_one(), if !rendezvous_tasks.is_empty() => {
-            }
-            msg = stream.next() => {
-                let Some(msg) = msg else {
-                    break 'control Ok(());
-                };
-                let msg = match msg {
-                    Ok(msg) => msg,
-                    Err(err) => {
-                        break 'control Err(RelayConnectError::Handshake(format!(
-                            "control channel: {err}"
-                        )));
-                    }
-                };
-                match msg {
-                    Message::Text(text) => {
-                        let v: serde_json::Value = match serde_json::from_str(&text) {
-                            Ok(v) => v,
-                            Err(_) => continue,
-                        };
-                        if let Some(addr) = v
-                            .get("accept")
-                            .and_then(|a| a.get("address"))
-                            .and_then(|s| s.as_str())
-                        {
-                            let Ok(slot) = rendezvous_slots.clone().try_acquire_owned() else {
-                                tracing::warn!("relay rendezvous concurrency bound reached");
-                                continue;
-                            };
-                            let address = addr.to_owned();
-                            let local = local.clone();
-                            let ca = ca_pem.map(|c| c.to_vec());
-                            let verify = verify.clone();
-                            let ready = ready.clone();
-                            rendezvous_tasks.spawn(async move {
-                                let _slot = slot;
-                                if let Err(err) =
-                                    accept_one_verified(&address, &local, ca.as_deref(), verify, ready)
-                                        .await
-                                {
-                                    tracing::warn!(error = %err, "verified relay rendezvous ended");
-                                }
-                            });
-                        }
-                    }
-                    Message::Ping(p) => {
-                        tokio::select! {
-                            _ = wait_for_listener_cancellation(&mut cancellation) => {
-                                break 'control Ok(());
-                            }
-                            _ = sink.send(Message::Pong(p)) => {}
-                        }
-                    }
-                    Message::Close(_) => break 'control Ok(()),
-                    _ => {}
-                }
-            }
-        }
-    };
-    rendezvous_tasks.cancel_and_join().await;
-    result
+        })
+    })
+    .await
 }
 
 async fn wait_for_listener_cancellation(cancellation: &mut Option<watch::Receiver<bool>>) {
@@ -827,341 +822,4 @@ pub async fn run_sender_with_prologue(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::future::pending;
-    use std::os::unix::fs::PermissionsExt;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    struct PumpProbe {
-        active: Arc<AtomicUsize>,
-        stopped: Arc<AtomicUsize>,
-    }
-
-    impl PumpProbe {
-        fn new(active: &Arc<AtomicUsize>, stopped: &Arc<AtomicUsize>) -> Self {
-            active.fetch_add(1, Ordering::SeqCst);
-            Self {
-                active: Arc::clone(active),
-                stopped: Arc::clone(stopped),
-            }
-        }
-    }
-
-    impl Drop for PumpProbe {
-        fn drop(&mut self) {
-            self.active.fetch_sub(1, Ordering::SeqCst);
-            self.stopped.fetch_add(1, Ordering::SeqCst);
-        }
-    }
-
-    async fn parked_pump(probe: PumpProbe) {
-        let _probe = probe;
-        pending::<()>().await;
-    }
-
-    #[tokio::test]
-    async fn close_frame_stops_both_pump_directions_before_reconnect() {
-        let active = Arc::new(AtomicUsize::new(0));
-        let stopped = Arc::new(AtomicUsize::new(0));
-        let mut owner = RendezvousTasks::default();
-        owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
-        owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
-        tokio::task::yield_now().await;
-        assert_eq!(active.load(Ordering::SeqCst), 2);
-
-        // The control-channel Close path uses this owner teardown before the
-        // listener returns to its reconnect loop.
-        owner.cancel_and_join().await;
-
-        assert!(owner.is_empty());
-        assert_eq!(stopped.load(Ordering::SeqCst), 2);
-        assert_eq!(active.load(Ordering::SeqCst), 0);
-    }
-
-    #[tokio::test]
-    async fn session_cancellation_joins_every_rendezvous_task() {
-        let active = Arc::new(AtomicUsize::new(0));
-        let stopped = Arc::new(AtomicUsize::new(0));
-        let mut owner = RendezvousTasks::default();
-        for _ in 0..3 {
-            owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
-        }
-        tokio::task::yield_now().await;
-        owner.cancel_and_join().await;
-
-        assert!(owner.is_empty());
-        assert_eq!(stopped.load(Ordering::SeqCst), 3);
-        assert_eq!(active.load(Ordering::SeqCst), 0);
-    }
-
-    #[tokio::test]
-    async fn second_bridge_starts_only_after_prior_local_session_stops() {
-        let active = Arc::new(AtomicUsize::new(0));
-        let stopped = Arc::new(AtomicUsize::new(0));
-        let mut owner = RendezvousTasks::default();
-        owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
-        tokio::task::yield_now().await;
-        assert_eq!(active.load(Ordering::SeqCst), 1);
-
-        owner.cancel_and_join().await;
-        assert_eq!(active.load(Ordering::SeqCst), 0);
-
-        let second = PumpProbe::new(&active, &stopped);
-        assert_eq!(active.load(Ordering::SeqCst), 1);
-        drop(second);
-        assert_eq!(active.load(Ordering::SeqCst), 0);
-    }
-
-    #[test]
-    fn extract_prologue_needs_full_length_prefix() {
-        // Fewer than 4 bytes -> need more.
-        assert_eq!(extract_prologue_frame(&[0, 0]).unwrap(), None);
-    }
-
-    #[test]
-    fn extract_prologue_waits_for_full_body() {
-        // length=5 but only 3 body bytes present -> need more.
-        let mut buf = (5u32).to_be_bytes().to_vec();
-        buf.extend_from_slice(b"abc");
-        assert_eq!(extract_prologue_frame(&buf).unwrap(), None);
-    }
-
-    #[test]
-    fn extract_prologue_returns_frame_and_consumed() {
-        let mut buf = (5u32).to_be_bytes().to_vec();
-        buf.extend_from_slice(b"hello");
-        buf.extend_from_slice(b"LEFTOVER");
-        let (frame, consumed) = extract_prologue_frame(&buf).unwrap().unwrap();
-        assert_eq!(frame, b"hello");
-        assert_eq!(consumed, 9); // 4 + 5
-        assert_eq!(&buf[consumed..], b"LEFTOVER");
-    }
-
-    #[test]
-    fn extract_prologue_rejects_oversize() {
-        let buf = (u32::MAX).to_be_bytes().to_vec();
-        assert!(extract_prologue_frame(&buf).is_err());
-    }
-
-    fn endpoint() -> RelayEndpoint {
-        RelayEndpoint {
-            namespace: "relns-test.servicebus.windows.net".into(),
-            entity: "hc-d2b-display".into(),
-        }
-    }
-
-    fn now_unix_secs() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-    }
-
-    fn sas_param<'a>(token: &'a str, name: &str) -> &'a str {
-        let prefix = format!("{name}=");
-        token
-            .strip_prefix("SharedAccessSignature ")
-            .unwrap()
-            .split('&')
-            .find_map(|part| part.strip_prefix(&prefix))
-            .unwrap()
-    }
-
-    #[test]
-    fn mint_sas_is_deterministic_for_fixed_inputs_modulo_expiry() {
-        let ep = endpoint();
-        let a = mint_sas(&ep, "gateway-listen", "c2VjcmV0a2V5", DEFAULT_SAS_TTL_SECS).unwrap();
-        // Shape: a SharedAccessSignature with sr/sig/se/skn.
-        assert!(a.starts_with("SharedAccessSignature sr="));
-        assert!(a.contains("&skn=gateway-listen"));
-        assert!(a.contains("&sig="));
-        assert!(a.contains("&se="));
-        // The resource is the lowercased url-encoded http form of the entity.
-        assert!(a.contains("relns-test.servicebus.windows.net"));
-    }
-
-    #[test]
-    fn mint_sas_rejects_ttl_above_short_lived_cap() {
-        let ep = endpoint();
-        assert_eq!(
-            mint_sas(&ep, "gateway-send", "c2VjcmV0a2V5", MAX_SAS_TTL_SECS + 1).unwrap_err(),
-            RelayError::TtlTooLong {
-                requested: MAX_SAS_TTL_SECS + 1,
-                max: MAX_SAS_TTL_SECS
-            }
-        );
-    }
-
-    #[test]
-    fn mint_sas_expiry_matches_requested_short_ttl() {
-        let ep = endpoint();
-        let ttl = 60;
-        let before = now_unix_secs();
-        let token = mint_sas(&ep, "gateway-send", "c2VjcmV0a2V5", ttl).unwrap();
-        let after = now_unix_secs();
-        let expiry = sas_param(&token, "se").parse::<u64>().unwrap();
-        assert!(expiry >= before + ttl);
-        assert!(expiry <= after + ttl);
-        assert!(expiry <= before + MAX_SAS_TTL_SECS);
-    }
-
-    #[test]
-    fn entra_sender_uses_header_not_url_token() {
-        let ep = endpoint();
-        let cred = RelayCredential::EntraBearer("jwt.abc.def".into());
-        let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
-        // The bearer NEVER appears in the URL.
-        assert!(!c.url.contains("jwt.abc.def"));
-        assert!(!c.url.contains("sb-hc-token"));
-        assert!(c.url.contains("sb-hc-action=connect"));
-        // The sender omits sb-hc-id; the relay generates the rendezvous GUID.
-        assert!(!c.url.contains("sb-hc-id="));
-        let scheme: String = ['B', 'e', 'a', 'r', 'e', 'r'].into_iter().collect();
-        let expected = format!("{scheme} jwt.abc.def");
-        assert_eq!(c.auth_header.as_deref(), Some(expected.as_str()));
-    }
-
-    #[test]
-    fn sas_listener_puts_token_in_url_and_no_header() {
-        let ep = endpoint();
-        let cred = RelayCredential::Sas {
-            key_name: "gateway-listen".into(),
-            key: "c2VjcmV0a2V5".into(),
-        };
-        let c = build_connect(&ep, RelayRole::Listener, &cred, DEFAULT_SAS_TTL_SECS).unwrap();
-        assert!(c.url.contains("sb-hc-action=listen"));
-        assert!(c.url.contains("sb-hc-token="));
-        assert!(!c.url.contains("sb-hc-id=")); // listener has no rendezvous id
-        assert!(c.auth_header.is_none());
-    }
-
-    #[test]
-    fn build_connect_rejects_sas_ttl_above_short_lived_cap() {
-        let ep = endpoint();
-        let cred = RelayCredential::Sas {
-            key_name: "gateway-listen".into(),
-            key: "c2VjcmV0a2V5".into(),
-        };
-        assert!(matches!(
-            build_connect(&ep, RelayRole::Listener, &cred, MAX_SAS_TTL_SECS + 1),
-            Err(RelayError::TtlTooLong { .. })
-        ));
-    }
-
-    #[test]
-    fn credential_debug_redacts_secrets() {
-        let sas = RelayCredential::Sas {
-            key_name: "gateway-send".into(),
-            key: "supersecretkey".into(),
-        };
-        let d = format!("{sas:?}");
-        assert!(d.contains("gateway-send"));
-        assert!(!d.contains("supersecretkey"));
-        let bearer = RelayCredential::EntraBearer("jwt.secret.token".into());
-        let d = format!("{bearer:?}");
-        assert!(!d.contains("jwt.secret.token"));
-        let token = RelayCredential::SasToken("SharedAccessSignature secret".into());
-        let d = format!("{token:?}");
-        assert!(!d.contains("SharedAccessSignature secret"));
-    }
-
-    #[test]
-    fn pre_minted_sas_sender_puts_token_in_url_without_key() {
-        let ep = endpoint();
-        let cred = RelayCredential::SasToken("SharedAccessSignature sr=x&sig=y".into());
-        let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
-        assert!(c.url.contains("sb-hc-action=connect"));
-        assert!(c.url.contains("sb-hc-token="));
-        assert!(!c.url.contains("sb-hc-id="));
-        assert!(c.auth_header.is_none());
-    }
-
-    #[test]
-    fn connect_debug_redacts_preminted_sas_query_token() {
-        let ep = endpoint();
-        let secret_token =
-            "SharedAccessSignature sr=x&sig=very-secret-signature&se=123&skn=gateway-send";
-        let cred = RelayCredential::SasToken(secret_token.into());
-        let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
-        let d = format!("{c:?}");
-        assert!(!d.contains("SharedAccessSignature"));
-        assert!(!d.contains("very-secret-signature"));
-        assert!(d.contains("?<redacted>"));
-    }
-
-    #[test]
-    fn connect_debug_redacts_url_query_and_header() {
-        let ep = endpoint();
-        let cred = RelayCredential::EntraBearer("jwt.abc.def".into());
-        let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
-        let d = format!("{c:?}");
-        assert!(!d.contains("jwt.abc.def"));
-        assert!(!d.contains("Bearer"));
-        assert!(d.contains("<redacted>"));
-    }
-
-    #[test]
-    fn unsolicited_bridge_ack_cannot_create_credit() {
-        let mut available = 0;
-        let mut in_flight = 0;
-        acknowledge_bridge_credit(&mut available, &mut in_flight, 4096);
-        assert_eq!((available, in_flight), (0, 0));
-
-        available = BRIDGE_CREDIT_BYTES - 1024;
-        in_flight = 1024;
-        acknowledge_bridge_credit(&mut available, &mut in_flight, 4096);
-        assert_eq!((available, in_flight), (BRIDGE_CREDIT_BYTES, 0));
-    }
-
-    #[test]
-    fn local_target_parses_each_form() {
-        assert!(matches!(
-            LocalTarget::parse("unix-listen:/run/wp.sock"),
-            LocalTarget::UnixListen(p) if p == "/run/wp.sock"
-        ));
-        assert!(matches!(
-            LocalTarget::parse("unix:/run/wpc.sock"),
-            LocalTarget::UnixConnect(p) if p == "/run/wpc.sock"
-        ));
-        assert!(matches!(
-            LocalTarget::parse("tcp:127.0.0.1:8080"),
-            LocalTarget::TcpConnect(a) if a == "127.0.0.1:8080"
-        ));
-        assert!(matches!(
-            LocalTarget::parse("127.0.0.1:9000"),
-            LocalTarget::TcpConnect(a) if a == "127.0.0.1:9000"
-        ));
-    }
-
-    #[test]
-    fn checked_unix_target_revalidates_owner_and_mode() {
-        let dir = tempfile::tempdir().unwrap();
-        let socket_path = dir.path().join("wpc.sock");
-        let _listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
-        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        let meta = std::fs::symlink_metadata(&socket_path).unwrap();
-        let path = socket_path.to_string_lossy().into_owned();
-        open_checked_unix_socket_target(&path, meta.uid(), 0o600).unwrap();
-        open_checked_unix_socket_target(&path, meta.uid(), 0o660).unwrap_err();
-
-        let link_path = dir.path().join("link.sock");
-        std::os::unix::fs::symlink(&socket_path, &link_path).unwrap();
-        open_checked_unix_socket_target(&link_path.to_string_lossy(), meta.uid(), 0o600)
-            .unwrap_err();
-    }
-
-    #[tokio::test]
-    async fn checked_unix_target_validates_connected_peer_uid() {
-        let dir = tempfile::tempdir().unwrap();
-        let socket_path = dir.path().join("wpc.sock");
-        let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
-        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        let meta = std::fs::symlink_metadata(&socket_path).unwrap();
-        let stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
-        let (_accepted, _) = listener.accept().await.unwrap();
-        validate_connected_unix_peer(&stream, meta.uid()).unwrap();
-        validate_connected_unix_peer(&stream, meta.uid().saturating_add(1)).unwrap_err();
-    }
-}
+mod tests;

--- a/packages/d2b-gateway-runtime/src/relay_bridge/tests.rs
+++ b/packages/d2b-gateway-runtime/src/relay_bridge/tests.rs
@@ -1,0 +1,445 @@
+use super::*;
+use d2b_provider_transport_azure_relay::auth::{DEFAULT_SAS_TTL_SECS, MAX_SAS_TTL_SECS, mint_sas};
+use futures_util::sink::drain;
+use std::future::pending;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::AsyncReadExt;
+use tokio_tungstenite::tungstenite::Message;
+
+struct PumpProbe {
+    active: Arc<AtomicUsize>,
+    stopped: Arc<AtomicUsize>,
+}
+
+impl PumpProbe {
+    fn new(active: &Arc<AtomicUsize>, stopped: &Arc<AtomicUsize>) -> Self {
+        active.fetch_add(1, Ordering::SeqCst);
+        Self {
+            active: Arc::clone(active),
+            stopped: Arc::clone(stopped),
+        }
+    }
+}
+
+impl Drop for PumpProbe {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        self.stopped.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+async fn parked_pump(probe: PumpProbe) {
+    let _probe = probe;
+    pending::<()>().await;
+}
+
+#[tokio::test]
+async fn completed_rendezvous_tasks_are_reaped_while_control_stays_open() {
+    let completed = Arc::new(AtomicUsize::new(0));
+    let mut owner = RendezvousTasks::default();
+    for _ in 0..8 {
+        let completed = Arc::clone(&completed);
+        owner.spawn(async move {
+            completed.fetch_add(1, Ordering::SeqCst);
+        });
+    }
+    while completed.load(Ordering::SeqCst) != 8 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(owner.len(), 8);
+
+    while !owner.is_empty() {
+        owner.reap_one().await;
+    }
+
+    assert_eq!(owner.len(), 0);
+}
+
+#[tokio::test]
+async fn control_close_joins_before_second_bridge_can_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("display.sock");
+    let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+    let (control_tx, control_rx) =
+        tokio::sync::mpsc::unbounded_channel::<Result<Message, RelayConnectError>>();
+    let control = futures_util::stream::unfold(control_rx, |mut receiver| async move {
+        receiver.recv().await.map(|message| (message, receiver))
+    });
+    let task_socket_path = socket_path.clone();
+    let control_task = tokio::spawn(run_listener_control_loop(
+        control,
+        drain(),
+        None,
+        move |_address| {
+            let socket_path = task_socket_path.clone();
+            Some(async move {
+                let _local = tokio::net::UnixStream::connect(socket_path).await.unwrap();
+                pending::<()>().await;
+            })
+        },
+    ));
+
+    control_tx
+        .send(Ok(Message::Text(
+            r#"{"accept":{"address":"local-test"}}"#.into(),
+        )))
+        .unwrap();
+    let (mut first_local, _) = timeout(Duration::from_secs(1), listener.accept())
+        .await
+        .unwrap()
+        .unwrap();
+
+    control_tx.send(Ok(Message::Close(None))).unwrap();
+    control_task.await.unwrap().unwrap();
+
+    let mut byte = [0u8; 1];
+    assert_eq!(
+        timeout(Duration::from_secs(1), first_local.read(&mut byte))
+            .await
+            .unwrap()
+            .unwrap(),
+        0
+    );
+
+    let second_local = tokio::net::UnixStream::connect(&socket_path)
+        .await
+        .unwrap();
+    let _second_session = timeout(Duration::from_secs(1), listener.accept())
+        .await
+        .unwrap()
+        .unwrap();
+    drop(second_local);
+}
+
+#[tokio::test]
+async fn control_error_joins_active_rendezvous_tasks() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let stopped = Arc::new(AtomicUsize::new(0));
+    let control = futures_util::stream::iter([
+        Ok(Message::Text(
+            r#"{"accept":{"address":"local-test"}}"#.into(),
+        )),
+        Err(RelayConnectError::Handshake("control closed".into())),
+    ]);
+    let active_for_spawn = Arc::clone(&active);
+    let stopped_for_spawn = Arc::clone(&stopped);
+
+    let err = run_listener_control_loop(control, drain(), None, move |_address| {
+        Some(parked_pump(PumpProbe::new(
+            &active_for_spawn,
+            &stopped_for_spawn,
+        )))
+    })
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, RelayConnectError::Handshake(_)));
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+    assert_eq!(stopped.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn close_frame_stops_both_pump_directions_before_reconnect() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let stopped = Arc::new(AtomicUsize::new(0));
+    let mut owner = RendezvousTasks::default();
+    owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+    owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+    tokio::task::yield_now().await;
+    assert_eq!(active.load(Ordering::SeqCst), 2);
+
+    // The control-channel Close path uses this owner teardown before the
+    // listener returns to its reconnect loop.
+    owner.cancel_and_join().await;
+
+    assert!(owner.is_empty());
+    assert_eq!(stopped.load(Ordering::SeqCst), 2);
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn session_cancellation_joins_every_rendezvous_task() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let stopped = Arc::new(AtomicUsize::new(0));
+    let mut owner = RendezvousTasks::default();
+    for _ in 0..3 {
+        owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+    }
+    tokio::task::yield_now().await;
+    owner.cancel_and_join().await;
+
+    assert!(owner.is_empty());
+    assert_eq!(stopped.load(Ordering::SeqCst), 3);
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn second_bridge_starts_only_after_prior_local_session_stops() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let stopped = Arc::new(AtomicUsize::new(0));
+    let mut owner = RendezvousTasks::default();
+    owner.spawn(parked_pump(PumpProbe::new(&active, &stopped)));
+    tokio::task::yield_now().await;
+    assert_eq!(active.load(Ordering::SeqCst), 1);
+
+    owner.cancel_and_join().await;
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+
+    let second = PumpProbe::new(&active, &stopped);
+    assert_eq!(active.load(Ordering::SeqCst), 1);
+    drop(second);
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn extract_prologue_needs_full_length_prefix() {
+    // Fewer than 4 bytes -> need more.
+    assert_eq!(extract_prologue_frame(&[0, 0]).unwrap(), None);
+}
+
+#[test]
+fn extract_prologue_waits_for_full_body() {
+    // length=5 but only 3 body bytes present -> need more.
+    let mut buf = (5u32).to_be_bytes().to_vec();
+    buf.extend_from_slice(b"abc");
+    assert_eq!(extract_prologue_frame(&buf).unwrap(), None);
+}
+
+#[test]
+fn extract_prologue_returns_frame_and_consumed() {
+    let mut buf = (5u32).to_be_bytes().to_vec();
+    buf.extend_from_slice(b"hello");
+    buf.extend_from_slice(b"LEFTOVER");
+    let (frame, consumed) = extract_prologue_frame(&buf).unwrap().unwrap();
+    assert_eq!(frame, b"hello");
+    assert_eq!(consumed, 9); // 4 + 5
+    assert_eq!(&buf[consumed..], b"LEFTOVER");
+}
+
+#[test]
+fn extract_prologue_rejects_oversize() {
+    let buf = (u32::MAX).to_be_bytes().to_vec();
+    assert!(extract_prologue_frame(&buf).is_err());
+}
+
+fn endpoint() -> RelayEndpoint {
+    RelayEndpoint {
+        namespace: "relns-test.servicebus.windows.net".into(),
+        entity: "hc-d2b-display".into(),
+    }
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn sas_param<'a>(token: &'a str, name: &str) -> &'a str {
+    let prefix = format!("{name}=");
+    token
+        .strip_prefix("SharedAccessSignature ")
+        .unwrap()
+        .split('&')
+        .find_map(|part| part.strip_prefix(&prefix))
+        .unwrap()
+}
+
+#[test]
+fn mint_sas_is_deterministic_for_fixed_inputs_modulo_expiry() {
+    let ep = endpoint();
+    let a = mint_sas(&ep, "gateway-listen", "c2VjcmV0a2V5", DEFAULT_SAS_TTL_SECS).unwrap();
+    // Shape: a SharedAccessSignature with sr/sig/se/skn.
+    assert!(a.starts_with("SharedAccessSignature sr="));
+    assert!(a.contains("&skn=gateway-listen"));
+    assert!(a.contains("&sig="));
+    assert!(a.contains("&se="));
+    // The resource is the lowercased url-encoded http form of the entity.
+    assert!(a.contains("relns-test.servicebus.windows.net"));
+}
+
+#[test]
+fn mint_sas_rejects_ttl_above_short_lived_cap() {
+    let ep = endpoint();
+    assert_eq!(
+        mint_sas(&ep, "gateway-send", "c2VjcmV0a2V5", MAX_SAS_TTL_SECS + 1).unwrap_err(),
+        RelayError::TtlTooLong {
+            requested: MAX_SAS_TTL_SECS + 1,
+            max: MAX_SAS_TTL_SECS
+        }
+    );
+}
+
+#[test]
+fn mint_sas_expiry_matches_requested_short_ttl() {
+    let ep = endpoint();
+    let ttl = 60;
+    let before = now_unix_secs();
+    let token = mint_sas(&ep, "gateway-send", "c2VjcmV0a2V5", ttl).unwrap();
+    let after = now_unix_secs();
+    let expiry = sas_param(&token, "se").parse::<u64>().unwrap();
+    assert!(expiry >= before + ttl);
+    assert!(expiry <= after + ttl);
+    assert!(expiry <= before + MAX_SAS_TTL_SECS);
+}
+
+#[test]
+fn entra_sender_uses_header_not_url_token() {
+    let ep = endpoint();
+    let cred = RelayCredential::EntraBearer("jwt.abc.def".into());
+    let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
+    // The bearer NEVER appears in the URL.
+    assert!(!c.url.contains("jwt.abc.def"));
+    assert!(!c.url.contains("sb-hc-token"));
+    assert!(c.url.contains("sb-hc-action=connect"));
+    // The sender omits sb-hc-id; the relay generates the rendezvous GUID.
+    assert!(!c.url.contains("sb-hc-id="));
+    let scheme: String = ['B', 'e', 'a', 'r', 'e', 'r'].into_iter().collect();
+    let expected = format!("{scheme} jwt.abc.def");
+    assert_eq!(c.auth_header.as_deref(), Some(expected.as_str()));
+}
+
+#[test]
+fn sas_listener_puts_token_in_url_and_no_header() {
+    let ep = endpoint();
+    let cred = RelayCredential::Sas {
+        key_name: "gateway-listen".into(),
+        key: "c2VjcmV0a2V5".into(),
+    };
+    let c = build_connect(&ep, RelayRole::Listener, &cred, DEFAULT_SAS_TTL_SECS).unwrap();
+    assert!(c.url.contains("sb-hc-action=listen"));
+    assert!(c.url.contains("sb-hc-token="));
+    assert!(!c.url.contains("sb-hc-id=")); // listener has no rendezvous id
+    assert!(c.auth_header.is_none());
+}
+
+#[test]
+fn build_connect_rejects_sas_ttl_above_short_lived_cap() {
+    let ep = endpoint();
+    let cred = RelayCredential::Sas {
+        key_name: "gateway-listen".into(),
+        key: "c2VjcmV0a2V5".into(),
+    };
+    assert!(matches!(
+        build_connect(&ep, RelayRole::Listener, &cred, MAX_SAS_TTL_SECS + 1),
+        Err(RelayError::TtlTooLong { .. })
+    ));
+}
+
+#[test]
+fn credential_debug_redacts_secrets() {
+    let sas = RelayCredential::Sas {
+        key_name: "gateway-send".into(),
+        key: "supersecretkey".into(),
+    };
+    let d = format!("{sas:?}");
+    assert!(d.contains("gateway-send"));
+    assert!(!d.contains("supersecretkey"));
+    let bearer = RelayCredential::EntraBearer("jwt.secret.token".into());
+    let d = format!("{bearer:?}");
+    assert!(!d.contains("jwt.secret.token"));
+    let token = RelayCredential::SasToken("SharedAccessSignature secret".into());
+    let d = format!("{token:?}");
+    assert!(!d.contains("SharedAccessSignature secret"));
+}
+
+#[test]
+fn pre_minted_sas_sender_puts_token_in_url_without_key() {
+    let ep = endpoint();
+    let cred = RelayCredential::SasToken("SharedAccessSignature sr=x&sig=y".into());
+    let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
+    assert!(c.url.contains("sb-hc-action=connect"));
+    assert!(c.url.contains("sb-hc-token="));
+    assert!(!c.url.contains("sb-hc-id="));
+    assert!(c.auth_header.is_none());
+}
+
+#[test]
+fn connect_debug_redacts_preminted_sas_query_token() {
+    let ep = endpoint();
+    let secret_token =
+        "SharedAccessSignature sr=x&sig=very-secret-signature&se=123&skn=gateway-send";
+    let cred = RelayCredential::SasToken(secret_token.into());
+    let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
+    let d = format!("{c:?}");
+    assert!(!d.contains("SharedAccessSignature"));
+    assert!(!d.contains("very-secret-signature"));
+    assert!(d.contains("?<redacted>"));
+}
+
+#[test]
+fn connect_debug_redacts_url_query_and_header() {
+    let ep = endpoint();
+    let cred = RelayCredential::EntraBearer("jwt.abc.def".into());
+    let c = build_connect(&ep, RelayRole::Sender, &cred, 3600).unwrap();
+    let d = format!("{c:?}");
+    assert!(!d.contains("jwt.abc.def"));
+    assert!(!d.contains("Bearer"));
+    assert!(d.contains("<redacted>"));
+}
+
+#[test]
+fn unsolicited_bridge_ack_cannot_create_credit() {
+    let mut available = 0;
+    let mut in_flight = 0;
+    acknowledge_bridge_credit(&mut available, &mut in_flight, 4096);
+    assert_eq!((available, in_flight), (0, 0));
+
+    available = BRIDGE_CREDIT_BYTES - 1024;
+    in_flight = 1024;
+    acknowledge_bridge_credit(&mut available, &mut in_flight, 4096);
+    assert_eq!((available, in_flight), (BRIDGE_CREDIT_BYTES, 0));
+}
+
+#[test]
+fn local_target_parses_each_form() {
+    assert!(matches!(
+        LocalTarget::parse("unix-listen:/run/wp.sock"),
+        LocalTarget::UnixListen(p) if p == "/run/wp.sock"
+    ));
+    assert!(matches!(
+        LocalTarget::parse("unix:/run/wpc.sock"),
+        LocalTarget::UnixConnect(p) if p == "/run/wpc.sock"
+    ));
+    assert!(matches!(
+        LocalTarget::parse("tcp:127.0.0.1:8080"),
+        LocalTarget::TcpConnect(a) if a == "127.0.0.1:8080"
+    ));
+    assert!(matches!(
+        LocalTarget::parse("127.0.0.1:9000"),
+        LocalTarget::TcpConnect(a) if a == "127.0.0.1:9000"
+    ));
+}
+
+#[test]
+fn checked_unix_target_revalidates_owner_and_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("wpc.sock");
+    let _listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
+    std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    let meta = std::fs::symlink_metadata(&socket_path).unwrap();
+    let path = socket_path.to_string_lossy().into_owned();
+    open_checked_unix_socket_target(&path, meta.uid(), 0o600).unwrap();
+    open_checked_unix_socket_target(&path, meta.uid(), 0o660).unwrap_err();
+
+    let link_path = dir.path().join("link.sock");
+    std::os::unix::fs::symlink(&socket_path, &link_path).unwrap();
+    open_checked_unix_socket_target(&link_path.to_string_lossy(), meta.uid(), 0o600).unwrap_err();
+}
+
+#[tokio::test]
+async fn checked_unix_target_validates_connected_peer_uid() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("wpc.sock");
+    let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+    std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    let meta = std::fs::symlink_metadata(&socket_path).unwrap();
+    let stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+    let (_accepted, _) = listener.accept().await.unwrap();
+    validate_connected_unix_peer(&stream, meta.uid()).unwrap();
+    validate_connected_unix_peer(&stream, meta.uid().saturating_add(1)).unwrap_err();
+}

--- a/packages/d2b-gateway-runtime/src/relay_bridge/tests.rs
+++ b/packages/d2b-gateway-runtime/src/relay_bridge/tests.rs
@@ -6,7 +6,6 @@ use std::os::unix::fs::PermissionsExt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::io::AsyncReadExt;
 use tokio_tungstenite::tungstenite::Message;
 
 struct PumpProbe {
@@ -97,10 +96,7 @@ async fn control_close_joins_before_second_bridge_can_start() {
 
     let mut byte = [0u8; 1];
     assert_eq!(
-        timeout(Duration::from_secs(1), first_local.read(&mut byte))
-            .await
-            .unwrap()
-            .unwrap(),
+        first_local.try_read(&mut byte).unwrap(),
         0
     );
 


### PR DESCRIPTION
## Summary

Relay display reconnects now stop every accepted pump before the listener returns, so a later session cannot overlap stale Waypipe traffic.

- Own rendezvous tasks in the listener control loop and reap completed work while the control channel stays open.
- Route Close, cancellation, EOF, and control errors through one teardown path that aborts and joins remaining tasks.
- Join the listener runtime thread during close, and reserve bounded rendezvous capacity before cloning per-session inputs.
- Preserve Relay authentication, verifier readiness, socket ownership checks, redacted errors, and existing retry behavior.

## Validation

- `tests/tools/bazel-check --profile local -- //packages/d2b-gateway-runtime:d2b_gateway_runtime_test`
- Fresh independent code review after rebasing onto the current `v3` head: no actionable findings.

Fixes #453
