### PR TITLE
fix(tests): keep repository-wide policy to four classes

### DIFF
--- a/bazel/checks/policy/BUILD.bazel
+++ b/bazel/checks/policy/BUILD.bazel
@@ -2,7 +2,10 @@ package(default_visibility = ["//visibility:public"])
 
 test_suite(
     name = "source_hygiene",
-    tests = ["//bazel/checks/meta:tier0"],
+    tests = [
+        "//bazel/checks/meta:tier0",
+        "//tests/tools/no-bash-ast-walker:no_bash_ast_test",
+    ],
 )
 
 test_suite(
@@ -21,20 +24,9 @@ test_suite(
 )
 
 test_suite(
-    name = "rust_policy",
-    tests = [
-        "//packages/d2b:stub_no_socket",
-        "//packages/d2bd:stub_no_socket",
-        "//packages/xtask:schema_reproducibility_test",
-        "//tests/tools/no-bash-ast-walker:no_bash_ast_test",
-    ],
-)
-
-test_suite(
     name = "policy",
     tests = [
         ":changelog",
-        ":rust_policy",
         ":source_hygiene",
         ":supply_chain",
         ":workspace_lock",

--- a/changelog.d/issue-452-policy-classes.md
+++ b/changelog.d/issue-452-policy-classes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Keep the Bazel policy aggregate limited to source hygiene, workspace and
+  lock integrity, supply chain, and changelog policy while retaining
+  owner-local Rust and schema checks.

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -165,6 +165,7 @@ test_suite(
         ":gen_resource_schemas_drift",
         ":gen_resource_ttrpc_drift",
         ":gen_schemas_drift",
+        ":schema_reproducibility_test",
         ":gen_semantic_service_schemas_drift",
         ":gen_zone_nix_options_drift",
         ":gen_zone_schemas_drift",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -47,14 +47,6 @@ without the enforcing lane's declared environment fails rather than skipping.
 Repository-wide policy is limited to source hygiene, workspace and lock
 integrity, supply chain, and changelog policy.
 
-`test-policy` also runs `guest-workspace-drift`. It fails when the guest crates
-copied by `mkGuestRustPackagesSrc` diverge from
-`tests/fixtures/guest-rust-workspace/Cargo.toml`, its per-crate
-`*.Cargo.toml` overrides, or `packages/Cargo.guest.lock`. If a shared crate
-mirrored into the guest workspace gains or changes a dependency, update the
-fixture and any affected override, refresh `packages/Cargo.guest.lock`, then
-run `make test-policy`.
-
 ### Layer 2 - integration tiers (only when Layer 1 genuinely can't cover it)
 
 | # | Type | What it is | Lives in | Runs **where** |

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,16 +78,6 @@ labels. Cargo manifests and `Cargo.lock` remain rules_rs metadata authority,
 while standalone crate Cargo commands are not documented or required gate
 evidence.
 
-`make test-policy` includes the fail-closed `guest-workspace-drift` guard. The
-guard checks that the crates copied by `mkGuestRustPackagesSrc`, the members and
-workspace dependencies in
-`tests/fixtures/guest-rust-workspace/Cargo.toml`, any
-`tests/fixtures/guest-rust-workspace/*.Cargo.toml` overrides, and
-`packages/Cargo.guest.lock` remain one resolvable locked workspace. When a
-mirrored shared crate gains or changes a dependency, update the guest workspace
-fixture and any affected override, refresh `packages/Cargo.guest.lock`, and run
-`make test-policy`.
-
 All Layer-2 lanes (types 9-11) run behind one sole-use semaphore (two slots
 per uid via open file description locks), so concurrent heavy lanes cannot
 oversubscribe the shared Nix store, Bazel output tree, or KVM device. The


### PR DESCRIPTION
## Summary

The repository-wide policy aggregate now contains only the four documented classes: source hygiene, workspace and lock integrity, supply chain, and changelog policy. Checks removed with `rust_policy` remain enforced through their owner-local Rust and drift targets or through source hygiene. Stale guest workspace drift guidance is removed instead of preserving an incorrect `make test-policy` claim.

Fixes #452

## Validation

- `make test-policy`
- `tests/tools/bazel-check --profile remote -- //packages/d2b:stub_no_socket //packages/d2bd:stub_no_socket //packages/xtask:schema_reproducibility_test //tests/tools/no-bash-ast-walker:no_bash_ast_test`
- Bazel topology queries confirmed exactly four direct policy classes and owner-local reachability for every removed member.
- Independent code review found no actionable findings on the current reviewed head.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This change only updates repository test aggregation and contributor documentation; CI remains the enforcement signal.
