### PR TITLE
tests: make test-lint fail closed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,10 @@ installed; Make selects the pinned shell and preserves those profile and trust
 variables. Cargo manifests and `Cargo.lock` remain rules_rs metadata
 authority, but Cargo is not a contributor or CI gate.
 
+Run `make test-lint` from `nix develop .#bazel -c ...` (or the default Nix
+shell). The gate requires the declared `D2B_SHELLCHECK_BIN` and fails closed
+instead of using a host-provided shellcheck.
+
 <a id="rust-workspace-checks"></a>
 
 ### Rust and Nix owner checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,8 @@ installed; Make selects the pinned shell and preserves those profile and trust
 variables. Cargo manifests and `Cargo.lock` remain rules_rs metadata
 authority, but Cargo is not a contributor or CI gate.
 
-Run `make test-lint` from `nix develop .#bazel -c ...` (or the default Nix
-shell). The gate requires the declared `D2B_SHELLCHECK_BIN` and fails closed
-instead of using a host-provided shellcheck.
+The `make test-lint` gate requires the declared `D2B_SHELLCHECK_BIN` and fails
+closed instead of using a host-provided shellcheck.
 
 <a id="rust-workspace-checks"></a>
 

--- a/bazel/checks/meta/BUILD.bazel
+++ b/bazel/checks/meta/BUILD.bazel
@@ -15,7 +15,7 @@ sh_test(
     name = "tier0_first_pass",
     srcs = ["//:tests/tools/tier0-first-pass.sh"],
     data = [":carrier_sources"],
-    env_inherit = ["D2B_REPO_ROOT", "PATH", "ROOT"],
+    env_inherit = ["D2B_REPO_ROOT", "D2B_SHELLCHECK_BIN", "PATH", "ROOT"],
     tags = [
         "local",
         "no-sandbox",

--- a/changelog.d/fix-issue-455-test-lint.md
+++ b/changelog.d/fix-issue-455-test-lint.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Make `test-lint` fail closed when its required shellcheck tool is unavailable and provision shellcheck through the pinned Bazel Nix environment.

--- a/flake.nix
+++ b/flake.nix
@@ -220,6 +220,7 @@
           export D2B_PROJECT_SHELL=d2b
           export D2B_BAZEL_BIN="${bazel920}/bin/bazel"
           export BAZEL_SH="''${BAZEL_SH:-${bazelActionShell}/bin/bash}"
+          export D2B_SHELLCHECK_BIN="${pkgs.shellcheck}/bin/shellcheck"
           export D2B_BAZEL_TEST_PATH="${testPath}"
         '';
       in {
@@ -257,6 +258,7 @@
               pkgs.gnumake
               pkgs.jq
               pkgs.rustup
+              pkgs.shellcheck
             ])}
             export SCCACHE_DIR="''${SCCACHE_DIR:-$HOME/.cache/d2b-sccache}"
             echo "d2b dev shell: rust $(sed -n 's/.*channel = "\(.*\)".*/\1/p' rust-toolchain.toml) via rustup, sccache at $SCCACHE_DIR"
@@ -289,6 +291,7 @@
             gnused
             jq
             rustup
+            shellcheck
           ];
           shellHook = ''
             ${mkBazelShellHook (pkgs.lib.makeBinPath [
@@ -303,6 +306,7 @@
               pkgs.gnused
               pkgs.jq
               pkgs.rustup
+              pkgs.shellcheck
             ])}
             echo "d2b Bazel compatibility shell: $(${bazel920}/bin/bazel --version)"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -261,6 +261,7 @@
               pkgs.shellcheck
             ])}
             export SCCACHE_DIR="''${SCCACHE_DIR:-$HOME/.cache/d2b-sccache}"
+            export D2B_SHELLCHECK_BIN="${pkgs.shellcheck}/bin/shellcheck"
             echo "d2b dev shell: rust $(sed -n 's/.*channel = "\(.*\)".*/\1/p' rust-toolchain.toml) via rustup, sccache at $SCCACHE_DIR"
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -261,7 +261,6 @@
               pkgs.shellcheck
             ])}
             export SCCACHE_DIR="''${SCCACHE_DIR:-$HOME/.cache/d2b-sccache}"
-            export D2B_SHELLCHECK_BIN="${pkgs.shellcheck}/bin/shellcheck"
             echo "d2b dev shell: rust $(sed -n 's/.*channel = "\(.*\)".*/\1/p' rust-toolchain.toml) via rustup, sccache at $SCCACHE_DIR"
           '';
         };

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -192,6 +192,7 @@ rust_test(
         "//:docs/reference/bazel-buildbuddy.md",
         "//:nix/bazel-worker-image.nix",
         "//:tests/tools/bazel-check",
+        "//:tests/tools/tier0-first-pass.sh",
         "//:tests/golden/bazel/cache-policy.json",
         "//packages/d2b-bus:BUILD.bazel",
         "//packages/d2b:BUILD.bazel",

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -191,6 +191,7 @@ rust_test(
         "//bazel/checks:BUILD.bazel",
         "//:docs/reference/bazel-buildbuddy.md",
         "//:nix/bazel-worker-image.nix",
+        "//bazel/checks/meta:BUILD.bazel",
         "//:tests/tools/bazel-check",
         "//:tests/tools/tier0-first-pass.sh",
         "//:tests/golden/bazel/cache-policy.json",

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -411,11 +411,8 @@ fn committed_profiles_share_authentication_and_worker_policy() {
     );
     let flake = read_text("flake.nix");
     assert!(
-        flake
-            .matches("export D2B_SHELLCHECK_BIN=\"${pkgs.shellcheck}/bin/shellcheck\"")
-            .count()
-            >= 2,
-        "default and Bazel Nix shells must export the pinned shellcheck binary"
+        flake.contains("export D2B_SHELLCHECK_BIN=\"${pkgs.shellcheck}/bin/shellcheck\""),
+        "Nix shells must export the pinned shellcheck binary through the shared contract"
     );
     assert!(
         read_text("bazel/checks/meta/BUILD.bazel")
@@ -1012,6 +1009,7 @@ fn focused_bazel_shell_exports_the_complete_facade_contract() {
         "gnumake",
         "jq",
         "rustup",
+        "shellcheck",
     ] {
         assert!(
             packages
@@ -1040,6 +1038,7 @@ fn focused_bazel_shell_exports_the_complete_facade_contract() {
         "D2B_PROJECT_SHELL=d2b",
         "D2B_BAZEL_BIN",
         "BAZEL_SH",
+        "D2B_SHELLCHECK_BIN",
         "D2B_BAZEL_TEST_PATH",
     ] {
         assert!(
@@ -1072,7 +1071,12 @@ fn default_shell_includes_the_pinned_bazel_contract() {
         default_shell.contains("mkBazelShellHook"),
         "default development shell must use the shared shell contract helper"
     );
-    for export in ["D2B_PROJECT_SHELL=d2b", "D2B_BAZEL_BIN", "BAZEL_SH"] {
+    for export in [
+        "D2B_PROJECT_SHELL=d2b",
+        "D2B_BAZEL_BIN",
+        "BAZEL_SH",
+        "D2B_SHELLCHECK_BIN",
+    ] {
         assert!(
             flake.contains(export),
             "default development shell contract must export {export}"

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -405,6 +405,56 @@ fn committed_profiles_share_authentication_and_worker_policy() {
         ),
         "remote test runners must receive worker-standard PATH entries"
     );
+    assert!(
+        wrapper.contains("--test_env=D2B_SHELLCHECK_BIN=\"${D2B_SHELLCHECK_BIN:-}\""),
+        "source-hygiene tests must receive the declared shellcheck binary"
+    );
+    let flake = read_text("flake.nix");
+    assert!(
+        flake
+            .matches("export D2B_SHELLCHECK_BIN=\"${pkgs.shellcheck}/bin/shellcheck\"")
+            .count()
+            >= 2,
+        "default and Bazel Nix shells must export the pinned shellcheck binary"
+    );
+}
+
+#[test]
+fn source_hygiene_fails_when_declared_shellcheck_is_missing() {
+    let scratch = repo_root().join(".scratch").join(format!(
+        "tier0-shellcheck-missing-test-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(scratch.join("tests")).expect("create source-hygiene fixture");
+    std::fs::write(
+        scratch.join("tests/input.sh"),
+        "#!/usr/bin/env bash\nprintf 'fixture\\n'\n",
+    )
+    .expect("write source-hygiene fixture");
+
+    let output = Command::new("/bin/bash")
+        .arg(repo_root().join("tests/tools/tier0-first-pass.sh"))
+        .env("ROOT", &scratch)
+        .env("PATH", "/usr/bin:/bin")
+        .env_remove("D2B_SHELLCHECK_BIN")
+        .output()
+        .expect("run source-hygiene gate");
+    let diagnostics = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&scratch);
+
+    assert_eq!(output.status.code(), Some(1), "{diagnostics}");
+    assert!(
+        diagnostics.contains("shellcheck is required for the source-hygiene gate"),
+        "missing-tool diagnostic absent:\n{diagnostics}"
+    );
 }
 
 #[test]

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -417,6 +417,11 @@ fn committed_profiles_share_authentication_and_worker_policy() {
             >= 2,
         "default and Bazel Nix shells must export the pinned shellcheck binary"
     );
+    assert!(
+        read_text("bazel/checks/meta/BUILD.bazel")
+            .contains("env_inherit = [\"D2B_REPO_ROOT\", \"D2B_SHELLCHECK_BIN\", \"PATH\", \"ROOT\"]"),
+        "the direct tier0 test must inherit the declared shellcheck binary"
+    );
 }
 
 #[test]

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -439,7 +439,6 @@ fn source_hygiene_fails_when_declared_shellcheck_is_missing() {
     let output = Command::new("/bin/bash")
         .arg(repo_root().join("tests/tools/tier0-first-pass.sh"))
         .env("ROOT", &scratch)
-        .env("PATH", "/usr/bin:/bin")
         .env_remove("D2B_SHELLCHECK_BIN")
         .output()
         .expect("run source-hygiene gate");

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ Rust tests (types 2-5: unit, integration, contract, policy-lint) live under
 | `make check` | complete PR-equivalent Bazel Layer-1 suite graph | local + CI |
 | `make test-unit` | complete Bazel Layer-1 development suite graph | local + CI |
 | `make check-tier0` | fast Bazel toolchain and source-policy suite | local + CI |
-| `make test-lint` | fixed Bazel source-hygiene and shell-lint suite | local + CI |
+| `make test-lint` | fixed Bazel source-hygiene and required shell-lint suite | local + CI |
 | `make test-changelog` | require release notes for code changes and validate every changelog fragment | local + CI |
 | `make test-rust` | composed Bazel Rust unit, integration, and doctest suites | local + CI |
 | `make test-rust-<leaf>` | focused Bazel suites for main, broker, guest shell runner, policy, schema, and supply-chain coverage | CI (local for a focused rerun) |

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,10 @@ Rust tests (types 2-5: unit, integration, contract, policy-lint) live under
 
 ## Running tests
 
+Bazel-backed lint aliases must run in a declared Nix shell, for example
+`nix develop .#bazel -c make test-lint`. The source-hygiene gate fails closed
+when `D2B_SHELLCHECK_BIN` is not supplied by that environment.
+
 | Command | Runs | Where |
 |---------|------|-------|
 | `make check` | complete PR-equivalent Bazel Layer-1 suite graph | local + CI |

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,9 +47,7 @@ Rust tests (types 2-5: unit, integration, contract, policy-lint) live under
 
 ## Running tests
 
-Bazel-backed lint aliases must run in a declared Nix shell, for example
-`nix develop .#bazel -c make test-lint`. The source-hygiene gate fails closed
-when `D2B_SHELLCHECK_BIN` is not supplied by that environment.
+The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 
 | Command | Runs | Where |
 |---------|------|-------|

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -302,6 +302,7 @@ run_bazel() {
     --test_env=D2B_REPO_ROOT="$ROOT" \
     --test_env=D2B_BAZEL_BIN="$bazel_bin" \
     --test_env=D2B_PROJECT_SHELL=d2b \
+    --test_env=D2B_SHELLCHECK_BIN="${D2B_SHELLCHECK_BIN:-}" \
     --test_env=PATH="$test_path" \
     --test_env=BAZEL_SH="$test_bazel_sh" \
     "$@" \

--- a/tests/tools/no-bash-ast-walker/BUILD.bazel
+++ b/tests/tools/no-bash-ast-walker/BUILD.bazel
@@ -40,6 +40,7 @@ rust_test(
         "//bazel/checks/rust:source_hygiene_sources",
     ],
     env_inherit = ["D2B_REPO_ROOT", "PATH", "TEST_SRCDIR", "TEST_WORKSPACE"],
+    tags = ["local"],
     visibility = ["//visibility:public"],
     deps = [":no_bash_ast_walker"] + all_crate_deps(normal_dev = True, cargo_only = True),
 )

--- a/tests/tools/tier0-first-pass.sh
+++ b/tests/tools/tier0-first-pass.sh
@@ -117,12 +117,11 @@ mapfile -t shell_files < <(
 bash -n "${shell_files[@]}"
 ok "bash -n on ${#shell_files[@]} shell scripts"
 
-if command -v shellcheck >/dev/null 2>&1; then
-  shellcheck --severity=warning -x "${shell_files[@]}"
-  ok "shellcheck --severity=warning on ${#shell_files[@]} shell scripts"
-else
-  log "  SKIP: shellcheck not on PATH here; authoritative lint is make test-lint"
+if ! shellcheck_bin=$(command -v shellcheck); then
+  fail "shellcheck is required for the source-hygiene gate; enter the declared Nix/Bazel test environment"
 fi
+"$shellcheck_bin" --severity=warning -x "${shell_files[@]}"
+ok "shellcheck --severity=warning on ${#shell_files[@]} shell scripts"
 
 scan_dashes "$ROOT"
 ok "source-hygiene gate complete"

--- a/tests/tools/tier0-first-pass.sh
+++ b/tests/tools/tier0-first-pass.sh
@@ -117,7 +117,8 @@ mapfile -t shell_files < <(
 bash -n "${shell_files[@]}"
 ok "bash -n on ${#shell_files[@]} shell scripts"
 
-if ! shellcheck_bin=$(command -v shellcheck); then
+shellcheck_bin=${D2B_SHELLCHECK_BIN:-}
+if [ -z "$shellcheck_bin" ] || [ ! -x "$shellcheck_bin" ]; then
   fail "shellcheck is required for the source-hygiene gate; enter the declared Nix/Bazel test environment"
 fi
 "$shellcheck_bin" --severity=warning -x "${shell_files[@]}"


### PR DESCRIPTION
## Summary

`make test-lint` now fails closed when ShellCheck is missing or not executable instead of producing a success-shaped skip. The declared Nix shell exports the pinned ShellCheck path, Bazel forwards that path explicitly, and the source-hygiene suite keeps the existing shell, ShellCheck, ASCII-dash, and no-bash AST checks.

## Validation

- `//packages/xtask:buildbuddy_config` focused Bazel tests passed with the local profile.
- `D2B_BAZEL_PROFILE=local make test-lint` passed.
- `D2B_BAZEL_PROFILE=local make test-rust-no-bash-ast` passed.
- The default remote-profile `make test-lint` fails closed in this checkout because its selected local compilation path requires unavailable `/usr/bin/gcc`; it does not retry as a success-shaped local pass.

Fixes #455
