### PR TITLE
ci: serialize Rust toolchain bootstrap

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -202,6 +202,23 @@ jobs:
           set -euo pipefail
           test "$(git -C trusted rev-parse HEAD)" = "$D2B_TRUSTED_SHA"
           test "$(git -C workspace rev-parse HEAD)" = "$D2B_TESTED_SHA"
+      - name: Prepare pinned Rust toolchain for parallel Layer-1 gates
+        working-directory: workspace
+        run: |
+          set -euo pipefail
+          if ! command -v rustup >/dev/null 2>&1; then
+            echo "rustup is unavailable; Rust gates will use their Nix fallback."
+            exit 0
+          fi
+          pinned_channel="$(
+            sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+              packages/rust-toolchain.toml | head -1
+          )"
+          [ -n "$pinned_channel" ] || {
+            echo "::error::could not read the pinned Rust channel" >&2
+            exit 76
+          }
+          rustup toolchain install "$pinned_channel" --profile minimal --component rustfmt --component clippy
       - name: Run credential-free local Layer-1 gate
         working-directory: workspace
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,11 +89,19 @@ jobs:
           git -C source check-ref-format --branch "$D2B_BRANCH" >/dev/null 2>&1 ||
             fail "branch metadata is not an approved ref"
 
+          validate_optional_reusable_workflow() {
+            if [ -n "$D2B_JOB_WORKFLOW_REF" ] || [ -n "$D2B_JOB_WORKFLOW_SHA" ]; then
+              [ "$D2B_JOB_WORKFLOW_REF" = "vicondoa/d2b/.github/workflows/build.yaml@refs/heads/main" ] ||
+                fail "reusable build controls must be sourced from protected main"
+              is_sha "$D2B_JOB_WORKFLOW_SHA" ||
+                fail "reusable workflow SHA is not a full immutable commit SHA"
+            fi
+          }
+
           if [ "$D2B_EVENT_NAME" = "pull_request_target" ]; then
             [ "$D2B_CALLER_WORKFLOW_REF" = "vicondoa/d2b/.github/workflows/pr.yml@refs/heads/main" ] ||
               fail "PR workflow controls must be sourced from protected main"
-            [ "$D2B_JOB_WORKFLOW_REF" = "vicondoa/d2b/.github/workflows/build.yaml@refs/heads/main" ] ||
-              fail "reusable build controls must be sourced from protected main"
+            validate_optional_reusable_workflow
             case "$D2B_BASE_REF" in
               main|v3) ;;
               *) fail "pull request target is not main or v3" ;;
@@ -110,6 +118,7 @@ jobs:
           elif [ "$D2B_EVENT_NAME" = "push" ]; then
             [ "$D2B_CALLER_WORKFLOW_REF" = "vicondoa/d2b/.github/workflows/build.yaml@refs/heads/main" ] ||
               fail "push workflow controls must be sourced from protected main"
+            validate_optional_reusable_workflow
             [ "$D2B_REF" = "refs/heads/main" ] ||
               fail "trusted build pushes are restricted to main"
             [ -z "$D2B_BASE_REF" ] || fail "push events must not carry a base ref"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ deprecations ship one minor release before removal.
 - Fixed trusted `main` push validation and reusable workflow resolution so the
   BuildBuddy seed workflow executes its metadata checks instead of failing on
   shell test parsing.
+- Accepted GitHub runs that omit `job_workflow_ref` and `job_workflow_sha` for
+  same-repository reusable workflows while still validating those immutable
+  identifiers whenever GitHub provides them.
 - Prepared the pinned Rust toolchain before parallel local Layer-1 gates so
   concurrent Rust and proof jobs do not race during rustup installation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ deprecations ship one minor release before removal.
 - Fixed trusted `main` push validation and reusable workflow resolution so the
   BuildBuddy seed workflow executes its metadata checks instead of failing on
   shell test parsing.
+- Prepared the pinned Rust toolchain before parallel local Layer-1 gates so
+  concurrent Rust and proof jobs do not race during rustup installation.
 
 ## [1.4.1] - 2026-07-12
 

--- a/packages/xtask/tests/policy_ci.rs
+++ b/packages/xtask/tests/policy_ci.rs
@@ -211,16 +211,28 @@ fn main_controlled_buildbuddy_workflows_preserve_trust_contract() {
             && build.contains("D2B_BAZEL_UNTRUSTED: \"1\""),
         "full PR coverage must retain a credential-free local Layer-1 gate"
     );
-    let rust_bootstrap = build
-        .find("Prepare pinned Rust toolchain for parallel Layer-1 gates")
+    let local_job_start = build
+        .find("\n  local:\n")
+        .expect("build workflow must define a local job");
+    let local_job_end = local_job_start
+        + build[local_job_start..]
+            .find("\n  remote:\n")
+            .expect("build workflow must define a remote job");
+    let local_job = &build[local_job_start..local_job_end];
+    let rust_bootstrap = local_job
+        .find("      - name: Prepare pinned Rust toolchain for parallel Layer-1 gates")
         .expect("local Layer-1 gate must prepare the shared Rust toolchain");
-    let local_gate = build
-        .find("Run credential-free local Layer-1 gate")
+    let local_gate = local_job
+        .find("      - name: Run credential-free local Layer-1 gate")
         .expect("local Layer-1 gate step must be present");
+    let rust_bootstrap_step = &local_job[rust_bootstrap..local_gate];
     assert!(
         rust_bootstrap < local_gate
-            && build.contains("rustup toolchain install \"$pinned_channel\" --profile minimal")
-            && build.contains("--component rustfmt --component clippy"),
+            && rust_bootstrap_step.contains("working-directory: workspace")
+            && rust_bootstrap_step.contains("packages/rust-toolchain.toml")
+            && rust_bootstrap_step
+                .contains("rustup toolchain install \"$pinned_channel\" --profile minimal")
+            && rust_bootstrap_step.contains("--component rustfmt --component clippy"),
         "parallel local Layer-1 jobs must share a preinstalled pinned Rust toolchain"
     );
     assert!(

--- a/packages/xtask/tests/policy_ci.rs
+++ b/packages/xtask/tests/policy_ci.rs
@@ -171,26 +171,40 @@ fn main_controlled_buildbuddy_workflows_preserve_trust_contract() {
         "build workflow must bind trusted and tested immutable OIDs"
     );
     assert!(
-        build.contains("trusted_sha=\"${D2B_JOB_WORKFLOW_SHA:-$D2B_CALLER_WORKFLOW_SHA}\"")
-            && build.contains(
-                "if [ -n \"$D2B_JOB_WORKFLOW_REF\" ] || [ -n \"$D2B_JOB_WORKFLOW_SHA\" ]; then"
-            )
-            && build.contains(
-                "[ \"$D2B_JOB_WORKFLOW_REF\" = \"vicondoa/d2b/.github/workflows/build.yaml@refs/heads/main\" ]"
-            )
-            && build.contains("is_sha \"$D2B_JOB_WORKFLOW_SHA\""),
-        "optional reusable-workflow metadata must be validated when GitHub provides it"
+        build.contains("trusted_sha=\"${D2B_JOB_WORKFLOW_SHA:-$D2B_CALLER_WORKFLOW_SHA}\""),
+        "trusted workflow SHA must fall back to the caller SHA when job metadata is absent"
     );
+    let helper_start = build
+        .find("          validate_optional_reusable_workflow() {")
+        .expect("build workflow must define optional reusable-workflow validation");
     let pr_validation_start = build
-        .find("if [ \"$D2B_EVENT_NAME\" = \"pull_request_target\" ]")
+        .find("          if [ \"$D2B_EVENT_NAME\" = \"pull_request_target\" ]")
         .expect("build workflow must validate pull_request_target metadata");
     let push_validation_start = build
-        .find("elif [ \"$D2B_EVENT_NAME\" = \"push\" ]")
+        .find("          elif [ \"$D2B_EVENT_NAME\" = \"push\" ]")
         .expect("build workflow must validate push metadata");
+    let helper_end = helper_start
+        + build[helper_start..pr_validation_start]
+            .find("\n          }\n\n")
+            .expect("optional reusable-workflow validator must end before event validation");
+    let helper = &build[helper_start..helper_end];
+    assert!(
+        helper.contains(
+            "if [ -n \"$D2B_JOB_WORKFLOW_REF\" ] || [ -n \"$D2B_JOB_WORKFLOW_SHA\" ]; then"
+        ) && helper.contains(
+            "[ \"$D2B_JOB_WORKFLOW_REF\" = \"vicondoa/d2b/.github/workflows/build.yaml@refs/heads/main\" ]"
+        ) && helper.contains("is_sha \"$D2B_JOB_WORKFLOW_SHA\""),
+        "optional reusable-workflow metadata checks must stay inside their validator"
+    );
+    let push_validation_end = push_validation_start
+        + build[push_validation_start..]
+            .find("\n          else\n            fail \"only pull_request_target and push events are accepted\"")
+            .expect("build workflow event validation must have a bounded fallback branch");
     assert!(
         build[pr_validation_start..push_validation_start]
-            .contains("validate_optional_reusable_workflow")
-            && build[push_validation_start..].contains("validate_optional_reusable_workflow"),
+            .contains("            validate_optional_reusable_workflow\n")
+            && build[push_validation_start..push_validation_end]
+                .contains("            validate_optional_reusable_workflow\n"),
         "optional reusable-workflow metadata validation must bind to both event paths"
     );
     assert!(

--- a/packages/xtask/tests/policy_ci.rs
+++ b/packages/xtask/tests/policy_ci.rs
@@ -175,8 +175,23 @@ fn main_controlled_buildbuddy_workflows_preserve_trust_contract() {
             && build.contains(
                 "if [ -n \"$D2B_JOB_WORKFLOW_REF\" ] || [ -n \"$D2B_JOB_WORKFLOW_SHA\" ]; then"
             )
+            && build.contains(
+                "[ \"$D2B_JOB_WORKFLOW_REF\" = \"vicondoa/d2b/.github/workflows/build.yaml@refs/heads/main\" ]"
+            )
             && build.contains("is_sha \"$D2B_JOB_WORKFLOW_SHA\""),
         "optional reusable-workflow metadata must be validated when GitHub provides it"
+    );
+    let pr_validation_start = build
+        .find("if [ \"$D2B_EVENT_NAME\" = \"pull_request_target\" ]")
+        .expect("build workflow must validate pull_request_target metadata");
+    let push_validation_start = build
+        .find("elif [ \"$D2B_EVENT_NAME\" = \"push\" ]")
+        .expect("build workflow must validate push metadata");
+    assert!(
+        build[pr_validation_start..push_validation_start]
+            .contains("validate_optional_reusable_workflow")
+            && build[push_validation_start..].contains("validate_optional_reusable_workflow"),
+        "optional reusable-workflow metadata validation must bind to both event paths"
     );
     assert!(
         build.matches("persist-credentials: false").count() >= 4,

--- a/packages/xtask/tests/policy_ci.rs
+++ b/packages/xtask/tests/policy_ci.rs
@@ -211,6 +211,18 @@ fn main_controlled_buildbuddy_workflows_preserve_trust_contract() {
             && build.contains("D2B_BAZEL_UNTRUSTED: \"1\""),
         "full PR coverage must retain a credential-free local Layer-1 gate"
     );
+    let rust_bootstrap = build
+        .find("Prepare pinned Rust toolchain for parallel Layer-1 gates")
+        .expect("local Layer-1 gate must prepare the shared Rust toolchain");
+    let local_gate = build
+        .find("Run credential-free local Layer-1 gate")
+        .expect("local Layer-1 gate step must be present");
+    assert!(
+        rust_bootstrap < local_gate
+            && build.contains("rustup toolchain install \"$pinned_channel\" --profile minimal")
+            && build.contains("--component rustfmt --component clippy"),
+        "parallel local Layer-1 jobs must share a preinstalled pinned Rust toolchain"
+    );
     assert!(
         build.contains("github.event_name == 'push'")
             && build.contains("github.event_name == 'push' }}"),

--- a/packages/xtask/tests/policy_ci.rs
+++ b/packages/xtask/tests/policy_ci.rs
@@ -171,6 +171,14 @@ fn main_controlled_buildbuddy_workflows_preserve_trust_contract() {
         "build workflow must bind trusted and tested immutable OIDs"
     );
     assert!(
+        build.contains("trusted_sha=\"${D2B_JOB_WORKFLOW_SHA:-$D2B_CALLER_WORKFLOW_SHA}\"")
+            && build.contains(
+                "if [ -n \"$D2B_JOB_WORKFLOW_REF\" ] || [ -n \"$D2B_JOB_WORKFLOW_SHA\" ]; then"
+            )
+            && build.contains("is_sha \"$D2B_JOB_WORKFLOW_SHA\""),
+        "optional reusable-workflow metadata must be validated when GitHub provides it"
+    );
+    assert!(
         build.matches("persist-credentials: false").count() >= 4,
         "trusted and source checkouts must not persist credentials"
     );


### PR DESCRIPTION
## Summary

The trusted `main` build workflow now prepares the pinned Rust toolchain before `make check` starts its parallel Layer-1 jobs. This prevents concurrent `rustup` downloads from corrupting the shared runner installation and causing Rust/proof lanes to fail with missing tools.

The workflow also tolerates GitHub runs that omit reusable-workflow job metadata for same-repository calls. When GitHub provides that metadata, the workflow still requires the protected `main` ref and a full immutable SHA. The policy test binds those checks to the helper body and to both accepted event paths.

This is a follow-up to the landed BuildBuddy workflow change. It does not modify `v3` or use PR #473 as the vehicle.

Related: #474

## Validation

- `cargo test --manifest-path packages/Cargo.toml -p xtask --test policy_ci` - 3 passed.
- `make test-lint` - passed.
- `make test-policy` - passed.
- YAML parsing, pinned Rust bootstrap, and `git diff --check` - passed.
- CodeQL and all main-required PR checks (`check`, `eval`, `eval-shell-tests`) - passed.
- Fresh independent review after the final policy-test fix - no P0/P1 findings.

## Bootstrap note

The `build / metadata` and `build / check` runs shown on this PR are sourced from the pre-fix workflow on default `main`, as required by `pull_request_target`; they therefore retain the old `job_workflow_ref` failure until this fix lands. The corrected workflow will be exercised by the post-merge `main` push run. No merge bypass or policy change is used.

## Security and trust boundaries

PR workflows remain credential-free and main-controlled. The change preserves immutable tested base/head/merge OID checks, pinned actions, local-only Nix/fixture/hardware behavior, the push-only BuildBuddy credential gate, descriptor-based credential handling, redaction, warning fail-closed behavior, and the stable aggregate `build / check` context.
