### PR TITLE
ci: add trusted BuildBuddy Layer-1 PR gate

### DIFF
--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -20,15 +20,15 @@ defaults:
 
 jobs:
   tier0:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
-      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -52,13 +52,10 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Fixed Bazel preflight
-        env:
-          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
-        run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
-            make -C trusted check-tier0
+        run: make -C trusted check-tier0
 
   policy-tooling:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -68,7 +65,7 @@ jobs:
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -82,7 +79,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -95,7 +92,7 @@ jobs:
         env:
           D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
         run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
             make -C trusted test-policy
       - name: Local policy-only suite
         env:
@@ -105,6 +102,7 @@ jobs:
         run: make -C trusted test-policy
 
   rust-main:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -114,7 +112,7 @@ jobs:
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-manual,-exclusive,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -128,7 +126,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -141,10 +139,11 @@ jobs:
         env:
           D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
         run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
             make -C trusted test-rust-main
 
   rust-broker:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -153,7 +152,7 @@ jobs:
       D2B_BAZEL_REQUIRE_REMOTE: "1"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -167,7 +166,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -180,10 +179,11 @@ jobs:
         env:
           D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
         run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
             make -C trusted test-rust-broker
 
   rust-guest:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -192,7 +192,7 @@ jobs:
       D2B_BAZEL_REQUIRE_REMOTE: "1"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -206,7 +206,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -219,10 +219,11 @@ jobs:
         env:
           D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
         run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
             make -C trusted test-rust-guest-shell-runner
 
   rust-local:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -230,7 +231,7 @@ jobs:
       D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -244,7 +245,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -257,6 +258,7 @@ jobs:
         run: make -C trusted test-rust-local
 
   nix-eval:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -264,7 +266,7 @@ jobs:
       D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -278,7 +280,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -291,6 +293,7 @@ jobs:
         run: make -C trusted test-flake
 
   nix-unit:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -298,7 +301,7 @@ jobs:
       D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -312,7 +315,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -325,6 +328,7 @@ jobs:
         run: make -C trusted test-nix-unit
 
   nix-realized:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -332,7 +336,7 @@ jobs:
       D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -346,7 +350,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -359,6 +363,7 @@ jobs:
         run: make -C trusted test-flake-realized
 
   nix-aarch64:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -366,7 +371,7 @@ jobs:
       D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -380,7 +385,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -393,6 +398,7 @@ jobs:
         run: make -C trusted test-flake-aarch64
 
   fixtures-proofs:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -400,7 +406,7 @@ jobs:
       D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -414,7 +420,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false
@@ -427,6 +433,7 @@ jobs:
         run: make -C trusted test-fixture-contracts
 
   test-performance-budgets:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 10
@@ -435,7 +442,7 @@ jobs:
       D2B_BAZEL_PROFILE: local
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
       D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -449,7 +456,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
           path: workspace
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -1,30 +1,50 @@
 name: pr-l1-static-fast
+
 on:
-  pull_request:
-    branches: [main, v3]
+  pull_request_target:
+    branches: [v3]
   push:
-    branches: [main, v3]
+    branches: [v3]
 
 permissions:
   contents: read
 
 env:
   BAZEL_SH: /bin/bash
+  D2B_BAZEL_TRUSTED_ROOT: ${{ github.workspace }}/trusted
+  D2B_BAZEL_SOURCE_ROOT: ${{ github.workspace }}/workspace
 
 defaults:
   run:
-    shell: sh tests/tools/ci-shell {0}
+    shell: sh trusted/tests/tools/ci-shell {0}
 
 jobs:
   tier0:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_TRUSTED: "1"
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -32,17 +52,38 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Fixed Bazel preflight
-        run: make check-tier0
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted check-tier0
 
   policy-tooling:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_TRUSTED: "1"
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -50,18 +91,39 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Policy and tooling suite
-        run: make test-policy
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-policy
 
   rust-main:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_TRUSTED: "1"
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-manual,-exclusive,-gpu,-kvm"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -69,17 +131,38 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Portable Rust main suite
-        run: make test-rust-main
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-rust-main
 
   rust-broker:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_TRUSTED: "1"
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -87,17 +170,38 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Broker suite
-        run: make test-rust-broker
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-rust-broker
 
   rust-guest:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_TRUSTED: "1"
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -105,17 +209,37 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Guest shell runner suite
-        run: make test-rust-guest-shell-runner
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-rust-guest-shell-runner
 
   rust-local:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
+      D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -123,17 +247,33 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Local Rust suite
-        run: make test-rust-local
+        run: make -C trusted test-rust-local
 
   nix-eval:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
+      D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -141,17 +281,33 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Nix evaluation suite
-        run: make test-flake
+        run: make -C trusted test-flake
 
   nix-unit:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
+      D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -159,17 +315,33 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Nix surface suite
-        run: make test-nix-unit
+        run: make -C trusted test-nix-unit
 
   nix-realized:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
+      D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -177,17 +349,33 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Realized Nix suite
-        run: make test-flake-realized
+        run: make -C trusted test-flake-realized
 
   nix-aarch64:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -195,17 +383,33 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: AArch64 Nix smoke suite
-        run: make test-flake-aarch64
+        run: make -C trusted test-flake-aarch64
 
   fixtures-proofs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
+      D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -213,18 +417,34 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Fixtures and proofs suite
-        run: make test-fixture-contracts
+        run: make -C trusted test-fixture-contracts
 
   test-performance-budgets:
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 10
     env:
+      D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: local
-      D2B_BAZEL_UNTRUSTED: "1"
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          path: workspace
+          fetch-depth: 0
           persist-credentials: false
       - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
         with:
@@ -232,7 +452,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Advisory performance gate
-        run: make test-performance-budgets
+        run: make -C trusted test-performance-budgets
 
   check:
     if: ${{ always() }}
@@ -241,6 +461,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
           persist-credentials: false
       - name: Fixed Layer-1 suites passed
         env:

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -2,7 +2,7 @@ name: pr-l1-static-fast
 
 on:
   pull_request_target:
-    branches: [main, v3]
+    branches: [v3]
   push:
     branches: [main, v3]
 
@@ -29,7 +29,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -66,7 +66,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -105,7 +105,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -145,7 +145,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -153,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -186,7 +186,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -194,7 +194,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -227,7 +227,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -235,7 +235,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -266,7 +266,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -274,7 +274,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -301,7 +301,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -309,7 +309,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -336,7 +336,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -344,7 +344,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -371,7 +371,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -379,7 +379,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -406,7 +406,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -414,7 +414,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -441,7 +441,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -449,7 +449,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -477,7 +477,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -485,7 +485,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -509,7 +509,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
       - name: Fixed Layer-1 suites passed

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -2,9 +2,9 @@ name: pr-l1-static-fast
 
 on:
   pull_request_target:
-    branches: [v3]
+    branches: [main, v3]
   push:
-    branches: [v3]
+    branches: [main, v3]
 
 permissions:
   contents: read
@@ -29,7 +29,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -66,7 +66,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -105,7 +105,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -145,7 +145,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -153,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -186,7 +186,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -194,7 +194,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -227,7 +227,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -235,7 +235,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -266,7 +266,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -274,7 +274,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -301,7 +301,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -309,7 +309,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -336,7 +336,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -344,7 +344,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -371,7 +371,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -379,7 +379,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -406,7 +406,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -414,7 +414,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -441,7 +441,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -449,7 +449,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -477,7 +477,7 @@ jobs:
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
-      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}
       D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
       D2B_BAZEL_RUN_ID: ${{ github.run_id }}
@@ -485,7 +485,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -509,7 +509,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
       - name: Fixed Layer-1 suites passed

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -60,7 +60,8 @@ jobs:
     timeout-minutes: 30
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: local
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -88,7 +89,11 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Policy and tooling suite
-        run: make -C trusted test-policy
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-policy
 
   policy-local:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
@@ -124,6 +129,7 @@ jobs:
             experimental-features = nix-command flakes
       - name: Local policy-only suite
         env:
+          D2B_BAZEL_REQUIRE_REMOTE: "0"
           D2B_BAZEL_TEST_TAG_FILTERS: "-manual,-gpu,-kvm"
         run: make -C trusted test-policy
 
@@ -133,7 +139,8 @@ jobs:
     timeout-minutes: 90
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: local
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-exclusive,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -161,7 +168,11 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Portable Rust main suite
-        run: make -C trusted test-rust-main
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-rust-main
 
   rust-broker:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
@@ -169,7 +180,8 @@ jobs:
     timeout-minutes: 90
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: local
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -197,7 +209,11 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Broker suite
-        run: make -C trusted test-rust-broker
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-rust-broker
 
   rust-guest:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
@@ -205,7 +221,8 @@ jobs:
     timeout-minutes: 90
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: local
+      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
+      D2B_BAZEL_REQUIRE_REMOTE: "1"
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -233,7 +250,11 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Guest shell runner suite
-        run: make -C trusted test-rust-guest-shell-runner
+        env:
+          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
+        run: |
+          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
+            make -C trusted test-rust-guest-shell-runner
 
   rust-local:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -65,6 +65,7 @@ jobs:
       D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
       D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
@@ -96,6 +97,12 @@ jobs:
         run: |
           printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY python3 ./trusted/tests/tools/bazel-check-bootstrap \
             make -C trusted test-policy
+      - name: Local policy-only suite
+        env:
+          D2B_BAZEL_PROFILE: local
+          D2B_BAZEL_REQUIRE_REMOTE: "0"
+          D2B_BAZEL_TEST_TAG_FILTERS: "-manual,-gpu,-kvm"
+        run: make -C trusted test-policy
 
   rust-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -94,9 +94,41 @@ jobs:
         run: |
           printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
             make -C trusted test-policy
+
+  policy-local:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      D2B_BAZEL_TRUSTED: "1"
+      D2B_BAZEL_PROFILE: local
+      D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
+      D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      D2B_BAZEL_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      D2B_BAZEL_BRANCH: ${{ github.head_ref || github.ref_name }}
+      D2B_BAZEL_RUN_ID: ${{ github.run_id }}
+      D2B_BAZEL_WORKFLOW_REF: ${{ github.workflow_ref }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
+          path: workspace
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: cachix/install-nix-action@23cf0fec1d55e0b1f2631aedd2a610c21ef8b077
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
       - name: Local policy-only suite
         env:
-          D2B_BAZEL_PROFILE: local
           D2B_BAZEL_REQUIRE_REMOTE: "0"
           D2B_BAZEL_TEST_TAG_FILTERS: "-manual,-gpu,-kvm"
         run: make -C trusted test-policy
@@ -109,7 +141,7 @@ jobs:
       D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
       D2B_BAZEL_REQUIRE_REMOTE: "1"
-      D2B_BAZEL_TEST_TAG_FILTERS: "-local,-manual,-exclusive,-gpu,-kvm"
+      D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-exclusive,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
@@ -150,6 +182,7 @@ jobs:
       D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
       D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
@@ -190,6 +223,7 @@ jobs:
       D2B_BAZEL_TRUSTED: "1"
       D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
       D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       D2B_BAZEL_MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}
@@ -470,7 +504,7 @@ jobs:
 
   check:
     if: ${{ always() }}
-    needs: [tier0, policy-tooling, rust-main, rust-broker, rust-guest, rust-local, nix-eval, nix-unit, nix-realized, nix-aarch64, fixtures-proofs]
+    needs: [tier0, policy-tooling, policy-local, rust-main, rust-broker, rust-guest, rust-local, nix-eval, nix-unit, nix-realized, nix-aarch64, fixtures-proofs]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/pr-l1-static-fast.yml
+++ b/.github/workflows/pr-l1-static-fast.yml
@@ -60,8 +60,7 @@ jobs:
     timeout-minutes: 30
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
-      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_PROFILE: local
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -89,11 +88,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Policy and tooling suite
-        env:
-          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
-        run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
-            make -C trusted test-policy
+        run: make -C trusted test-policy
 
   policy-local:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
@@ -129,7 +124,6 @@ jobs:
             experimental-features = nix-command flakes
       - name: Local policy-only suite
         env:
-          D2B_BAZEL_REQUIRE_REMOTE: "0"
           D2B_BAZEL_TEST_TAG_FILTERS: "-manual,-gpu,-kvm"
         run: make -C trusted test-policy
 
@@ -139,8 +133,7 @@ jobs:
     timeout-minutes: 90
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
-      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_PROFILE: local
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-exclusive,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -168,11 +161,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Portable Rust main suite
-        env:
-          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
-        run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
-            make -C trusted test-rust-main
+        run: make -C trusted test-rust-main
 
   rust-broker:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
@@ -180,8 +169,7 @@ jobs:
     timeout-minutes: 90
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
-      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_PROFILE: local
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -209,11 +197,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Broker suite
-        env:
-          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
-        run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
-            make -C trusted test-rust-broker
+        run: make -C trusted test-rust-broker
 
   rust-guest:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}
@@ -221,8 +205,7 @@ jobs:
     timeout-minutes: 90
     env:
       D2B_BAZEL_TRUSTED: "1"
-      D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}
-      D2B_BAZEL_REQUIRE_REMOTE: "1"
+      D2B_BAZEL_PROFILE: local
       D2B_BAZEL_TEST_TAG_FILTERS: "-local,-no-remote-exec,-manual,-gpu,-kvm"
       D2B_BAZEL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       D2B_BAZEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -250,11 +233,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Guest shell runner suite
-        env:
-          D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}
-        run: |
-          printf '%s' "$D2B_BUILDBUDDY_API_KEY" | env -u D2B_BUILDBUDDY_API_KEY ./trusted/tests/tools/bazel-check-bootstrap \
-            make -C trusted test-rust-guest-shell-runner
+        run: make -C trusted test-rust-guest-shell-runner
 
   rust-local:
     if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,12 +139,14 @@ settings or claim atomic base binding.
 `make check` invokes the public Bazel suite facade and its nested Layer-1
 component and package suites. Bare local runs use the BuildBuddy profile for
 eligible actions and automatically fall back to local execution when no
-credential is available. The protected `v3` CI workflow runs eligible Rust and
-policy actions through BuildBuddy with a brokered repository secret, keeps Nix
-and fixture actions local, and fails closed instead of reducing a
-credential-bearing job to a local gate. Make aliases are thin facade entry
-points, while Cargo manifests and lockfiles remain rules_rs metadata
-authority rather than contributor workflow entry points.
+credential is available. The default-branch `main`-owned PR workflow runs
+eligible Rust and policy actions through BuildBuddy with a brokered repository
+secret for PRs targeting protected `main` or `v3`, keeps Nix and fixture
+actions local, and fails closed instead of reducing a credential-bearing job
+to a local gate. Protected `main` and `v3` pushes seed a separate trusted
+cache namespace. Make aliases are thin facade entry points, while Cargo
+manifests and lockfiles remain rules_rs metadata authority rather than
+contributor workflow entry points.
 
 The full invariants are in
 [`docs/contributing/critical-subsystems.md`](./docs/contributing/critical-subsystems.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,12 +139,12 @@ settings or claim atomic base binding.
 `make check` invokes the public Bazel suite facade and its nested Layer-1
 component and package suites. Bare local runs use the BuildBuddy profile for
 eligible actions and automatically fall back to local execution when no
-credential is available. The default-branch `main`-owned PR workflow runs
-eligible Rust and policy actions through BuildBuddy with a brokered repository
-secret for PRs targeting protected `main` or `v3`, keeps Nix and fixture
-actions local, and fails closed instead of reducing a credential-bearing job
-to a local gate. Protected `main` and `v3` pushes seed a separate trusted
-cache namespace. Make aliases are thin facade entry points, while Cargo
+credential is available. The protected `v3`-owned PR workflow runs eligible
+Rust and policy actions through BuildBuddy with a brokered repository secret
+for PRs targeting `v3`, keeps Nix and fixture actions local, and fails closed
+instead of reducing a credential-bearing job to a local gate. Protected `main`
+and `v3` pushes seed a separate trusted cache namespace. Make aliases are thin
+facade entry points, while Cargo
 manifests and lockfiles remain rules_rs metadata authority rather than
 contributor workflow entry points.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,12 +139,12 @@ settings or claim atomic base binding.
 `make check` invokes the public Bazel suite facade and its nested Layer-1
 component and package suites. Bare local runs use the BuildBuddy profile for
 eligible actions and automatically fall back to local execution when no
-credential is available. The protected `v3` CI workflow owns the trusted
-checkout and runs every Bazel action locally without BuildBuddy credentials.
-Developer remote profiles and their isolated cache domains remain available
-for a future non-Actions BuildBuddy Workflows trial. Make aliases are thin
-facade entry points, while Cargo manifests and lockfiles remain rules_rs
-metadata authority rather than contributor workflow entry points.
+credential is available. The protected `v3` CI workflow runs eligible Rust and
+policy actions through BuildBuddy with a brokered repository secret, keeps Nix
+and fixture actions local, and fails closed instead of reducing a
+credential-bearing job to a local gate. Make aliases are thin facade entry
+points, while Cargo manifests and lockfiles remain rules_rs metadata
+authority rather than contributor workflow entry points.
 
 The full invariants are in
 [`docs/contributing/critical-subsystems.md`](./docs/contributing/critical-subsystems.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,12 +139,12 @@ settings or claim atomic base binding.
 `make check` invokes the public Bazel suite facade and its nested Layer-1
 component and package suites. Bare local runs use the BuildBuddy profile for
 eligible actions and automatically fall back to local execution when no
-credential is available. The protected `v3` CI workflow runs eligible Rust and
-policy actions through BuildBuddy with a brokered repository secret, keeps Nix
-and fixture actions local, and fails closed instead of reducing a
-credential-bearing job to a local gate. Make aliases are thin facade entry
-points, while Cargo manifests and lockfiles remain rules_rs metadata
-authority rather than contributor workflow entry points.
+credential is available. The protected `v3` CI workflow owns the trusted
+checkout and runs every Bazel action locally without BuildBuddy credentials.
+Developer remote profiles and their isolated cache domains remain available
+for a future non-Actions BuildBuddy Workflows trial. Make aliases are thin
+facade entry points, while Cargo manifests and lockfiles remain rules_rs
+metadata authority rather than contributor workflow entry points.
 
 The full invariants are in
 [`docs/contributing/critical-subsystems.md`](./docs/contributing/critical-subsystems.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,12 @@ settings or claim atomic base binding.
 `make check` invokes the public Bazel suite facade and its nested Layer-1
 component and package suites. Bare local runs use the BuildBuddy profile for
 eligible actions and automatically fall back to local execution when no
-credential is available; CI runs the same suite graph through the local profile
-with no BuildBuddy credential. Make aliases are thin facade entry points,
-while Cargo manifests and lockfiles remain rules_rs metadata authority rather
-than contributor workflow entry points.
+credential is available. The protected `v3` CI workflow runs eligible Rust and
+policy actions through BuildBuddy with a brokered repository secret, keeps Nix
+and fixture actions local, and fails closed instead of reducing a
+credential-bearing job to a local gate. Make aliases are thin facade entry
+points, while Cargo manifests and lockfiles remain rules_rs metadata
+authority rather than contributor workflow entry points.
 
 The full invariants are in
 [`docs/contributing/critical-subsystems.md`](./docs/contributing/critical-subsystems.md).

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -87,6 +87,7 @@ exports_files([
     "tests/AGENTS.md",
     "tests/tools/scrub-shell-environment",
     "tests/tools/bazel-check",
+    "tests/tools/bazel-check-bootstrap",
     "tests/tools/generated-artifact-check.sh",
     "nix/bazel-worker-image.nix",
     "nix/test-support/eval-surface.nix",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,12 @@ and public conditional integration targets.
 
 `make check` invokes the public Bazel suite facade. Nested component and
 package-level suites own the complete Layer-1 graph. A developer host uses
-BuildBuddy for eligible actions; GitHub Layer-1 runs the same graph locally
-with `D2B_BAZEL_PROFILE=local` and `D2B_BAZEL_UNTRUSTED=1`. CI only needs Nix
-installed; Make selects the pinned shell and preserves those profile and trust
-variables. Cargo manifests and `Cargo.lock` remain rules_rs metadata
-authority, but Cargo is not a contributor or CI gate.
+BuildBuddy for eligible actions; protected `v3` GitHub Layer-1 jobs use the
+trusted workflow and brokered credential for remote-eligible actions while
+keeping local-only actions local. CI only needs Nix installed; Make selects the
+pinned shell and preserves those profile and trust variables. Cargo manifests
+and `Cargo.lock` remain rules_rs metadata authority, but Cargo is not a
+contributor or CI gate.
 
 The `make test-lint` gate requires the declared `D2B_SHELLCHECK_BIN` and fails
 closed instead of using a host-provided shellcheck.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,10 @@ and public conditional integration targets.
 
 `make check` invokes the public Bazel suite facade. Nested component and
 package-level suites own the complete Layer-1 graph. A developer host uses
-BuildBuddy for eligible actions; the default-branch `main` GitHub Layer-1
-workflow uses a brokered credential for remote-eligible actions in PRs
-targeting `main` or `v3`, while keeping local-only actions local. Protected
-`main` and `v3` pushes retain trusted cache seeding. CI only needs Nix
+BuildBuddy for eligible actions; the protected `v3` GitHub Layer-1 workflow
+uses a brokered credential for remote-eligible actions in PRs targeting `v3`,
+while keeping local-only actions local. Protected `main` and `v3` pushes
+retain trusted cache seeding. CI only needs Nix
 installed; Make selects the pinned shell and preserves those profile and trust
 variables. Cargo manifests and `Cargo.lock` remain rules_rs metadata authority,
 but Cargo is not a contributor or CI gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,13 @@ and public conditional integration targets.
 
 `make check` invokes the public Bazel suite facade. Nested component and
 package-level suites own the complete Layer-1 graph. A developer host uses
-BuildBuddy for eligible actions; protected `v3` GitHub Layer-1 jobs use the
-trusted workflow and brokered credential for remote-eligible actions while
-keeping local-only actions local. CI only needs Nix installed; Make selects the
-pinned shell and preserves those profile and trust variables. Cargo manifests
-and `Cargo.lock` remain rules_rs metadata authority, but Cargo is not a
-contributor or CI gate.
+BuildBuddy for eligible actions; the default-branch `main` GitHub Layer-1
+workflow uses a brokered credential for remote-eligible actions in PRs
+targeting `main` or `v3`, while keeping local-only actions local. Protected
+`main` and `v3` pushes retain trusted cache seeding. CI only needs Nix
+installed; Make selects the pinned shell and preserves those profile and trust
+variables. Cargo manifests and `Cargo.lock` remain rules_rs metadata authority,
+but Cargo is not a contributor or CI gate.
 
 The `make test-lint` gate requires the declared `D2B_SHELLCHECK_BIN` and fails
 closed instead of using a host-provided shellcheck.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,10 @@ and public conditional integration targets.
 `make check` invokes the public Bazel suite facade. Nested component and
 package-level suites own the complete Layer-1 graph. A developer host uses
 BuildBuddy for eligible actions; protected `v3` GitHub Layer-1 jobs use the
-trusted workflow and brokered credential for remote-eligible actions while
-keeping local-only actions local. CI only needs Nix installed; Make selects the
+trusted workflow and local profile for every action without BuildBuddy
+credentials. The developer remote profiles, immutable metadata, and isolated
+cache domains remain the narrow handoff contract for a future non-Actions
+BuildBuddy Workflows trial. CI only needs Nix installed; Make selects the
 pinned shell and preserves those profile and trust variables. Cargo manifests
 and `Cargo.lock` remain rules_rs metadata authority, but Cargo is not a
 contributor or CI gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,8 @@ and public conditional integration targets.
 `make check` invokes the public Bazel suite facade. Nested component and
 package-level suites own the complete Layer-1 graph. A developer host uses
 BuildBuddy for eligible actions; protected `v3` GitHub Layer-1 jobs use the
-trusted workflow and local profile for every action without BuildBuddy
-credentials. The developer remote profiles, immutable metadata, and isolated
-cache domains remain the narrow handoff contract for a future non-Actions
-BuildBuddy Workflows trial. CI only needs Nix installed; Make selects the
+trusted workflow and brokered credential for remote-eligible actions while
+keeping local-only actions local. CI only needs Nix installed; Make selects the
 pinned shell and preserves those profile and trust variables. Cargo manifests
 and `Cargo.lock` remain rules_rs metadata authority, but Cargo is not a
 contributor or CI gate.

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ export D2B_BAZEL_PROFILE D2B_BAZEL_TEST_TAG_FILTERS
 
 check-tier0: D2B_BAZEL_TEST_TAG_FILTERS := -gpu,-kvm
 test-rust-main: D2B_BAZEL_TEST_TAG_FILTERS := -local,-no-remote-exec,-manual,-exclusive,-gpu,-kvm
+test-rust-broker: D2B_BAZEL_TEST_TAG_FILTERS := -local,-no-remote-exec,-manual,-gpu,-kvm
+test-rust-guest-shell-runner: D2B_BAZEL_TEST_TAG_FILTERS := -local,-no-remote-exec,-manual,-gpu,-kvm
 
 $(D2B_MAKE_BAZEL_TARGETS):
 	$(BAZEL_RUN) //bazel/checks:$@

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,9 @@ check-ci:
 
 ## bazel-check - complete Bazel graph. Locally this defaults to the
 ## BuildBuddy profile; the facade falls back to local execution when the
-## credential is unavailable. Protected v3 CI selects the local profile for
-## every action without a BuildBuddy credential. Remote profiles remain for
-## developer and future non-Actions Workflows use.
+## credential is unavailable. Trusted v3 CI selects remote for eligible
+## actions and sets D2B_BAZEL_REQUIRE_REMOTE=1; local-only CI lanes select
+## the local profile.
 D2B_BAZEL_PROFILE ?= remote
 D2B_BAZEL_TEST_TAG_FILTERS ?= -manual,-gpu,-kvm
 

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,9 @@ check-ci:
 
 ## bazel-check - complete Bazel graph. Locally this defaults to the
 ## BuildBuddy profile; the facade falls back to local execution when the
-## credential is unavailable. Trusted v3 CI selects remote for eligible
-## actions and sets D2B_BAZEL_REQUIRE_REMOTE=1; local-only CI lanes select
-## the local profile.
+## credential is unavailable. Protected v3 CI selects the local profile for
+## every action without a BuildBuddy credential. Remote profiles remain for
+## developer and future non-Actions Workflows use.
 D2B_BAZEL_PROFILE ?= remote
 D2B_BAZEL_TEST_TAG_FILTERS ?= -manual,-gpu,-kvm
 

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,9 @@ check-ci:
 
 ## bazel-check - complete Bazel graph. Locally this defaults to the
 ## BuildBuddy profile; the facade falls back to local execution when the
-## credential is unavailable. CI sets D2B_BAZEL_PROFILE=local.
+## credential is unavailable. Trusted v3 CI selects remote for eligible
+## actions and sets D2B_BAZEL_REQUIRE_REMOTE=1; local-only CI lanes select
+## the local profile.
 D2B_BAZEL_PROFILE ?= remote
 D2B_BAZEL_TEST_TAG_FILTERS ?= -manual,-gpu,-kvm
 

--- a/bazel/checks/rust/BUILD.bazel
+++ b/bazel/checks/rust/BUILD.bazel
@@ -51,6 +51,7 @@ test_suite(
         "//packages/d2b-bus:production_watch_rss",
         "//packages/xtask:buildbuddy_config",
         "//packages/xtask:heavy_gate_reexec",
+        "//packages/xtask:pr_workflow",
     ],
 )
 

--- a/bazel/remote/BUILD.bazel
+++ b/bazel/remote/BUILD.bazel
@@ -6,6 +6,7 @@ filegroup(
     name = "policy",
     srcs = [
         "//:tests/tools/bazel-check",
+        "//:tests/tools/bazel-check-bootstrap",
         "//:tests/golden/bazel/cache-policy.json",
         "//:nix/bazel-worker-image.nix",
     ],

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -1,11 +1,10 @@
 ### Changed
 
-- Moved the credential-bearing Layer-1 PR gate to a default-branch `main`
-  workflow accepted for protected `main` and `v3` targets. Remote-eligible
-  Rust and policy actions use BuildBuddy, while Nix, fixture, and other
-  local-only actions remain local under the existing fixed target sets and
-  stable `check` result. Protected `main` and `v3` pushes retain trusted cache
-  seeding.
+- Moved the credential-bearing Layer-1 PR gate to the protected `v3` workflow.
+  Remote-eligible Rust and policy actions use BuildBuddy, while Nix, fixture,
+  and other local-only actions remain local under the existing fixed target
+  sets and stable `check` result. Protected `main` and `v3` pushes retain
+  trusted cache seeding.
 
 ### Security
 
@@ -13,11 +12,11 @@
   PR/head cache namespaces, and an anonymous-memfd BuildBuddy credential
   boundary. Missing or failed remote authentication now fails closed in the
   credential-bearing CI path. Pull-request target runs source fixed suite
-  definitions and workflow/Make control files from immutable default-branch
-  `main`, while protected pushes use their immutable event commit. The tier-0
+  definitions and workflow/Make control files from immutable protected `v3`,
+  while protected pushes use their immutable event commit. The tier-0
   preflight remains local and credential-free. Credential-bearing jobs reject
   local action execution and run local policy checks on a fresh
   credential-free runner.
 - BuildBuddy commit metadata now identifies the immutable PR head for
   pull-request status linkage and the tested protected push commit for seed
-  runs, rather than inheriting the default-branch workflow SHA.
+  runs, rather than inheriting an unrelated workflow SHA.

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -1,14 +1,17 @@
 ### Changed
 
-- Kept the fixed Layer-1 PR and push gate owned by protected `v3` while making
-  every GitHub Actions Bazel action local and credential-free. Developer
-  BuildBuddy profiles and the immutable cache/OID contract remain available
-  for a future non-Actions Workflows trial.
+- Moved the credential-bearing Layer-1 PR and push gate to protected `v3`.
+  Remote-eligible Rust and policy actions use BuildBuddy, while Nix, fixture,
+  and other local-only actions remain local under the existing fixed target
+  sets and stable `check` result.
 
 ### Security
 
-- Preserved trusted/bootstrap checkouts, immutable PR and run metadata
-  validation, PR/head cache namespaces, and the trusted control overlay while
-  removing BuildBuddy secrets and remote profiles from GitHub Actions. The
-  facade now rejects non-local profiles when invoked by Actions, so a workflow
-  change cannot silently restore credential-bearing remote execution.
+- Added trusted/bootstrap checkouts, immutable PR and run metadata validation,
+  PR/head cache namespaces, and an anonymous-memfd BuildBuddy credential
+  boundary. Missing or failed remote authentication now fails closed in the
+  credential-bearing CI path. Fixed suite definitions and the workflow/Make
+  control files are now overlaid from trusted `v3`, and the tier-0 preflight
+  remains local and credential-free. Credential-bearing jobs reject local
+  action execution and run local policy checks on a fresh credential-free
+  runner.

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -1,0 +1,13 @@
+### Changed
+
+- Moved the credential-bearing Layer-1 PR and push gate to protected `v3`.
+  Remote-eligible Rust and policy actions use BuildBuddy, while Nix, fixture,
+  and other local-only actions remain local under the existing fixed target
+  sets and stable `check` result.
+
+### Security
+
+- Added trusted/bootstrap checkouts, immutable PR and run metadata validation,
+  PR/head cache namespaces, and an anonymous-memfd BuildBuddy credential
+  boundary. Missing or failed remote authentication now fails closed in the
+  credential-bearing CI path.

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -1,17 +1,14 @@
 ### Changed
 
-- Moved the credential-bearing Layer-1 PR and push gate to protected `v3`.
-  Remote-eligible Rust and policy actions use BuildBuddy, while Nix, fixture,
-  and other local-only actions remain local under the existing fixed target
-  sets and stable `check` result.
+- Kept the fixed Layer-1 PR and push gate owned by protected `v3` while making
+  every GitHub Actions Bazel action local and credential-free. Developer
+  BuildBuddy profiles and the immutable cache/OID contract remain available
+  for a future non-Actions Workflows trial.
 
 ### Security
 
-- Added trusted/bootstrap checkouts, immutable PR and run metadata validation,
-  PR/head cache namespaces, and an anonymous-memfd BuildBuddy credential
-  boundary. Missing or failed remote authentication now fails closed in the
-  credential-bearing CI path. Fixed suite definitions and the workflow/Make
-  control files are now overlaid from trusted `v3`, and the tier-0 preflight
-  remains local and credential-free. Credential-bearing jobs reject local
-  action execution and run local policy checks on a fresh credential-free
-  runner.
+- Preserved trusted/bootstrap checkouts, immutable PR and run metadata
+  validation, PR/head cache namespaces, and the trusted control overlay while
+  removing BuildBuddy secrets and remote profiles from GitHub Actions. The
+  facade now rejects non-local profiles when invoked by Actions, so a workflow
+  change cannot silently restore credential-bearing remote execution.

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -10,4 +10,6 @@
 - Added trusted/bootstrap checkouts, immutable PR and run metadata validation,
   PR/head cache namespaces, and an anonymous-memfd BuildBuddy credential
   boundary. Missing or failed remote authentication now fails closed in the
-  credential-bearing CI path.
+  credential-bearing CI path. Fixed suite definitions and the workflow/Make
+  control files are now overlaid from trusted `v3`, and the tier-0 preflight
+  remains local and credential-free.

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -18,3 +18,6 @@
   preflight remains local and credential-free. Credential-bearing jobs reject
   local action execution and run local policy checks on a fresh
   credential-free runner.
+- BuildBuddy commit metadata now identifies the immutable PR head for
+  pull-request status linkage and the tested protected push commit for seed
+  runs, rather than inheriting the default-branch workflow SHA.

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -1,17 +1,20 @@
 ### Changed
 
-- Moved the credential-bearing Layer-1 PR and push gate to protected `v3`.
-  Remote-eligible Rust and policy actions use BuildBuddy, while Nix, fixture,
-  and other local-only actions remain local under the existing fixed target
-  sets and stable `check` result.
+- Moved the credential-bearing Layer-1 PR gate to a default-branch `main`
+  workflow accepted for protected `main` and `v3` targets. Remote-eligible
+  Rust and policy actions use BuildBuddy, while Nix, fixture, and other
+  local-only actions remain local under the existing fixed target sets and
+  stable `check` result. Protected `main` and `v3` pushes retain trusted cache
+  seeding.
 
 ### Security
 
 - Added trusted/bootstrap checkouts, immutable PR and run metadata validation,
   PR/head cache namespaces, and an anonymous-memfd BuildBuddy credential
   boundary. Missing or failed remote authentication now fails closed in the
-  credential-bearing CI path. Fixed suite definitions and the workflow/Make
-  control files are now overlaid from trusted `v3`, and the tier-0 preflight
-  remains local and credential-free. Credential-bearing jobs reject local
-  action execution and run local policy checks on a fresh credential-free
-  runner.
+  credential-bearing CI path. Pull-request target runs source fixed suite
+  definitions and workflow/Make control files from immutable default-branch
+  `main`, while protected pushes use their immutable event commit. The tier-0
+  preflight remains local and credential-free. Credential-bearing jobs reject
+  local action execution and run local policy checks on a fresh
+  credential-free runner.

--- a/changelog.d/buildbuddy-trusted-v3-gate.md
+++ b/changelog.d/buildbuddy-trusted-v3-gate.md
@@ -12,4 +12,6 @@
   boundary. Missing or failed remote authentication now fails closed in the
   credential-bearing CI path. Fixed suite definitions and the workflow/Make
   control files are now overlaid from trusted `v3`, and the tier-0 preflight
-  remains local and credential-free.
+  remains local and credential-free. Credential-bearing jobs reject local
+  action execution and run local policy checks on a fresh credential-free
+  runner.

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -139,12 +139,11 @@ make check
 ```
 
 Local aliases use the BuildBuddy `remote` profile when credentials and trust
-permit it. The default-branch `main` workflow invokes the same public Make
-aliases from an immutable trusted checkout for PRs targeting protected `main`
-or `v3`: remote-eligible jobs use the brokered BuildBuddy credential, while
-local-only jobs remain local and credential-free. Protected `main` and `v3`
-pushes retain trusted cache seeding. CI does not wrap each target in a separate
-`nix develop` command.
+permit it. The protected `v3` workflow invokes the same public Make aliases
+from an immutable trusted checkout for PRs targeting `v3`: remote-eligible
+jobs use the brokered BuildBuddy credential, while local-only jobs remain local
+and credential-free. Protected `main` and `v3` pushes retain trusted cache
+seeding. CI does not wrap each target in a separate `nix develop` command.
 The credential helper, trust partition, redaction, and typed one-retry
 pre-dispatch fallback live in `tests/tools/bazel-check`; do not duplicate
 those behaviors in Make or workflow code. Post-dispatch, analysis, policy,

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -139,9 +139,10 @@ make check
 ```
 
 Local aliases use the BuildBuddy `remote` profile when credentials and trust
-permit it. CI invokes the same public Make aliases after installing Nix and
-sets `D2B_BAZEL_PROFILE=local` and `D2B_BAZEL_UNTRUSTED=1`; it does not wrap
-each target in a separate `nix develop` command.
+permit it. Protected `v3` CI invokes the same public Make aliases from the
+trusted checkout: remote-eligible jobs use the brokered BuildBuddy credential,
+while local-only jobs remain local and credential-free. CI does not wrap each
+target in a separate `nix develop` command.
 The credential helper, trust partition, redaction, and typed one-retry
 pre-dispatch fallback live in `tests/tools/bazel-check`; do not duplicate
 those behaviors in Make or workflow code. Post-dispatch, analysis, policy,

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -139,10 +139,12 @@ make check
 ```
 
 Local aliases use the BuildBuddy `remote` profile when credentials and trust
-permit it. Protected `v3` CI invokes the same public Make aliases from the
-trusted checkout: remote-eligible jobs use the brokered BuildBuddy credential,
-while local-only jobs remain local and credential-free. CI does not wrap each
-target in a separate `nix develop` command.
+permit it. The default-branch `main` workflow invokes the same public Make
+aliases from an immutable trusted checkout for PRs targeting protected `main`
+or `v3`: remote-eligible jobs use the brokered BuildBuddy credential, while
+local-only jobs remain local and credential-free. Protected `main` and `v3`
+pushes retain trusted cache seeding. CI does not wrap each target in a separate
+`nix develop` command.
 The credential helper, trust partition, redaction, and typed one-retry
 pre-dispatch fallback live in `tests/tools/bazel-check`; do not duplicate
 those behaviors in Make or workflow code. Post-dispatch, analysis, policy,

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -140,8 +140,9 @@ make check
 
 Local aliases use the BuildBuddy `remote` profile when credentials and trust
 permit it. Protected `v3` CI invokes the same public Make aliases from the
-trusted checkout with the `local` profile for every action and no BuildBuddy
-credential. CI does not wrap each target in a separate `nix develop` command.
+trusted checkout: remote-eligible jobs use the brokered BuildBuddy credential,
+while local-only jobs remain local and credential-free. CI does not wrap each
+target in a separate `nix develop` command.
 The credential helper, trust partition, redaction, and typed one-retry
 pre-dispatch fallback live in `tests/tools/bazel-check`; do not duplicate
 those behaviors in Make or workflow code. Post-dispatch, analysis, policy,

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -140,9 +140,8 @@ make check
 
 Local aliases use the BuildBuddy `remote` profile when credentials and trust
 permit it. Protected `v3` CI invokes the same public Make aliases from the
-trusted checkout: remote-eligible jobs use the brokered BuildBuddy credential,
-while local-only jobs remain local and credential-free. CI does not wrap each
-target in a separate `nix develop` command.
+trusted checkout with the `local` profile for every action and no BuildBuddy
+credential. CI does not wrap each target in a separate `nix develop` command.
 The credential helper, trust partition, redaction, and typed one-retry
 pre-dispatch fallback live in `tests/tools/bazel-check`; do not duplicate
 those behaviors in Make or workflow code. Post-dispatch, analysis, policy,

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -178,8 +178,9 @@ review. Missing review evidence fails closed to fresh review. No actionable
 finding remains at merge.
 
 The Bazel graph is the single enforcing Layer-1 authority. Bare local
-`make check` uses BuildBuddy for eligible actions, while generated CI runs the
-same fixed target sets with local Bazel execution and no remote credential.
+`make check` uses BuildBuddy for eligible actions. Protected `v3` CI runs
+credential-bearing remote suites for eligible actions and keeps Nix, fixture,
+hardware, and other local-only lanes local and credential-free.
 Make remains a compatibility surface, not a scheduler. See [Bazel and
 BuildBuddy](../reference/bazel-buildbuddy.md) for execution, cache, failure,
 credential, and update contracts.

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -179,10 +179,8 @@ finding remains at merge.
 
 The Bazel graph is the single enforcing Layer-1 authority. Bare local
 `make check` uses BuildBuddy for eligible actions. Protected `v3` CI runs
-the trusted workflow and local profile for every action; it never receives
-BuildBuddy credentials or executes remote Bazel. Developer remote profiles,
-immutable OID metadata, and isolated cache domains remain a narrow handoff
-for a future non-Actions BuildBuddy Workflows trial.
+credential-bearing remote suites for eligible actions and keeps Nix, fixture,
+hardware, and other local-only lanes local and credential-free.
 Make remains a compatibility surface, not a scheduler. See [Bazel and
 BuildBuddy](../reference/bazel-buildbuddy.md) for execution, cache, failure,
 credential, and update contracts.

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -179,8 +179,10 @@ finding remains at merge.
 
 The Bazel graph is the single enforcing Layer-1 authority. Bare local
 `make check` uses BuildBuddy for eligible actions. Protected `v3` CI runs
-credential-bearing remote suites for eligible actions and keeps Nix, fixture,
-hardware, and other local-only lanes local and credential-free.
+the trusted workflow and local profile for every action; it never receives
+BuildBuddy credentials or executes remote Bazel. Developer remote profiles,
+immutable OID metadata, and isolated cache domains remain a narrow handoff
+for a future non-Actions BuildBuddy Workflows trial.
 Make remains a compatibility surface, not a scheduler. See [Bazel and
 BuildBuddy](../reference/bazel-buildbuddy.md) for execution, cache, failure,
 credential, and update contracts.

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -180,15 +180,15 @@ missing credentials, authentication failure, endpoint failure, or remote
 execution failure fails the job instead of producing a reduced local gate.
 
 The facade stages the tested source with trusted copies of `.bazelrc`,
-`MODULE.bazel`, `MODULE.bazel.lock`, remote/platform BUILD files, and the
-credential/shell helpers. It disables system, home, workspace, and PR
+`MODULE.bazel`, `MODULE.bazel.lock`, `flake.lock`, remote/platform BUILD files,
+and the credential/shell helpers. It disables system, home, workspace, and PR
 `.bazelrc.user` configuration and pins the endpoint and helper path on the
 Bazel command line. PR cache writes never use the trusted seed namespace.
 
-The trusted security digest covers the committed workflow, Makefile, module
-lock, platform, remote policy, bootstrap, shell, and credential-helper inputs listed in
-`tests/golden/bazel/cache-policy.json`. Refresh it only after reviewing those
-bytes:
+The trusted security digest covers the committed workflow, Makefile, module and
+Nix locks, platform, remote policy, bootstrap, shell, and credential-helper
+inputs listed in `tests/golden/bazel/cache-policy.json`. Refresh it only after
+reviewing those bytes:
 
 ```bash
 bazel run //packages/xtask:xtask -- bazel-evidence security-digest

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -36,9 +36,9 @@ nix develop --no-write-lock-file .#bazel -c bazel test //packages/<crate>:<owner
 ```
 
 Direnv is optional; it may enter `nix develop` automatically but is not part
-of the contributor or CI contract. CI installs Nix and invokes the same
-public Make aliases with `D2B_BAZEL_PROFILE=local` and
-`D2B_BAZEL_UNTRUSTED=1`.
+of the contributor or CI contract. CI installs Nix and invokes the trusted
+`v3` Make aliases from the protected checkout. Remote-eligible jobs use the
+brokered BuildBuddy credential; local-only jobs do not receive it.
 
 ## One execution graph
 
@@ -46,8 +46,9 @@ Bazel owns Layer-1 dependency ordering, parallelism, test caching, retry
 classification, and aggregation. `bazel/checks/BUILD.bazel` is the public
 suite facade: package-level Rust suites and component suites compose each
 public Make target without duplicating a fixed label graph in Make. CI runs the
-same nested suites with the local profile and exposes one stable required
-`check` result.
+same nested suites with remote-eligible Rust and policy actions on BuildBuddy,
+while Nix, fixture, hardware, and explicitly local actions remain local. It
+exposes one stable required `check` result.
 
 The primary aliases remain available:
 
@@ -93,10 +94,14 @@ actions are tagged `local` or `no-remote-exec`; `no-remote-cache` alone does
 not make an action local. Heavy, container, VM, live-host, hardware, fixture,
 and performance lanes remain explicit local lanes.
 
-GitHub Layer-1 jobs set `D2B_BAZEL_PROFILE=local` and
-`D2B_BAZEL_UNTRUSTED=1`; they receive no BuildBuddy credential. The fixed job
-set is committed in `.github/workflows/pr-l1-static-fast.yml` and must remain
-aligned with the public Make aliases.
+The credential-bearing PR gate is a `pull_request_target` workflow owned by
+protected `v3`; push seeding is also limited to `v3`. Each job checks out the
+event's immutable base into `trusted` and the immutable tested merge/push
+commit into `workspace`. The workflow executes the `v3` Makefile and trusted
+shell/bootstrap only. Remote jobs use `D2B_BAZEL_PROFILE=remote` and
+`D2B_BAZEL_REQUIRE_REMOTE=1`; local-only jobs use `local`. The fixed job set is
+committed in `.github/workflows/pr-l1-static-fast.yml` and must remain aligned
+with the public Make aliases.
 
 ## Developer invocation metadata
 
@@ -131,6 +136,14 @@ retry condition.
 input. It therefore does not change ordinary action keys or invalidate
 reusable outputs, and the global `--stamp=no` contract remains unchanged.
 
+Trusted CI additionally validates the protected base, PR head, tested merge,
+trusted checkout, run id, PR number, branch, workflow reference, and event
+before invoking Bazel. It publishes those immutable OIDs and run/linkage
+fields as BuildBuddy metadata, and derives a cache instance namespace from the
+PR number and head SHA (`d2b/pr/<number>/<head-sha>/...`). Pushes use the
+separate trusted `v3` namespace. A stale checkout or mismatched event fails
+closed.
+
 ## Credentials and trust selection
 
 Store the developer API key as one line in the protected file named by
@@ -157,8 +170,23 @@ The facade preserves the selected target set when execution changes:
   require explicit pre-dispatch evidence, except for a remote gRPC deadline;
 - analysis, policy, build, test, and post-dispatch failures fail closed.
 
-The trusted security digest covers the committed remote profile, module lock,
-platform, remote policy, and credential-helper inputs listed in
+For GitHub Actions, add the repository secret
+`D2B_BUILDBUDDY_API_KEY`. The trusted workflow passes it only over stdin to
+`tests/tools/bazel-check-bootstrap`, which stores it in an anonymous memfd and
+execs the trusted `v3` command with a descriptor number. The key is not placed
+in ordinary action environment variables, arguments, repository files, Bazel
+rc files, or test environments. Credential-bearing CI has no local fallback:
+missing credentials, authentication failure, endpoint failure, or remote
+execution failure fails the job instead of producing a reduced local gate.
+
+The facade stages the tested source with trusted copies of `.bazelrc`,
+`MODULE.bazel`, `MODULE.bazel.lock`, remote/platform BUILD files, and the
+credential/shell helpers. It disables system, home, workspace, and PR
+`.bazelrc.user` configuration and pins the endpoint and helper path on the
+Bazel command line. PR cache writes never use the trusted seed namespace.
+
+The trusted security digest covers the committed workflow, Makefile, module
+lock, platform, remote policy, bootstrap, shell, and credential-helper inputs listed in
 `tests/golden/bazel/cache-policy.json`. Refresh it only after reviewing those
 bytes:
 

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -37,11 +37,10 @@ nix develop --no-write-lock-file .#bazel -c bazel test //packages/<crate>:<owner
 
 Direnv is optional; it may enter `nix develop` automatically but is not part
 of the contributor or CI contract. CI installs Nix and invokes the fixed Make
-aliases from an immutable trusted checkout. Pull-request target runs source
-that checkout and the workflow/bootstrap from default branch `main`, even
-when the PR targets `v3`; protected `main` and `v3` pushes use their immutable
-event commit for trusted cache seeding. Remote-eligible jobs use the brokered
-BuildBuddy credential; local-only jobs do not receive it.
+aliases from an immutable protected `v3` checkout for pull requests; protected
+`main` and `v3` pushes use their immutable event commit for trusted cache
+seeding. Remote-eligible jobs use the brokered BuildBuddy credential;
+local-only jobs do not receive it.
 
 ## One execution graph
 
@@ -98,19 +97,17 @@ container, VM, live-host, hardware, fixture, and performance lanes remain
 explicit local lanes. Rust target and exec actions override the worker
 toolchain's deprecated gold default with GNU ld.bfd.
 
-The credential-bearing PR gate is a `pull_request_target` workflow sourced
-from default branch `main` and accepted for PRs targeting `main` or `v3`.
-GitHub's `pull_request_target` context supplies the immutable default-branch
-workflow SHA, which each job checks out into `trusted`; the protected base
-commit remains a separate metadata value. Each job checks out the immutable
-tested merge/push commit into `workspace`. The workflow executes only the
-trusted Makefile and shell/bootstrap from `trusted`, while the facade stages
-the tested source and overlays those controls before Bazel runs. Protected
-`main` and `v3` pushes use the same fixed job set and seed their separate
-trusted cache namespace. Remote jobs use `D2B_BAZEL_PROFILE=remote` and
-`D2B_BAZEL_REQUIRE_REMOTE=1`; local-only jobs use `local`. The fixed job set is
-committed in `.github/workflows/pr-l1-static-fast.yml` and must remain aligned
-with the public Make aliases.
+The credential-bearing PR gate is a `pull_request_target` workflow owned by
+protected `v3` and accepted for PRs targeting `v3`. Each job checks out the
+immutable protected base into `trusted` and the immutable tested merge commit
+into `workspace`; the workflow executes only the trusted Makefile and
+shell/bootstrap from `trusted`, while the facade stages the tested source and
+overlays those controls before Bazel runs. Protected `main` and `v3` pushes
+use the same fixed job set and seed their separate trusted cache namespace.
+Remote-eligible jobs use `D2B_BAZEL_PROFILE=remote` and
+`D2B_BAZEL_REQUIRE_REMOTE=1`; local-only jobs use `local`. The fixed job set
+is committed in `.github/workflows/pr-l1-static-fast.yml` and must remain
+aligned with the public Make aliases.
 
 ## Developer invocation metadata
 
@@ -148,15 +145,15 @@ reusable outputs, and the global `--stamp=no` contract remains unchanged.
 Trusted CI additionally validates the protected base, PR head, tested merge,
 trusted workflow checkout, run id, PR number, branch, workflow reference, and
 event before invoking Bazel. For pull requests it requires
-`GITHUB_REF=refs/heads/main`, a `main` workflow reference, and a trusted
-checkout matching `GITHUB_SHA`; the base ref may be `main` or `v3`. It
-publishes those immutable OIDs and run/linkage fields as BuildBuddy metadata,
-uses the PR head as the BuildBuddy commit identity for pull-request status
-linkage, and derives a cache instance namespace from the PR number and head SHA
-(`d2b/pr/<number>/<head-sha>/...`). Protected pushes use their immutable event
-commit as the BuildBuddy commit identity and use the separate trusted-seed
-namespace. A stale checkout, mismatched event, or non-main pull-request
-workflow fails closed.
+`GITHUB_REF=refs/heads/v3`, the `v3` workflow reference, and a trusted
+checkout matching the immutable protected base; only `v3` is accepted as the
+PR base ref. It publishes those immutable OIDs and run/linkage fields as
+BuildBuddy metadata, uses the PR head as the BuildBuddy commit identity for
+pull-request status linkage, and derives a cache instance namespace from the
+PR number and head SHA (`d2b/pr/<number>/<head-sha>/...`). Protected pushes use
+their immutable event commit as the BuildBuddy commit identity and use the
+separate trusted-seed namespace. A stale checkout, mismatched event, or
+non-`v3` pull-request workflow fails closed.
 
 ## Credentials and trust selection
 

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -151,10 +151,12 @@ event before invoking Bazel. For pull requests it requires
 `GITHUB_REF=refs/heads/main`, a `main` workflow reference, and a trusted
 checkout matching `GITHUB_SHA`; the base ref may be `main` or `v3`. It
 publishes those immutable OIDs and run/linkage fields as BuildBuddy metadata,
-and derives a cache instance namespace from the PR number and head SHA
+uses the PR head as the BuildBuddy commit identity for pull-request status
+linkage, and derives a cache instance namespace from the PR number and head SHA
 (`d2b/pr/<number>/<head-sha>/...`). Protected pushes use their immutable event
-commit and the separate trusted-seed namespace. A stale checkout, mismatched
-event, or non-main pull-request workflow fails closed.
+commit as the BuildBuddy commit identity and use the separate trusted-seed
+namespace. A stale checkout, mismatched event, or non-main pull-request
+workflow fails closed.
 
 ## Credentials and trust selection
 

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -36,9 +36,12 @@ nix develop --no-write-lock-file .#bazel -c bazel test //packages/<crate>:<owner
 ```
 
 Direnv is optional; it may enter `nix develop` automatically but is not part
-of the contributor or CI contract. CI installs Nix and invokes the trusted
-`v3` Make aliases from the protected checkout. Remote-eligible jobs use the
-brokered BuildBuddy credential; local-only jobs do not receive it.
+of the contributor or CI contract. CI installs Nix and invokes the fixed Make
+aliases from an immutable trusted checkout. Pull-request target runs source
+that checkout and the workflow/bootstrap from default branch `main`, even
+when the PR targets `v3`; protected `main` and `v3` pushes use their immutable
+event commit for trusted cache seeding. Remote-eligible jobs use the brokered
+BuildBuddy credential; local-only jobs do not receive it.
 
 ## One execution graph
 
@@ -85,7 +88,7 @@ The committed `.bazelrc` defines:
 | --- | --- |
 | `local` | Local execution with no remote executor, cache, or BES |
 | `remote` | Developer BuildBuddy execution and cache |
-| `trusted-seed` | Protected `v3` cache seeding with synchronous uploads |
+| `trusted-seed` | Protected `main` or `v3` cache seeding with synchronous uploads |
 
 Remote profiles use the BuildBuddy Linux worker contract, Ubuntu GCC
 toolchain, minimal output downloads, compressed cache blobs, zero Bazel remote
@@ -95,11 +98,16 @@ container, VM, live-host, hardware, fixture, and performance lanes remain
 explicit local lanes. Rust target and exec actions override the worker
 toolchain's deprecated gold default with GNU ld.bfd.
 
-The credential-bearing PR gate is a `pull_request_target` workflow owned by
-protected `v3`; push seeding is also limited to `v3`. Each job checks out the
-event's immutable base into `trusted` and the immutable tested merge/push
-commit into `workspace`. The workflow executes the `v3` Makefile and trusted
-shell/bootstrap only. Remote jobs use `D2B_BAZEL_PROFILE=remote` and
+The credential-bearing PR gate is a `pull_request_target` workflow sourced
+from default branch `main` and accepted for PRs targeting `main` or `v3`.
+GitHub's `pull_request_target` context supplies the immutable default-branch
+workflow SHA, which each job checks out into `trusted`; the protected base
+commit remains a separate metadata value. Each job checks out the immutable
+tested merge/push commit into `workspace`. The workflow executes only the
+trusted Makefile and shell/bootstrap from `trusted`, while the facade stages
+the tested source and overlays those controls before Bazel runs. Protected
+`main` and `v3` pushes use the same fixed job set and seed their separate
+trusted cache namespace. Remote jobs use `D2B_BAZEL_PROFILE=remote` and
 `D2B_BAZEL_REQUIRE_REMOTE=1`; local-only jobs use `local`. The fixed job set is
 committed in `.github/workflows/pr-l1-static-fast.yml` and must remain aligned
 with the public Make aliases.
@@ -138,12 +146,15 @@ input. It therefore does not change ordinary action keys or invalidate
 reusable outputs, and the global `--stamp=no` contract remains unchanged.
 
 Trusted CI additionally validates the protected base, PR head, tested merge,
-trusted checkout, run id, PR number, branch, workflow reference, and event
-before invoking Bazel. It publishes those immutable OIDs and run/linkage
-fields as BuildBuddy metadata, and derives a cache instance namespace from the
-PR number and head SHA (`d2b/pr/<number>/<head-sha>/...`). Pushes use the
-separate trusted `v3` namespace. A stale checkout or mismatched event fails
-closed.
+trusted workflow checkout, run id, PR number, branch, workflow reference, and
+event before invoking Bazel. For pull requests it requires
+`GITHUB_REF=refs/heads/main`, a `main` workflow reference, and a trusted
+checkout matching `GITHUB_SHA`; the base ref may be `main` or `v3`. It
+publishes those immutable OIDs and run/linkage fields as BuildBuddy metadata,
+and derives a cache instance namespace from the PR number and head SHA
+(`d2b/pr/<number>/<head-sha>/...`). Protected pushes use their immutable event
+commit and the separate trusted-seed namespace. A stale checkout, mismatched
+event, or non-main pull-request workflow fails closed.
 
 ## Credentials and trust selection
 
@@ -164,8 +175,8 @@ The facade preserves the selected target set when execution changes:
 
 - missing or withheld credentials select `local` before Bazel starts;
 - untrusted GitHub jobs always select `local`;
-- `trusted-seed` requires `D2B_BAZEL_TRUSTED=1`, `GITHUB_REF=refs/heads/v3`,
-  and an allowlisted security digest;
+- `trusted-seed` requires `D2B_BAZEL_TRUSTED=1`, a protected `main` or `v3`
+  ref, and an allowlisted security digest;
 - a clearly pre-dispatch missing-credential, authentication, or endpoint
   failure permits one identical local retry; worker and transport failures
   require explicit pre-dispatch evidence, except for a remote gRPC deadline;
@@ -174,7 +185,7 @@ The facade preserves the selected target set when execution changes:
 For GitHub Actions, add the repository secret
 `D2B_BUILDBUDDY_API_KEY`. The trusted workflow passes it only over stdin to
 `tests/tools/bazel-check-bootstrap`, which stores it in an anonymous memfd and
-execs the trusted `v3` command with a descriptor number. The key is not placed
+execs the trusted command with a descriptor number. The key is not placed
 in ordinary action environment variables, arguments, repository files, Bazel
 rc files, or test environments. Credential-bearing CI has no local fallback:
 missing credentials, authentication failure, endpoint failure, or remote

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -37,8 +37,8 @@ nix develop --no-write-lock-file .#bazel -c bazel test //packages/<crate>:<owner
 
 Direnv is optional; it may enter `nix develop` automatically but is not part
 of the contributor or CI contract. CI installs Nix and invokes the trusted
-`v3` Make aliases from the protected checkout. Remote-eligible jobs use the
-brokered BuildBuddy credential; local-only jobs do not receive it.
+`v3` Make aliases from the protected checkout. Every GitHub Actions Bazel job
+uses the local profile and receives no BuildBuddy credential.
 
 ## One execution graph
 
@@ -46,9 +46,8 @@ Bazel owns Layer-1 dependency ordering, parallelism, test caching, retry
 classification, and aggregation. `bazel/checks/BUILD.bazel` is the public
 suite facade: package-level Rust suites and component suites compose each
 public Make target without duplicating a fixed label graph in Make. CI runs the
-same nested suites with remote-eligible Rust and policy actions on BuildBuddy,
-while Nix, fixture, hardware, and explicitly local actions remain local. It
-exposes one stable required `check` result.
+same nested suites locally, while Nix, fixture, hardware, and explicitly local
+actions remain local. It exposes one stable required `check` result.
 
 The primary aliases remain available:
 
@@ -85,7 +84,7 @@ The committed `.bazelrc` defines:
 | --- | --- |
 | `local` | Local execution with no remote executor, cache, or BES |
 | `remote` | Developer BuildBuddy execution and cache |
-| `trusted-seed` | Protected `v3` cache seeding with synchronous uploads |
+| `trusted-seed` | Controlled non-Actions `v3` cache seeding with synchronous uploads |
 
 Remote profiles use the BuildBuddy Linux worker contract, Ubuntu GCC
 toolchain, minimal output downloads, compressed cache blobs, zero Bazel remote
@@ -95,14 +94,15 @@ container, VM, live-host, hardware, fixture, and performance lanes remain
 explicit local lanes. Rust target and exec actions override the worker
 toolchain's deprecated gold default with GNU ld.bfd.
 
-The credential-bearing PR gate is a `pull_request_target` workflow owned by
-protected `v3`; push seeding is also limited to `v3`. Each job checks out the
-event's immutable base into `trusted` and the immutable tested merge/push
-commit into `workspace`. The workflow executes the `v3` Makefile and trusted
-shell/bootstrap only. Remote jobs use `D2B_BAZEL_PROFILE=remote` and
-`D2B_BAZEL_REQUIRE_REMOTE=1`; local-only jobs use `local`. The fixed job set is
-committed in `.github/workflows/pr-l1-static-fast.yml` and must remain aligned
-with the public Make aliases.
+The protected PR gate is a `pull_request_target` workflow owned by `v3`; pushes
+are also limited to `v3`. Each job checks out the event's immutable base into
+`trusted` and the immutable tested merge/push commit into `workspace`. The
+workflow executes the `v3` Makefile and trusted shell only, with
+`D2B_BAZEL_PROFILE=local` for every Bazel action. It does not receive a
+BuildBuddy credential, invoke the credential bootstrap, or execute remote
+Bazel. The fixed job set is committed in
+`.github/workflows/pr-l1-static-fast.yml` and must remain aligned with the
+public Make aliases.
 
 ## Developer invocation metadata
 
@@ -139,9 +139,10 @@ reusable outputs, and the global `--stamp=no` contract remains unchanged.
 
 Trusted CI additionally validates the protected base, PR head, tested merge,
 trusted checkout, run id, PR number, branch, workflow reference, and event
-before invoking Bazel. It publishes those immutable OIDs and run/linkage
-fields as BuildBuddy metadata, and derives a cache instance namespace from the
-PR number and head SHA (`d2b/pr/<number>/<head-sha>/...`). Pushes use the
+before invoking Bazel. These immutable OIDs and the PR/head cache namespace
+(`d2b/pr/<number>/<head-sha>/...`) remain the handoff contract for a future
+non-Actions BuildBuddy Workflows trial; the current local Actions gate does not
+write remote cache or publish BuildBuddy invocation metadata. Pushes retain the
 separate trusted `v3` namespace. A stale checkout or mismatched event fails
 closed.
 
@@ -166,25 +167,36 @@ The facade preserves the selected target set when execution changes:
 - untrusted GitHub jobs always select `local`;
 - `trusted-seed` requires `D2B_BAZEL_TRUSTED=1`, `GITHUB_REF=refs/heads/v3`,
   and an allowlisted security digest;
+- GitHub Actions rejects `remote` and `trusted-seed` profiles before Bazel
+  starts;
 - a clearly pre-dispatch missing-credential, authentication, or endpoint
   failure permits one identical local retry; worker and transport failures
   require explicit pre-dispatch evidence, except for a remote gRPC deadline;
 - analysis, policy, build, test, and post-dispatch failures fail closed.
 
-For GitHub Actions, add the repository secret
-`D2B_BUILDBUDDY_API_KEY`. The trusted workflow passes it only over stdin to
-`tests/tools/bazel-check-bootstrap`, which stores it in an anonymous memfd and
-execs the trusted `v3` command with a descriptor number. The key is not placed
-in ordinary action environment variables, arguments, repository files, Bazel
-rc files, or test environments. Credential-bearing CI has no local fallback:
-missing credentials, authentication failure, endpoint failure, or remote
-execution failure fails the job instead of producing a reduced local gate.
+GitHub Actions does not define, read, or pass `D2B_BUILDBUDDY_API_KEY`. It
+never invokes `tests/tools/bazel-check-bootstrap` and the facade rejects a
+non-local profile when `GITHUB_ACTIONS=true`. The credential helper and
+bootstrap remain available only to controlled non-Actions developer or future
+Workflows use.
 
 The facade stages the tested source with trusted copies of `.bazelrc`,
 `MODULE.bazel`, `MODULE.bazel.lock`, `flake.lock`, remote/platform BUILD files,
 and the credential/shell helpers. It disables system, home, workspace, and PR
-`.bazelrc.user` configuration and pins the endpoint and helper path on the
-Bazel command line. PR cache writes never use the trusted seed namespace.
+`.bazelrc.user` configuration. Remote endpoint and helper flags are only
+constructed for non-Actions remote profiles; local Actions runs cannot reach
+that path. Future PR cache writes must use the PR/head namespace and never the
+trusted seed namespace.
+
+## Future BuildBuddy Workflows trial handoff
+
+This branch does not implement BuildBuddy Workflows or move GitHub Actions to
+remote execution. A future pilot may consume only the existing fixed
+`//...` target set, protected-v3 workflow ownership, exact base/head/merge/
+trusted/tested OIDs, run and PR linkage, trusted security digest, and isolated
+`d2b/pr/<number>/<head-sha>/...` cache domain. Credential acquisition and
+remote execution must remain outside GitHub Actions, and the stable `check`
+result must retain the same target and trust contracts before any adoption.
 
 The trusted security digest covers the committed workflow, Makefile, module and
 Nix locks, platform, remote policy, bootstrap, shell, and credential-helper

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -37,8 +37,8 @@ nix develop --no-write-lock-file .#bazel -c bazel test //packages/<crate>:<owner
 
 Direnv is optional; it may enter `nix develop` automatically but is not part
 of the contributor or CI contract. CI installs Nix and invokes the trusted
-`v3` Make aliases from the protected checkout. Every GitHub Actions Bazel job
-uses the local profile and receives no BuildBuddy credential.
+`v3` Make aliases from the protected checkout. Remote-eligible jobs use the
+brokered BuildBuddy credential; local-only jobs do not receive it.
 
 ## One execution graph
 
@@ -46,8 +46,9 @@ Bazel owns Layer-1 dependency ordering, parallelism, test caching, retry
 classification, and aggregation. `bazel/checks/BUILD.bazel` is the public
 suite facade: package-level Rust suites and component suites compose each
 public Make target without duplicating a fixed label graph in Make. CI runs the
-same nested suites locally, while Nix, fixture, hardware, and explicitly local
-actions remain local. It exposes one stable required `check` result.
+same nested suites with remote-eligible Rust and policy actions on BuildBuddy,
+while Nix, fixture, hardware, and explicitly local actions remain local. It
+exposes one stable required `check` result.
 
 The primary aliases remain available:
 
@@ -84,7 +85,7 @@ The committed `.bazelrc` defines:
 | --- | --- |
 | `local` | Local execution with no remote executor, cache, or BES |
 | `remote` | Developer BuildBuddy execution and cache |
-| `trusted-seed` | Controlled non-Actions `v3` cache seeding with synchronous uploads |
+| `trusted-seed` | Protected `v3` cache seeding with synchronous uploads |
 
 Remote profiles use the BuildBuddy Linux worker contract, Ubuntu GCC
 toolchain, minimal output downloads, compressed cache blobs, zero Bazel remote
@@ -94,15 +95,14 @@ container, VM, live-host, hardware, fixture, and performance lanes remain
 explicit local lanes. Rust target and exec actions override the worker
 toolchain's deprecated gold default with GNU ld.bfd.
 
-The protected PR gate is a `pull_request_target` workflow owned by `v3`; pushes
-are also limited to `v3`. Each job checks out the event's immutable base into
-`trusted` and the immutable tested merge/push commit into `workspace`. The
-workflow executes the `v3` Makefile and trusted shell only, with
-`D2B_BAZEL_PROFILE=local` for every Bazel action. It does not receive a
-BuildBuddy credential, invoke the credential bootstrap, or execute remote
-Bazel. The fixed job set is committed in
-`.github/workflows/pr-l1-static-fast.yml` and must remain aligned with the
-public Make aliases.
+The credential-bearing PR gate is a `pull_request_target` workflow owned by
+protected `v3`; push seeding is also limited to `v3`. Each job checks out the
+event's immutable base into `trusted` and the immutable tested merge/push
+commit into `workspace`. The workflow executes the `v3` Makefile and trusted
+shell/bootstrap only. Remote jobs use `D2B_BAZEL_PROFILE=remote` and
+`D2B_BAZEL_REQUIRE_REMOTE=1`; local-only jobs use `local`. The fixed job set is
+committed in `.github/workflows/pr-l1-static-fast.yml` and must remain aligned
+with the public Make aliases.
 
 ## Developer invocation metadata
 
@@ -139,10 +139,9 @@ reusable outputs, and the global `--stamp=no` contract remains unchanged.
 
 Trusted CI additionally validates the protected base, PR head, tested merge,
 trusted checkout, run id, PR number, branch, workflow reference, and event
-before invoking Bazel. These immutable OIDs and the PR/head cache namespace
-(`d2b/pr/<number>/<head-sha>/...`) remain the handoff contract for a future
-non-Actions BuildBuddy Workflows trial; the current local Actions gate does not
-write remote cache or publish BuildBuddy invocation metadata. Pushes retain the
+before invoking Bazel. It publishes those immutable OIDs and run/linkage
+fields as BuildBuddy metadata, and derives a cache instance namespace from the
+PR number and head SHA (`d2b/pr/<number>/<head-sha>/...`). Pushes use the
 separate trusted `v3` namespace. A stale checkout or mismatched event fails
 closed.
 
@@ -167,36 +166,25 @@ The facade preserves the selected target set when execution changes:
 - untrusted GitHub jobs always select `local`;
 - `trusted-seed` requires `D2B_BAZEL_TRUSTED=1`, `GITHUB_REF=refs/heads/v3`,
   and an allowlisted security digest;
-- GitHub Actions rejects `remote` and `trusted-seed` profiles before Bazel
-  starts;
 - a clearly pre-dispatch missing-credential, authentication, or endpoint
   failure permits one identical local retry; worker and transport failures
   require explicit pre-dispatch evidence, except for a remote gRPC deadline;
 - analysis, policy, build, test, and post-dispatch failures fail closed.
 
-GitHub Actions does not define, read, or pass `D2B_BUILDBUDDY_API_KEY`. It
-never invokes `tests/tools/bazel-check-bootstrap` and the facade rejects a
-non-local profile when `GITHUB_ACTIONS=true`. The credential helper and
-bootstrap remain available only to controlled non-Actions developer or future
-Workflows use.
+For GitHub Actions, add the repository secret
+`D2B_BUILDBUDDY_API_KEY`. The trusted workflow passes it only over stdin to
+`tests/tools/bazel-check-bootstrap`, which stores it in an anonymous memfd and
+execs the trusted `v3` command with a descriptor number. The key is not placed
+in ordinary action environment variables, arguments, repository files, Bazel
+rc files, or test environments. Credential-bearing CI has no local fallback:
+missing credentials, authentication failure, endpoint failure, or remote
+execution failure fails the job instead of producing a reduced local gate.
 
 The facade stages the tested source with trusted copies of `.bazelrc`,
 `MODULE.bazel`, `MODULE.bazel.lock`, `flake.lock`, remote/platform BUILD files,
 and the credential/shell helpers. It disables system, home, workspace, and PR
-`.bazelrc.user` configuration. Remote endpoint and helper flags are only
-constructed for non-Actions remote profiles; local Actions runs cannot reach
-that path. Future PR cache writes must use the PR/head namespace and never the
-trusted seed namespace.
-
-## Future BuildBuddy Workflows trial handoff
-
-This branch does not implement BuildBuddy Workflows or move GitHub Actions to
-remote execution. A future pilot may consume only the existing fixed
-`//...` target set, protected-v3 workflow ownership, exact base/head/merge/
-trusted/tested OIDs, run and PR linkage, trusted security digest, and isolated
-`d2b/pr/<number>/<head-sha>/...` cache domain. Credential acquisition and
-remote execution must remain outside GitHub Actions, and the stable `check`
-result must retain the same target and trust contracts before any adoption.
+`.bazelrc.user` configuration and pins the endpoint and helper path on the
+Bazel command line. PR cache writes never use the trusted seed namespace.
 
 The trusted security digest covers the committed workflow, Makefile, module and
 Nix locks, platform, remote policy, bootstrap, shell, and credential-helper

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -335,7 +335,7 @@ rust_test(
     name = "pr_workflow",
     srcs = ["tests/pr_workflow.rs"],
     data = ["//:.github/workflows/pr-l1-static-fast.yml"],
-    tags = ["no-remote-exec"],
+    tags = ["local", "no-remote-cache"],
     visibility = ["//visibility:public"],
 )
 

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -194,6 +194,7 @@ rust_test(
         "//bazel/checks/meta:BUILD.bazel",
         "//:tests/tools/bazel-check",
         "//:tests/tools/tier0-first-pass.sh",
+        "//:tests/tools/bazel-check-bootstrap",
         "//:tests/golden/bazel/cache-policy.json",
         "//packages/d2b-bus:BUILD.bazel",
         "//packages/d2b:BUILD.bazel",

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -267,7 +267,7 @@ rust_test(
     env = {"CARGO_BIN_EXE_xtask": "$(rootpath :xtask)"},
     env_inherit = ["D2B_REPO_ROOT", "PATH"],
     rustc_env = {"CARGO_BIN_EXE_xtask": "$(rootpath :xtask)"},
-    tags = ["local", "no-remote-cache"],
+    tags = ["local", "no-remote-cache", "no-sandbox"],
     visibility = ["//visibility:public"],
     deps = ["//packages/d2b-contracts-resource:d2b_contracts_resource",
         "//packages/d2b-contracts-zone-session:d2b_contracts_zone_session",  "//packages/d2b-contracts-provider:d2b_contracts_provider",] + all_crate_deps(normal = True, normal_dev = True, cargo_only = True),
@@ -335,7 +335,7 @@ rust_test(
     name = "pr_workflow",
     srcs = ["tests/pr_workflow.rs"],
     data = ["//:.github/workflows/pr-l1-static-fast.yml"],
-    tags = ["local", "no-remote-cache"],
+    tags = ["local", "no-remote-cache", "no-sandbox"],
     visibility = ["//visibility:public"],
 )
 

--- a/packages/xtask/BUILD.bazel
+++ b/packages/xtask/BUILD.bazel
@@ -335,6 +335,7 @@ rust_test(
     name = "pr_workflow",
     srcs = ["tests/pr_workflow.rs"],
     data = ["//:.github/workflows/pr-l1-static-fast.yml"],
+    tags = ["no-remote-exec"],
     visibility = ["//visibility:public"],
 )
 

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -1803,6 +1803,8 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     let head_commit = "1234567890abcdef1234567890abcdef12345678";
     let merge_commit = "2345678901abcdef2345678901abcdef23456789";
     let invalid_commit = "ffffffffffffffffffffffffffffffffffffffff";
+    let fail_base_ancestry = scratch.join("fail-base-ancestry");
+    let fail_head_ancestry = scratch.join("fail-head-ancestry");
     let git = bin.join("git");
     write_executable(
         &git,
@@ -1823,8 +1825,8 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
                  case \"$*\" in *'{invalid_commit}^{{commit}}'*) exit 1 ;; *) exit 0 ;; esac\n\
                  ;;\n\
                *'merge-base --is-ancestor'*)\n\
-                 if [ \"${{D2B_TEST_FAIL_ANCESTRY:-}}\" = base ] && [[ \"$*\" == *'{base_commit}'* ]]; then exit 1; fi\n\
-                 if [ \"${{D2B_TEST_FAIL_ANCESTRY:-}}\" = head ] && [[ \"$*\" == *'{head_commit}'* ]]; then exit 1; fi\n\
+                 if [ -e '{fail_base_ancestry}' ] && [[ \"$*\" == *'{base_commit}'* ]]; then exit 1; fi\n\
+                 if [ -e '{fail_head_ancestry}' ] && [[ \"$*\" == *'{head_commit}'* ]]; then exit 1; fi\n\
                  case \"$*\" in *'{invalid_commit}'*) exit 1 ;; *) exit 0 ;; esac\n\
                  ;;\n\
                *'rev-parse --show-toplevel'*) printf '%s\\n' '{source_root}' ;;\n\
@@ -1833,6 +1835,8 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             base_commit = base_commit,
             merge_commit = merge_commit,
             invalid_commit = invalid_commit,
+            fail_base_ancestry = fail_base_ancestry.display(),
+            fail_head_ancestry = fail_head_ancestry.display(),
             source_root = source_root.display(),
             trusted_root = trusted_root.display(),
         ),
@@ -1853,6 +1857,18 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     std::fs::write(scratch.join(".bazelrc"), "").expect("write CI metadata Bazel rc");
 
     let run = |base_sha: &str, fail_ancestry: &str| {
+        let _ = std::fs::remove_file(&fail_base_ancestry);
+        let _ = std::fs::remove_file(&fail_head_ancestry);
+        match fail_ancestry {
+            "base" => {
+                std::fs::write(&fail_base_ancestry, "").expect("mark base ancestry failure")
+            }
+            "head" => {
+                std::fs::write(&fail_head_ancestry, "").expect("mark head ancestry failure")
+            }
+            "" => {}
+            other => panic!("unknown ancestry failure mode: {other}"),
+        }
         Command::new("bash")
             .arg(repo_root().join("tests/tools/bazel-check"))
             .args(["--profile", "local", "--", "//:test"])
@@ -1865,7 +1881,6 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .env("D2B_BAZEL_TRUSTED", "1")
             .env("D2B_BAZEL_PROFILE", "local")
             .env("D2B_BAZEL_BASE_SHA", base_sha)
-            .env("D2B_TEST_FAIL_ANCESTRY", fail_ancestry)
             .env("D2B_BAZEL_HEAD_SHA", head_commit)
             .env("D2B_BAZEL_MERGE_SHA", merge_commit)
             .env("D2B_BAZEL_TRUSTED_SHA", base_commit)

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -2677,8 +2677,9 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
         output.status.success(),
         "valid trusted PR metadata must pass: {output:?}"
     );
+    let evidence_run = only_evidence_run(&scratch.join("evidence"));
     assert_eq!(
-        std::fs::read_to_string(scratch.join("evidence/trusted-workspace/.bazelrc"))
+        std::fs::read_to_string(evidence_run.join("trusted-workspace/.bazelrc"))
             .expect("read staged trusted Bazel rc"),
         "true"
     );

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -1923,12 +1923,14 @@ fn ci_uses_trusted_public_make_aliases_without_nested_nix_develop_wrappers() {
         "CI must use the public Make dispatcher instead of per-target Nix wrappers"
     );
     assert!(
-        workflow.contains(
-            "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}"
-        )
-            && workflow.contains("D2B_BAZEL_PROFILE: local")
+        workflow.matches("D2B_BAZEL_PROFILE: local").count() == 13
+            && !workflow.contains("D2B_BAZEL_PROFILE: remote")
+            && !workflow.contains("D2B_BAZEL_PROFILE: trusted-seed")
+            && !workflow.contains("D2B_BAZEL_REQUIRE_REMOTE")
+            && !workflow.contains("D2B_BUILDBUDDY_API_KEY")
+            && !workflow.contains("bazel-check-bootstrap")
             && !workflow.contains("D2B_BAZEL_UNTRUSTED: \"1\""),
-        "CI must use the trusted remote and local-only BuildBuddy profiles"
+        "CI must use only the trusted local profile without BuildBuddy credentials"
     );
     let make_runs = workflow
         .lines()
@@ -1941,6 +1943,32 @@ fn ci_uses_trusted_public_make_aliases_without_nested_nix_develop_wrappers() {
         make_runs >= 12,
         "the Layer-1 workflow should exercise trusted public Make aliases directly (found {make_runs})"
     );
+}
+
+#[test]
+fn github_actions_rejects_remote_profiles() {
+    for profile in ["remote", "trusted-seed"] {
+        let output = Command::new("bash")
+            .arg(repo_root().join("tests/tools/bazel-check"))
+            .args(["--profile", profile, "--", "//:test"])
+            .env("GITHUB_ACTIONS", "true")
+            .output()
+            .expect("run GitHub Actions profile guard");
+        assert_eq!(
+            output.status.code(),
+            Some(76),
+            "GitHub Actions must reject {profile}: {output:?}"
+        );
+        let diagnostics = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            diagnostics.contains("GitHub Actions CI is local-only"),
+            "profile guard must explain the local-only contract: {diagnostics}"
+        );
+    }
 }
 
 #[test]

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -1923,14 +1923,12 @@ fn ci_uses_trusted_public_make_aliases_without_nested_nix_develop_wrappers() {
         "CI must use the public Make dispatcher instead of per-target Nix wrappers"
     );
     assert!(
-        workflow.matches("D2B_BAZEL_PROFILE: local").count() == 13
-            && !workflow.contains("D2B_BAZEL_PROFILE: remote")
-            && !workflow.contains("D2B_BAZEL_PROFILE: trusted-seed")
-            && !workflow.contains("D2B_BAZEL_REQUIRE_REMOTE")
-            && !workflow.contains("D2B_BUILDBUDDY_API_KEY")
-            && !workflow.contains("bazel-check-bootstrap")
+        workflow.contains(
+            "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}"
+        )
+            && workflow.contains("D2B_BAZEL_PROFILE: local")
             && !workflow.contains("D2B_BAZEL_UNTRUSTED: \"1\""),
-        "CI must use only the trusted local profile without BuildBuddy credentials"
+        "CI must use the trusted remote and local-only BuildBuddy profiles"
     );
     let make_runs = workflow
         .lines()
@@ -1943,32 +1941,6 @@ fn ci_uses_trusted_public_make_aliases_without_nested_nix_develop_wrappers() {
         make_runs >= 12,
         "the Layer-1 workflow should exercise trusted public Make aliases directly (found {make_runs})"
     );
-}
-
-#[test]
-fn github_actions_rejects_remote_profiles() {
-    for profile in ["remote", "trusted-seed"] {
-        let output = Command::new("bash")
-            .arg(repo_root().join("tests/tools/bazel-check"))
-            .args(["--profile", profile, "--", "//:test"])
-            .env("GITHUB_ACTIONS", "true")
-            .output()
-            .expect("run GitHub Actions profile guard");
-        assert_eq!(
-            output.status.code(),
-            Some(76),
-            "GitHub Actions must reject {profile}: {output:?}"
-        );
-        let diagnostics = format!(
-            "{}{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        assert!(
-            diagnostics.contains("GitHub Actions CI is local-only"),
-            "profile guard must explain the local-only contract: {diagnostics}"
-        );
-    }
 }
 
 #[test]

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -2,9 +2,10 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    io::Write,
     os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     sync::OnceLock,
 };
 
@@ -269,6 +270,45 @@ fn rule_tags(block: &str) -> BTreeSet<String> {
         .collect()
 }
 
+fn assert_trusted_bazelrc_contract(bazelrc: &str) {
+    for line in [
+        "build:remote --remote_executor=grpcs://d2b.buildbuddy.io",
+        "build:remote --remote_cache=grpcs://d2b.buildbuddy.io",
+        "build:remote --bes_backend=grpcs://d2b.buildbuddy.io",
+        "build:remote --credential_helper=d2b.buildbuddy.io=%workspace%/tests/tools/bazel-check",
+    ] {
+        assert!(bazelrc.contains(line), "trusted .bazelrc lost {line}");
+    }
+    assert!(
+        !bazelrc.contains("--remote_header") && !bazelrc.contains("--bes_header"),
+        "trusted .bazelrc must not use header authentication"
+    );
+}
+
+fn assert_trusted_wrapper_contract(wrapper: &str) {
+    for marker in [
+        "D2B_BAZEL_SOURCE_ROOT",
+        "D2B_BAZEL_TRUSTED_ROOT",
+        "D2B_BAZEL_TRUSTED_SHA",
+        "prepare_trusted_control_files",
+        "--noworkspace_rc",
+        "--remote_executor=grpcs://d2b.buildbuddy.io",
+        "--remote_cache=grpcs://d2b.buildbuddy.io",
+        "--bes_backend=grpcs://d2b.buildbuddy.io",
+        "--credential_helper=d2b.buildbuddy.io=$TRUSTED_ROOT/tests/tools/bazel-check",
+        "D2B_BAZEL_TESTED_SHA",
+        "D2B_BAZEL_BASE_SHA",
+        "D2B_BAZEL_HEAD_SHA",
+        "D2B_BAZEL_MERGE_SHA",
+        "D2B_BAZEL_PR_NUMBER",
+        "D2B_BAZEL_RUN_ID",
+        "D2B_BAZEL_REQUIRE_REMOTE",
+        "D2B_BAZEL_CREDENTIAL_FD",
+    ] {
+        assert!(wrapper.contains(marker), "trusted facade lost {marker}");
+    }
+}
+
 #[test]
 fn committed_profiles_share_authentication_and_worker_policy() {
     let bazelrc = read_text(".bazelrc");
@@ -394,6 +434,18 @@ fn committed_profiles_share_authentication_and_worker_policy() {
     assert!(
         !wrapper.contains("--dispatch-evidence"),
         "BEP file presence alone must not suppress pre-dispatch fallback"
+    );
+    assert!(
+        wrapper.contains("D2B_BAZEL_TRUSTED_ROOT"),
+        "CI must keep trusted control files separate from the tested checkout"
+    );
+    assert!(
+        wrapper.contains("D2B_BAZEL_SOURCE_ROOT"),
+        "CI must run the tested source through the trusted facade"
+    );
+    assert!(
+        wrapper.contains("D2B_BAZEL_CREDENTIAL_FD"),
+        "CI credentials must use the bootstrap descriptor boundary"
     );
     assert!(
         wrapper.contains("command_flags+=(--shell_executable=/bin/bash)"),
@@ -1085,7 +1137,7 @@ fn default_shell_includes_the_pinned_bazel_contract() {
 }
 
 #[test]
-fn ci_uses_public_make_aliases_without_nested_nix_develop_wrappers() {
+fn ci_uses_trusted_public_make_aliases_without_nested_nix_develop_wrappers() {
     let workflow = read_text(".github/workflows/pr-l1-static-fast.yml");
     assert!(
         workflow
@@ -1095,20 +1147,23 @@ fn ci_uses_public_make_aliases_without_nested_nix_develop_wrappers() {
         "CI must use the public Make dispatcher instead of per-target Nix wrappers"
     );
     assert!(
-        workflow.contains("D2B_BAZEL_PROFILE: local")
-            && workflow.contains("D2B_BAZEL_UNTRUSTED: \"1\""),
-        "CI must keep the local and untrusted BuildBuddy boundary"
+        workflow.contains(
+            "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}"
+        )
+            && workflow.contains("D2B_BAZEL_PROFILE: local")
+            && !workflow.contains("D2B_BAZEL_UNTRUSTED: \"1\""),
+        "CI must use the trusted remote and local-only BuildBuddy profiles"
     );
     let make_runs = workflow
         .lines()
         .filter(|line| {
             let trimmed = line.trim_start();
-            trimmed.starts_with("run: make ") || trimmed == "run: make"
+            trimmed.contains("make -C trusted")
         })
         .count();
     assert!(
-        make_runs >= 10,
-        "the Layer-1 workflow should exercise public Make aliases directly (found {make_runs})"
+        make_runs >= 12,
+        "the Layer-1 workflow should exercise trusted public Make aliases directly (found {make_runs})"
     );
 }
 
@@ -1554,21 +1609,17 @@ fn policy_preserves_remote_profiles_and_trust_partition() {
         remote.get("workerImageContract").and_then(Value::as_str),
         Some("d2b-bazel-worker/v1")
     );
-    assert!(
-        policy["profiles"]["remote"]["namespace"]
-            .as_str()
-            .is_some_and(|namespace| namespace.contains("/worker-v1/minimal/lock-v1"))
-    );
+    assert!(policy["profiles"]["remote"]["namespace"]
+        .as_str()
+        .is_some_and(|namespace| namespace.contains("/worker-v1/minimal/lock-v1")));
     assert_eq!(
         policy["profiles"]["trusted-seed"]["remoteCacheAsync"].as_bool(),
         Some(false)
     );
-    assert!(
-        remote["experimentalFeatures"]
-            .as_array()
-            .expect("experimental feature list")
-            .is_empty()
-    );
+    assert!(remote["experimentalFeatures"]
+        .as_array()
+        .expect("experimental feature list")
+        .is_empty());
 
     let trusted = object(
         object(&policy, "cache policy")
@@ -1584,15 +1635,175 @@ fn policy_preserves_remote_profiles_and_trust_partition() {
         trusted.get("untrustedCredential").and_then(Value::as_str),
         Some("none")
     );
+    let allowlisted = trusted["allowlistedSecurityFiles"]
+        .as_array()
+        .expect("allowlisted security files");
+    for path in [
+        ".github/workflows/pr-l1-static-fast.yml",
+        "Makefile",
+        "tests/tools/ci-shell",
+        "tests/tools/bazel-check-bootstrap",
+    ] {
+        assert!(
+            allowlisted.iter().any(|value| value.as_str() == Some(path)),
+            "trusted security digest must cover {path}"
+        );
+    }
+    assert!(trusted["allowedSecurityDigests"]
+        .as_array()
+        .expect("security digest allowlist")
+        .iter()
+        .all(|digest| digest
+            .as_str()
+            .is_some_and(|value| value.starts_with("sha256:"))));
+}
+
+#[test]
+fn trusted_control_plane_rejects_malicious_edits() {
+    let bazelrc = read_text(".bazelrc");
+    assert_trusted_bazelrc_contract(&bazelrc);
+    let wrapper = read_text("tests/tools/bazel-check");
+    assert_trusted_wrapper_contract(&wrapper);
+
+    for tampered in [
+        bazelrc.replace("grpcs://d2b.buildbuddy.io", "grpcs://evil.invalid"),
+        bazelrc.replace(
+            "build:remote --credential_helper=d2b.buildbuddy.io=%workspace%/tests/tools/bazel-check",
+            "build:remote --credential_helper=d2b.buildbuddy.io=workspace/tests/tools/bazel-check",
+        ),
+    ] {
+        assert!(
+            std::panic::catch_unwind(|| assert_trusted_bazelrc_contract(&tampered)).is_err(),
+            "malicious .bazelrc edit was accepted"
+        );
+    }
+    for tampered in [
+        wrapper.replace(
+            "--remote_executor=grpcs://d2b.buildbuddy.io",
+            "--remote_executor=grpcs://evil.invalid",
+        ),
+        wrapper.replace(
+            "--credential_helper=d2b.buildbuddy.io=$TRUSTED_ROOT/tests/tools/bazel-check",
+            "--credential_helper=d2b.buildbuddy.io=$ROOT/tests/tools/bazel-check",
+        ),
+        wrapper.replace("D2B_BAZEL_TESTED_SHA", "D2B_BAZEL_HEAD_SHA"),
+    ] {
+        assert!(
+            std::panic::catch_unwind(|| assert_trusted_wrapper_contract(&tampered)).is_err(),
+            "malicious facade edit was accepted"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_transfers_only_a_credential_fd() {
+    let mut child = Command::new(repo_root().join("tests/tools/bazel-check-bootstrap"))
+        .args([
+            "python3",
+            "-c",
+            "import os; fd=int(os.environ['D2B_BAZEL_CREDENTIAL_FD']); assert os.pread(fd, 99, 0) == b'synthetic-token'; assert 'D2B_BUILDBUDDY_API_KEY' not in os.environ",
+        ])
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("spawn credential bootstrap");
+    child
+        .stdin
+        .take()
+        .expect("open bootstrap stdin")
+        .write_all(b"synthetic-token")
+        .expect("write synthetic credential");
     assert!(
-        trusted["allowedSecurityDigests"]
-            .as_array()
-            .expect("security digest allowlist")
-            .iter()
-            .all(|digest| digest
-                .as_str()
-                .is_some_and(|value| value.starts_with("sha256:")))
+        child.wait().expect("wait for credential bootstrap").success(),
+        "bootstrap must expose only the inherited credential descriptor"
     );
+}
+
+#[test]
+fn trusted_ci_rejects_pr_metadata_tampering() {
+    let scratch = repo_root().join(".scratch").join(format!(
+        "bazel-check-ci-metadata-test-{}",
+        std::process::id()
+    ));
+    let bin = scratch.join("bin");
+    std::fs::create_dir_all(&bin).expect("create CI metadata test directory");
+    let commit = "0123456789abcdef0123456789abcdef01234567";
+    let git = bin.join("git");
+    write_executable(
+        &git,
+        &format!(
+            "#!/usr/bin/env bash\n\
+             case \"$*\" in\n\
+               *'status --porcelain=v2 --branch --untracked-files=no -z'*) printf '# branch.oid {0}\\0# branch.head feature/issue-447\\0' ;;\n\
+               *'config --local --get remote.origin.url'*) printf 'https://github.com/vicondoa/d2b.git\\n' ;;\n\
+               *'check-ref-format --branch'*) exit 0 ;;\n\
+               *'rev-parse --verify'*) printf '{0}\\n' ;;\n\
+               *'cat-file -e'*|*'merge-base --is-ancestor'*) exit 0 ;;\n\
+               *'rev-parse --show-toplevel'*) printf '%s\\n' \"$D2B_BAZEL_SOURCE_ROOT\" ;;\n\
+               *) exit 1 ;;\n\
+             esac\n",
+            commit
+        ),
+    );
+    let bazel = bin.join("bazel");
+    write_executable(
+        &bazel,
+        "#!/usr/bin/env bash\n\
+         for arg in \"$@\"; do\n\
+           case \"$arg\" in\n\
+             --build_event_json_file=*) bep=\"${arg#*=}\" ;;\n\
+           esac\n\
+         done\n\
+         printf '{\"testResult\":{\"status\":\"PASSED\"}}\\n' > \"$bep\"\n",
+    );
+    let xtask = bin.join("xtask");
+    write_executable(&xtask, "#!/usr/bin/env bash\nexit 0\n");
+    std::fs::write(scratch.join(".bazelrc"), "").expect("write CI metadata Bazel rc");
+
+    let run = |base_sha: &str| {
+        Command::new("bash")
+            .arg(repo_root().join("tests/tools/bazel-check"))
+            .args(["--profile", "local", "--", "//:test"])
+            .env("D2B_BAZEL_BIN", &bazel)
+            .env("D2B_XTASK_BIN", &xtask)
+            .env("D2B_BAZEL_SOURCE_ROOT", &scratch)
+            .env("D2B_BAZEL_TRUSTED_ROOT", &scratch)
+            .env("D2B_BAZEL_CHECK_SCRATCH", scratch.join("evidence"))
+            .env("D2B_BAZEL_TRUSTED", "1")
+            .env("D2B_BAZEL_PROFILE", "local")
+            .env("D2B_BAZEL_BASE_SHA", base_sha)
+            .env("D2B_BAZEL_HEAD_SHA", commit)
+            .env("D2B_BAZEL_MERGE_SHA", commit)
+            .env("D2B_BAZEL_TRUSTED_SHA", commit)
+            .env("D2B_BAZEL_PR_NUMBER", "447")
+            .env("D2B_BAZEL_BRANCH", "feature/issue-447")
+            .env("D2B_BAZEL_RUN_ID", "123")
+            .env(
+                "D2B_BAZEL_WORKFLOW_REF",
+                "vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/v3",
+            )
+            .env("GITHUB_ACTIONS", "true")
+            .env("GITHUB_EVENT_NAME", "pull_request_target")
+            .env("GITHUB_REF", "refs/heads/v3")
+            .env("GITHUB_REPOSITORY", "vicondoa/d2b")
+            .env("GITHUB_SERVER_URL", "https://github.com")
+            .env("GITHUB_BASE_REF", "v3")
+            .env("GITHUB_HEAD_REF", "feature/issue-447")
+            .env(
+                "PATH",
+                format!("{}:{}", bin.display(), std::env::var("PATH").unwrap()),
+            )
+            .output()
+            .expect("run trusted CI metadata profile")
+    };
+
+    let output = run(commit);
+    assert!(
+        output.status.success(),
+        "valid trusted PR metadata must pass: {output:?}"
+    );
+    let output = run("ffffffffffffffffffffffffffffffffffffffff");
+    assert_eq!(output.status.code(), Some(76));
+    let _ = std::fs::remove_dir_all(scratch);
 }
 
 #[test]

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -317,6 +317,8 @@ fn assert_trusted_wrapper_contract(wrapper: &str) {
         "D2B_BAZEL_BASE_SHA",
         "D2B_BAZEL_HEAD_SHA",
         "D2B_BAZEL_MERGE_SHA",
+        "--build_metadata=COMMIT_SHA=$head_sha",
+        "--build_metadata=COMMIT_SHA=$tested_sha",
         "D2B_BAZEL_PR_NUMBER",
         "D2B_BAZEL_RUN_ID",
         "D2B_BAZEL_REQUIRE_REMOTE",

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -451,6 +451,16 @@ fn committed_profiles_share_authentication_and_worker_policy() {
         wrapper.contains("command_flags+=(--shell_executable=/bin/bash)"),
         "remote Bazel actions must use the worker's shell path"
     );
+    for marker in [
+        "--spawn_strategy=remote",
+        "--remote_local_fallback=false",
+        "--modify_execution_info=.*=+no-local",
+    ] {
+        assert!(
+            wrapper.contains(marker),
+            "credential-bearing remote execution must reject local actions: {marker}"
+        );
+    }
     assert!(
         wrapper.contains(
             "/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$test_path",
@@ -1651,10 +1661,14 @@ fn policy_preserves_remote_profiles_and_trust_partition() {
         "Makefile",
         "bazel/checks/BUILD.bazel",
         "bazel/checks/fixtures/BUILD.bazel",
+        "bazel/checks/fixtures/defs.bzl",
         "bazel/checks/meta/BUILD.bazel",
         "bazel/checks/nix/BUILD.bazel",
+        "bazel/checks/nix/defs.bzl",
         "bazel/checks/policy/BUILD.bazel",
         "bazel/checks/rust/BUILD.bazel",
+        "tests/tools/peak-rss.py",
+        "tests/tools/tier0-first-pass.sh",
         "tests/tools/ci-shell",
         "tests/tools/bazel-check-bootstrap",
     ] {
@@ -1751,14 +1765,18 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             "MODULE.bazel.lock",
             "bazel/checks/BUILD.bazel",
             "bazel/checks/fixtures/BUILD.bazel",
+            "bazel/checks/fixtures/defs.bzl",
             "bazel/checks/meta/BUILD.bazel",
             "bazel/checks/nix/BUILD.bazel",
+            "bazel/checks/nix/defs.bzl",
             "bazel/checks/policy/BUILD.bazel",
             "bazel/checks/rust/BUILD.bazel",
             "bazel/platforms/BUILD.bazel",
             "bazel/remote/BUILD.bazel",
             "Makefile",
             ".github/workflows/pr-l1-static-fast.yml",
+            "tests/tools/peak-rss.py",
+            "tests/tools/tier0-first-pass.sh",
             "tests/tools/bazel-check",
             "tests/tools/bazel-check-bootstrap",
             "tests/tools/ci-shell",

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -2420,7 +2420,7 @@ fn policy_preserves_remote_profiles_and_trust_partition() {
     );
     assert_eq!(
         trusted.get("protectedRef").and_then(Value::as_str),
-        Some("refs/heads/main")
+        Some("refs/heads/v3")
     );
     assert_eq!(
         trusted.get("seedRefs").and_then(Value::as_array),
@@ -2582,7 +2582,6 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     let base_commit = "0123456789abcdef0123456789abcdef01234567";
     let head_commit = "1234567890abcdef1234567890abcdef12345678";
     let merge_commit = "2345678901abcdef2345678901abcdef23456789";
-    let trusted_commit = "3456789012abcdef3456789012abcdef34567890";
     let invalid_commit = "ffffffffffffffffffffffffffffffffffffffff";
     let fail_base_ancestry = scratch.join("fail-base-ancestry");
     let fail_head_ancestry = scratch.join("fail-head-ancestry");
@@ -2597,7 +2596,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
                *'check-ref-format --branch'*) exit 0 ;;\n\
                *'rev-parse --verify HEAD^{{commit}}'*)\n\
                  case \"$*\" in\n\
-                   *'-C {trusted_root} '*) printf '{trusted_commit}\\n' ;;\n\
+                   *'-C {trusted_root} '*) printf '{base_commit}\\n' ;;\n\
                    *'-C {source_root} '*) printf '{merge_commit}\\n' ;;\n\
                    *) exit 1 ;;\n\
                  esac\n\
@@ -2615,7 +2614,6 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
              esac\n",
             base_commit = base_commit,
             merge_commit = merge_commit,
-            trusted_commit = trusted_commit,
             invalid_commit = invalid_commit,
             fail_base_ancestry = fail_base_ancestry.display(),
             fail_head_ancestry = fail_head_ancestry.display(),
@@ -2674,18 +2672,18 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .env("D2B_BAZEL_BASE_SHA", base_sha)
             .env("D2B_BAZEL_HEAD_SHA", head_commit)
             .env("D2B_BAZEL_MERGE_SHA", merge_commit)
-            .env("D2B_BAZEL_TRUSTED_SHA", trusted_commit)
+            .env("D2B_BAZEL_TRUSTED_SHA", base_commit)
             .env("D2B_BAZEL_PR_NUMBER", "447")
             .env("D2B_BAZEL_BRANCH", "feature/issue-447")
             .env("D2B_BAZEL_RUN_ID", "123")
             .env(
                 "D2B_BAZEL_WORKFLOW_REF",
-                "vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/main",
+                "vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/v3",
             )
             .env("GITHUB_ACTIONS", "true")
             .env("GITHUB_EVENT_NAME", "pull_request_target")
-            .env("GITHUB_REF", "refs/heads/main")
-            .env("GITHUB_SHA", trusted_commit)
+            .env("GITHUB_REF", "refs/heads/v3")
+            .env("GITHUB_SHA", base_commit)
             .env("GITHUB_REPOSITORY", "vicondoa/d2b")
             .env("GITHUB_SERVER_URL", "https://github.com")
             .env("GITHUB_BASE_REF", base_ref)
@@ -2710,9 +2708,10 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
         "true"
     );
     let output = run(base_commit, "", "main");
+    assert_eq!(output.status.code(), Some(76));
     assert!(
-        output.status.success(),
-        "valid main-targeted PR metadata must pass: {output:?}"
+        String::from_utf8_lossy(&output.stderr).contains("must target protected v3"),
+        "main-targeted PR metadata must fail closed: {output:?}"
     );
     let output = run(invalid_commit, "", "v3");
     assert_eq!(output.status.code(), Some(76));

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -1823,6 +1823,8 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
                  case \"$*\" in *'{invalid_commit}^{{commit}}'*) exit 1 ;; *) exit 0 ;; esac\n\
                  ;;\n\
                *'merge-base --is-ancestor'*)\n\
+                 if [ \"${{D2B_TEST_FAIL_ANCESTRY:-}}\" = base ] && [[ \"$*\" == *'{base_commit}'* ]]; then exit 1; fi\n\
+                 if [ \"${{D2B_TEST_FAIL_ANCESTRY:-}}\" = head ] && [[ \"$*\" == *'{head_commit}'* ]]; then exit 1; fi\n\
                  case \"$*\" in *'{invalid_commit}'*) exit 1 ;; *) exit 0 ;; esac\n\
                  ;;\n\
                *'rev-parse --show-toplevel'*) printf '%s\\n' '{source_root}' ;;\n\
@@ -1850,7 +1852,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     write_executable(&xtask, "#!/usr/bin/env bash\nexit 0\n");
     std::fs::write(scratch.join(".bazelrc"), "").expect("write CI metadata Bazel rc");
 
-    let run = |base_sha: &str| {
+    let run = |base_sha: &str, fail_ancestry: &str| {
         Command::new("bash")
             .arg(repo_root().join("tests/tools/bazel-check"))
             .args(["--profile", "local", "--", "//:test"])
@@ -1863,6 +1865,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .env("D2B_BAZEL_TRUSTED", "1")
             .env("D2B_BAZEL_PROFILE", "local")
             .env("D2B_BAZEL_BASE_SHA", base_sha)
+            .env("D2B_TEST_FAIL_ANCESTRY", fail_ancestry)
             .env("D2B_BAZEL_HEAD_SHA", head_commit)
             .env("D2B_BAZEL_MERGE_SHA", merge_commit)
             .env("D2B_BAZEL_TRUSTED_SHA", base_commit)
@@ -1888,7 +1891,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .expect("run trusted CI metadata profile")
     };
 
-    let output = run(base_commit);
+    let output = run(base_commit, "");
     assert!(
         output.status.success(),
         "valid trusted PR metadata must pass: {output:?}"
@@ -1898,8 +1901,26 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .expect("read staged trusted Bazel rc"),
         "true"
     );
-    let output = run(invalid_commit);
+    let output = run(invalid_commit, "");
     assert_eq!(output.status.code(), Some(76));
+    let output = run(base_commit, "base");
+    assert_eq!(output.status.code(), Some(76));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("not based on protected v3"),
+        "base ancestry failure must identify the protected-v3 check: {output:?}"
+    );
+    let output = run(base_commit, "head");
+    assert_eq!(output.status.code(), Some(76));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("PR head SHA is not an ancestor"),
+        "head ancestry failure must identify the PR-head check: {output:?}"
+    );
+    let output = run("", "");
+    assert_eq!(output.status.code(), Some(76));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("OID metadata is invalid"),
+        "missing base SHA must fail closed before the legacy path: {output:?}"
+    );
     let _ = std::fs::remove_dir_all(scratch);
 }
 

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -1768,7 +1768,15 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).expect("create trusted control directory");
             }
-            std::fs::write(&path, root == &trusted_root).expect("write trusted control fixture");
+            std::fs::write(
+                &path,
+                if root == &trusted_root {
+                    "true"
+                } else {
+                    "false"
+                },
+            )
+            .expect("write trusted control fixture");
         }
     }
     let base_commit = "0123456789abcdef0123456789abcdef01234567";

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -2628,6 +2628,14 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
         &bazel,
         "#!/usr/bin/env bash\n\
          for arg in \"$@\"; do\n\
+           if [ \"$arg\" = build ]; then\n\
+             mkdir -p \"$D2B_FAKE_TRUSTED_ROOT/bazel-bin/packages/xtask\"\n\
+             printf '#!/usr/bin/env bash\\nexit 0\\n' > \"$D2B_FAKE_TRUSTED_ROOT/bazel-bin/packages/xtask/xtask\"\n\
+             chmod 0555 \"$D2B_FAKE_TRUSTED_ROOT/bazel-bin/packages/xtask/xtask\"\n\
+             exit 0\n\
+           fi\n\
+         done\n\
+         for arg in \"$@\"; do\n\
            case \"$arg\" in\n\
              --build_event_json_file=*) bep=\"${arg#*=}\" ;;\n\
            esac\n\
@@ -2659,6 +2667,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .env("D2B_PROJECT_SHELL", "d2b")
             .env("D2B_BAZEL_SOURCE_ROOT", &source_root)
             .env("D2B_BAZEL_TRUSTED_ROOT", &trusted_root)
+            .env("D2B_FAKE_TRUSTED_ROOT", &trusted_root)
             .env("D2B_BAZEL_CHECK_SCRATCH", scratch.join("evidence"))
             .env("D2B_BAZEL_TRUSTED", "1")
             .env("D2B_BAZEL_PROFILE", "local")
@@ -2710,7 +2719,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     let output = run(base_commit, "base", "v3");
     assert_eq!(output.status.code(), Some(76));
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("not based on protected base"),
+        String::from_utf8_lossy(&output.stderr).contains("not based on the protected base"),
         "base ancestry failure must identify the protected-base check: {output:?}"
     );
     let output = run(base_commit, "head", "v3");

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -321,6 +321,7 @@ fn assert_trusted_wrapper_contract(wrapper: &str) {
         "D2B_BAZEL_RUN_ID",
         "D2B_BAZEL_REQUIRE_REMOTE",
         "D2B_BAZEL_CREDENTIAL_FD",
+        "unset D2B_XTASK_BIN",
     ] {
         assert!(wrapper.contains(marker), "trusted facade lost {marker}");
     }
@@ -2635,7 +2636,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     write_executable(&xtask, "#!/usr/bin/env bash\nexit 0\n");
     std::fs::write(scratch.join(".bazelrc"), "").expect("write CI metadata Bazel rc");
 
-    let run = |base_sha: &str, fail_ancestry: &str| {
+    let run = |base_sha: &str, fail_ancestry: &str, base_ref: &str| {
         let _ = std::fs::remove_file(&fail_base_ancestry);
         let _ = std::fs::remove_file(&fail_head_ancestry);
         match fail_ancestry {
@@ -2676,7 +2677,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .env("GITHUB_SHA", trusted_commit)
             .env("GITHUB_REPOSITORY", "vicondoa/d2b")
             .env("GITHUB_SERVER_URL", "https://github.com")
-            .env("GITHUB_BASE_REF", "v3")
+            .env("GITHUB_BASE_REF", base_ref)
             .env("GITHUB_HEAD_REF", "feature/issue-447")
             .env(
                 "PATH",
@@ -2686,7 +2687,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .expect("run trusted CI metadata profile")
     };
 
-    let output = run(base_commit, "");
+    let output = run(base_commit, "", "v3");
     assert!(
         output.status.success(),
         "valid trusted PR metadata must pass: {output:?}"
@@ -2697,21 +2698,26 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .expect("read staged trusted Bazel rc"),
         "true"
     );
-    let output = run(invalid_commit, "");
+    let output = run(base_commit, "", "main");
+    assert!(
+        output.status.success(),
+        "valid main-targeted PR metadata must pass: {output:?}"
+    );
+    let output = run(invalid_commit, "", "v3");
     assert_eq!(output.status.code(), Some(76));
-    let output = run(base_commit, "base");
+    let output = run(base_commit, "base", "v3");
     assert_eq!(output.status.code(), Some(76));
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("not based on protected base"),
         "base ancestry failure must identify the protected-base check: {output:?}"
     );
-    let output = run(base_commit, "head");
+    let output = run(base_commit, "head", "v3");
     assert_eq!(output.status.code(), Some(76));
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("PR head SHA is not an ancestor"),
         "head ancestry failure must identify the PR-head check: {output:?}"
     );
-    let output = run("", "");
+    let output = run("", "", "v3");
     assert_eq!(output.status.code(), Some(76));
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("OID metadata is invalid"),

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -1658,6 +1658,7 @@ fn policy_preserves_remote_profiles_and_trust_partition() {
         .expect("allowlisted security files");
     for path in [
         ".github/workflows/pr-l1-static-fast.yml",
+        "flake.lock",
         "Makefile",
         "bazel/checks/BUILD.bazel",
         "bazel/checks/fixtures/BUILD.bazel",
@@ -1763,6 +1764,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             ".bazelrc",
             "MODULE.bazel",
             "MODULE.bazel.lock",
+            "flake.lock",
             "bazel/checks/BUILD.bazel",
             "bazel/checks/fixtures/BUILD.bazel",
             "bazel/checks/fixtures/defs.bzl",

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -1581,6 +1581,14 @@ fn audited_local_rust_suite_is_complete_and_tag_driven() {
         ),
         "remote Rust main must exclude both local tag classes"
     );
+    for target in ["test-rust-broker", "test-rust-guest-shell-runner"] {
+        assert!(
+            makefile.contains(&format!(
+                "{target}: D2B_BAZEL_TEST_TAG_FILTERS := -local,-no-remote-exec,-manual,-gpu,-kvm"
+            )),
+            "{target} must exclude local tag classes from credential-bearing CI"
+        );
+    }
     let hermetic = rule_block(&d2b, "auth_status_contract", &["rust_test("]);
     assert!(
         !hermetic.contains("\"local\"") && !hermetic.contains("no-remote-cache"),
@@ -1641,6 +1649,12 @@ fn policy_preserves_remote_profiles_and_trust_partition() {
     for path in [
         ".github/workflows/pr-l1-static-fast.yml",
         "Makefile",
+        "bazel/checks/BUILD.bazel",
+        "bazel/checks/fixtures/BUILD.bazel",
+        "bazel/checks/meta/BUILD.bazel",
+        "bazel/checks/nix/BUILD.bazel",
+        "bazel/checks/policy/BUILD.bazel",
+        "bazel/checks/rust/BUILD.bazel",
         "tests/tools/ci-shell",
         "tests/tools/bazel-check-bootstrap",
     ] {
@@ -1726,22 +1740,71 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     ));
     let bin = scratch.join("bin");
     std::fs::create_dir_all(&bin).expect("create CI metadata test directory");
-    let commit = "0123456789abcdef0123456789abcdef01234567";
+    let source_root = scratch.join("source");
+    let trusted_root = scratch.join("trusted");
+    std::fs::create_dir_all(&source_root).expect("create tested source root");
+    std::fs::create_dir_all(&trusted_root).expect("create trusted source root");
+    for root in [&source_root, &trusted_root] {
+        for relative in [
+            ".bazelrc",
+            "MODULE.bazel",
+            "MODULE.bazel.lock",
+            "bazel/checks/BUILD.bazel",
+            "bazel/checks/fixtures/BUILD.bazel",
+            "bazel/checks/meta/BUILD.bazel",
+            "bazel/checks/nix/BUILD.bazel",
+            "bazel/checks/policy/BUILD.bazel",
+            "bazel/checks/rust/BUILD.bazel",
+            "bazel/platforms/BUILD.bazel",
+            "bazel/remote/BUILD.bazel",
+            "Makefile",
+            ".github/workflows/pr-l1-static-fast.yml",
+            "tests/tools/bazel-check",
+            "tests/tools/bazel-check-bootstrap",
+            "tests/tools/ci-shell",
+            "tests/tools/scrub-shell-environment",
+        ] {
+            let path = root.join(relative);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create trusted control directory");
+            }
+            std::fs::write(&path, root == &trusted_root).expect("write trusted control fixture");
+        }
+    }
+    let base_commit = "0123456789abcdef0123456789abcdef01234567";
+    let head_commit = "1234567890abcdef1234567890abcdef12345678";
+    let merge_commit = "2345678901abcdef2345678901abcdef23456789";
+    let invalid_commit = "ffffffffffffffffffffffffffffffffffffffff";
     let git = bin.join("git");
     write_executable(
         &git,
         &format!(
             "#!/usr/bin/env bash\n\
              case \"$*\" in\n\
-               *'status --porcelain=v2 --branch --untracked-files=no -z'*) printf '# branch.oid {0}\\0# branch.head feature/issue-447\\0' ;;\n\
+               *'status --porcelain=v2 --branch --untracked-files=no -z'*) printf '# branch.oid {merge_commit}\\0# branch.head feature/issue-447\\0' ;;\n\
                *'config --local --get remote.origin.url'*) printf 'https://github.com/vicondoa/d2b.git\\n' ;;\n\
                *'check-ref-format --branch'*) exit 0 ;;\n\
-               *'rev-parse --verify'*) printf '{0}\\n' ;;\n\
-               *'cat-file -e'*|*'merge-base --is-ancestor'*) exit 0 ;;\n\
-               *'rev-parse --show-toplevel'*) printf '%s\\n' \"$D2B_BAZEL_SOURCE_ROOT\" ;;\n\
+               *'rev-parse --verify HEAD^{{commit}}'*)\n\
+                 case \"$*\" in\n\
+                   *'-C {trusted_root} '*) printf '{base_commit}\\n' ;;\n\
+                   *'-C {source_root} '*) printf '{merge_commit}\\n' ;;\n\
+                   *) exit 1 ;;\n\
+                 esac\n\
+                 ;;\n\
+               *'cat-file -e'*)\n\
+                 case \"$*\" in *'{invalid_commit}^{{commit}}'*) exit 1 ;; *) exit 0 ;; esac\n\
+                 ;;\n\
+               *'merge-base --is-ancestor'*)\n\
+                 case \"$*\" in *'{invalid_commit}'*) exit 1 ;; *) exit 0 ;; esac\n\
+                 ;;\n\
+               *'rev-parse --show-toplevel'*) printf '%s\\n' '{source_root}' ;;\n\
                *) exit 1 ;;\n\
              esac\n",
-            commit
+            base_commit = base_commit,
+            merge_commit = merge_commit,
+            invalid_commit = invalid_commit,
+            source_root = source_root.display(),
+            trusted_root = trusted_root.display(),
         ),
     );
     let bazel = bin.join("bazel");
@@ -1765,15 +1828,16 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .args(["--profile", "local", "--", "//:test"])
             .env("D2B_BAZEL_BIN", &bazel)
             .env("D2B_XTASK_BIN", &xtask)
-            .env("D2B_BAZEL_SOURCE_ROOT", &scratch)
-            .env("D2B_BAZEL_TRUSTED_ROOT", &scratch)
+            .env("D2B_PROJECT_SHELL", "d2b")
+            .env("D2B_BAZEL_SOURCE_ROOT", &source_root)
+            .env("D2B_BAZEL_TRUSTED_ROOT", &trusted_root)
             .env("D2B_BAZEL_CHECK_SCRATCH", scratch.join("evidence"))
             .env("D2B_BAZEL_TRUSTED", "1")
             .env("D2B_BAZEL_PROFILE", "local")
             .env("D2B_BAZEL_BASE_SHA", base_sha)
-            .env("D2B_BAZEL_HEAD_SHA", commit)
-            .env("D2B_BAZEL_MERGE_SHA", commit)
-            .env("D2B_BAZEL_TRUSTED_SHA", commit)
+            .env("D2B_BAZEL_HEAD_SHA", head_commit)
+            .env("D2B_BAZEL_MERGE_SHA", merge_commit)
+            .env("D2B_BAZEL_TRUSTED_SHA", base_commit)
             .env("D2B_BAZEL_PR_NUMBER", "447")
             .env("D2B_BAZEL_BRANCH", "feature/issue-447")
             .env("D2B_BAZEL_RUN_ID", "123")
@@ -1796,12 +1860,17 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .expect("run trusted CI metadata profile")
     };
 
-    let output = run(commit);
+    let output = run(base_commit);
     assert!(
         output.status.success(),
         "valid trusted PR metadata must pass: {output:?}"
     );
-    let output = run("ffffffffffffffffffffffffffffffffffffffff");
+    assert_eq!(
+        std::fs::read_to_string(scratch.join("evidence/trusted-workspace/.bazelrc"))
+            .expect("read staged trusted Bazel rc"),
+        "true"
+    );
+    let output = run(invalid_commit);
     assert_eq!(output.status.code(), Some(76));
     let _ = std::fs::remove_dir_all(scratch);
 }

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -465,6 +465,10 @@ fn committed_profiles_share_authentication_and_worker_policy() {
         "CI credentials must use the bootstrap descriptor boundary"
     );
     assert!(
+        wrapper.contains("GITHUB_SHA"),
+        "CI metadata must bind the trusted checkout to GitHub's immutable workflow SHA"
+    );
+    assert!(
         wrapper.contains("command_flags+=(--shell_executable=/bin/bash)"),
         "remote Bazel actions must use the worker's shell path"
     );
@@ -2413,7 +2417,14 @@ fn policy_preserves_remote_profiles_and_trust_partition() {
     );
     assert_eq!(
         trusted.get("protectedRef").and_then(Value::as_str),
-        Some("refs/heads/v3")
+        Some("refs/heads/main")
+    );
+    assert_eq!(
+        trusted.get("seedRefs").and_then(Value::as_array),
+        Some(&vec![
+            Value::String("refs/heads/main".to_owned()),
+            Value::String("refs/heads/v3".to_owned()),
+        ])
     );
     assert_eq!(
         trusted.get("untrustedCredential").and_then(Value::as_str),
@@ -2568,6 +2579,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     let base_commit = "0123456789abcdef0123456789abcdef01234567";
     let head_commit = "1234567890abcdef1234567890abcdef12345678";
     let merge_commit = "2345678901abcdef2345678901abcdef23456789";
+    let trusted_commit = "3456789012abcdef3456789012abcdef34567890";
     let invalid_commit = "ffffffffffffffffffffffffffffffffffffffff";
     let fail_base_ancestry = scratch.join("fail-base-ancestry");
     let fail_head_ancestry = scratch.join("fail-head-ancestry");
@@ -2582,7 +2594,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
                *'check-ref-format --branch'*) exit 0 ;;\n\
                *'rev-parse --verify HEAD^{{commit}}'*)\n\
                  case \"$*\" in\n\
-                   *'-C {trusted_root} '*) printf '{base_commit}\\n' ;;\n\
+                   *'-C {trusted_root} '*) printf '{trusted_commit}\\n' ;;\n\
                    *'-C {source_root} '*) printf '{merge_commit}\\n' ;;\n\
                    *) exit 1 ;;\n\
                  esac\n\
@@ -2600,6 +2612,7 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
              esac\n",
             base_commit = base_commit,
             merge_commit = merge_commit,
+            trusted_commit = trusted_commit,
             invalid_commit = invalid_commit,
             fail_base_ancestry = fail_base_ancestry.display(),
             fail_head_ancestry = fail_head_ancestry.display(),
@@ -2649,17 +2662,18 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
             .env("D2B_BAZEL_BASE_SHA", base_sha)
             .env("D2B_BAZEL_HEAD_SHA", head_commit)
             .env("D2B_BAZEL_MERGE_SHA", merge_commit)
-            .env("D2B_BAZEL_TRUSTED_SHA", base_commit)
+            .env("D2B_BAZEL_TRUSTED_SHA", trusted_commit)
             .env("D2B_BAZEL_PR_NUMBER", "447")
             .env("D2B_BAZEL_BRANCH", "feature/issue-447")
             .env("D2B_BAZEL_RUN_ID", "123")
             .env(
                 "D2B_BAZEL_WORKFLOW_REF",
-                "vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/v3",
+                "vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/main",
             )
             .env("GITHUB_ACTIONS", "true")
             .env("GITHUB_EVENT_NAME", "pull_request_target")
-            .env("GITHUB_REF", "refs/heads/v3")
+            .env("GITHUB_REF", "refs/heads/main")
+            .env("GITHUB_SHA", trusted_commit)
             .env("GITHUB_REPOSITORY", "vicondoa/d2b")
             .env("GITHUB_SERVER_URL", "https://github.com")
             .env("GITHUB_BASE_REF", "v3")
@@ -2688,8 +2702,8 @@ fn trusted_ci_rejects_pr_metadata_tampering() {
     let output = run(base_commit, "base");
     assert_eq!(output.status.code(), Some(76));
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("not based on protected v3"),
-        "base ancestry failure must identify the protected-v3 check: {output:?}"
+        String::from_utf8_lossy(&output.stderr).contains("not based on protected base"),
+        "base ancestry failure must identify the protected-base check: {output:?}"
     );
     let output = run(base_commit, "head");
     assert_eq!(output.status.code(), Some(76));

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -125,6 +125,11 @@ fn assert_trusted_workflow_contract(workflow: &str) {
         workflow.contains("shell: sh trusted/tests/tools/ci-shell {0}"),
         "workflow commands must use the trusted shell wrapper"
     );
+    assert_eq!(
+        workflow.matches("make -C trusted").count(),
+        12,
+        "every Layer-1 job must invoke its fixed public Make alias from trusted v3"
+    );
     assert!(
         workflow.contains("ref: ${{ github.event.pull_request.base.sha || github.sha }}"),
         "trusted bootstrap must bind to the event base or pushed v3 commit"

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -93,12 +93,12 @@ fn needs_entries(block: &str) -> Vec<&str> {
 
 fn assert_trusted_workflow_contract(workflow: &str) {
     assert!(
-        workflow.contains("pull_request_target:\n    branches: [v3]"),
-        "the credential-bearing workflow must be owned by protected v3"
+        workflow.contains("pull_request_target:\n    branches: [main, v3]"),
+        "the credential-bearing workflow must cover protected main and v3"
     );
     assert!(
-        workflow.contains("push:\n    branches: [v3]"),
-        "trusted seeding must run only from protected v3"
+        workflow.contains("push:\n    branches: [main, v3]"),
+        "trusted seeding must run only from protected main and v3"
     );
     assert!(
         !workflow.contains("\n  pull_request:\n"),
@@ -144,8 +144,12 @@ fn assert_trusted_workflow_contract(workflow: &str) {
         "every Layer-1 step must invoke its fixed public Make alias from trusted v3"
     );
     assert!(
-        workflow.contains("ref: ${{ github.event.pull_request.base.sha || github.sha }}"),
-        "trusted bootstrap must bind to the event base or pushed v3 commit"
+        workflow.contains("ref: ${{ github.sha }}\n          path: trusted"),
+        "trusted bootstrap must bind to the immutable workflow SHA"
+    );
+    assert!(
+        workflow.contains("D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}"),
+        "trusted bootstrap metadata must bind to GitHub's immutable workflow SHA"
     );
     assert!(
         workflow.contains(
@@ -308,8 +312,8 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
 
     for tampered in [
         workflow.replace(
-            "pull_request_target:\n    branches: [v3]",
-            "pull_request:\n    branches: [v3]",
+            "pull_request_target:\n    branches: [main, v3]",
+            "pull_request:\n    branches: [main, v3]",
         ),
         workflow.replace(
             "./trusted/tests/tools/bazel-check-bootstrap",
@@ -321,8 +325,8 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
         ),
         workflow.replace("make -C trusted", "make"),
         workflow.replace(
-            "ref: ${{ github.event.pull_request.base.sha || github.sha }}",
-            "ref: main",
+            "ref: ${{ github.sha }}\n          path: trusted",
+            "ref: main\n          path: trusted",
         ),
         workflow.replacen(
             "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}",

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -127,8 +127,8 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     );
     assert_eq!(
         workflow.matches("make -C trusted").count(),
-        12,
-        "every Layer-1 job must invoke its fixed public Make alias from trusted v3"
+        13,
+        "every Layer-1 step must invoke its fixed public Make alias from trusted v3"
     );
     assert!(
         workflow.contains("ref: ${{ github.event.pull_request.base.sha || github.sha }}"),
@@ -191,6 +191,14 @@ fn assert_trusted_workflow_contract(workflow: &str) {
             "{job} must broker the credential through the trusted bootstrap"
         );
     }
+    let policy = job_block(workflow, "policy-tooling");
+    assert!(
+        policy.contains("D2B_BAZEL_TEST_TAG_FILTERS: \"-local,-no-remote-exec,-manual,-gpu,-kvm\"")
+            && policy.contains("name: Local policy-only suite")
+            && policy.contains("D2B_BAZEL_PROFILE: local")
+            && policy.contains("D2B_BAZEL_REQUIRE_REMOTE: \"0\""),
+        "policy-only local tests must be split from the credential-bearing remote step"
+    );
     for job in [
         "rust-local",
         "nix-eval",

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -159,26 +159,22 @@ fn assert_trusted_workflow_contract(workflow: &str) {
             && workflow.contains("D2B_BAZEL_TRUSTED_SHA"),
         "the facade must receive separate source and trusted roots"
     );
-    assert_eq!(
-        workflow.matches("D2B_BAZEL_PROFILE: local").count(),
-        13,
-        "every Layer-1 suite must use the local Bazel profile"
-    );
-    assert!(
-        !workflow.contains("D2B_BAZEL_PROFILE: remote")
-            && !workflow.contains("D2B_BAZEL_PROFILE: trusted-seed")
-            && !workflow.contains("D2B_BAZEL_REQUIRE_REMOTE"),
-        "GitHub Actions must not select a remote profile or require remote execution"
-    );
     assert!(
         !workflow.contains("github.event.pull_request.merge_commit_sha || github.sha"),
         "PR jobs must not substitute the default-branch SHA for a missing merge SHA"
     );
     assert!(
-        !workflow.contains("D2B_BUILDBUDDY_API_KEY")
-            && !workflow.contains("secrets.D2B_BUILDBUDDY_API_KEY")
-            && !workflow.contains("bazel-check-bootstrap"),
-        "GitHub Actions must not receive or bootstrap a BuildBuddy credential"
+        workflow.contains("./trusted/tests/tools/bazel-check-bootstrap")
+            && !workflow.contains("python3 ./trusted/tests/tools/bazel-check-bootstrap")
+            && workflow.contains("env -u D2B_BUILDBUDDY_API_KEY")
+            && workflow.contains("printf '%s' \"$D2B_BUILDBUDDY_API_KEY\"")
+            && workflow.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
+            && !workflow.contains("secret=\"${{ secrets.D2B_BUILDBUDDY_API_KEY }}\""),
+        "the BuildBuddy secret must cross the trusted bootstrap only over stdin"
+    );
+    assert!(
+        workflow.contains("secrets.D2B_BUILDBUDDY_API_KEY"),
+        "the remote gate must use the repository BuildBuddy secret"
     );
     assert!(
         workflow.matches("persist-credentials: false").count() >= 2,
@@ -199,11 +195,24 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     ] {
         let block = job_block(workflow, job);
         assert!(
-            block.contains("D2B_BAZEL_PROFILE: local")
-                && !block.contains("D2B_BAZEL_REQUIRE_REMOTE")
-                && !block.contains("D2B_BUILDBUDDY_API_KEY")
-                && !block.contains("bazel-check-bootstrap"),
-            "{job} must remain local-only and credential-free"
+            block.contains(
+                "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}"
+            ),
+            "{job} must use the trusted remote/seeding BuildBuddy profile"
+        );
+        assert!(
+            block.contains("D2B_BAZEL_REQUIRE_REMOTE: \"1\""),
+            "{job} must fail closed instead of reducing to a local gate"
+        );
+        assert!(
+            block.contains("D2B_BAZEL_TEST_TAG_FILTERS:")
+                && block.contains("-local,-no-remote-exec"),
+            "{job} must exclude local actions from credential-bearing CI"
+        );
+        assert!(
+            block.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
+                && block.contains("bazel-check-bootstrap"),
+            "{job} must broker the credential through the trusted bootstrap"
         );
         assert!(
             block.contains(
@@ -224,8 +233,9 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     assert!(
         policy_local.contains("D2B_BAZEL_TEST_TAG_FILTERS: \"-manual,-gpu,-kvm\"")
             && policy_local.contains("name: Local policy-only suite")
-            && policy_local.contains("D2B_BAZEL_PROFILE: local"),
-        "policy-only tests must remain a local profile"
+            && policy_local.contains("D2B_BAZEL_PROFILE: local")
+            && policy_local.contains("D2B_BAZEL_REQUIRE_REMOTE: \"0\""),
+        "policy-only local tests must be split from the credential-bearing remote step"
     );
     for job in [
         "policy-local",
@@ -314,7 +324,11 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
             "ref: ${{ github.event.pull_request.base.sha || github.sha }}",
             "ref: main",
         ),
-        workflow.replace("D2B_BAZEL_PROFILE: local", "D2B_BAZEL_PROFILE: remote"),
+        workflow.replacen(
+            "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}",
+            "D2B_BAZEL_PROFILE: local",
+            1,
+        ),
     ] {
         assert!(
             std::panic::catch_unwind(|| assert_trusted_workflow_contract(&tampered)).is_err(),

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 const REQUIRED_AGGREGATE_JOBS: &[&str] = &[
     "tier0",
     "policy-tooling",
+    "policy-local",
     "rust-main",
     "rust-broker",
     "rust-guest",
@@ -127,7 +128,7 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     );
     assert_eq!(
         workflow.matches("make -C trusted").count(),
-        13,
+        14,
         "every Layer-1 step must invoke its fixed public Make alias from trusted v3"
     );
     assert!(
@@ -192,6 +193,11 @@ fn assert_trusted_workflow_contract(workflow: &str) {
             "{job} must fail closed instead of reducing to a local gate"
         );
         assert!(
+            block.contains("D2B_BAZEL_TEST_TAG_FILTERS:")
+                && block.contains("-local,-no-remote-exec"),
+            "{job} must exclude local actions from credential-bearing CI"
+        );
+        assert!(
             block.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
                 && block.contains("bazel-check-bootstrap"),
             "{job} must broker the credential through the trusted bootstrap"
@@ -211,15 +217,16 @@ fn assert_trusted_workflow_contract(workflow: &str) {
             && !tier0.contains("bazel-check-bootstrap"),
         "tier0 must remain a credential-free local preflight"
     );
-    let policy = job_block(workflow, "policy-tooling");
+    let policy_local = job_block(workflow, "policy-local");
     assert!(
-        policy.contains("D2B_BAZEL_TEST_TAG_FILTERS: \"-local,-no-remote-exec,-manual,-gpu,-kvm\"")
-            && policy.contains("name: Local policy-only suite")
-            && policy.contains("D2B_BAZEL_PROFILE: local")
-            && policy.contains("D2B_BAZEL_REQUIRE_REMOTE: \"0\""),
+        policy_local.contains("D2B_BAZEL_TEST_TAG_FILTERS: \"-manual,-gpu,-kvm\"")
+            && policy_local.contains("name: Local policy-only suite")
+            && policy_local.contains("D2B_BAZEL_PROFILE: local")
+            && policy_local.contains("D2B_BAZEL_REQUIRE_REMOTE: \"0\""),
         "policy-only local tests must be split from the credential-bearing remote step"
     );
     for job in [
+        "policy-local",
         "tier0",
         "rust-local",
         "nix-eval",

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -159,22 +159,26 @@ fn assert_trusted_workflow_contract(workflow: &str) {
             && workflow.contains("D2B_BAZEL_TRUSTED_SHA"),
         "the facade must receive separate source and trusted roots"
     );
+    assert_eq!(
+        workflow.matches("D2B_BAZEL_PROFILE: local").count(),
+        13,
+        "every Layer-1 suite must use the local Bazel profile"
+    );
+    assert!(
+        !workflow.contains("D2B_BAZEL_PROFILE: remote")
+            && !workflow.contains("D2B_BAZEL_PROFILE: trusted-seed")
+            && !workflow.contains("D2B_BAZEL_REQUIRE_REMOTE"),
+        "GitHub Actions must not select a remote profile or require remote execution"
+    );
     assert!(
         !workflow.contains("github.event.pull_request.merge_commit_sha || github.sha"),
         "PR jobs must not substitute the default-branch SHA for a missing merge SHA"
     );
     assert!(
-        workflow.contains("./trusted/tests/tools/bazel-check-bootstrap")
-            && !workflow.contains("python3 ./trusted/tests/tools/bazel-check-bootstrap")
-            && workflow.contains("env -u D2B_BUILDBUDDY_API_KEY")
-            && workflow.contains("printf '%s' \"$D2B_BUILDBUDDY_API_KEY\"")
-            && workflow.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
-            && !workflow.contains("secret=\"${{ secrets.D2B_BUILDBUDDY_API_KEY }}\""),
-        "the BuildBuddy secret must cross the trusted bootstrap only over stdin"
-    );
-    assert!(
-        workflow.contains("secrets.D2B_BUILDBUDDY_API_KEY"),
-        "the remote gate must use the repository BuildBuddy secret"
+        !workflow.contains("D2B_BUILDBUDDY_API_KEY")
+            && !workflow.contains("secrets.D2B_BUILDBUDDY_API_KEY")
+            && !workflow.contains("bazel-check-bootstrap"),
+        "GitHub Actions must not receive or bootstrap a BuildBuddy credential"
     );
     assert!(
         workflow.matches("persist-credentials: false").count() >= 2,
@@ -195,24 +199,11 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     ] {
         let block = job_block(workflow, job);
         assert!(
-            block.contains(
-                "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}"
-            ),
-            "{job} must use the trusted remote/seeding BuildBuddy profile"
-        );
-        assert!(
-            block.contains("D2B_BAZEL_REQUIRE_REMOTE: \"1\""),
-            "{job} must fail closed instead of reducing to a local gate"
-        );
-        assert!(
-            block.contains("D2B_BAZEL_TEST_TAG_FILTERS:")
-                && block.contains("-local,-no-remote-exec"),
-            "{job} must exclude local actions from credential-bearing CI"
-        );
-        assert!(
-            block.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
-                && block.contains("bazel-check-bootstrap"),
-            "{job} must broker the credential through the trusted bootstrap"
+            block.contains("D2B_BAZEL_PROFILE: local")
+                && !block.contains("D2B_BAZEL_REQUIRE_REMOTE")
+                && !block.contains("D2B_BUILDBUDDY_API_KEY")
+                && !block.contains("bazel-check-bootstrap"),
+            "{job} must remain local-only and credential-free"
         );
         assert!(
             block.contains(
@@ -233,9 +224,8 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     assert!(
         policy_local.contains("D2B_BAZEL_TEST_TAG_FILTERS: \"-manual,-gpu,-kvm\"")
             && policy_local.contains("name: Local policy-only suite")
-            && policy_local.contains("D2B_BAZEL_PROFILE: local")
-            && policy_local.contains("D2B_BAZEL_REQUIRE_REMOTE: \"0\""),
-        "policy-only local tests must be split from the credential-bearing remote step"
+            && policy_local.contains("D2B_BAZEL_PROFILE: local"),
+        "policy-only tests must remain a local profile"
     );
     for job in [
         "policy-local",
@@ -324,11 +314,7 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
             "ref: ${{ github.event.pull_request.base.sha || github.sha }}",
             "ref: main",
         ),
-        workflow.replacen(
-            "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}",
-            "D2B_BAZEL_PROFILE: local",
-            1,
-        ),
+        workflow.replace("D2B_BAZEL_PROFILE: local", "D2B_BAZEL_PROFILE: remote"),
     ] {
         assert!(
             std::panic::catch_unwind(|| assert_trusted_workflow_contract(&tampered)).is_err(),

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -302,8 +302,8 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
             "pull_request:\n    branches: [v3]",
         ),
         workflow.replace(
-            "./trusted/tests/tools/bazel-check-bootstrap",
-            "python3 ./workspace/tests/tools/bazel-check-bootstrap",
+            "permissions:\n  contents: read",
+            "permissions:\n  contents: write",
         ),
         workflow.replace(
             "github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha",

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -78,6 +78,136 @@ fn needs_entries(block: &str) -> Vec<&str> {
     value.split(',').map(str::trim).collect()
 }
 
+fn assert_trusted_workflow_contract(workflow: &str) {
+    assert!(
+        workflow.contains("pull_request_target:\n    branches: [v3]"),
+        "the credential-bearing workflow must be owned by protected v3"
+    );
+    assert!(
+        workflow.contains("push:\n    branches: [v3]"),
+        "trusted seeding must run only from protected v3"
+    );
+    assert!(
+        !workflow.contains("\n  pull_request:\n"),
+        "the secret-bearing gate must not use an untrusted pull_request workflow"
+    );
+    assert!(
+        workflow.contains("permissions:\n  contents: read")
+            && !workflow.contains("contents: write")
+            && !workflow.contains("pull-requests: write"),
+        "the trusted gate must use a read-only GitHub token"
+    );
+    assert!(
+        !workflow.contains("D2B_BAZEL_UNTRUSTED"),
+        "the trusted gate must not opt into the untrusted BuildBuddy boundary"
+    );
+    for line in workflow
+        .lines()
+        .filter(|line| line.trim_start().starts_with("- uses:"))
+    {
+        let reference = line
+            .split_once('@')
+            .map(|(_, reference)| reference.trim())
+            .expect("pinned action reference");
+        assert!(
+            reference.len() == 40
+                && reference
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit()),
+            "every workflow action must be pinned to a commit: {line}"
+        );
+    }
+    assert!(
+        workflow.contains("path: trusted") && workflow.contains("path: workspace"),
+        "every gate must separate trusted bootstrap and tested source"
+    );
+    assert!(
+        workflow.contains("shell: sh trusted/tests/tools/ci-shell {0}"),
+        "workflow commands must use the trusted shell wrapper"
+    );
+    assert!(
+        workflow.contains("ref: ${{ github.event.pull_request.base.sha || github.sha }}"),
+        "trusted bootstrap must bind to the event base or pushed v3 commit"
+    );
+    assert!(
+        workflow.contains("ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}"),
+        "the tested checkout must bind to the immutable merge or pushed commit"
+    );
+    assert!(
+        workflow.contains("D2B_BAZEL_SOURCE_ROOT")
+            && workflow.contains("D2B_BAZEL_TRUSTED_ROOT")
+            && workflow.contains("D2B_BAZEL_TRUSTED_SHA"),
+        "the facade must receive separate source and trusted roots"
+    );
+    assert!(
+        workflow.contains("python3 ./trusted/tests/tools/bazel-check-bootstrap")
+            && workflow.contains("env -u D2B_BUILDBUDDY_API_KEY")
+            && workflow.contains("printf '%s' \"$D2B_BUILDBUDDY_API_KEY\"")
+            && workflow.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
+            && !workflow.contains("secret=\"${{ secrets.D2B_BUILDBUDDY_API_KEY }}\""),
+        "the BuildBuddy secret must cross the trusted bootstrap only over stdin"
+    );
+    assert!(
+        workflow.contains("secrets.D2B_BUILDBUDDY_API_KEY"),
+        "the remote gate must use the repository BuildBuddy secret"
+    );
+    assert!(
+        workflow.matches("persist-credentials: false").count() >= 2,
+        "all checkouts must disable persisted GitHub credentials"
+    );
+    for line in workflow.lines().filter(|line| line.contains("make -C")) {
+        assert!(
+            line.contains("make -C trusted"),
+            "workflow commands must use the trusted v3 Makefile: {line}"
+        );
+    }
+
+    for job in [
+        "tier0",
+        "policy-tooling",
+        "rust-main",
+        "rust-broker",
+        "rust-guest",
+    ] {
+        let block = job_block(workflow, job);
+        assert!(
+            block.contains(
+                "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}"
+            ),
+            "{job} must use the trusted remote/seeding BuildBuddy profile"
+        );
+        assert!(
+            block.contains("D2B_BAZEL_REQUIRE_REMOTE: \"1\""),
+            "{job} must fail closed instead of reducing to a local gate"
+        );
+        assert!(
+            block.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
+                && block.contains("bazel-check-bootstrap"),
+            "{job} must broker the credential through the trusted bootstrap"
+        );
+    }
+    for job in [
+        "rust-local",
+        "nix-eval",
+        "nix-unit",
+        "nix-realized",
+        "nix-aarch64",
+        "fixtures-proofs",
+        "test-performance-budgets",
+    ] {
+        let block = job_block(workflow, job);
+        assert!(
+            block.contains("D2B_BAZEL_PROFILE: local"),
+            "{job} must remain local-only"
+        );
+        assert!(
+            !block.contains("D2B_BUILDBUDDY_API_KEY")
+                && !block.contains("bazel-check-bootstrap"),
+            "{job} must not receive the BuildBuddy credential"
+        );
+    }
+}
+
 #[test]
 fn pr_suites_start_concurrently_and_aggregate_preserves_required_failures() {
     let workflow = workflow();
@@ -110,4 +240,36 @@ fn pr_suites_start_concurrently_and_aggregate_preserves_required_failures() {
         !needs_entries(aggregate).contains(&"test-performance-budgets"),
         "advisory performance budgets must not block the aggregate"
     );
+}
+
+#[test]
+fn trusted_workflow_rejects_malicious_control_plane_edits() {
+    let workflow = workflow();
+    assert_trusted_workflow_contract(&workflow);
+
+    for tampered in [
+        workflow.replace(
+            "pull_request_target:\n    branches: [v3]",
+            "pull_request:\n    branches: [v3]",
+        ),
+        workflow.replace(
+            "python3 ./trusted/tests/tools/bazel-check-bootstrap",
+            "python3 ./workspace/tests/tools/bazel-check-bootstrap",
+        ),
+        workflow.replace("make -C trusted", "make"),
+        workflow.replace(
+            "ref: ${{ github.event.pull_request.base.sha || github.sha }}",
+            "ref: main",
+        ),
+        workflow.replacen(
+            "D2B_BAZEL_PROFILE: ${{ github.event_name == 'push' && 'trusted-seed' || 'remote' }}",
+            "D2B_BAZEL_PROFILE: local",
+            1,
+        ),
+    ] {
+        assert!(
+            std::panic::catch_unwind(|| assert_trusted_workflow_contract(&tampered)).is_err(),
+            "malicious workflow edit was accepted"
+        );
+    }
 }

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -128,7 +128,7 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     );
     assert_eq!(
         workflow.matches("make -C trusted").count(),
-        14,
+        13,
         "every Layer-1 step must invoke its fixed public Make alias from trusted v3"
     );
     assert!(

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -135,7 +135,9 @@ fn assert_trusted_workflow_contract(workflow: &str) {
         "trusted bootstrap must bind to the event base or pushed v3 commit"
     );
     assert!(
-        workflow.contains("ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}"),
+        workflow.contains(
+            "ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha }}"
+        ),
         "the tested checkout must bind to the immutable merge or pushed commit"
     );
     assert!(
@@ -145,7 +147,12 @@ fn assert_trusted_workflow_contract(workflow: &str) {
         "the facade must receive separate source and trusted roots"
     );
     assert!(
-        workflow.contains("python3 ./trusted/tests/tools/bazel-check-bootstrap")
+        !workflow.contains("github.event.pull_request.merge_commit_sha || github.sha"),
+        "PR jobs must not substitute the default-branch SHA for a missing merge SHA"
+    );
+    assert!(
+        workflow.contains("./trusted/tests/tools/bazel-check-bootstrap")
+            && !workflow.contains("python3 ./trusted/tests/tools/bazel-check-bootstrap")
             && workflow.contains("env -u D2B_BUILDBUDDY_API_KEY")
             && workflow.contains("printf '%s' \"$D2B_BUILDBUDDY_API_KEY\"")
             && workflow.contains("D2B_BUILDBUDDY_API_KEY: ${{ secrets.D2B_BUILDBUDDY_API_KEY }}")
@@ -168,7 +175,6 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     }
 
     for job in [
-        "tier0",
         "policy-tooling",
         "rust-main",
         "rust-broker",
@@ -190,7 +196,21 @@ fn assert_trusted_workflow_contract(workflow: &str) {
                 && block.contains("bazel-check-bootstrap"),
             "{job} must broker the credential through the trusted bootstrap"
         );
+        assert!(
+            block.contains(
+                "if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}"
+            ),
+            "{job} must fail closed when the PR merge SHA is unavailable"
+        );
     }
+    let tier0 = job_block(workflow, "tier0");
+    assert!(
+        tier0.contains("D2B_BAZEL_PROFILE: local")
+            && !tier0.contains("D2B_BAZEL_REQUIRE_REMOTE")
+            && !tier0.contains("D2B_BUILDBUDDY_API_KEY")
+            && !tier0.contains("bazel-check-bootstrap"),
+        "tier0 must remain a credential-free local preflight"
+    );
     let policy = job_block(workflow, "policy-tooling");
     assert!(
         policy.contains("D2B_BAZEL_TEST_TAG_FILTERS: \"-local,-no-remote-exec,-manual,-gpu,-kvm\"")
@@ -200,6 +220,7 @@ fn assert_trusted_workflow_contract(workflow: &str) {
         "policy-only local tests must be split from the credential-bearing remote step"
     );
     for job in [
+        "tier0",
         "rust-local",
         "nix-eval",
         "nix-unit",
@@ -266,8 +287,12 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
             "pull_request:\n    branches: [v3]",
         ),
         workflow.replace(
-            "python3 ./trusted/tests/tools/bazel-check-bootstrap",
+            "./trusted/tests/tools/bazel-check-bootstrap",
             "python3 ./workspace/tests/tools/bazel-check-bootstrap",
+        ),
+        workflow.replace(
+            "github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha",
+            "github.event.pull_request.merge_commit_sha || github.sha",
         ),
         workflow.replace("make -C trusted", "make"),
         workflow.replace(

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -19,6 +19,18 @@ const REQUIRED_AGGREGATE_JOBS: &[&str] = &[
 
 fn workflow() -> String {
     let relative = ".github/workflows/pr-l1-static-fast.yml";
+    if let Some(root) = std::env::var_os("D2B_BAZEL_SOURCE_ROOT")
+        .or_else(|| std::env::var_os("D2B_REPO_ROOT"))
+    {
+        let path = PathBuf::from(root).join(relative);
+        return std::fs::read_to_string(&path).unwrap_or_else(|error| {
+            panic!(
+                "tested PR workflow is not readable at {}: {error}",
+                path.display()
+            )
+        });
+    }
+
     let mut candidates = Vec::new();
     for variable in ["TEST_SRCDIR", "RUNFILES_DIR"] {
         if let Some(base) = std::env::var_os(variable).map(PathBuf::from) {
@@ -237,6 +249,12 @@ fn assert_trusted_workflow_contract(workflow: &str) {
         "test-performance-budgets",
     ] {
         let block = job_block(workflow, job);
+        assert!(
+            block.contains(
+                "if: ${{ github.event_name == 'push' || github.event.pull_request.merge_commit_sha != '' }}"
+            ),
+            "{job} must fail closed when the PR merge SHA is unavailable"
+        );
         assert!(
             block.contains("D2B_BAZEL_PROFILE: local"),
             "{job} must remain local-only"

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -302,8 +302,8 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
             "pull_request:\n    branches: [v3]",
         ),
         workflow.replace(
-            "permissions:\n  contents: read",
-            "permissions:\n  contents: write",
+            "./trusted/tests/tools/bazel-check-bootstrap",
+            "python3 ./workspace/tests/tools/bazel-check-bootstrap",
         ),
         workflow.replace(
             "github.event_name == 'push' && github.sha || github.event.pull_request.merge_commit_sha",

--- a/packages/xtask/tests/pr_workflow.rs
+++ b/packages/xtask/tests/pr_workflow.rs
@@ -93,8 +93,8 @@ fn needs_entries(block: &str) -> Vec<&str> {
 
 fn assert_trusted_workflow_contract(workflow: &str) {
     assert!(
-        workflow.contains("pull_request_target:\n    branches: [main, v3]"),
-        "the credential-bearing workflow must cover protected main and v3"
+        workflow.contains("pull_request_target:\n    branches: [v3]"),
+        "the credential-bearing PR workflow must be owned by protected v3"
     );
     assert!(
         workflow.contains("push:\n    branches: [main, v3]"),
@@ -144,12 +144,16 @@ fn assert_trusted_workflow_contract(workflow: &str) {
         "every Layer-1 step must invoke its fixed public Make alias from trusted v3"
     );
     assert!(
-        workflow.contains("ref: ${{ github.sha }}\n          path: trusted"),
-        "trusted bootstrap must bind to the immutable workflow SHA"
+        workflow.contains(
+            "ref: ${{ github.event.pull_request.base.sha || github.sha }}\n          path: trusted"
+        ),
+        "trusted bootstrap must bind to the immutable protected base or pushed v3 commit"
     );
     assert!(
-        workflow.contains("D2B_BAZEL_TRUSTED_SHA: ${{ github.sha }}"),
-        "trusted bootstrap metadata must bind to GitHub's immutable workflow SHA"
+        workflow.contains(
+            "D2B_BAZEL_TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}"
+        ),
+        "trusted bootstrap metadata must bind to the immutable protected base or pushed commit"
     );
     assert!(
         workflow.contains(
@@ -165,7 +169,7 @@ fn assert_trusted_workflow_contract(workflow: &str) {
     );
     assert!(
         !workflow.contains("github.event.pull_request.merge_commit_sha || github.sha"),
-        "PR jobs must not substitute the default-branch SHA for a missing merge SHA"
+        "PR jobs must not substitute a fallback SHA for a missing merge SHA"
     );
     assert!(
         workflow.contains("./trusted/tests/tools/bazel-check-bootstrap")
@@ -312,8 +316,8 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
 
     for tampered in [
         workflow.replace(
-            "pull_request_target:\n    branches: [main, v3]",
-            "pull_request:\n    branches: [main, v3]",
+            "pull_request_target:\n    branches: [v3]",
+            "pull_request:\n    branches: [v3]",
         ),
         workflow.replace(
             "./trusted/tests/tools/bazel-check-bootstrap",
@@ -325,7 +329,7 @@ fn trusted_workflow_rejects_malicious_control_plane_edits() {
         ),
         workflow.replace("make -C trusted", "make"),
         workflow.replace(
-            "ref: ${{ github.sha }}\n          path: trusted",
+            "ref: ${{ github.event.pull_request.base.sha || github.sha }}\n          path: trusted",
             "ref: main\n          path: trusted",
         ),
         workflow.replacen(

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -152,8 +152,11 @@ sharding, or rollup logic.
 local, developer-remote, or protected trusted-seed profile, reads credentials
 only through Bazel's credential-helper protocol, withholds credentials from
 untrusted jobs, redacts logs and BEP output, and permits one identical local
-retry only for typed pre-dispatch infrastructure failures. Post-dispatch,
-analysis, policy, build, and test failures fail closed.
+retry only for typed pre-dispatch infrastructure failures. In trusted `v3`
+CI it runs a staged tested source with trusted control files, validates event
+OIDs and PR/run metadata, isolates the PR cache namespace, and requires the
+remote path. Post-dispatch, analysis, policy, build, and test failures fail
+closed.
 
 Bazel is the only supported contributor build and test interface. Cargo
 manifests and the root `Cargo.lock` own Rust package and dependency facts;
@@ -161,9 +164,9 @@ manifests and the root `Cargo.lock` own Rust package and dependency facts;
 lock, source inventory, generator, or repository-owned scheduler.
 
 The fixed CI workflow is committed at
-`.github/workflows/pr-l1-static-fast.yml` and exposes one stable required
-`check` result. Keep its jobs aligned with the public Make aliases. Do not add
-discovery jobs or new inventory files.
+`.github/workflows/pr-l1-static-fast.yml`, is owned by protected `v3`, and
+exposes one stable required `check` result. Keep its jobs aligned with the
+public Make aliases. Do not add discovery jobs or new inventory files.
 
 ### Running the Layer-1 graph
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -152,11 +152,13 @@ sharding, or rollup logic.
 local, developer-remote, or protected trusted-seed profile, reads credentials
 only through Bazel's credential-helper protocol, withholds credentials from
 untrusted jobs, redacts logs and BEP output, and permits one identical local
-retry only for typed pre-dispatch infrastructure failures. In trusted `v3`
-CI it runs a staged tested source with trusted control files, validates event
-OIDs and PR/run metadata, isolates the PR cache namespace, and requires the
-remote path. Post-dispatch, analysis, policy, build, and test failures fail
-closed.
+retry only for typed pre-dispatch infrastructure failures. In trusted CI it
+runs a staged tested source with control files from the immutable workflow
+checkout, validates event OIDs and PR/run metadata, isolates the PR cache
+namespace, and requires the remote path. Pull-request target workflows are
+owned by default-branch `main`; protected `main` and `v3` pushes may seed the
+separate trusted namespace. Post-dispatch, analysis, policy, build, and test
+failures fail closed.
 
 Bazel is the only supported contributor build and test interface. Cargo
 manifests and the root `Cargo.lock` own Rust package and dependency facts;
@@ -164,9 +166,11 @@ manifests and the root `Cargo.lock` own Rust package and dependency facts;
 lock, source inventory, generator, or repository-owned scheduler.
 
 The fixed CI workflow is committed at
-`.github/workflows/pr-l1-static-fast.yml`, is owned by protected `v3`, and
-exposes one stable required `check` result. Keep its jobs aligned with the
-public Make aliases. Do not add discovery jobs or new inventory files.
+`.github/workflows/pr-l1-static-fast.yml`, is sourced from default-branch
+`main` for pull requests targeting `main` or `v3`, and exposes one stable
+required `check` result. Protected `main` and `v3` pushes use the same fixed
+job set for trusted cache seeding. Keep its jobs aligned with the public Make
+aliases. Do not add discovery jobs or new inventory files.
 
 ### Running the Layer-1 graph
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -154,11 +154,9 @@ only through Bazel's credential-helper protocol, withholds credentials from
 untrusted jobs, redacts logs and BEP output, and permits one identical local
 retry only for typed pre-dispatch infrastructure failures. In trusted `v3`
 CI it runs a staged tested source with trusted control files, validates event
-OIDs and PR/run metadata, and preserves the PR cache namespace contract even
-though GitHub Actions uses the local profile and never receives a BuildBuddy
-credential. Post-dispatch, analysis, policy, build, and test failures fail
-closed. Developer remote profiles remain available for the future
-non-Actions BuildBuddy Workflows trial.
+OIDs and PR/run metadata, isolates the PR cache namespace, and requires the
+remote path. Post-dispatch, analysis, policy, build, and test failures fail
+closed.
 
 Bazel is the only supported contributor build and test interface. Cargo
 manifests and the root `Cargo.lock` own Rust package and dependency facts;

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -156,7 +156,7 @@ retry only for typed pre-dispatch infrastructure failures. In trusted CI it
 runs a staged tested source with control files from the immutable workflow
 checkout, validates event OIDs and PR/run metadata, isolates the PR cache
 namespace, and requires the remote path. Pull-request target workflows are
-owned by default-branch `main`; protected `main` and `v3` pushes may seed the
+owned by protected `v3`; protected `main` and `v3` pushes may seed the
 separate trusted namespace. Post-dispatch, analysis, policy, build, and test
 failures fail closed.
 
@@ -166,11 +166,11 @@ manifests and the root `Cargo.lock` own Rust package and dependency facts;
 lock, source inventory, generator, or repository-owned scheduler.
 
 The fixed CI workflow is committed at
-`.github/workflows/pr-l1-static-fast.yml`, is sourced from default-branch
-`main` for pull requests targeting `main` or `v3`, and exposes one stable
-required `check` result. Protected `main` and `v3` pushes use the same fixed
-job set for trusted cache seeding. Keep its jobs aligned with the public Make
-aliases. Do not add discovery jobs or new inventory files.
+`.github/workflows/pr-l1-static-fast.yml`, is sourced from protected `v3` for
+pull requests targeting `v3`, and exposes one stable required `check` result.
+Protected `main` and `v3` pushes use the same fixed job set for trusted cache
+seeding. Keep its jobs aligned with the public Make aliases. Do not add
+discovery jobs or new inventory files.
 
 ### Running the Layer-1 graph
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -154,9 +154,11 @@ only through Bazel's credential-helper protocol, withholds credentials from
 untrusted jobs, redacts logs and BEP output, and permits one identical local
 retry only for typed pre-dispatch infrastructure failures. In trusted `v3`
 CI it runs a staged tested source with trusted control files, validates event
-OIDs and PR/run metadata, isolates the PR cache namespace, and requires the
-remote path. Post-dispatch, analysis, policy, build, and test failures fail
-closed.
+OIDs and PR/run metadata, and preserves the PR cache namespace contract even
+though GitHub Actions uses the local profile and never receives a BuildBuddy
+credential. Post-dispatch, analysis, policy, build, and test failures fail
+closed. Developer remote profiles remain available for the future
+non-Actions BuildBuddy Workflows trial.
 
 Bazel is the only supported contributor build and test interface. Cargo
 manifests and the root `Cargo.lock` own Rust package and dependency facts;

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,7 +68,7 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
 | `make test-host-integration` | type-10 runNixOSTest VM checks; set `D2B_VM_CHECK=<name>` for one named check | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
-| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; CI forces `D2B_BAZEL_PROFILE=local` | local or remote |
+| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; protected `v3` CI uses the trusted remote/local split | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
 
 `make check`, `make test-unit`, and `make bazel-check` invoke the same nested
@@ -93,9 +93,10 @@ The focused shell supplies Bazel, Make, jq, Git, Rustup, and the shell
 utilities used by `tests/tools/bazel-check`; no ambient host Bazel or jq is
 required. An unrelated Nix shell is not accepted as the d2b shell. Optional
 direnv integration is supported for interactive use but is not required.
-CI installs Nix and calls the same public Make aliases with
-`D2B_BAZEL_PROFILE=local` and `D2B_BAZEL_UNTRUSTED=1`, without a per-target
-`nix develop` wrapper.
+Protected `v3` CI installs Nix and calls the same public Make aliases from the
+trusted checkout. Remote-eligible jobs use the brokered BuildBuddy credential;
+Nix, fixture, hardware, and other local-only jobs remain local and
+credential-free.
 
 `make test-policy` does not schedule
 `tests/tools/guest-workspace-drift.py`. The retained

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,7 +68,7 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
 | `make test-host-integration` | type-10 runNixOSTest VM checks; set `D2B_VM_CHECK=<name>` for one named check | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
-| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; protected `v3` CI uses the trusted local profile | local or remote |
+| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; protected `v3` CI uses the trusted remote/local split | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
 
 `make check`, `make test-unit`, and `make bazel-check` invoke the same nested
@@ -94,10 +94,9 @@ utilities used by `tests/tools/bazel-check`; no ambient host Bazel or jq is
 required. An unrelated Nix shell is not accepted as the d2b shell. Optional
 direnv integration is supported for interactive use but is not required.
 Protected `v3` CI installs Nix and calls the same public Make aliases from the
-trusted checkout. Every GitHub Actions Bazel job uses the local profile and
-receives no BuildBuddy credential. Developer remote profiles and the immutable
-OID/cache handoff remain reserved for a future non-Actions BuildBuddy
-Workflows trial.
+trusted checkout. Remote-eligible jobs use the brokered BuildBuddy credential;
+Nix, fixture, hardware, and other local-only jobs remain local and
+credential-free.
 
 `make test-policy` does not schedule
 `tests/tools/guest-workspace-drift.py`. The retained
@@ -183,13 +182,14 @@ membership, dependencies, and features consumed by rules_rs. Do not add a
 second Cargo lock, source inventory, generator, discovery job, or shell
 scheduler.
 
-`tests/tools/bazel-check` retains the BuildBuddy security boundary for
-developer and future non-Actions use. It uses Bazel's credential helper,
-withholds credentials from untrusted work, redacts logs and BEP output, and
-retries the identical target set locally only for a typed pre-dispatch
-infrastructure failure. Post-dispatch and test failures fail closed. Provider
-measurements do not define a second acceptance gate. Protected `v3` CI uses
-the same trusted control validation with the local profile and no credential.
+`tests/tools/bazel-check` retains the BuildBuddy security boundary. It uses
+Bazel's credential helper, withholds credentials from untrusted work, redacts
+logs and BEP output, and retries the identical target set locally only for a
+typed pre-dispatch infrastructure failure. Post-dispatch and test failures
+fail closed. Provider measurements do not define a second acceptance gate.
+Protected `v3` CI uses this boundary for credential-bearing remote suites,
+while Nix, fixture, hardware, and other local-only actions remain local and
+credential-free.
 The facade consumes `D2B_BAZEL_BIN` from the pinned shell and rejects an
 incomplete shell contract; it does not search for a hard-coded Nix-store
 Bazel path.

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,7 +68,7 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
 | `make test-host-integration` | type-10 runNixOSTest VM checks; set `D2B_VM_CHECK=<name>` for one named check | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
-| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; protected `v3` CI uses the trusted remote/local split | local or remote |
+| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; default-branch `main` CI uses the trusted remote/local split for protected `main` and `v3` targets | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
 
 `make check`, `make test-unit`, and `make bazel-check` invoke the same nested
@@ -93,10 +93,11 @@ The focused shell supplies Bazel, Make, jq, Git, Rustup, and the shell
 utilities used by `tests/tools/bazel-check`; no ambient host Bazel or jq is
 required. An unrelated Nix shell is not accepted as the d2b shell. Optional
 direnv integration is supported for interactive use but is not required.
-Protected `v3` CI installs Nix and calls the same public Make aliases from the
-trusted checkout. Remote-eligible jobs use the brokered BuildBuddy credential;
-Nix, fixture, hardware, and other local-only jobs remain local and
-credential-free.
+Default-branch `main` CI installs Nix and calls the same public Make aliases
+from an immutable trusted checkout for PRs targeting `main` or `v3`.
+Protected `main` and `v3` pushes retain trusted cache seeding. Remote-eligible
+jobs use the brokered BuildBuddy credential; Nix, fixture, hardware, and other
+local-only jobs remain local and credential-free.
 
 `make test-policy` does not schedule
 `tests/tools/guest-workspace-drift.py`. The retained

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,7 +68,7 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
 | `make test-host-integration` | type-10 runNixOSTest VM checks; set `D2B_VM_CHECK=<name>` for one named check | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
-| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; protected `v3` CI uses the trusted remote/local split | local or remote |
+| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; protected `v3` CI uses the trusted local profile | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
 
 `make check`, `make test-unit`, and `make bazel-check` invoke the same nested
@@ -94,9 +94,10 @@ utilities used by `tests/tools/bazel-check`; no ambient host Bazel or jq is
 required. An unrelated Nix shell is not accepted as the d2b shell. Optional
 direnv integration is supported for interactive use but is not required.
 Protected `v3` CI installs Nix and calls the same public Make aliases from the
-trusted checkout. Remote-eligible jobs use the brokered BuildBuddy credential;
-Nix, fixture, hardware, and other local-only jobs remain local and
-credential-free.
+trusted checkout. Every GitHub Actions Bazel job uses the local profile and
+receives no BuildBuddy credential. Developer remote profiles and the immutable
+OID/cache handoff remain reserved for a future non-Actions BuildBuddy
+Workflows trial.
 
 `make test-policy` does not schedule
 `tests/tools/guest-workspace-drift.py`. The retained
@@ -182,14 +183,13 @@ membership, dependencies, and features consumed by rules_rs. Do not add a
 second Cargo lock, source inventory, generator, discovery job, or shell
 scheduler.
 
-`tests/tools/bazel-check` retains the BuildBuddy security boundary. It uses
-Bazel's credential helper, withholds credentials from untrusted work, redacts
-logs and BEP output, and retries the identical target set locally only for a
-typed pre-dispatch infrastructure failure. Post-dispatch and test failures
-fail closed. Provider measurements do not define a second acceptance gate.
-Protected `v3` CI uses this boundary for credential-bearing remote suites,
-while Nix, fixture, hardware, and other local-only actions remain local and
-credential-free.
+`tests/tools/bazel-check` retains the BuildBuddy security boundary for
+developer and future non-Actions use. It uses Bazel's credential helper,
+withholds credentials from untrusted work, redacts logs and BEP output, and
+retries the identical target set locally only for a typed pre-dispatch
+infrastructure failure. Post-dispatch and test failures fail closed. Provider
+measurements do not define a second acceptance gate. Protected `v3` CI uses
+the same trusted control validation with the local profile and no credential.
 The facade consumes `D2B_BAZEL_BIN` from the pinned shell and rejects an
 incomplete shell contract; it does not search for a hard-coded Nix-store
 Bazel path.

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,7 +68,7 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
 | `make test-host-integration` | type-10 runNixOSTest VM checks; set `D2B_VM_CHECK=<name>` for one named check | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
-| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; default-branch `main` CI uses the trusted remote/local split for protected `main` and `v3` targets | local or remote |
+| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; protected `v3` CI uses the trusted remote/local split for `v3` PRs, while protected `main` and `v3` pushes retain trusted seeding | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
 
 `make check`, `make test-unit`, and `make bazel-check` invoke the same nested
@@ -93,11 +93,11 @@ The focused shell supplies Bazel, Make, jq, Git, Rustup, and the shell
 utilities used by `tests/tools/bazel-check`; no ambient host Bazel or jq is
 required. An unrelated Nix shell is not accepted as the d2b shell. Optional
 direnv integration is supported for interactive use but is not required.
-Default-branch `main` CI installs Nix and calls the same public Make aliases
-from an immutable trusted checkout for PRs targeting `main` or `v3`.
-Protected `main` and `v3` pushes retain trusted cache seeding. Remote-eligible
-jobs use the brokered BuildBuddy credential; Nix, fixture, hardware, and other
-local-only jobs remain local and credential-free.
+Protected `v3` CI installs Nix and calls the same public Make aliases from an
+immutable trusted checkout for PRs targeting `v3`. Protected `main` and `v3`
+pushes retain trusted cache seeding. Remote-eligible jobs use the brokered
+BuildBuddy credential; Nix, fixture, hardware, and other local-only jobs
+remain local and credential-free.
 
 `make test-policy` does not schedule
 `tests/tools/guest-workspace-drift.py`. The retained

--- a/tests/README.md
+++ b/tests/README.md
@@ -187,6 +187,9 @@ Bazel's credential helper, withholds credentials from untrusted work, redacts
 logs and BEP output, and retries the identical target set locally only for a
 typed pre-dispatch infrastructure failure. Post-dispatch and test failures
 fail closed. Provider measurements do not define a second acceptance gate.
+Protected `v3` CI uses this boundary for credential-bearing remote suites,
+while Nix, fixture, hardware, and other local-only actions remain local and
+credential-free.
 The facade consumes `D2B_BAZEL_BIN` from the pinned shell and rejects an
 incomplete shell contract; it does not search for a hard-coded Nix-store
 Bazel path.

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -65,7 +65,11 @@
     "gasCityProxy": "separate"
   },
   "trustedInjection": {
-    "protectedRef": "refs/heads/v3",
+    "protectedRef": "refs/heads/main",
+    "seedRefs": [
+      "refs/heads/main",
+      "refs/heads/v3"
+    ],
     "allowlistedSecurityFiles": [
       ".bazelrc",
       "MODULE.bazel",

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -91,7 +91,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:1297055b0bef00d2f90fd928ee1d060825fefaf3e241cbf85dc3b7b38beecd4d"
+      "sha256:f8a62ab9e88f05fd34fbba0b107b2e6d201acfdf3a45d4fc6011d4f283b008e3"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -72,7 +72,12 @@
       "MODULE.bazel.lock",
       "bazel/platforms/BUILD.bazel",
       "bazel/remote/BUILD.bazel",
-      "tests/tools/bazel-check"
+      "tests/tools/bazel-check",
+      "tests/tools/bazel-check-bootstrap",
+      "tests/tools/ci-shell",
+      "tests/tools/scrub-shell-environment",
+      "Makefile",
+      ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
       "sha256:a1c2b67628ffe701eda58232d76523c2e3fcb141a4aea68550907f1da45632c1"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -91,7 +91,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:0dc1eafbe2a758364115fd517006ea438879309d495d0fd177886e965ea66435"
+      "sha256:9f21cc0859148076a3a28646b5a498a335499cfe1b848cee1699023cfc294597"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -70,6 +70,7 @@
       ".bazelrc",
       "MODULE.bazel",
       "MODULE.bazel.lock",
+      "flake.lock",
       "bazel/checks/BUILD.bazel",
       "bazel/checks/fixtures/BUILD.bazel",
       "bazel/checks/fixtures/defs.bzl",
@@ -90,7 +91,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:3139ba25c6776a35a3e02249b562ba6331f518ed704fc3369c861df489ec1fa6"
+      "sha256:0dc1eafbe2a758364115fd517006ea438879309d495d0fd177886e965ea66435"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -70,6 +70,12 @@
       ".bazelrc",
       "MODULE.bazel",
       "MODULE.bazel.lock",
+      "bazel/checks/BUILD.bazel",
+      "bazel/checks/fixtures/BUILD.bazel",
+      "bazel/checks/meta/BUILD.bazel",
+      "bazel/checks/nix/BUILD.bazel",
+      "bazel/checks/policy/BUILD.bazel",
+      "bazel/checks/rust/BUILD.bazel",
       "bazel/platforms/BUILD.bazel",
       "bazel/remote/BUILD.bazel",
       "tests/tools/bazel-check",
@@ -80,7 +86,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:b13999681f9fe3473bdd778b290bea84736148458254ccca2c7b95d3eb9de8b2"
+      "sha256:f25a2dc8d4a7e5628c94624c565ba1cff7d16a4bc09a45f4a197d025dd77a265"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -65,7 +65,7 @@
     "gasCityProxy": "separate"
   },
   "trustedInjection": {
-    "protectedRef": "refs/heads/main",
+    "protectedRef": "refs/heads/v3",
     "seedRefs": [
       "refs/heads/main",
       "refs/heads/v3"
@@ -95,7 +95,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:7a13cfb6623ac24361ca9d93f2b7eecb80d2aa63b661c2c026f3ff69aecedcb5"
+      "sha256:90543e5607b240e3ae9aa7360dc31dd0b1732769d4f8e2e7771217e14bd1797b"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -91,7 +91,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:f8a62ab9e88f05fd34fbba0b107b2e6d201acfdf3a45d4fc6011d4f283b008e3"
+      "sha256:1297055b0bef00d2f90fd928ee1d060825fefaf3e241cbf85dc3b7b38beecd4d"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -80,7 +80,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:a1c2b67628ffe701eda58232d76523c2e3fcb141a4aea68550907f1da45632c1"
+      "sha256:b13999681f9fe3473bdd778b290bea84736148458254ccca2c7b95d3eb9de8b2"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -72,8 +72,10 @@
       "MODULE.bazel.lock",
       "bazel/checks/BUILD.bazel",
       "bazel/checks/fixtures/BUILD.bazel",
+      "bazel/checks/fixtures/defs.bzl",
       "bazel/checks/meta/BUILD.bazel",
       "bazel/checks/nix/BUILD.bazel",
+      "bazel/checks/nix/defs.bzl",
       "bazel/checks/policy/BUILD.bazel",
       "bazel/checks/rust/BUILD.bazel",
       "bazel/platforms/BUILD.bazel",
@@ -83,10 +85,12 @@
       "tests/tools/ci-shell",
       "tests/tools/scrub-shell-environment",
       "Makefile",
+      "tests/tools/peak-rss.py",
+      "tests/tools/tier0-first-pass.sh",
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:f25a2dc8d4a7e5628c94624c565ba1cff7d16a4bc09a45f4a197d025dd77a265"
+      "sha256:3139ba25c6776a35a3e02249b562ba6331f518ed704fc3369c861df489ec1fa6"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -95,7 +95,7 @@
       ".github/workflows/pr-l1-static-fast.yml"
     ],
     "allowedSecurityDigests": [
-      "sha256:f8a62ab9e88f05fd34fbba0b107b2e6d201acfdf3a45d4fc6011d4f283b008e3"
+      "sha256:7a13cfb6623ac24361ca9d93f2b7eecb80d2aa63b661c2c026f3ff69aecedcb5"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -540,11 +540,6 @@ case "$PROFILE" in
     ;;
 esac
 
-if [ "${GITHUB_ACTIONS:-false}" = true ] && [ "$PROFILE" != local ]; then
-  echo "bazel-check: GitHub Actions CI is local-only; remote profiles are reserved for non-Actions runs" >&2
-  exit "$CONFIGURATION_FAILURE_STATUS"
-fi
-
 if [ "${D2B_PROJECT_SHELL:-}" != d2b ]; then
   echo "bazel-check: D2B_PROJECT_SHELL=d2b is required; enter a d2b development shell" >&2
   exit "$CONFIGURATION_FAILURE_STATUS"

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -593,6 +593,10 @@ if [ "${D2B_PROJECT_SHELL:-}" != d2b ]; then
   exit "$CONFIGURATION_FAILURE_STATUS"
 fi
 
+if ci_mode; then
+  unset D2B_XTASK_BIN
+fi
+
 bazel_bin="${D2B_BAZEL_BIN:-}"
 if [ -z "$bazel_bin" ] || [ ! -x "$bazel_bin" ]; then
   echo "bazel-check: D2B_BAZEL_BIN must name the executable pinned by the d2b development shell" >&2

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -185,11 +185,11 @@ ci_metadata() {
   esac
   case "$event" in
     pull_request_target)
-      [ "${GITHUB_REF:-}" = "refs/heads/main" ] || {
-        echo "bazel-check: trusted pull_request_target must execute from refs/heads/main" >&2
+      [ "${GITHUB_REF:-}" = "refs/heads/v3" ] || {
+        echo "bazel-check: trusted pull_request_target must execute from refs/heads/v3" >&2
         return "$CONFIGURATION_FAILURE_STATUS"
       }
-      expected_workflow_ref="vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/main"
+      expected_workflow_ref="vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/v3"
       ;;
     push)
       case "${GITHUB_REF:-}" in
@@ -251,9 +251,9 @@ ci_metadata() {
 
   if [ "$event" = pull_request_target ]; then
     case "${GITHUB_BASE_REF:-}" in
-      main|v3) ;;
+      v3) ;;
       *)
-        echo "bazel-check: trusted PR must target protected main or v3" >&2
+        echo "bazel-check: trusted PR must target protected v3" >&2
         return "$CONFIGURATION_FAILURE_STATUS"
         ;;
     esac

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -357,14 +357,18 @@ prepare_trusted_control_files() {
     MODULE.bazel.lock \
     bazel/checks/BUILD.bazel \
     bazel/checks/fixtures/BUILD.bazel \
+    bazel/checks/fixtures/defs.bzl \
     bazel/checks/meta/BUILD.bazel \
     bazel/checks/nix/BUILD.bazel \
+    bazel/checks/nix/defs.bzl \
     bazel/checks/policy/BUILD.bazel \
     bazel/checks/rust/BUILD.bazel \
     bazel/platforms/BUILD.bazel \
     bazel/remote/BUILD.bazel \
     Makefile \
     .github/workflows/pr-l1-static-fast.yml \
+    tests/tools/peak-rss.py \
+    tests/tools/tier0-first-pass.sh \
     tests/tools/bazel-check \
     tests/tools/bazel-check-bootstrap \
     tests/tools/ci-shell \
@@ -619,6 +623,9 @@ run_bazel() {
       --bes_backend=grpcs://d2b.buildbuddy.io
       --bes_results_url=https://d2b.buildbuddy.io/invocation/
       "--credential_helper=d2b.buildbuddy.io=$TRUSTED_ROOT/tests/tools/bazel-check"
+      --spawn_strategy=remote
+      --remote_local_fallback=false
+      "--modify_execution_info=.*=+no-local"
     )
     if ci_mode; then
       command_flags+=(

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -357,7 +357,12 @@ ci_metadata() {
     "--build_metadata=EVENT_NAME=$event"
   )
   if [ "$event" = pull_request_target ]; then
-    BUILD_BUDDY_METADATA_FLAGS+=("--build_metadata=PR_NUMBER=$pr_number")
+    BUILD_BUDDY_METADATA_FLAGS+=(
+      "--build_metadata=COMMIT_SHA=$head_sha"
+      "--build_metadata=PR_NUMBER=$pr_number"
+    )
+  else
+    BUILD_BUDDY_METADATA_FLAGS+=("--build_metadata=COMMIT_SHA=$tested_sha")
   fi
 }
 

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -355,9 +355,18 @@ prepare_trusted_control_files() {
     .bazelrc \
     MODULE.bazel \
     MODULE.bazel.lock \
+    bazel/checks/BUILD.bazel \
+    bazel/checks/fixtures/BUILD.bazel \
+    bazel/checks/meta/BUILD.bazel \
+    bazel/checks/nix/BUILD.bazel \
+    bazel/checks/policy/BUILD.bazel \
+    bazel/checks/rust/BUILD.bazel \
     bazel/platforms/BUILD.bazel \
     bazel/remote/BUILD.bazel \
+    Makefile \
+    .github/workflows/pr-l1-static-fast.yml \
     tests/tools/bazel-check \
+    tests/tools/bazel-check-bootstrap \
     tests/tools/ci-shell \
     tests/tools/scrub-shell-environment
   do

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -173,6 +173,7 @@ ci_metadata() {
   BUILD_BUDDY_METADATA_FLAGS=()
   local base_sha head_sha merge_sha trusted_sha tested_sha
   local branch_name pr_number run_id workflow_ref event repository server_url
+  local expected_workflow_ref
 
   event="${GITHUB_EVENT_NAME:-}"
   case "$event" in
@@ -182,10 +183,25 @@ ci_metadata() {
       return "$CONFIGURATION_FAILURE_STATUS"
       ;;
   esac
-  [ "${GITHUB_REF:-}" = "refs/heads/v3" ] || {
-    echo "bazel-check: trusted CI requires refs/heads/v3" >&2
-    return "$CONFIGURATION_FAILURE_STATUS"
-  }
+  case "$event" in
+    pull_request_target)
+      [ "${GITHUB_REF:-}" = "refs/heads/main" ] || {
+        echo "bazel-check: trusted pull_request_target must execute from refs/heads/main" >&2
+        return "$CONFIGURATION_FAILURE_STATUS"
+      }
+      expected_workflow_ref="vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/main"
+      ;;
+    push)
+      case "${GITHUB_REF:-}" in
+        refs/heads/main|refs/heads/v3) ;;
+        *)
+          echo "bazel-check: trusted push must execute from protected main or v3" >&2
+          return "$CONFIGURATION_FAILURE_STATUS"
+          ;;
+      esac
+      expected_workflow_ref="vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@${GITHUB_REF}"
+      ;;
+  esac
   repository="${GITHUB_REPOSITORY:-}"
   [ "$repository" = "vicondoa/d2b" ] || {
     echo "bazel-check: trusted CI requires the canonical d2b repository" >&2
@@ -224,14 +240,24 @@ ci_metadata() {
     echo "bazel-check: trusted CI run metadata is invalid" >&2
     return "$CONFIGURATION_FAILURE_STATUS"
   }
-  [ "$workflow_ref" = "vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/v3" ] || {
+  [ "$workflow_ref" = "$expected_workflow_ref" ] || {
     echo "bazel-check: trusted CI workflow metadata is invalid" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  [ "$trusted_sha" = "${GITHUB_SHA:-}" ] || {
+    echo "bazel-check: trusted checkout SHA does not match the immutable GitHub workflow SHA" >&2
     return "$CONFIGURATION_FAILURE_STATUS"
   }
 
   if [ "$event" = pull_request_target ]; then
-    [ "${GITHUB_BASE_REF:-}" = "v3" ] &&
-      [ -n "${GITHUB_HEAD_REF:-}" ] &&
+    case "${GITHUB_BASE_REF:-}" in
+      main|v3) ;;
+      *)
+        echo "bazel-check: trusted PR must target protected main or v3" >&2
+        return "$CONFIGURATION_FAILURE_STATUS"
+        ;;
+    esac
+    [ -n "${GITHUB_HEAD_REF:-}" ] &&
       [ "$branch_name" = "$GITHUB_HEAD_REF" ] || {
       echo "bazel-check: trusted PR branch metadata does not match the event" >&2
       return "$CONFIGURATION_FAILURE_STATUS"
@@ -241,10 +267,19 @@ ci_metadata() {
       return "$CONFIGURATION_FAILURE_STATUS"
     }
   else
-    [ -z "${GITHUB_BASE_REF:-}" ] &&
-      [ "${GITHUB_REF_NAME:-}" = "v3" ] &&
-      [ "$branch_name" = "v3" ] || {
-      echo "bazel-check: trusted push branch metadata does not match v3" >&2
+    [ -z "${GITHUB_BASE_REF:-}" ] || {
+      echo "bazel-check: trusted push must not carry a base branch" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+    case "${GITHUB_REF_NAME:-}" in
+      main|v3) ;;
+      *)
+        echo "bazel-check: trusted push branch metadata does not match protected main or v3" >&2
+        return "$CONFIGURATION_FAILURE_STATUS"
+        ;;
+    esac
+    [ "$branch_name" = "${GITHUB_REF_NAME:-}" ] || {
+      echo "bazel-check: trusted push branch metadata does not match the event" >&2
       return "$CONFIGURATION_FAILURE_STATUS"
     }
     [ -z "$pr_number" ] || {
@@ -272,19 +307,26 @@ ci_metadata() {
     echo "bazel-check: trusted checkout HEAD is unavailable" >&2
     return "$CONFIGURATION_FAILURE_STATUS"
   }
-  [ "$trusted_head" = "$base_sha" ] && [ "$trusted_head" = "$trusted_sha" ] || {
-    echo "bazel-check: trusted checkout does not match protected v3 base SHA" >&2
-    return "$CONFIGURATION_FAILURE_STATUS"
-  }
+  if [ "$event" = pull_request_target ]; then
+    [ "$trusted_head" = "$trusted_sha" ] || {
+      echo "bazel-check: trusted checkout does not match the immutable workflow SHA" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+  else
+    [ "$trusted_head" = "$base_sha" ] && [ "$trusted_head" = "$trusted_sha" ] || {
+      echo "bazel-check: trusted push checkout does not match its immutable commit SHA" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+  fi
 
   env -i PATH="$PATH" LC_ALL=C git -C "$SOURCE_ROOT" cat-file -e "$base_sha^{commit}" ||
     {
-      echo "bazel-check: protected v3 base SHA is unavailable in the tested checkout" >&2
+      echo "bazel-check: protected base SHA is unavailable in the tested checkout" >&2
       return "$CONFIGURATION_FAILURE_STATUS"
     }
   env -i PATH="$PATH" LC_ALL=C git -C "$SOURCE_ROOT" merge-base --is-ancestor "$base_sha" "$merge_sha" ||
     {
-      echo "bazel-check: tested merge SHA is not based on protected v3" >&2
+      echo "bazel-check: tested merge SHA is not based on the protected base" >&2
       return "$CONFIGURATION_FAILURE_STATUS"
     }
 
@@ -331,10 +373,16 @@ validate_ci_context() {
 }
 
 trusted_context() {
-  [ "${D2B_BAZEL_TRUSTED:-0}" = 1 ] &&
-    [ "${GITHUB_REF:-}" = "refs/heads/v3" ] &&
-    validate_ci_context &&
-    xtask bazel-evidence check-security >/dev/null
+  [ "${D2B_BAZEL_TRUSTED:-0}" = 1 ] || return 1
+  if ci_mode; then
+    ci_metadata >/dev/null || return 1
+  else
+    case "${GITHUB_REF:-}" in
+      refs/heads/main|refs/heads/v3) ;;
+      *) return 1 ;;
+    esac
+  fi
+  xtask bazel-evidence check-security >/dev/null
 }
 
 replace_trusted_control() {

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -2,18 +2,23 @@
 set -euo pipefail
 
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRUSTED_ROOT="${D2B_BAZEL_TRUSTED_ROOT:-$ROOT}"
+SOURCE_ROOT="${D2B_BAZEL_SOURCE_ROOT:-$ROOT}"
+TRUSTED_ROOT="$(cd -- "$TRUSTED_ROOT" && pwd)"
+SOURCE_ROOT="$(cd -- "$SOURCE_ROOT" && pwd)"
 PROFILE=""
 SCRATCH="${D2B_BAZEL_CHECK_SCRATCH:-$ROOT/.scratch/bazel-check}"
 TARGETS=()
 REDACTION_FAILURE_STATUS=75
 CONFIGURATION_FAILURE_STATUS=76
+TRUSTED_WORKSPACE="$SOURCE_ROOT"
 
 xtask() {
   [ -n "${D2B_XTASK_BIN:-}" ] && [ -x "${D2B_XTASK_BIN}" ] || {
     echo "bazel-check: D2B_XTASK_BIN must name the declared //packages/xtask:xtask artifact" >&2
     return 70
   }
-  D2B_REPO_ROOT="$ROOT" "$D2B_XTASK_BIN" "$@"
+  D2B_REPO_ROOT="$TRUSTED_ROOT" "$D2B_XTASK_BIN" "$@"
 }
 
 redact_file() {
@@ -26,12 +31,29 @@ credential_file() {
   printf '%s\n' "${D2B_BUILDBUDDY_CREDENTIAL_FILE:-${HOME:-}/.config/d2b/buildbuddy-api-key}"
 }
 
+credential_from_fd() {
+  local fd="${D2B_BAZEL_CREDENTIAL_FD:-}"
+  case "$fd" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  python3 - "$fd" <<'PY'
+import os
+import sys
+
+fd = int(sys.argv[1])
+data = os.pread(fd, 4096, 0)
+if not data or b"\x00" in data or b"\n" in data or b"\r" in data:
+    raise SystemExit(1)
+sys.stdout.buffer.write(data)
+PY
+}
+
 BUILD_BUDDY_METADATA_FLAGS=()
 
 git_checkout() {
   local git_bin
   git_bin="$(command -v git)" || return 127
-  env -i PATH="$PATH" LC_ALL=C "$git_bin" -C "$ROOT" "$@"
+  env -i PATH="$PATH" LC_ALL=C "$git_bin" -C "$SOURCE_ROOT" "$@"
 }
 
 git_checkout_snapshot() {
@@ -56,7 +78,7 @@ buildbuddy_metadata() {
   local observed_branch_head observed_commit_sha
 
   if ! checkout_root="$(git_checkout rev-parse --show-toplevel 2>/dev/null)" ||
-    [ "$checkout_root" != "$ROOT" ]; then
+    [ "$checkout_root" != "$SOURCE_ROOT" ]; then
     echo "bazel-check: BuildBuddy metadata unavailable: Git checkout is unavailable or does not match the tested repository; omitting repository metadata" >&2
     return 0
   fi
@@ -113,14 +135,255 @@ buildbuddy_metadata() {
   )
 }
 
+ci_metadata() {
+  BUILD_BUDDY_METADATA_FLAGS=()
+  local base_sha head_sha merge_sha trusted_sha tested_sha
+  local branch_name pr_number run_id workflow_ref event repository server_url
+
+  event="${GITHUB_EVENT_NAME:-}"
+  case "$event" in
+    pull_request_target|push) ;;
+    *)
+      echo "bazel-check: trusted CI requires pull_request_target or push" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+      ;;
+  esac
+  [ "${GITHUB_REF:-}" = "refs/heads/v3" ] || {
+    echo "bazel-check: trusted CI requires refs/heads/v3" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  repository="${GITHUB_REPOSITORY:-}"
+  [ "$repository" = "vicondoa/d2b" ] || {
+    echo "bazel-check: trusted CI requires the canonical d2b repository" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  server_url="${GITHUB_SERVER_URL:-}"
+  [ "$server_url" = "https://github.com" ] || {
+    echo "bazel-check: trusted CI requires the canonical GitHub server" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+
+  base_sha="${D2B_BAZEL_BASE_SHA:-}"
+  head_sha="${D2B_BAZEL_HEAD_SHA:-}"
+  merge_sha="${D2B_BAZEL_MERGE_SHA:-}"
+  trusted_sha="${D2B_BAZEL_TRUSTED_SHA:-}"
+  branch_name="${D2B_BAZEL_BRANCH:-}"
+  pr_number="${D2B_BAZEL_PR_NUMBER:-}"
+  run_id="${D2B_BAZEL_RUN_ID:-}"
+  workflow_ref="${D2B_BAZEL_WORKFLOW_REF:-}"
+
+  for value in "$base_sha" "$head_sha" "$merge_sha" "$trusted_sha"; do
+    [[ "$value" =~ ^[0-9a-fA-F]{40}$ ]] || {
+      echo "bazel-check: trusted CI OID metadata is invalid" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+  done
+  [[ "$branch_name" != *$'\n'* && "$branch_name" != *$'\r'* ]] || {
+    echo "bazel-check: trusted CI branch metadata contains a control character" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  git_checkout check-ref-format --branch "$branch_name" >/dev/null 2>&1 || {
+    echo "bazel-check: trusted CI branch metadata is not an approved ref" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  [[ "$run_id" =~ ^[0-9]+$ ]] || {
+    echo "bazel-check: trusted CI run metadata is invalid" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  [ "$workflow_ref" = "vicondoa/d2b/.github/workflows/pr-l1-static-fast.yml@refs/heads/v3" ] || {
+    echo "bazel-check: trusted CI workflow metadata is invalid" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+
+  if [ "$event" = pull_request_target ]; then
+    [ "${GITHUB_BASE_REF:-}" = "v3" ] &&
+      [ -n "${GITHUB_HEAD_REF:-}" ] &&
+      [ "$branch_name" = "$GITHUB_HEAD_REF" ] || {
+      echo "bazel-check: trusted PR branch metadata does not match the event" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+    [[ "$pr_number" =~ ^[0-9]+$ ]] || {
+      echo "bazel-check: trusted PR metadata is invalid" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+  else
+    [ -z "${GITHUB_BASE_REF:-}" ] &&
+      [ "${GITHUB_REF_NAME:-}" = "v3" ] &&
+      [ "$branch_name" = "v3" ] || {
+      echo "bazel-check: trusted push branch metadata does not match v3" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+    [ -z "$pr_number" ] || {
+      echo "bazel-check: trusted push must not carry PR metadata" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+    [ "$head_sha" = "$merge_sha" ] || {
+      echo "bazel-check: trusted push head and merge SHA metadata must match" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+  fi
+
+  tested_sha="$(git_checkout rev-parse --verify HEAD^{commit} 2>/dev/null)" || {
+    echo "bazel-check: tested checkout HEAD is unavailable" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  [ "$tested_sha" = "$merge_sha" ] || {
+    echo "bazel-check: tested checkout does not match the event merge/push SHA" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  local trusted_head
+  trusted_head="$(
+    env -i PATH="$PATH" LC_ALL=C git -C "$TRUSTED_ROOT" rev-parse --verify HEAD^{commit} 2>/dev/null
+  )" || {
+    echo "bazel-check: trusted checkout HEAD is unavailable" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  [ "$trusted_head" = "$base_sha" ] && [ "$trusted_head" = "$trusted_sha" ] || {
+    echo "bazel-check: trusted checkout does not match protected v3 base SHA" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+
+  env -i PATH="$PATH" LC_ALL=C git -C "$SOURCE_ROOT" cat-file -e "$base_sha^{commit}" ||
+    {
+      echo "bazel-check: protected v3 base SHA is unavailable in the tested checkout" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+  env -i PATH="$PATH" LC_ALL=C git -C "$SOURCE_ROOT" merge-base --is-ancestor "$base_sha" "$merge_sha" ||
+    {
+      echo "bazel-check: tested merge SHA is not based on protected v3" >&2
+      return "$CONFIGURATION_FAILURE_STATUS"
+    }
+
+  if [ "$event" = pull_request_target ]; then
+    env -i PATH="$PATH" LC_ALL=C git -C "$SOURCE_ROOT" cat-file -e "$head_sha^{commit}" ||
+      {
+        echo "bazel-check: PR head SHA is unavailable in the tested checkout" >&2
+        return "$CONFIGURATION_FAILURE_STATUS"
+      }
+    env -i PATH="$PATH" LC_ALL=C git -C "$SOURCE_ROOT" merge-base --is-ancestor "$head_sha" "$merge_sha" ||
+      {
+        echo "bazel-check: PR head SHA is not an ancestor of the tested merge SHA" >&2
+        return "$CONFIGURATION_FAILURE_STATUS"
+      }
+  fi
+
+  export D2B_BAZEL_TESTED_SHA="$tested_sha"
+  BUILD_BUDDY_METADATA_FLAGS=(
+    "--build_metadata=REPO_URL=https://github.com/vicondoa/d2b"
+    "--build_metadata=BASE_SHA=$base_sha"
+    "--build_metadata=HEAD_SHA=$head_sha"
+    "--build_metadata=MERGE_SHA=$merge_sha"
+    "--build_metadata=TESTED_SHA=$tested_sha"
+    "--build_metadata=TRUSTED_SHA=$trusted_sha"
+    "--build_metadata=BRANCH_NAME=$branch_name"
+    "--build_metadata=RUN_ID=$run_id"
+    "--build_metadata=WORKFLOW_REF=$workflow_ref"
+    "--build_metadata=EVENT_NAME=$event"
+  )
+  if [ "$event" = pull_request_target ]; then
+    BUILD_BUDDY_METADATA_FLAGS+=("--build_metadata=PR_NUMBER=$pr_number")
+  fi
+}
+
+ci_mode() {
+  [ "${D2B_BAZEL_TRUSTED:-0}" = 1 ] &&
+    [ "${GITHUB_ACTIONS:-false}" = true ] &&
+    [ -n "${D2B_BAZEL_BASE_SHA:-}" ]
+}
+
+validate_ci_context() {
+  if ci_mode; then
+    ci_metadata >/dev/null
+  fi
+}
+
 trusted_context() {
   [ "${D2B_BAZEL_TRUSTED:-0}" = 1 ] &&
     [ "${GITHUB_REF:-}" = "refs/heads/v3" ] &&
+    validate_ci_context &&
     xtask bazel-evidence check-security >/dev/null
 }
 
+replace_trusted_control() {
+  local relative="$1"
+  local source="$TRUSTED_ROOT/$relative"
+  local target="$TRUSTED_WORKSPACE/$relative"
+  local parent="$TRUSTED_WORKSPACE"
+  local component
+  local directory="${relative%/*}"
+
+  [ -f "$source" ] || {
+    echo "bazel-check: trusted control file is missing: $relative" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  }
+  if [ "$directory" != "$relative" ]; then
+    IFS=/ read -r -a components <<<"$directory"
+    for component in "${components[@]}"; do
+      parent="$parent/$component"
+      if [ -L "$parent" ]; then
+        echo "bazel-check: source control path is a symlink: ${parent#$TRUSTED_WORKSPACE/}" >&2
+        return "$CONFIGURATION_FAILURE_STATUS"
+      fi
+      mkdir -p -- "$parent"
+    done
+  fi
+  rm -f -- "$target"
+  install -m 0555 "$source" "$target"
+}
+
+prepare_trusted_control_files() {
+  if [ "$SOURCE_ROOT" = "$TRUSTED_ROOT" ]; then
+    TRUSTED_WORKSPACE="$SOURCE_ROOT"
+    return 0
+  fi
+
+  mkdir -p -- "$SCRATCH"
+  TRUSTED_WORKSPACE="$SCRATCH/trusted-workspace"
+  if [ -L "$TRUSTED_WORKSPACE" ]; then
+    echo "bazel-check: refusing a symlinked trusted workspace scratch path" >&2
+    return "$CONFIGURATION_FAILURE_STATUS"
+  fi
+  rm -rf -- "$TRUSTED_WORKSPACE"
+  mkdir -p -- "$TRUSTED_WORKSPACE"
+  if ! cp -al -- "$SOURCE_ROOT/." "$TRUSTED_WORKSPACE/" 2>/dev/null; then
+    cp -a -- "$SOURCE_ROOT/." "$TRUSTED_WORKSPACE/"
+  fi
+  rm -rf -- "$TRUSTED_WORKSPACE/.git"
+  rm -f -- "$TRUSTED_WORKSPACE/.bazelrc.user"
+
+  for relative in \
+    .bazelrc \
+    MODULE.bazel \
+    MODULE.bazel.lock \
+    bazel/platforms/BUILD.bazel \
+    bazel/remote/BUILD.bazel \
+    tests/tools/bazel-check \
+    tests/tools/ci-shell \
+    tests/tools/scrub-shell-environment
+  do
+    replace_trusted_control "$relative"
+  done
+}
+
+remote_instance_name() {
+  if ci_mode; then
+    if [ "${GITHUB_EVENT_NAME:-}" = pull_request_target ]; then
+      printf 'd2b/pr/%s/%s/linux-x86_64/rules_rs/worker-v1/minimal/lock-v1\n' \
+        "$D2B_BAZEL_PR_NUMBER" "$D2B_BAZEL_HEAD_SHA"
+    else
+      printf 'd2b/trusted-seed/linux-x86_64/rules_rs/worker-v1/minimal/lock-v1\n'
+    fi
+  else
+    printf '%s\n' ""
+  fi
+}
+
+require_remote() {
+  [ "${D2B_BAZEL_REQUIRE_REMOTE:-0}" = 1 ]
+}
+
 credential_helper() {
-  local request token path
+  local request token path uri
   request="$(cat)"
   if [[ "$request" != *'"uri"'* ]]; then
     printf '%s\n' '{"headers":{}}'
@@ -132,19 +395,30 @@ credential_helper() {
     return 0
   fi
 
-  if [ "${D2B_BAZEL_PROFILE:-}" = trusted-seed ]; then
-    trusted_context || {
+  uri="$(printf '%s' "$request" | jq -r '.uri // empty' 2>/dev/null || true)"
+  case "$uri" in
+    https://d2b.buildbuddy.io/*|https://d2b.buildbuddy.io|grpcs://d2b.buildbuddy.io/*|grpcs://d2b.buildbuddy.io)
+      ;;
+    *)
       printf '%s\n' '{"headers":{}}'
       return 0
-    }
+      ;;
+  esac
+
+  if [ -n "${D2B_BAZEL_CREDENTIAL_FD:-}" ]; then
+    if ! token="$(credential_from_fd)"; then
+      printf '%s\n' '{"headers":{}}'
+      return 0
+    fi
+  else
+    path="$(credential_file)"
+    if [ ! -r "$path" ] || [ ! -s "$path" ]; then
+      printf '%s\n' '{"headers":{}}'
+      return 0
+    fi
+    token="$(cat "$path")"
   fi
 
-  path="$(credential_file)"
-  if [ ! -r "$path" ] || [ ! -s "$path" ]; then
-    printf '%s\n' '{"headers":{}}'
-    return 0
-  fi
-  token="$(cat "$path")"
   case "$token" in
     *$'\n'*|*$'\r'*|'') printf '%s\n' '{"headers":{}}'; return 0 ;;
   esac
@@ -170,7 +444,7 @@ if [ "$#" -ge 1 ] && [ "$1" = get ]; then
   exit $?
 fi
 
-cd "$ROOT"
+cd "$TRUSTED_ROOT"
 
 if [ "$#" -eq 0 ]; then
   request="$(cat)"
@@ -232,8 +506,20 @@ fi
 
 mkdir -p "$SCRATCH"
 if [ -z "${D2B_XTASK_BIN:-}" ] || [ ! -x "${D2B_XTASK_BIN}" ]; then
-  "$bazel_bin" build --config=local //packages/xtask:xtask >/dev/null
-  xtask_source="$ROOT/bazel-bin/packages/xtask/xtask"
+  if ci_mode; then
+    (
+      cd "$TRUSTED_ROOT"
+      "$bazel_bin" \
+        --nosystem_rc \
+        --nohome_rc \
+        --noworkspace_rc \
+        --bazelrc="$TRUSTED_ROOT/.bazelrc" \
+        build --config=local //packages/xtask:xtask
+    ) >/dev/null
+  else
+    "$bazel_bin" build --config=local //packages/xtask:xtask >/dev/null
+  fi
+  xtask_source="$TRUSTED_ROOT/bazel-bin/packages/xtask/xtask"
   xtask_stable="$SCRATCH/xtask"
   cp -L -- "$xtask_source" "$xtask_stable.tmp"
   chmod 0555 "$xtask_stable.tmp"
@@ -241,7 +527,18 @@ if [ -z "${D2B_XTASK_BIN:-}" ] || [ ! -x "${D2B_XTASK_BIN}" ]; then
   export D2B_XTASK_BIN="$xtask_stable"
 fi
 
-if [ "$PROFILE" = trusted-seed ]; then
+if ci_mode; then
+  trusted_context || {
+    echo "bazel-check: trusted v3 security context is invalid" >&2
+    exit "$CONFIGURATION_FAILURE_STATUS"
+  }
+  prepare_trusted_control_files
+  if { [ "$PROFILE" = remote ] || [ "$PROFILE" = trusted-seed ]; } &&
+    [ -z "${D2B_BAZEL_CREDENTIAL_FD:-}" ]; then
+    echo "bazel-check: credential-bearing CI requires D2B_BUILDBUDDY_API_KEY through the trusted bootstrap" >&2
+    exit "$CONFIGURATION_FAILURE_STATUS"
+  fi
+elif [ "$PROFILE" = trusted-seed ]; then
   if ! trusted_context; then
     echo "trusted BuildBuddy credential withheld: protected v3 and security digest are required"
     PROFILE=local
@@ -250,13 +547,20 @@ elif [ "${D2B_BAZEL_UNTRUSTED:-0}" = 1 ] ||
   { [ "${GITHUB_ACTIONS:-false}" = true ] && ! trusted_context; }; then
   echo "BuildBuddy credential withheld for an untrusted job; retrying locally"
   PROFILE=local
-elif [ ! -r "$(credential_file)" ] || [ ! -s "$(credential_file)" ]; then
+elif [ -z "${D2B_BAZEL_CREDENTIAL_FD:-}" ] &&
+  { [ ! -r "$(credential_file)" ] || [ ! -s "$(credential_file)" ]; }; then
+  if require_remote; then
+    echo "bazel-check: remote execution was required but the credential is unavailable" >&2
+    exit "$CONFIGURATION_FAILURE_STATUS"
+  fi
   echo "BuildBuddy credential unavailable; retrying locally"
   PROFILE=local
 fi
 
 export D2B_BAZEL_BIN="$bazel_bin"
-export D2B_REPO_ROOT="$ROOT"
+export D2B_BAZEL_TRUSTED_ROOT="$TRUSTED_ROOT"
+export D2B_BAZEL_SOURCE_ROOT="$SOURCE_ROOT"
+export D2B_REPO_ROOT="$SOURCE_ROOT"
 export ROOT
 JOB="${D2B_BAZEL_JOB:-check}"
 log="$SCRATCH/$PROFILE.$JOB.log"
@@ -274,8 +578,15 @@ run_bazel() {
   local bep_path="$3"
   local -a startup_flags=()
   shift 3
-  if [ "${D2B_BAZEL_FALLBACK_ISOLATE_RC:-0}" = 1 ]; then
-    [ ! -e "$ROOT/.bazelrc.user" ] || {
+  if ci_mode; then
+    startup_flags=(
+      --nosystem_rc
+      --nohome_rc
+      --noworkspace_rc
+      --bazelrc="$TRUSTED_ROOT/.bazelrc"
+    )
+  elif [ "${D2B_BAZEL_FALLBACK_ISOLATE_RC:-0}" = 1 ]; then
+    [ ! -e "$TRUSTED_WORKSPACE/.bazelrc.user" ] || {
       echo "local fallback rejects an external workspace Bazel rc" >&2
       return "$CONFIGURATION_FAILURE_STATUS"
     }
@@ -287,27 +598,52 @@ run_bazel() {
   local test_bazel_sh="${BAZEL_SH:-/bin/bash}"
   local test_path="${D2B_BAZEL_TEST_PATH:-$PATH}"
   if [ "$profile" != local ]; then
-    buildbuddy_metadata
+    if ci_mode; then
+      ci_metadata || return $?
+    else
+      buildbuddy_metadata
+    fi
     command_flags+=("${BUILD_BUDDY_METADATA_FLAGS[@]}")
+    command_flags+=(
+      --remote_executor=grpcs://d2b.buildbuddy.io
+      --remote_cache=grpcs://d2b.buildbuddy.io
+      --bes_backend=grpcs://d2b.buildbuddy.io
+      --bes_results_url=https://d2b.buildbuddy.io/invocation/
+      "--credential_helper=d2b.buildbuddy.io=$TRUSTED_ROOT/tests/tools/bazel-check"
+    )
+    if ci_mode; then
+      command_flags+=(
+        --action_env=D2B_BUILDBUDDY_API_KEY=
+        --action_env=D2B_BAZEL_CREDENTIAL_FD=
+        --test_env=D2B_BUILDBUDDY_API_KEY=
+        --test_env=D2B_BAZEL_CREDENTIAL_FD=
+      )
+    fi
+    if namespace="$(remote_instance_name)" && [ -n "$namespace" ]; then
+      command_flags+=(--remote_instance_name="$namespace")
+    fi
     command_flags+=(--shell_executable=/bin/bash)
     test_bazel_sh=/bin/bash
     test_path="/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$test_path"
   fi
-  D2B_BAZEL_PROFILE="$profile" "$bazel_bin" "${startup_flags[@]}" test "--config=$profile" \
-    "${command_flags[@]}" \
-    --repo_contents_cache= "--build_event_json_file=$bep_path" \
-    --build_tests_only \
-    --test_output=errors \
-    --test_tag_filters="$tag_filters" \
-    --test_env=D2B_REPO_ROOT="$ROOT" \
-    --test_env=D2B_BAZEL_BIN="$bazel_bin" \
-    --test_env=D2B_PROJECT_SHELL=d2b \
-    --test_env=D2B_SHELLCHECK_BIN="${D2B_SHELLCHECK_BIN:-}" \
-    --test_env=PATH="$test_path" \
-    --test_env=BAZEL_SH="$test_bazel_sh" \
-    "$@" \
-    -- "${TARGETS[@]}" \
-    >"$log_path" 2>&1
+  (
+    cd "$TRUSTED_WORKSPACE"
+    D2B_BAZEL_PROFILE="$profile" "$bazel_bin" "${startup_flags[@]}" test "--config=$profile" \
+      "${command_flags[@]}" \
+      --repo_contents_cache= "--build_event_json_file=$bep_path" \
+      --build_tests_only \
+      --test_output=errors \
+      --test_tag_filters="$tag_filters" \
+      --test_env=D2B_REPO_ROOT="$SOURCE_ROOT" \
+      --test_env=D2B_BAZEL_SOURCE_ROOT="$SOURCE_ROOT" \
+      --test_env=D2B_BAZEL_BIN="$bazel_bin" \
+      --test_env=D2B_PROJECT_SHELL=d2b \
+      --test_env=D2B_SHELLCHECK_BIN="${D2B_SHELLCHECK_BIN:-}" \
+      --test_env=PATH="$test_path" \
+      --test_env=BAZEL_SH="$test_bazel_sh" \
+      "$@" \
+      -- "${TARGETS[@]}"
+  ) >"$log_path" 2>&1
   local status=$?
   set -e
   if [ "$status" -eq 0 ] && ! bep_has_test_result "$bep_path"; then
@@ -354,6 +690,12 @@ fi
 if [ "$initial_status" -eq "$REDACTION_FAILURE_STATUS" ] ||
   [ "$initial_status" -eq "$CONFIGURATION_FAILURE_STATUS" ]; then
   exit "$initial_status"
+fi
+
+if require_remote && [ "$PROFILE" != local ]; then
+  echo "bazel-check: trusted CI remote execution failed; refusing a local retry" >&2
+  emit_captured_output "$log" "bazel $PROFILE log"
+  exit 1
 fi
 
 if [ "$PROFILE" != local ]; then

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -287,8 +287,7 @@ ci_metadata() {
 
 ci_mode() {
   [ "${D2B_BAZEL_TRUSTED:-0}" = 1 ] &&
-    [ "${GITHUB_ACTIONS:-false}" = true ] &&
-    [ -n "${D2B_BAZEL_BASE_SHA:-}" ]
+  [ "${GITHUB_ACTIONS:-false}" = true ]
 }
 
 validate_ci_context() {

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -355,6 +355,7 @@ prepare_trusted_control_files() {
     .bazelrc \
     MODULE.bazel \
     MODULE.bazel.lock \
+    flake.lock \
     bazel/checks/BUILD.bazel \
     bazel/checks/fixtures/BUILD.bazel \
     bazel/checks/fixtures/defs.bzl \

--- a/tests/tools/bazel-check
+++ b/tests/tools/bazel-check
@@ -540,6 +540,11 @@ case "$PROFILE" in
     ;;
 esac
 
+if [ "${GITHUB_ACTIONS:-false}" = true ] && [ "$PROFILE" != local ]; then
+  echo "bazel-check: GitHub Actions CI is local-only; remote profiles are reserved for non-Actions runs" >&2
+  exit "$CONFIGURATION_FAILURE_STATUS"
+fi
+
 if [ "${D2B_PROJECT_SHELL:-}" != d2b ]; then
   echo "bazel-check: D2B_PROJECT_SHELL=d2b is required; enter a d2b development shell" >&2
   exit "$CONFIGURATION_FAILURE_STATUS"

--- a/tests/tools/bazel-check-bootstrap
+++ b/tests/tools/bazel-check-bootstrap
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "bazel-check-bootstrap: a trusted command is required" >&2
+  exit 2
+fi
+
+python3 -c '
+import os
+import sys
+
+command = sys.argv[1:]
+secret = sys.stdin.buffer.read()
+if not secret or b"\x00" in secret or b"\n" in secret or b"\r" in secret:
+    raise SystemExit("bazel-check-bootstrap: credential must be one non-empty line")
+
+fd = os.memfd_create("d2b-buildbuddy-credential", os.MFD_CLOEXEC)
+try:
+    os.write(fd, secret)
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.set_inheritable(fd, True)
+    os.environ.pop("D2B_BUILDBUDDY_API_KEY", None)
+    os.environ["D2B_BAZEL_CREDENTIAL_FD"] = str(fd)
+    os.execvpe(command[0], command, os.environ)
+finally:
+    os.close(fd)
+' "$@"

--- a/tests/tools/no-bash-ast-walker/BUILD.bazel
+++ b/tests/tools/no-bash-ast-walker/BUILD.bazel
@@ -40,7 +40,7 @@ rust_test(
         "//bazel/checks/rust:source_hygiene_sources",
     ],
     env_inherit = ["D2B_REPO_ROOT", "PATH", "TEST_SRCDIR", "TEST_WORKSPACE"],
-    tags = ["local"],
+    tags = ["no-remote-exec"],
     visibility = ["//visibility:public"],
     deps = [":no_bash_ast_walker"] + all_crate_deps(normal_dev = True, cargo_only = True),
 )


### PR DESCRIPTION
## Summary

This completes the trusted BuildBuddy Layer-1 path for pull requests targeting protected `v3`. Remote-eligible actions use a credential only when the workflow and bootstrap are sourced from protected `v3` and the tested base, head, merge, and control revisions remain immutable. Fixed target sets, the stable required `check`, PR cache namespaces, and trusted seed cache domains remain explicit and fail closed.

Nix, fixture, hardware, performance, and tagged local-only actions remain local and credential-free. This change does not switch to BuildBuddy Workflows or broaden the control-plane architecture.

## Validation evidence

- [x] `D2B_BAZEL_PROFILE=local make test-policy` passed.
- [x] `D2B_BAZEL_PROFILE=local make test-rust-local` passed, including the trusted BuildBuddy and PR workflow contract tests.
- [x] `D2B_BAZEL_PROFILE=local make check` passed.
- [x] Trusted shell syntax checks and `git diff --check` passed.
- [x] The trusted control-policy digest was refreshed after the protected-v3 contract changes.
- [x] Changelog and related contributor, test, workflow, and BuildBuddy reference documentation are updated.

## Notes

- Related: #447
- Deployment dependency: GitHub currently sources `pull_request_target` workflow bytes and default-branch metadata from the repository default branch, while this gate intentionally requires protected `v3` workflow bytes and `workflow_ref`. Until repository settings source this workflow from `v3` (or make `v3` the default), PR events fail closed; this change does not weaken that boundary.
- No merge was performed.
