### PR TITLE
test: reuse Bazel host binaries in NixOS VM checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	stage_tool packages/d2b-provider-display-wayland/d2b-wayland-proxy d2b-wayland-proxy; \
 	bundle_store_path="$$(nix store add-path --name d2b-bazel-host-tools "$$stage")"; \
 	nix-store --add-root "$$run_dir/bundle-root" --indirect --realise "$$bundle_store_path" >/dev/null; \
+	rm -rf -- "$$stage"; \
 	echo "test-host-integration: Bazel host-tool bundle: $$bundle_store_path"; \
 	set --; \
 	for name in $$names; do \

--- a/Makefile
+++ b/Makefile
@@ -283,10 +283,18 @@ heavy-lane-host-integration: heavy-lane-guard
 	nix build --impure --out-link "$$run_dir/result" --print-build-logs --print-out-paths "$$@" >"$$run_dir/outputs"; \
 	cat "$$run_dir/outputs"; \
 	if [ -n "$$attic_cache" ]; then \
-	: >"$$run_dir/attic-closure"; \
+	: >"$$run_dir/attic-closure-all"; \
 	while IFS= read -r output; do \
-	nix-store -qR --include-outputs "$$(nix-store -qd "$$output")"; \
-	done <"$$run_dir/outputs" | sort -u >"$$run_dir/attic-closure-all"; \
+	drv="$$(nix-store -qd "$$output")" || { \
+	echo "test-host-integration: could not resolve a vmCheck derivation for Attic" >&2; \
+	exit 1; \
+	}; \
+	if ! nix-store -qR --include-outputs "$$drv" >>"$$run_dir/attic-closure-all"; then \
+	echo "test-host-integration: could not resolve a vmCheck dependency closure for Attic" >&2; \
+	exit 1; \
+	fi; \
+	done <"$$run_dir/outputs"; \
+	sort -u -o "$$run_dir/attic-closure-all" "$$run_dir/attic-closure-all"; \
 	awk 'NR == FNR { skip[$$0] = 1; next } !skip[$$0]' \
 	"$$run_dir/outputs" "$$run_dir/attic-closure-all" >"$$run_dir/attic-closure"; \
 	if [ ! -s "$$run_dir/attic-closure" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	fi; \
 	run_dir="$$(mktemp -d "$${TMPDIR:-/tmp}/d2b-host-integration.XXXXXX")"; \
 	chmod 700 "$$run_dir"; \
-	cleanup() { rm -rf -- "$$run_dir"; }; \
+	cleanup() { rm -rf -- "$$run_dir"; nix-store --gc --print-roots >/dev/null 2>&1 || true; }; \
 	trap cleanup EXIT; \
 	trap 'exit 129' HUP; \
 	trap 'exit 130' INT; \
@@ -239,7 +239,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	attic_meta="$$(ATTIC_CONFIG="$$attic_config" nix eval --impure --json --expr 'let config = builtins.fromTOML (builtins.readFile (builtins.getEnv "ATTIC_CONFIG")); names = builtins.attrNames (config.servers or {}); server = if config ? "default-server" then config."default-server" else if builtins.length names == 1 then builtins.head names else throw "ambiguous Attic servers"; endpoint = config.servers.$${server}.endpoint or (throw "missing Attic endpoint"); in { inherit server endpoint; }' 2>/dev/null)" || fail_attic_state; \
 	attic_server="$$(printf '%s' "$$attic_meta" | jq -er '.server | select(test("^[A-Za-z0-9][A-Za-z0-9._+-]*$$"))')" || fail_attic_state; \
 	attic_base="$$(printf '%s' "$$attic_meta" | jq -er '.endpoint | capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?:/[^?#]*)?$$") | ((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase))')" || fail_attic_state; \
-	attic_name="$$(nix config show --json | jq -er --arg base "$$attic_base" '.substituters.value | if type == "string" then split(" ") else . end | map(try capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?<path>/[^?#]*)?(?:\\?[^#]*)?$$") catch empty | select(((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase)) == $$base) | ((.path // "") | rtrimstr("/") | split("/") | last)) | map(select(test("^[A-Za-z0-9][A-Za-z0-9_+-]*$$"))) | select(length == 1) | .[0]')" || fail_attic_state; \
+	attic_name="$$(nix config show --json | jq -er --arg base "$$attic_base" '.substituters.value | if type == "string" then split(" ") else . end | map(try capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?<path>/[^?#]*)?(?:\\?[^#]*)?$$") catch empty | select(((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase)) == $$base) | ((.path // "") | rtrimstr("/") | split("/") | last)) | map(select(test("^[A-Za-z0-9][A-Za-z0-9_+-]*$$"))) | unique | select(length == 1) | .[0]')" || fail_attic_state; \
 	attic_cache="$$attic_server:$$attic_name"; \
 	if ! attic cache info "$$attic_cache" >"$$run_dir/attic-info.log" 2>&1; then \
 	echo "test-host-integration: configured Attic cache preflight failed" >&2; \
@@ -271,15 +271,13 @@ heavy-lane-host-integration: heavy-lane-guard
 	stage_tool packages/d2b-unsafe-local-helper/d2b-unsafe-local-helper d2b-unsafe-local-helper; \
 	stage_tool packages/d2b-resource-compiler/d2b-resource-compiler d2b-resource-compiler; \
 	stage_tool packages/d2b-provider-display-wayland/d2b-wayland-proxy d2b-wayland-proxy; \
-	bundle_store_path="$$(D2B_BAZEL_STAGE="$$stage" nix build --impure --out-link "$$run_dir/bundle-root" --print-out-paths --expr 'builtins.path { path = builtins.getEnv "D2B_BAZEL_STAGE"; name = "d2b-bazel-host-tools"; }')"; \
-	rm -rf -- "$$stage"; \
-	echo "test-host-integration: Bazel host-tool bundle: $$bundle_store_path"; \
+	echo "test-host-integration: staged Bazel host-tool bundle"; \
 	set --; \
 	for name in $$names; do \
 	set -- "$$@" "git+file://$$root#vmChecks.$$system.$$name"; \
 	done; \
 	echo "test-host-integration: building vmChecks: $$names"; \
-	D2B_HOST_TOOL_BUNDLE="$$bundle_store_path" D2B_HOST_RUNTIME_PATH="$$run_dir/absent-host-runtime.json" \
+	D2B_HOST_TOOL_BUNDLE="$$stage" D2B_HOST_RUNTIME_PATH="$$run_dir/absent-host-runtime.json" \
 	nix build --impure --out-link "$$run_dir/result" --print-build-logs --print-out-paths "$$@" >"$$run_dir/outputs"; \
 	cat "$$run_dir/outputs"; \
 	if [ -n "$$attic_cache" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -215,60 +215,79 @@ heavy-lane-host-integration: heavy-lane-guard
 	exit 1;; \
 	esac; \
 	fi; \
-	fail_sccache_preflight() { \
-	echo "test-host-integration: sccache preflight failed: $$1" >&2; \
-	echo "Remediation: enable d2b.site.hostSccache.enable = true in the NixOS host configuration, then run:" >&2; \
-	echo "  sudo nixos-rebuild switch --flake /path/to/host#<host>" >&2; \
-	echo "The activated host must expose /var/cache/d2b-sccache in /etc/nix/nix.conf and keep it root:nixbld mode 2770." >&2; \
+	run_dir="$$(mktemp -d "$${TMPDIR:-/tmp}/d2b-host-integration.XXXXXX")"; \
+	chmod 700 "$$run_dir"; \
+	cleanup() { status="$$?"; trap - EXIT HUP INT TERM; rm -rf -- "$$run_dir"; exit "$$status"; }; \
+	trap cleanup EXIT HUP INT TERM; \
+	attic_cache=""; \
+	attic_config=""; \
+	if [ -n "$${XDG_CONFIG_HOME:-}" ]; then \
+	attic_config="$$XDG_CONFIG_HOME/attic/config.toml"; \
+	elif [ -n "$${HOME:-}" ]; then \
+	attic_config="$$HOME/.config/attic/config.toml"; \
+	fi; \
+	if ! command -v attic >/dev/null 2>&1; then \
+	echo "test-host-integration: Attic unavailable - skipping closure upload"; \
+	elif [ -z "$$attic_config" ] || [ ! -e "$$attic_config" ]; then \
+	echo "test-host-integration: Attic config absent - skipping closure upload"; \
+	else \
+	python_bin="$$(for candidate in python3 python; do command -v "$$candidate" >/dev/null 2>&1 && "$$candidate" -c 'import json, re, subprocess, sys, tomllib, urllib.parse' >/dev/null 2>&1 && { echo "$$candidate"; break; }; done)"; \
+	if [ -z "$$python_bin" ]; then \
+	echo "test-host-integration: configured Attic cache requires Python 3.11 or newer" >&2; \
+	exit 1; \
+	fi; \
+	attic_cache="$$("$$python_bin" -c 'import json,re,subprocess,sys,tomllib,urllib.parse as u;c=tomllib.load(open(sys.argv[1],"rb"));s=c.get("default-server");v=c.get("servers",{});assert isinstance(s,str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]*",s);e=u.urlparse(v[s]["endpoint"]);n=json.loads(subprocess.check_output(["nix","config","show","--json"],text=True))["substituters"]["value"];n=n.split() if isinstance(n,str) else n;m=[u.urlparse(x).path.rstrip("/").rsplit("/",1)[-1] for x in n if u.urlparse(x).hostname==e.hostname];assert len(m)==1 and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_+-]*",m[0]);print(f"{s}:{m[0]}")' "$$attic_config" 2>/dev/null)" || { \
+	echo "test-host-integration: configured Attic state is invalid or ambiguous" >&2; \
 	exit 1; \
 	}; \
+	if ! attic cache info "$$attic_cache" >"$$run_dir/attic-info.log" 2>&1; then \
+	echo "test-host-integration: configured Attic cache preflight failed" >&2; \
+	exit 1; \
+	fi; \
+	echo "test-host-integration: Attic cache preflight passed"; \
+	fi; \
+	echo "test-host-integration: building host tools with local Bazel"; \
+	'$(BAZEL_BIN)' build --config=local \
+	//packages/d2b:d2b \
+	//packages/d2bd:d2bd \
+	//packages/d2b-priv-broker:d2b-priv-broker \
+	//packages/d2b-host:d2b-activation-helper \
+	//packages/d2b-host-activation-helper:d2b-host-activation-helper \
+	//packages/d2b-cutover:d2b-cutover-runner \
+	//packages/d2b-unsafe-local-helper:d2b-unsafe-local-helper \
+	//packages/d2b-resource-compiler:d2b-resource-compiler \
+	//packages/d2b-provider-display-wayland:d2b-wayland-proxy; \
+	bazel_bin="$$(realpath -e "$$('$(BAZEL_BIN)' info --config=local bazel-bin)")"; \
+	stage="$$run_dir/bundle"; \
+	mkdir -m 700 "$$stage"; \
+	stage_tool() { source="$$(realpath -e "$$bazel_bin/$$1")"; case "$$source" in "$$bazel_bin"/*) ;; *) echo "test-host-integration: Bazel output escaped bazel-bin" >&2; return 1;; esac; [ -f "$$source" ] && [ -x "$$source" ] || { echo "test-host-integration: invalid Bazel output $$1" >&2; return 1; }; install -m 755 "$$source" "$$stage/$$2"; }; \
+	stage_tool packages/d2b/d2b d2b; \
+	stage_tool packages/d2bd/d2bd d2bd; \
+	stage_tool packages/d2b-priv-broker/d2b-priv-broker d2b-priv-broker; \
+	stage_tool packages/d2b-host/d2b-activation-helper d2b-activation-helper; \
+	stage_tool packages/d2b-host-activation-helper/d2b-host-activation-helper d2b-host-activation-helper; \
+	stage_tool packages/d2b-cutover/d2b-cutover-runner d2b-cutover-runner; \
+	stage_tool packages/d2b-unsafe-local-helper/d2b-unsafe-local-helper d2b-unsafe-local-helper; \
+	stage_tool packages/d2b-resource-compiler/d2b-resource-compiler d2b-resource-compiler; \
+	stage_tool packages/d2b-provider-display-wayland/d2b-wayland-proxy d2b-wayland-proxy; \
+	bundle_store_path="$$(nix store add-path --name d2b-bazel-host-tools "$$stage")"; \
+	nix-store --add-root "$$run_dir/bundle-root" --indirect --realise "$$bundle_store_path" >/dev/null; \
+	echo "test-host-integration: Bazel host-tool bundle: $$bundle_store_path"; \
 	set --; \
 	for name in $$names; do \
-	set -- "$$@" ".#vmChecks.$$system.$$name"; \
+	set -- "$$@" "git+file://$$root#vmChecks.$$system.$$name"; \
 	done; \
-	case "$${D2B_HOST_SCCACHE:-}" in \
-	1|yes|true) \
-	cache_dir=/var/cache/d2b-sccache; \
-	if [ ! -r /etc/nix/nix.conf ]; then \
-	fail_sccache_preflight "/etc/nix/nix.conf is missing or unreadable"; \
-	fi; \
-	if ! awk '\
-		/^[[:space:]]*#/ { next } \
-		/^[[:space:]]*extra-sandbox-paths[[:space:]]*=/ { \
-			line = $$0; \
-			sub(/^[^=]*=/, "", line); \
-			found = 0; \
-			count = split(line, fields, /[[:space:]]+/); \
-			for (i = 1; i <= count; i++) if (fields[i] == "/var/cache/d2b-sccache") found = 1; \
-		} \
-		END { exit(found ? 0 : 1) } \
-	' /etc/nix/nix.conf; then \
-	fail_sccache_preflight "/etc/nix/nix.conf does not expose extra-sandbox-paths = /var/cache/d2b-sccache"; \
-	fi; \
-	if [ ! -d "$$cache_dir" ]; then \
-	fail_sccache_preflight "$$cache_dir does not exist"; \
-	fi; \
-	cache_owner="$$(stat -c '%U' "$$cache_dir")"; \
-	cache_group="$$(stat -c '%G' "$$cache_dir")"; \
-	cache_mode="$$(stat -c '%a' "$$cache_dir")"; \
-	if [ "$$cache_owner" != root ] || [ "$$cache_group" != nixbld ] || [ "$$cache_mode" != 2770 ]; then \
-	fail_sccache_preflight "$$cache_dir must be owned by root:nixbld with mode 2770 (found $$cache_owner:$$cache_group mode $$cache_mode)"; \
-	fi; \
-	if ! getent group nixbld >/dev/null 2>&1; then \
-	fail_sccache_preflight "the nixbld daemon build-user group is unavailable"; \
-	fi; \
-	build_users_group="$$(nix show-config 2>/dev/null | awk '$$1 == \"build-users-group\" { print $$3; exit }')"; \
-	if [ "$$build_users_group" != nixbld ]; then \
-	fail_sccache_preflight "the Nix daemon build-users-group is not nixbld (found '$$build_users_group')"; \
-	fi; \
-	echo "test-host-integration: sccache preflight passed ($$cache_dir root:nixbld 2770, daemon build group nixbld)";; \
-	*) \
-	echo "test-host-integration: sccache disabled (set D2B_HOST_SCCACHE=1 to enable)"; \
-	;; \
-	esac; \
 	echo "test-host-integration: building vmChecks: $$names"; \
-	echo "==> nix build $$*"; \
-	nix build --no-link --print-build-logs "$$@"
+	D2B_HOST_TOOL_BUNDLE="$$bundle_store_path" D2B_HOST_RUNTIME_PATH= \
+	nix build --impure --out-link "$$run_dir/result" --print-build-logs --print-out-paths "$$@" >"$$run_dir/outputs"; \
+	cat "$$run_dir/outputs"; \
+	if [ -n "$$attic_cache" ]; then \
+	if ! attic push --stdin "$$attic_cache" <"$$run_dir/outputs" >"$$run_dir/attic-push.log" 2>&1; then \
+	echo "test-host-integration: Attic closure upload failed" >&2; \
+	exit 1; \
+	fi; \
+	echo "test-host-integration: Attic closure upload succeeded"; \
+	fi
 
 ## Public heavy lanes: acquire a slot, then run the raw work behind the gate.
 perf: heavy-gate-build

--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,11 @@ heavy-lane-host-integration: heavy-lane-guard
 	fi; \
 	run_dir="$$(mktemp -d "$${TMPDIR:-/tmp}/d2b-host-integration.XXXXXX")"; \
 	chmod 700 "$$run_dir"; \
-	cleanup() { status="$$?"; trap - EXIT HUP INT TERM; rm -rf -- "$$run_dir"; exit "$$status"; }; \
-	trap cleanup EXIT HUP INT TERM; \
+	cleanup() { rm -rf -- "$$run_dir"; }; \
+	trap cleanup EXIT; \
+	trap 'exit 129' HUP; \
+	trap 'exit 130' INT; \
+	trap 'exit 143' TERM; \
 	attic_cache=""; \
 	attic_config=""; \
 	if [ -n "$${XDG_CONFIG_HOME:-}" ]; then \
@@ -231,15 +234,12 @@ heavy-lane-host-integration: heavy-lane-guard
 	elif [ -z "$$attic_config" ] || [ ! -e "$$attic_config" ]; then \
 	echo "test-host-integration: Attic config absent - skipping closure upload"; \
 	else \
-	python_bin="$$(for candidate in python3 python; do command -v "$$candidate" >/dev/null 2>&1 && "$$candidate" -c 'import json, re, subprocess, sys, tomllib, urllib.parse' >/dev/null 2>&1 && { echo "$$candidate"; break; }; done)"; \
-	if [ -z "$$python_bin" ]; then \
-	echo "test-host-integration: configured Attic cache requires Python 3.11 or newer" >&2; \
-	exit 1; \
-	fi; \
-	attic_cache="$$("$$python_bin" -c 'import json,re,subprocess,sys,tomllib,urllib.parse as u;c=tomllib.load(open(sys.argv[1],"rb"));s=c.get("default-server");v=c.get("servers",{});assert isinstance(s,str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]*",s);e=u.urlparse(v[s]["endpoint"]);n=json.loads(subprocess.check_output(["nix","config","show","--json"],text=True))["substituters"]["value"];n=n.split() if isinstance(n,str) else n;m=[u.urlparse(x).path.rstrip("/").rsplit("/",1)[-1] for x in n if u.urlparse(x).hostname==e.hostname];assert len(m)==1 and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_+-]*",m[0]);print(f"{s}:{m[0]}")' "$$attic_config" 2>/dev/null)" || { \
-	echo "test-host-integration: configured Attic state is invalid or ambiguous" >&2; \
-	exit 1; \
-	}; \
+	fail_attic_state() { echo "test-host-integration: configured Attic state is invalid or ambiguous" >&2; exit 1; }; \
+	attic_meta="$$(ATTIC_CONFIG="$$attic_config" nix eval --impure --json --expr 'let config = builtins.fromTOML (builtins.readFile (builtins.getEnv "ATTIC_CONFIG")); names = builtins.attrNames (config.servers or {}); server = if config ? "default-server" then config."default-server" else if builtins.length names == 1 then builtins.head names else throw "ambiguous Attic servers"; endpoint = config.servers.$${server}.endpoint or (throw "missing Attic endpoint"); in { inherit server endpoint; }' 2>/dev/null)" || fail_attic_state; \
+	attic_server="$$(printf '%s' "$$attic_meta" | jq -er '.server | select(test("^[A-Za-z0-9][A-Za-z0-9._+-]*$$"))')" || fail_attic_state; \
+	attic_base="$$(printf '%s' "$$attic_meta" | jq -er '.endpoint | capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?:/[^?#]*)?$$") | ((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase))')" || fail_attic_state; \
+	attic_name="$$(nix config show --json | jq -er --arg base "$$attic_base" '.substituters.value | if type == "string" then split(" ") else . end | map(try capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?<path>/[^?#]*)?$$") catch empty | select(((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase)) == $$base) | ((.path // "") | rtrimstr("/") | split("/") | last)) | map(select(test("^[A-Za-z0-9][A-Za-z0-9_+-]*$$"))) | select(length == 1) | .[0]')" || fail_attic_state; \
+	attic_cache="$$attic_server:$$attic_name"; \
 	if ! attic cache info "$$attic_cache" >"$$run_dir/attic-info.log" 2>&1; then \
 	echo "test-host-integration: configured Attic cache preflight failed" >&2; \
 	exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	trap 'exit 129' HUP; \
 	trap 'exit 130' INT; \
 	trap 'exit 143' TERM; \
+	trap 'exit 131' QUIT; \
 	attic_cache=""; \
 	attic_config=""; \
 	if [ -n "$${XDG_CONFIG_HOME:-}" ]; then \
@@ -238,7 +239,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	attic_meta="$$(ATTIC_CONFIG="$$attic_config" nix eval --impure --json --expr 'let config = builtins.fromTOML (builtins.readFile (builtins.getEnv "ATTIC_CONFIG")); names = builtins.attrNames (config.servers or {}); server = if config ? "default-server" then config."default-server" else if builtins.length names == 1 then builtins.head names else throw "ambiguous Attic servers"; endpoint = config.servers.$${server}.endpoint or (throw "missing Attic endpoint"); in { inherit server endpoint; }' 2>/dev/null)" || fail_attic_state; \
 	attic_server="$$(printf '%s' "$$attic_meta" | jq -er '.server | select(test("^[A-Za-z0-9][A-Za-z0-9._+-]*$$"))')" || fail_attic_state; \
 	attic_base="$$(printf '%s' "$$attic_meta" | jq -er '.endpoint | capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?:/[^?#]*)?$$") | ((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase))')" || fail_attic_state; \
-	attic_name="$$(nix config show --json | jq -er --arg base "$$attic_base" '.substituters.value | if type == "string" then split(" ") else . end | map(try capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?<path>/[^?#]*)?$$") catch empty | select(((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase)) == $$base) | ((.path // "") | rtrimstr("/") | split("/") | last)) | map(select(test("^[A-Za-z0-9][A-Za-z0-9_+-]*$$"))) | select(length == 1) | .[0]')" || fail_attic_state; \
+	attic_name="$$(nix config show --json | jq -er --arg base "$$attic_base" '.substituters.value | if type == "string" then split(" ") else . end | map(try capture("^(?<scheme>https?)://(?<authority>[^/@?#]+)(?<path>/[^?#]*)?(?:\\?[^#]*)?$$") catch empty | select(((.scheme | ascii_downcase) + "://" + (.authority | ascii_downcase)) == $$base) | ((.path // "") | rtrimstr("/") | split("/") | last)) | map(select(test("^[A-Za-z0-9][A-Za-z0-9_+-]*$$"))) | select(length == 1) | .[0]')" || fail_attic_state; \
 	attic_cache="$$attic_server:$$attic_name"; \
 	if ! attic cache info "$$attic_cache" >"$$run_dir/attic-info.log" 2>&1; then \
 	echo "test-host-integration: configured Attic cache preflight failed" >&2; \
@@ -270,8 +271,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	stage_tool packages/d2b-unsafe-local-helper/d2b-unsafe-local-helper d2b-unsafe-local-helper; \
 	stage_tool packages/d2b-resource-compiler/d2b-resource-compiler d2b-resource-compiler; \
 	stage_tool packages/d2b-provider-display-wayland/d2b-wayland-proxy d2b-wayland-proxy; \
-	bundle_store_path="$$(nix store add-path --name d2b-bazel-host-tools "$$stage")"; \
-	nix-store --add-root "$$run_dir/bundle-root" --indirect --realise "$$bundle_store_path" >/dev/null; \
+	bundle_store_path="$$(D2B_BAZEL_STAGE="$$stage" nix build --impure --out-link "$$run_dir/bundle-root" --print-out-paths --expr 'builtins.path { path = builtins.getEnv "D2B_BAZEL_STAGE"; name = "d2b-bazel-host-tools"; }')"; \
 	rm -rf -- "$$stage"; \
 	echo "test-host-integration: Bazel host-tool bundle: $$bundle_store_path"; \
 	set --; \
@@ -279,7 +279,7 @@ heavy-lane-host-integration: heavy-lane-guard
 	set -- "$$@" "git+file://$$root#vmChecks.$$system.$$name"; \
 	done; \
 	echo "test-host-integration: building vmChecks: $$names"; \
-	D2B_HOST_TOOL_BUNDLE="$$bundle_store_path" D2B_HOST_RUNTIME_PATH= \
+	D2B_HOST_TOOL_BUNDLE="$$bundle_store_path" D2B_HOST_RUNTIME_PATH="$$run_dir/absent-host-runtime.json" \
 	nix build --impure --out-link "$$run_dir/result" --print-build-logs --print-out-paths "$$@" >"$$run_dir/outputs"; \
 	cat "$$run_dir/outputs"; \
 	if [ -n "$$attic_cache" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,17 @@ heavy-lane-host-integration: heavy-lane-guard
 	nix build --impure --out-link "$$run_dir/result" --print-build-logs --print-out-paths "$$@" >"$$run_dir/outputs"; \
 	cat "$$run_dir/outputs"; \
 	if [ -n "$$attic_cache" ]; then \
-	if ! attic push --stdin "$$attic_cache" <"$$run_dir/outputs" >"$$run_dir/attic-push.log" 2>&1; then \
+	: >"$$run_dir/attic-closure"; \
+	while IFS= read -r output; do \
+	nix-store -qR --include-outputs "$$(nix-store -qd "$$output")"; \
+	done <"$$run_dir/outputs" | sort -u >"$$run_dir/attic-closure-all"; \
+	awk 'NR == FNR { skip[$$0] = 1; next } !skip[$$0]' \
+	"$$run_dir/outputs" "$$run_dir/attic-closure-all" >"$$run_dir/attic-closure"; \
+	if [ ! -s "$$run_dir/attic-closure" ]; then \
+	echo "test-host-integration: no dependency closure paths available for Attic" >&2; \
+	exit 1; \
+	fi; \
+	if ! attic push --stdin "$$attic_cache" <"$$run_dir/attic-closure" >"$$run_dir/attic-push.log" 2>&1; then \
 	echo "test-host-integration: Attic closure upload failed" >&2; \
 	exit 1; \
 	fi; \

--- a/changelog.d/2026-08-19-host-sccache-multi-user.md
+++ b/changelog.d/2026-08-19-host-sccache-multi-user.md
@@ -1,14 +1,11 @@
 ### Changed
 
-- Host-integration Rust builds can opt into a fixed multi-user
-  `/var/cache/d2b-sccache` provisioned by the NixOS module as
-  `root:nixbld` mode `2770`, with the Nix daemon supplying the global
-  sandbox path. The lane now preflights that host contract and supports a
-  fail-closed focused `vmChecks` selector without accepting caller-home cache
-  mounts or restricted per-command sandbox options.
+- Nix source builds can opt into a fixed multi-user `/var/cache/d2b-sccache`
+  provisioned by the NixOS module as `root:nixbld` mode `2770`, with the Nix
+  daemon supplying the global sandbox path.
 
 ### Fixed
 
 - Host-tool derivations keep a bounded 10 GiB sccache and visibly reject an
   exposed but unsafe cache while retaining the plain-rustc fallback when the
-  opt-in cache is absent.
+  configured cache is absent.

--- a/changelog.d/refactor-bazel-host-integration-binaries.md
+++ b/changelog.d/refactor-bazel-host-integration-binaries.md
@@ -2,9 +2,10 @@
 
 - `make test-host-integration` now builds the fixed nine host tools with local
   Bazel, injects them into the selected NixOS VM checks, and uploads successful
-  output closures to a configured Attic cache. When Attic or its configuration
-  is unavailable, the lane explicitly skips the upload; invalid or unusable
-  configured state fails the lane.
+  dependency closures to a configured Attic cache without caching the VM test
+  results themselves. When Attic or its configuration is unavailable, the lane
+  explicitly skips the upload; invalid or unusable configured state fails the
+  lane.
 
 ### Removed
 

--- a/changelog.d/refactor-bazel-host-integration-binaries.md
+++ b/changelog.d/refactor-bazel-host-integration-binaries.md
@@ -1,0 +1,13 @@
+### Changed
+
+- `make test-host-integration` now builds the fixed nine host tools with local
+  Bazel, injects them into the selected NixOS VM checks, and uploads successful
+  output closures to a configured Attic cache. When Attic or its configuration
+  is unavailable, the lane explicitly skips the upload; invalid or unusable
+  configured state fails the lane.
+
+### Removed
+
+- The host-integration-only sccache switch is retired. The generic
+  `d2b.site.hostSccache.enable` option remains available for other Nix source
+  builds.

--- a/changelog.d/spec001-host-int-sccache.md
+++ b/changelog.d/spec001-host-int-sccache.md
@@ -1,5 +1,0 @@
-### Changed
-
-- Host-integration Rust tools keep Crane cargo artifacts and per-package
-  source isolation. sccache is opt-in via `D2B_HOST_SCCACHE=1`, uses a
-  constant sandbox path, and never world-writes the host cache.

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -193,8 +193,9 @@ make test-host-integration
 `make test-host-integration` builds the fixed set of nine host tools with
 local Bazel, stages them as one bundle, and injects that bundle into the
 selected NixOS `vmChecks`. After every selected check succeeds, the lane
-uploads all resulting output closures to the configured Attic cache in one
-operation.
+uploads the built dependency closures to the configured Attic cache in one
+operation. It excludes the `vmCheck` result paths so a capability `SKIP` or
+`BLOCKED` result cannot be substituted as a passing test on another host.
 
 Attic is optional for this lane. When the Attic client or its configuration is
 unavailable, the lane reports an explicit skip and continues with the Bazel

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -190,34 +190,29 @@ make test-integration
 make test-host-integration
 ```
 
-The host-tool build can optionally use one shared multi-user sccache. Enable
-it once in the NixOS host configuration, then rebuild the host so the daemon
-configuration and tmpfiles rule are active:
+`make test-host-integration` builds the fixed set of nine host tools with
+local Bazel, stages them as one bundle, and injects that bundle into the
+selected NixOS `vmChecks`. After every selected check succeeds, the lane
+uploads all resulting output closures to the configured Attic cache in one
+operation.
 
-```nix
-d2b.site.hostSccache.enable = true;
-```
+Attic is optional for this lane. When the Attic client or its configuration is
+unavailable, the lane reports an explicit skip and continues with the Bazel
+and VM work. A present configuration that is invalid, ambiguous, inaccessible,
+or otherwise unusable fails closed before the expensive work; an upload failure
+also fails the lane. Use `D2B_VM_CHECK=<name>` to select one named VM check.
 
-Activate that host configuration once with the normal privileged switch:
-
-```bash
-sudo nixos-rebuild switch --flake /path/to/host#<host>
-```
-
-The cache is fixed at `/var/cache/d2b-sccache`, owned by `root:nixbld` with
-mode `2770`, and exposed through the daemon's global
-`extra-sandbox-paths`. The host lane never mounts a caller-owned cache path or
-passes a restricted per-command sandbox option. The exact focused cached
-iteration is:
+For cold and unchanged warm evidence, run the same command twice:
 
 ```bash
-D2B_HOST_SCCACHE=1 D2B_HOST_VM_CHECK=daemon-smoke make test-host-integration
+make test-host-integration
+make test-host-integration
 ```
 
-The Make preflight fails before any VM build when activation is missing or
-the owner, mode, build-user group, or daemon setting is unsafe. Apply the
-option above and activate it before retrying. Leave `D2B_HOST_SCCACHE` unset
-for the normal rustc-fallback path.
+The unchanged repeat should reuse the Bazel and Nix outputs without Rust
+compilation actions. The optional `d2b.site.hostSccache.enable` module remains
+available for other Nix source builds; it is not required by this
+Bazel-backed host-integration lane.
 
 Hardware and live-host tests remain explicit manual tiers and require the
 matching devices or deployed d2b state.

--- a/docs/plans/2026-08-24-001-refactor-bazel-backed-host-integration-binaries-plan.md
+++ b/docs/plans/2026-08-24-001-refactor-bazel-backed-host-integration-binaries-plan.md
@@ -1,0 +1,384 @@
+---
+title: Bazel-Backed Host Integration Binaries - Plan
+type: refactor
+date: 2026-08-24
+topic: bazel-backed-host-integration-binaries
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+deepened: 2026-08-24
+---
+
+# Bazel-Backed Host Integration Binaries - Plan
+
+## Goal Capsule
+
+- **Objective:** Make `make test-host-integration` supply locally Bazel-built d2b host binaries to the existing NixOS VM tests, with no Nix-side Rust compilation for those binaries.
+- **Authority:** The Product Contract owns behavior and scope. `tests/AGENTS.md`, the current Make heavy lane, and existing Nix module package boundaries own implementation constraints.
+- **Stop conditions:** Stop if the bundle is incomplete, a configured Attic cache cannot be used, Nix selects a Rust source package for an overridden host tool, or the manual cold and warm evidence cannot be obtained.
+- **Execution profile:** Use the existing heavy lane, one direct local Bazel build, one deterministic Nix-store handoff, and the existing `vmChecks` realization.
+- **Worktree:** Keep this plan and all implementation changes on `refactor/bazel-host-integration-binaries` in a new isolated worktree.
+- **Tail ownership:** The implementation workflow owns the changelog, independent review, pull request, and final host validation on the committed head.
+
+---
+
+## Product Contract
+
+### Summary
+
+`make test-host-integration` will build the required d2b host binaries with Bazel and pass them into the existing NixOS VM-test path.
+Configured Attic hosts must cache the successful Nix outputs, while an unchanged repeat must execute zero Rust compilation actions.
+
+### Problem Frame
+
+The host-integration fixtures currently disable prebuilt host tools, so the Nix path selects source-built Rust packages even though Bazel is the contributor build authority.
+This duplicates Rust compilation across Bazel and Nix and makes the warm host-integration path more expensive than necessary.
+The current host-integration path also has no Attic integration.
+
+### Actors
+
+- A1. The contributor invoking `make test-host-integration`.
+- A2. Bazel, which owns the d2b Rust binary builds.
+- A3. Nix, which owns `vmChecks` realization and NixOS VM execution.
+- A4. Attic, when it is available and configured on the invoking host.
+
+### Key Decisions
+
+- **Use a test-only Bazel-to-Nix binary handoff.** (session-settled: user-directed - chosen over a general local-prebuilt mode or Bazel-owned VM action: the narrow handoff preserves the retained Layer-2 contract.) Governs R1-R4 and R9.
+- **Measure warm reuse by Rust compilation actions.** (session-settled: user-directed - chosen over a zero-`rustc`-process rule and a forced VM rerun: cache checks may occur and a complete Nix no-op is acceptable.) Governs R5-R6.
+- **Require Attic only where it is available and configured.** (session-settled: user-directed - chosen over universal provisioning or unconditional best-effort fallback: this host must prove cache use while hosts without Attic remain supported.) Governs R7-R8.
+- **Verify the infrastructure change manually.** (session-settled: user-directed - chosen over a new automated gate, harness, or testing scheme: the existing host-integration command and build evidence are sufficient.) Governs R10-R12.
+
+### Requirements
+
+**Bazel-to-Nix handoff**
+
+- R1. `make test-host-integration` must build every d2b Rust host binary required by the host-integration suite through its existing public Bazel target before Nix realization.
+- R2. The NixOS VM tests must consume the Bazel-built binaries for every required d2b Rust host tool instead of selecting equivalent Nix source-built Rust packages.
+- R3. The selected `vmChecks` must continue to run through the existing `make test-host-integration` heavy lane, with Nix retaining VM orchestration.
+- R4. A missing, incompatible, or incomplete Bazel binary handoff must fail rather than falling back to Nix-side Rust compilation.
+
+**Caching and warm behavior**
+
+- R5. The first invocation may execute the Bazel Rust compilation and Nix realization required by the current source state.
+- R6. A normal unchanged second invocation must execute zero Rust compilation actions; reusing the completed Nix result without rerunning the VM test is acceptable.
+- R7. When Attic is available and configured, the Nix build must cache its successful output closures and fail if required cache use fails.
+- R8. When Attic is unavailable or unconfigured, the command must continue without it and report an explicit cache skip.
+
+**Compatibility**
+
+- R9. Normal release packaging, consumer package selection, the `make check` BuildBuddy facade, and test lanes other than `make test-host-integration` must retain their current behavior.
+
+**Ad hoc verification**
+
+- R10. The change must not add an automated test target, gate, harness, persistent evidence script, or new testing scheme.
+- R11. Manual validation on the current host must run `make test-host-integration` successfully and confirm that Nix consumed the Bazel-built binaries and cached the Nix outputs through Attic.
+- R12. Manual validation must repeat the command without source changes and confirm from existing build output or one-off cache evidence that zero Rust compilation actions executed.
+
+### Key Flows
+
+```mermaid
+flowchart TB
+  M[make test-host-integration] --> A{Attic available and configured}
+  A -->|yes| C[Validate configured cache]
+  A -->|no| S[Record explicit cache skip]
+  C --> B[Local Bazel build of host tools]
+  S --> B
+  B --> H[Deterministic Nix-store handoff]
+  H --> N[Nix realizes selected vmChecks]
+  N --> V[NixOS VM integration result]
+  V --> U{Validated cache selected}
+  U -->|yes| P[Push successful output closures]
+  U -->|no| D[Done]
+  P --> D
+```
+
+- F1. Cold host-integration run
+  - **Trigger:** A1 invokes `make test-host-integration` for the current source state.
+  - **Actors:** A1, A2, A3, and A4 when configured.
+  - **Steps:** Bazel builds the host-tool set, the test-only handoff supplies it to Nix, Nix realizes the selected VM checks, and Attic stores the successful outputs when configured.
+  - **Outcome:** The existing VM integration lane completes without Nix compiling replacement d2b Rust binaries.
+  - **Covers:** R1-R5, R7-R9, R11.
+- F2. Unchanged warm run
+  - **Trigger:** A1 repeats the same command without source changes.
+  - **Actors:** A1, A2, A3, and A4 when configured.
+  - **Steps:** Existing Bazel and Nix results satisfy unchanged work, and Nix may reuse the completed VM-check result.
+  - **Outcome:** No Rust compilation action executes.
+  - **Covers:** R6, R12.
+
+### Acceptance Examples
+
+- AE1. **Covers R1-R4, R11.** Given a selected VM check that exercises d2b Rust host tools, when the current host runs `make test-host-integration`, then the VM test uses the complete Bazel-built binary handoff and no tool falls back to a Nix source build.
+- AE2. **Covers R7, R11.** Given this host has working Attic configuration, when the Nix build succeeds, then the selected output closures are pushed successfully and a required cache-use failure fails the command.
+- AE3. **Covers R8.** Given a contributor host has no usable Attic configuration, when host integration runs, then it reports the cache skip and continues through the same Bazel-to-Nix path.
+- AE4. **Covers R6, R12.** Given one successful run and no source changes, when the command is repeated, then build evidence shows zero Rust compilation actions even if Nix returns the cached `vmCheck` result without rerunning the VM.
+
+### Scope Boundaries
+
+- The active scope is the `make test-host-integration` Bazel-to-Nix binary handoff, optional-host Attic behavior, and ad hoc manual validation.
+- Normal release artifacts, consumer configuration, prebuilt release selection, and the `make check` BuildBuddy facade are unchanged.
+- Guest static packages and Rust binaries outside the Host-Tool Inventory remain on their current Nix paths.
+- Other Layer-1 and Layer-2 test lanes are unchanged.
+- Bazel does not become the scheduler for the NixOS VM test.
+- The work does not add a Bazel test, a new Bazel aggregate target, or a new build-facade action.
+- The work does not provision Attic, create a repository-wide cache policy, or require Attic on hosts where it is absent.
+- The work does not add a new automated verification framework or force warm VM-test execution.
+
+### Dependencies / Assumptions
+
+- The nine current public Bazel binary targets produce x86_64-linux outputs that `autoPatchelfHook` can normalize for the pinned Nixpkgs host runtime.
+- The current host's Attic installation exposes one default server whose endpoint matches one configured Nix substituter and whose cache accepts closure uploads.
+- Lix 2.94.2 provides `nix store add-path`, `builtins.storePath`, and the existing `nix build` behavior used by the test-only handoff.
+
+### Sources / Research
+
+- `Makefile` owns the host-integration heavy lane and its current `nix build` invocation.
+- `flake.nix` owns `vmChecks` discovery and NixOS VM-test realization.
+- `tests/host-integration/lib.nix` currently disables prebuilt host tools for shared daemon-host fixtures.
+- `nixos-modules/options-site.nix`, `nixos-modules/host-daemon.nix`, and `nixos-modules/host-broker.nix` define the existing prebuilt-versus-source package boundary.
+- `nixos-modules/rust-host-tools.nix` defines the current Nix Rust source-build path.
+- `tests/AGENTS.md` keeps host integration in the retained conditional Layer-2 lane.
+- `packages/d2b/BUILD.bazel`, `packages/d2bd/BUILD.bazel`, and `packages/d2b-priv-broker/BUILD.bazel` demonstrate the public Bazel binary pattern.
+- [Lix `nix store add-path`](https://docs.lix.systems/manual/lix/2.94/command-ref/new-cli/nix3-store-add-path.html) defines the deterministic raw bundle import.
+- [Nixpkgs AutoPatchelf](https://nixos.org/manual/nixpkgs/stable/#sec-auto-patchelf) defines the dynamic-binary normalization boundary.
+- [Attic client configuration](https://github.com/zhaofengli/attic/blob/7a19204df10d606c5070e6bb72615c3461900c05/client/src/config.rs) and [Attic push](https://github.com/zhaofengli/attic/blob/7a19204df10d606c5070e6bb72615c3461900c05/client/src/command/push.rs) define the configured-cache and closure-upload behavior.
+
+---
+
+## Planning Contract
+
+### Product Contract Preservation
+
+Product Contract clarified without scope change: R7, R11, AE2, and F1 bind configured Attic use to caching successful output closures.
+
+### Key Technical Decisions
+
+- KTD1. **Use one direct local Bazel build inside the existing heavy lane.** Invoke `BAZEL_BIN` with `build --config=local` after `heavy-lane-guard`, and list the production labels directly. Do not change `tests/tools/bazel-check`, `BAZEL_RUN`, `make check`, or the Bazel test graph. (session-settled: user-directed - chosen over extending the BuildBuddy facade: minimizing build-system changes matters more than remote execution for this lane.) Governs R1, R3, R5, R6, R9, and R10.
+- KTD2. **Import a deterministic raw bundle into the Nix store.** Stage fixed regular executable names with mode `0755`, dereference Bazel symlinks, reject missing or unexpected files, import the tree under the fixed name `d2b-bazel-host-tools`, and root it outside the staging tree. Root each realized `vmCheck` output through Attic upload. Governs R1-R6.
+- KTD3. **Normalize the bundle through one test-only Nix package.** Use `stdenv.mkDerivation` with `autoPatchelfHook`, then verify every installed file remains an x86_64 ELF with a Nix-store loader and resolved runtime libraries. Do not use Cargo, Crane, `rustPlatform.buildRustPackage`, `self`, or the release-prebuilt fallback. Governs R2, R4, R5, and R9.
+- KTD4. **Inject a complete private host-tool override map.** Add nullable `_module.args.d2bHostToolOverrides`; reject empty, malformed, missing-key, and unknown-key maps before fallback. Wrap the original module function with an importing module rather than shallow-merging it. When the map is absent, all current prebuilt and source selection remains unchanged. Governs R2, R4, and R9.
+- KTD5. **Build the fixed explicit host-tool set for every nonempty host-integration run.** This avoids a new aggregate target and per-check artifact inventory while keeping one stable handoff. `d2bGatewayRuntime` remains excluded because its only consumer is the retired gateway migration surface. (session-settled: user-approved - chosen over per-check label pruning or a new Bazel aggregate target: fixed explicit labels minimize build-system changes.) Governs R1-R6 and R9.
+- KTD6. **Use Attic as a post-build closure cache.** Preflight the installed client and existing configuration before Bazel, derive one cache name from the default endpoint and effective substituter, and suppress cache metadata and raw error output. After every selected check succeeds, push all rooted outputs in one deduplicated operation. Skip only when Attic or configuration is absent; ambiguity, access failure, or upload failure is fatal once configuration exists. Never run `attic use` from the test lane. Governs R7, R8, and R11.
+- KTD7. **Retire only the host-integration sccache path.** Remove the `D2B_HOST_SCCACHE` preflight and target-specific documentation because Nix no longer compiles these host tools. Preserve the generic host sccache option and implementation for other Nix source builds. (session-settled: user-approved - chosen over retaining two caches in the host lane: Attic caches Nix outputs and Bazel owns Rust compilation.) Governs R5, R7-R9, and R11.
+
+### Host-Tool Inventory
+
+| Override key | Executable | Bazel label |
+| --- | --- | --- |
+| `d2b` | `d2b` | `//packages/d2b:d2b` |
+| `d2bd` | `d2bd` | `//packages/d2bd:d2bd` |
+| `broker` | `d2b-priv-broker` | `//packages/d2b-priv-broker:d2b-priv-broker` |
+| `activationHelper` | `d2b-activation-helper` | `//packages/d2b-host:d2b-activation-helper` |
+| `hostActivationHelper` | `d2b-host-activation-helper` | `//packages/d2b-host-activation-helper:d2b-host-activation-helper` |
+| `cutoverRunner` | `d2b-cutover-runner` | `//packages/d2b-cutover:d2b-cutover-runner` |
+| `unsafeLocalHelper` | `d2b-unsafe-local-helper` | `//packages/d2b-unsafe-local-helper:d2b-unsafe-local-helper` |
+| `resourceCompiler` | `d2b-resource-compiler` | `//packages/d2b-resource-compiler:d2b-resource-compiler` |
+| `waylandProxy` | `d2b-wayland-proxy` | `//packages/d2b-provider-display-wayland:d2b-wayland-proxy` |
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  G[Existing heavy gate] --> V[Preserve platform and vmCheck selection]
+  V --> A{Attic configured}
+  A -->|yes| AP[Validate one cache privately]
+  A -->|no| AS[Record explicit cache skip]
+  AP --> B[Local bazel build of explicit labels]
+  AS --> B
+  B --> T[Unique scratch staging with fixed contents]
+  T --> I[nix store add-path with fixed store name]
+  I --> R[Root raw bundle outside staging]
+  R --> E[Impure vmChecks evaluation with bundle store path]
+  E --> P[Test-only autoPatchelf package]
+  P --> O[Private host-tool override map]
+  O --> N[Existing NixOS vmChecks realization]
+  N --> OR[Root realized vmCheck outputs]
+  OR --> U{Validated Attic cache}
+  U -->|yes| UP[Batch-push all output closures]
+  U -->|no| C[Cleanup roots and scratch]
+  UP --> C
+```
+
+```mermaid
+flowchart TB
+  Q{Host-tool override map present} -->|no| X[Keep current prebuilt or source selection]
+  Q -->|yes| M{Normalized package and all keys valid}
+  M -->|no| F[Fail before source fallback]
+  M -->|yes| H[Use normalized Bazel-built package]
+```
+
+The Make lane exports the imported store path only for the `vmChecks` evaluation and clears unrelated host-runtime path overrides before enabling impurity.
+`flake.nix` reads the path only in the impure host-integration invocation, converts it with `builtins.storePath`, creates the normalized package, and wraps the `self` passed from the discovery callback.
+The wrapped `self.nixosModules.default` imports the original module and injects the private override map, while a per-system package merge replaces only the standalone Wayland proxy package.
+Pure flake evaluation without the handoff environment remains unchanged.
+
+### Implementation Constraints
+
+- Preserve the current x86_64-only skip, KVM warning and TCG fallback, VM discovery, selected-check behavior, and heavy-gate ownership.
+- Keep temporary staging, GC roots, and any one-off evidence under unique per-run names without embedding those names in staged content or Nix derivation names.
+- Keep staging outside the flake input, delete it after store import, and realize the repository through its `git+file://` form so `.scratch` is never copied into the Nix source.
+- Clear `D2B_HOST_RUNTIME_PATH` and other unrelated impure host-tool overrides from the Nix invocation; only the bundle store path may change package selection.
+- Do not print Attic tokens, internal endpoints, public keys, or cache metadata.
+- Do not modify `nix/gas-city-contributor/**`.
+- Do not add a Bazel test, repository gate, automated evidence parser, or persistent benchmark artifact.
+- Keep the plan and implementation inside the isolated worktree; do not apply code changes in the protected `v3` checkout.
+- Commit the implementation before authoritative Nix validation so tracked inputs are visible to flake evaluation.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Bazel outputs use a non-Nix dynamic loader or unresolved runtime libraries. | Normalize all nine files with `autoPatchelfHook`, validate x86_64 ELF inputs, and fail on unresolved dependencies. |
+| A Bazel convenience symlink or remote-only output enters the bundle. | Build locally, dereference each exact output, require regular executable files, and stage only the inventory above. |
+| The imported raw bundle or realized VM outputs are collected before upload. | Root the bundle before evaluation, root each output before Attic, keep roots outside staging, and remove them through exit and signal cleanup. |
+| An incomplete override silently selects a Nix Rust source package. | Validate the complete inventory before import and make override lookup fail when the map is active. |
+| Attic is installed but its cache is ambiguous, inaccessible, or read-only. | Distinguish absence from configured failure, validate one matching cache with suppressed output, and fail before or after the build as appropriate. |
+| Local Bazel execution is slower than BuildBuddy. | Accept local execution to avoid modifying the shared BuildBuddy facade; unchanged runs still use the local Bazel action cache. |
+| Separate uploads repeat closure traversal or extend heavy-lane occupancy. | Root all selected outputs and pass them to one deduplicated Attic push after every check succeeds. |
+| A scratch directory is copied as part of the flake source. | Keep scratch outside the flake input and use the repository's `git+file://` realization discipline. |
+| The Make recipe becomes harder to review. | Remove the obsolete sccache block and keep the new flow as one bounded sequence inside the existing heavy lane. |
+
+### System-Wide Impact
+
+- Warm Bazel reuse is limited to the same worktree and output base because the selected local profile does not use BuildBuddy.
+- One changed host binary invalidates the complete raw bundle and normalized package, which can invalidate all VM outputs that consume the shared package.
+- Guest static packages and binaries outside the nine-tool host inventory remain independent of this handoff.
+- Attic stores the deduplicated closure of all selected successful `vmCheck` outputs and can extend heavy-lane occupancy during the upload.
+- A host without Attic performs the same local Bazel and VM work but keeps the outputs only in its local Nix store.
+- Staging, raw bundle import, normalized package realization, VM outputs, and Attic upload can overlap in disk usage during the cold run.
+- The lane creates temporary GC roots but does not run garbage collection or change the host's normal retention policy.
+
+### Sequencing
+
+1. Add the private module override seam.
+2. Add the deterministic Nix normalization and `vmChecks` injection.
+3. Replace the host lane's Nix Rust build path with the local Bazel staging flow and Attic upload.
+4. Update the sccache documentation, changelog fragments, and host-integration guidance.
+5. Commit, run the cold validation, repeat unchanged, and inspect the ad hoc evidence.
+
+---
+
+## Implementation Units
+
+### U1. Add fail-closed private host-tool overrides
+
+- **Goal:** Let host modules select a complete test-only package map without changing public package options or normal source and release behavior.
+- **Requirements:** R2, R4, R9; F1; AE1.
+- **Dependencies:** None.
+- **Files:**
+  - `nixos-modules/lib.nix`
+  - `nixos-modules/host-daemon.nix`
+  - `nixos-modules/host-broker.nix`
+  - `nixos-modules/host-activation.nix`
+  - `nixos-modules/processes-json.nix`
+  - `nixos-modules/resource-compiler.nix`
+  - `nixos-modules/unsafe-local-helper.nix`
+- **Approach:**
+  1. Add one shared selector that accepts the private override map, an inventory key, and the current fallback package.
+  2. When the map is absent, return the current fallback without changing evaluation.
+  3. When the map is present, require the named key and return its package without consulting release or source fallbacks.
+  4. Route the daemon, CLI, broker, activation helpers, cutover runner, unsafe helper, resource compiler, and Wayland proxy selectors through the helper.
+- **Patterns to follow:** Existing package selection in `nixos-modules/host-daemon.nix` and `nixos-modules/host-broker.nix`; shared pure helpers in `nixos-modules/lib.nix`.
+- **Test scenarios:** Test expectation: none - R10 excludes new automated tests for this build-infrastructure change; U3 validates the complete map through the real VM lane.
+- **Verification:** Normal pure evaluation remains unchanged when the private map is absent, and an active incomplete map cannot reach a source package.
+
+### U2. Normalize and inject the Bazel bundle
+
+- **Goal:** Convert the imported raw Bazel bundle into one Nix package and inject it only into impure host-integration evaluation.
+- **Requirements:** R1-R6, R9; F1-F2; AE1, AE4; KTD2-KTD5.
+- **Dependencies:** U1.
+- **Files:**
+  - `nix/test-support/bazel-host-tools.nix`
+  - `flake.nix`
+- **Approach:**
+  1. Add a test-support derivation that requires the exact executable inventory, installs it under one package `bin/`, validates ELF architecture, and runs `autoPatchelfHook`.
+  2. Verify the normalized loader, architecture, and runtime-library closure after fixup.
+  3. Return both the normalized package and the complete `d2bHostToolOverrides` map, with every key pointing at that package.
+  4. In `vmChecks`, read `D2B_HOST_TOOL_BUNDLE` only when the host lane invokes Nix with impurity enabled.
+  5. Convert the provided store path with `builtins.storePath`, import the test-support derivation, and wrap the `self` passed from the test discovery callback.
+  6. Wrap `nixosModules.default` as an importing module that injects the private map, and merge only the current system's `d2b-wayland-proxy` package projection.
+  7. Keep the current pure `vmChecks` output unchanged when the environment variable is absent.
+- **Patterns to follow:** `nix/prebuilt.nix` for `autoPatchelfHook` packaging; `flake.nix` for `vmChecks` discovery; existing `_module.args` injection in `tests/host-integration/guest-shell-service.nix`.
+- **Test scenarios:** Test expectation: none - the new expression is test-lane plumbing, and R10 requires ad hoc validation through the existing host integration command.
+- **Verification:** The normalized package contains the nine expected executables, no Rust builder enters its derivation closure, and both shared-node tests and the standalone Wayland proxy test resolve through the wrapped `self`.
+
+### U3. Stage Bazel outputs and cache Nix results
+
+- **Goal:** Replace the host lane's Nix Rust compilation with one local Bazel build, deterministic store import, and conditional Attic closure upload.
+- **Requirements:** R1-R12; F1-F2; AE1-AE4; KTD1-KTD7.
+- **Dependencies:** U2.
+- **Files:**
+  - `Makefile`
+- **Approach:**
+  1. Preserve the current heavy-lane guard, system check, KVM warning, VM discovery, selected-check handling, and empty-selection behavior.
+  2. Preflight Attic before expensive work; record absence as a skip and fail on malformed, ambiguous, inaccessible, or unusable configured state.
+  3. Remove the `D2B_HOST_SCCACHE` preflight and status branch.
+  4. Invoke the existing `BAZEL_BIN` directly with `build --config=local` and the nine labels in the Host-Tool Inventory.
+  5. Create a unique scratch directory outside the flake input, copy each exact `bazel-bin` executable as a regular file with fixed name and mode, and reject missing or unexpected content.
+  6. Import the staged tree with `nix store add-path --name d2b-bazel-host-tools`, register an indirect GC root outside staging, and delete staging after import.
+  7. Export the store path as `D2B_HOST_TOOL_BUNDLE`, clear unrelated impure host-tool variables, and run the selected `vmChecks` through a `git+file://` realization with output paths printed.
+  8. Root every successful output, then pass all selected outputs to one deduplicated `attic push` when the preflight selected a cache.
+  9. Remove scratch files and all GC roots on success, failure, or interruption without invoking garbage collection.
+- **Execution note:** This is packaging and environment plumbing. Prefer the real cold and warm host-integration smoke over unit coverage.
+- **Patterns to follow:** The existing `heavy-lane-host-integration` sequence; Bazel artifact dereferencing in `tests/tools/bazel-check`; Nix store ownership and cleanup conventions in `docs/contributing/workflow.md`.
+- **Test scenarios:** Test expectation: none - the user chose ad hoc execution of the existing host-integration lane instead of a new automated test scheme.
+- **Verification:** The cold run uses the normalized Bazel package, the configured Attic cache accepts the output closures, and an unchanged repeat executes zero Rust compilation actions.
+
+### U4. Align guidance and release notes
+
+- **Goal:** Remove obsolete host-integration sccache claims and document the new local Bazel and optional Attic behavior.
+- **Requirements:** R7-R12; AE2-AE4; KTD6-KTD7.
+- **Dependencies:** U3.
+- **Files:**
+  - `docs/contributing/gates-and-lints.md`
+  - `tests/README.md`
+  - `nixos-modules/options-host-sccache.nix`
+  - `nixos-modules/rust-host-tools.nix`
+  - `changelog.d/spec001-host-int-sccache.md`
+  - `changelog.d/2026-08-19-host-sccache-multi-user.md`
+  - `changelog.d/bazel-host-integration-binaries.md`
+- **Approach:**
+  1. Replace the target-specific sccache setup with the local Bazel binary handoff and Attic branch.
+  2. Retain general host sccache documentation only where it still describes Nix source-build acceleration outside this lane.
+  3. Remove the obsolete host-integration-only changelog fragment and narrow the multi-user sccache fragment to its remaining generic behavior.
+  4. Add one release-note fragment describing Bazel-built host binaries, Attic closure caching, and the retired target knob.
+  5. Document the cold run, unchanged warm run, expected Attic skip, and configured-cache failure behavior without publishing host-specific cache names or endpoints.
+- **Patterns to follow:** `docs/contributing/changelog-and-commits.md`; `changelog.d/README.md`; existing host-lane documentation in `docs/contributing/gates-and-lints.md`.
+- **Test scenarios:** Test expectation: none - documentation and changelog changes carry no independent behavior.
+- **Verification:** Contributor guidance matches the implemented lane, stale `D2B_HOST_SCCACHE` run instructions are gone, and changelog fragments remain valid.
+
+---
+
+## Verification Contract
+
+This change uses ad hoc infrastructure validation only, per R10.
+Run authoritative validation after the implementation is committed.
+
+| Validation | Covers | Required evidence |
+| --- | --- | --- |
+| `make test-host-integration` | U1-U4; R1-R5, R7-R11 | The direct local Bazel build succeeds; the bundle and normalized package paths are visible; the VM checks pass; no Nix Rust host-tool derivation is selected; configured Attic preflight and closure upload succeed. |
+| Repeat the identical `make test-host-integration` command without source changes | U2-U4; R6, R12 | Bazel executes zero Rust compilation actions; Nix may return the existing `vmCheck` outputs; Attic reuse or idempotent upload succeeds. |
+| One-off local Bazel build of the same nine labels with transient BEP output under `.scratch/` | U3; R6, R12 | `BuildMetrics.actionSummary.actionsExecuted` contains no Rust compilation action on the unchanged run. Cached stdout or absence of compiler text is not used as evidence. |
+| Manual Nix derivation inspection of the printed `vmCheck` outputs | U2-U3; R2, R4, R11 | The normalized Bazel package is an input, and `nixos-modules/rust-host-tools.nix` host-tool derivations are absent from the selected closure. |
+| Ad hoc invocation with no usable Attic client configuration | U3-U4; R8, AE3 | The lane reports an explicit cache skip, completes the same local Bazel and VM path, and creates no repository cache configuration. |
+| Changelog fragment validation through the repository's existing changelog gate when the owning workflow runs it | U4; R9-R10 | The new and edited fragments have valid headings and no stale host-integration sccache claim remains. |
+
+Unsupported-platform skips, fixture-level `SKIP` or `BLOCKED` output, and an Attic skip on this configured host are not validation evidence.
+
+---
+
+## Definition of Done
+
+- The Product Contract remains unchanged and every requirement is covered by at least one implementation unit and verification outcome.
+- `make test-host-integration` builds the fixed host-tool set through direct local Bazel labels and uses the normalized package in NixOS VM tests.
+- An active incomplete bundle fails before any Nix Rust source package can be selected.
+- Pure flake behavior, release prebuilts, consumer package selection, `make check`, BuildBuddy behavior, and other test lanes remain unchanged.
+- Configured Attic uploads successful `vmCheck` output closures without exposing credentials or endpoint details; absent Attic reports a skip.
+- Configured Attic receives all selected outputs through one deduplicated closure upload after every check succeeds.
+- The unchanged same-worktree run preserves the raw bundle, normalized package, and `vmCheck` output paths, executes zero Rust compilation actions, and does not require the VM test to rerun.
+- The host-integration `D2B_HOST_SCCACHE` path and stale documentation are removed, while generic host sccache support remains.
+- No automated test target, gate, harness, evidence script, Bazel aggregate target, or Bazel facade action is added.
+- The required changelog fragments and contributor documentation are complete.
+- Temporary staging, BEP files, GC roots, and abandoned implementation attempts are removed before landing.
+- Independent review and the repository PR tail complete on the same committed head that produced the host validation evidence.

--- a/flake.nix
+++ b/flake.nix
@@ -623,6 +623,36 @@
         if system == "x86_64-linux" then
           let
             pkgs = nixpkgsFor.${system};
+            hostToolBundleEnv = builtins.getEnv "D2B_HOST_TOOL_BUNDLE";
+            bazelHostTools =
+              if hostToolBundleEnv == "" then
+                null
+              else
+                import ./nix/test-support/bazel-host-tools.nix {
+                  inherit pkgs;
+                  rawBundle = builtins.storePath hostToolBundleEnv;
+                };
+            hostToolOverrides =
+              if bazelHostTools == null
+              then null
+              else bazelHostTools.d2bHostToolOverrides;
+            testSelf =
+              if bazelHostTools == null then
+                self
+              else
+                self // {
+                  nixosModules = self.nixosModules // {
+                    default = {
+                      imports = [ self.nixosModules.default ];
+                      _module.args.d2bHostToolOverrides = hostToolOverrides;
+                    };
+                  };
+                  packages = self.packages // {
+                    ${system} = self.packages.${system} // {
+                      d2b-wayland-proxy = bazelHostTools.package;
+                    };
+                  };
+                };
             testDir = ./tests/host-integration;
             testFiles = if builtins.pathExists testDir
               then builtins.attrNames (nixpkgs.lib.filterAttrs
@@ -634,7 +664,10 @@
               else [ ];
             mkTest = file: {
               name = nixpkgs.lib.removeSuffix ".nix" file;
-              value = import (testDir + "/${file}") { inherit pkgs self; };
+              value = import (testDir + "/${file}") {
+                inherit pkgs;
+                self = testSelf;
+              };
             };
           in builtins.listToAttrs (map mkTest testFiles)
         else { });

--- a/flake.nix
+++ b/flake.nix
@@ -630,7 +630,10 @@
               else
                 import ./nix/test-support/bazel-host-tools.nix {
                   inherit pkgs;
-                  rawBundle = builtins.storePath hostToolBundleEnv;
+                  rawBundle = builtins.path {
+                    path = /. + hostToolBundleEnv;
+                    name = "d2b-bazel-host-tools";
+                  };
                 };
             testSelf =
               if bazelHostTools == null then

--- a/flake.nix
+++ b/flake.nix
@@ -632,10 +632,6 @@
                   inherit pkgs;
                   rawBundle = builtins.storePath hostToolBundleEnv;
                 };
-            hostToolOverrides =
-              if bazelHostTools == null
-              then null
-              else bazelHostTools.d2bHostToolOverrides;
             testSelf =
               if bazelHostTools == null then
                 self
@@ -644,7 +640,8 @@
                   nixosModules = self.nixosModules // {
                     default = {
                       imports = [ self.nixosModules.default ];
-                      _module.args.d2bHostToolOverrides = hostToolOverrides;
+                      _module.args.d2bHostToolOverrides =
+                        bazelHostTools.d2bHostToolOverrides;
                     };
                   };
                   packages = self.packages // {

--- a/nix/test-support/bazel-host-tools.nix
+++ b/nix/test-support/bazel-host-tools.nix
@@ -1,0 +1,189 @@
+{ pkgs, rawBundle }:
+
+let
+  inherit (pkgs) lib;
+
+  inventory = [
+    "d2b"
+    "d2bd"
+    "d2b-priv-broker"
+    "d2b-activation-helper"
+    "d2b-host-activation-helper"
+    "d2b-cutover-runner"
+    "d2b-unsafe-local-helper"
+    "d2b-resource-compiler"
+    "d2b-wayland-proxy"
+  ];
+  inventoryShell = lib.concatStringsSep " " (map (name: "'${name}'") inventory);
+  overrideKeys = [
+    "d2b"
+    "d2bd"
+    "broker"
+    "activationHelper"
+    "hostActivationHelper"
+    "cutoverRunner"
+    "unsafeLocalHelper"
+    "resourceCompiler"
+    "waylandProxy"
+  ];
+
+  package = pkgs.stdenv.mkDerivation {
+    pname = "d2b-bazel-host-tools";
+    version = "0.0.0";
+    src = rawBundle;
+    strictDeps = true;
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [
+      pkgs.autoPatchelfHook
+      pkgs.binutils
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.gnugrep
+      pkgs.patchelf
+    ];
+    buildInputs = [
+      pkgs.glibc
+      pkgs.stdenv.cc.cc.lib
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      expected="$(printf '%s\n' ${inventoryShell} | sort)"
+      actual="$(find -P "$src" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
+      if [ "$actual" != "$expected" ]; then
+        echo "d2b-bazel-host-tools: raw bundle inventory mismatch" >&2
+        echo "expected:" >&2
+        printf '%s\n' "$expected" >&2
+        echo "actual:" >&2
+        printf '%s\n' "$actual" >&2
+        exit 1
+      fi
+
+      for name in ${inventoryShell}; do
+        source="$src/$name"
+        if [ ! -f "$source" ] || [ -L "$source" ] || [ ! -x "$source" ]; then
+          echo "d2b-bazel-host-tools: $name must be a regular executable file" >&2
+          exit 1
+        fi
+
+        install -Dm755 "$source" "$out/bin/$name"
+      done
+
+      topEntries="$(find -P "$out" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
+      if [ "$topEntries" != "bin" ]; then
+        echo "d2b-bazel-host-tools: unexpected installed top-level entries" >&2
+        printf '%s\n' "$topEntries" >&2
+        exit 1
+      fi
+      installed="$(find -P "$out/bin" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
+      if [ "$installed" != "$expected" ]; then
+        echo "d2b-bazel-host-tools: installed inventory mismatch" >&2
+        exit 1
+      fi
+
+      runHook postInstall
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      readelf=${pkgs.binutils}/bin/readelf
+      patchelf=${pkgs.patchelf}/bin/patchelf
+
+      topEntries="$(find -P "$out" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
+      if [ "$topEntries" != "bin" ]; then
+        echo "d2b-bazel-host-tools: unexpected installed top-level entries after fixup" >&2
+        printf '%s\n' "$topEntries" >&2
+        exit 1
+      fi
+      expected="$(printf '%s\n' ${inventoryShell} | sort)"
+      installed="$(find -P "$out/bin" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
+      if [ "$installed" != "$expected" ]; then
+        echo "d2b-bazel-host-tools: installed inventory changed during fixup" >&2
+        exit 1
+      fi
+
+      checkElf() {
+        name="$1"
+        bin="$2"
+        test -f "$bin"
+        test ! -L "$bin"
+
+        header="$("$readelf" -h "$bin" 2>/dev/null)" || {
+          echo "d2b-bazel-host-tools: $name is not an ELF binary after fixup" >&2
+          exit 1
+        }
+        if ! printf '%s\n' "$header" | grep -Eq 'Class:[[:space:]]+ELF64'; then
+          echo "d2b-bazel-host-tools: $name is not ELF64 after fixup" >&2
+          exit 1
+        fi
+        if ! printf '%s\n' "$header" | grep -Eq 'Data:[[:space:]]+2'; then
+          echo "d2b-bazel-host-tools: $name is not little-endian after fixup" >&2
+          exit 1
+        fi
+        if ! printf '%s\n' "$header" | grep -Eq 'Machine:[[:space:]]+(Advanced Micro Devices X86-64|x86-64)'; then
+          echo "d2b-bazel-host-tools: $name is not x86_64 after fixup" >&2
+          exit 1
+        fi
+
+        interpreter="$("$patchelf" --print-interpreter "$bin" 2>/dev/null)" || {
+          echo "d2b-bazel-host-tools: $name has no ELF interpreter" >&2
+          exit 1
+        }
+        case "$interpreter" in
+          /nix/store/*/lib/ld-linux-x86-64.so.2|/nix/store/*/lib64/ld-linux-x86-64.so.2)
+            ;;
+          *)
+            echo "d2b-bazel-host-tools: $name does not use a Nix-store x86_64 loader" >&2
+            echo "$interpreter" >&2
+            exit 1
+            ;;
+        esac
+        test -x "$interpreter"
+
+        runtime="$("$interpreter" --list "$bin" 2>&1)" || {
+          echo "d2b-bazel-host-tools: failed to resolve runtime libraries for $name" >&2
+          printf '%s\n' "$runtime" >&2
+          exit 1
+        }
+        if printf '%s\n' "$runtime" | grep -qi 'not found'; then
+          echo "d2b-bazel-host-tools: unresolved runtime library for $name" >&2
+          printf '%s\n' "$runtime" >&2
+          exit 1
+        fi
+        while IFS= read -r line; do
+          case "$line" in
+            *"=>"*)
+              resolved="''${line#*=> }"
+              resolved="''${resolved%% *}"
+              case "$resolved" in
+                /nix/store/*)
+                  ;;
+                *)
+                  echo "d2b-bazel-host-tools: $name resolves a library outside /nix/store" >&2
+                  echo "$resolved" >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
+          esac
+        done <<< "$runtime"
+      }
+
+      for name in ${inventoryShell}; do
+        checkElf "$name" "$out/bin/$name"
+      done
+
+      runHook postInstallCheck
+    '';
+  };
+in
+{
+  inherit package;
+  d2bHostToolOverrides = lib.genAttrs overrideKeys (_: package);
+}

--- a/nix/test-support/bazel-host-tools.nix
+++ b/nix/test-support/bazel-host-tools.nix
@@ -14,7 +14,7 @@ let
     "d2b-resource-compiler"
     "d2b-wayland-proxy"
   ];
-  inventoryShell = lib.concatStringsSep " " (map (name: "'${name}'") inventory);
+  inventoryShell = lib.escapeShellArgs inventory;
   overrideKeys = [
     "d2b"
     "d2bd"
@@ -72,18 +72,6 @@ let
 
         install -Dm755 "$source" "$out/bin/$name"
       done
-
-      topEntries="$(find -P "$out" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
-      if [ "$topEntries" != "bin" ]; then
-        echo "d2b-bazel-host-tools: unexpected installed top-level entries" >&2
-        printf '%s\n' "$topEntries" >&2
-        exit 1
-      fi
-      installed="$(find -P "$out/bin" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
-      if [ "$installed" != "$expected" ]; then
-        echo "d2b-bazel-host-tools: installed inventory mismatch" >&2
-        exit 1
-      fi
 
       runHook postInstall
     '';

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -31,6 +31,7 @@ let
 in
 {
   _module.args.d2bHostTools = d2bHostTools;
+  _module.args.d2bHostToolOverrides = lib.mkDefault null;
 
   imports = [
     ./options.nix

--- a/nixos-modules/host-activation.nix
+++ b/nixos-modules/host-activation.nix
@@ -30,7 +30,7 @@
 #   - d2bMigrateOwnership   - repair orphan swtpm-state UIDs after
 #                                 service-user renames, gated on
 #                                 `tpm.enable` and skipped for running VMs.
-{ config, pkgs, lib, d2bHostTools, ... }:
+{ config, pkgs, lib, d2bHostTools, d2bHostToolOverrides ? null, ... }:
 
 let
   cfg = config.d2b;
@@ -52,9 +52,20 @@ let
   # snippet references `${activationHelper}` to get the absolute
   # store-path of the binary.
   activationHelperSourcePackage = d2bHostTools.activationHelper;
-  activationHelperPackage = if prebuilt ? "d2b-activation-helper" then prebuilt."d2b-activation-helper" else activationHelperSourcePackage;
+  activationHelperPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "activationHelper";
+    fallback =
+      if prebuilt ? "d2b-activation-helper"
+      then prebuilt."d2b-activation-helper"
+      else activationHelperSourcePackage;
+  };
   activationHelper = "${activationHelperPackage}/bin/d2b-activation-helper";
-  groupMigrationHelperPackage = d2bHostTools.hostActivationHelper;
+  groupMigrationHelperPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "hostActivationHelper";
+    fallback = d2bHostTools.hostActivationHelper;
+  };
   groupMigrationHelper = "${groupMigrationHelperPackage}/bin/d2b-host-activation-helper";
   legacyLauncherGid = config.users.groups.d2b-launcher.gid or null;
   legacyLaunchersGid = config.users.groups.d2b-launchers.gid or null;

--- a/nixos-modules/host-broker.nix
+++ b/nixos-modules/host-broker.nix
@@ -12,7 +12,7 @@
 # CAP_CHOWN outside the cgroup-delegation startup window).
 { inputs }:
 
-{ pkgs, lib, config, d2bHostTools, ... }:
+{ pkgs, lib, config, d2bHostTools, d2bHostToolOverrides ? null, ... }:
 
 let
   cfg = config.d2b;
@@ -27,12 +27,23 @@ let
   brokerSourcePackage = d2bHostTools.broker.overrideAttrs (_: {
     meta.description = "d2b privileged broker (uid 0 host-mutation surface)";
   });
-  brokerPackage = if prebuilt ? "d2b-priv-broker" then prebuilt."d2b-priv-broker" else brokerSourcePackage;
+  brokerPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "broker";
+    fallback =
+      if prebuilt ? "d2b-priv-broker"
+      then prebuilt."d2b-priv-broker"
+      else brokerSourcePackage;
+  };
   cutoverRunnerSourcePackage = d2bHostTools.cutoverRunner;
-  cutoverRunnerPackage =
-    if prebuilt ? "d2b-cutover-runner"
-    then prebuilt."d2b-cutover-runner"
-    else cutoverRunnerSourcePackage;
+  cutoverRunnerPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "cutoverRunner";
+    fallback =
+      if prebuilt ? "d2b-cutover-runner"
+      then prebuilt."d2b-cutover-runner"
+      else cutoverRunnerSourcePackage;
+  };
   cutoverRunnerPath = "${cutoverRunnerPackage}/bin/d2b-cutover-runner";
 
   bundleManifestPath =

--- a/nixos-modules/host-daemon.nix
+++ b/nixos-modules/host-daemon.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, d2bHostTools, ... }:
+{ config, lib, pkgs, d2bHostTools, d2bHostToolOverrides ? null, ... }:
 
 let
   cfg = config.d2b;
@@ -6,14 +6,22 @@ let
   prebuilt = if cfg.site.usePrebuiltHostTools then import ./prebuilt-packages.nix { inherit pkgs lib; } else { };
 
   d2bdSourcePackage = d2bHostTools.d2bd;
-  d2bdPackage = if prebuilt ? d2bd then prebuilt.d2bd else d2bdSourcePackage;
+  d2bdPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "d2bd";
+    fallback = if prebuilt ? d2bd then prebuilt.d2bd else d2bdSourcePackage;
+  };
 
   # the user-facing CLI is now the Rust d2b crate
   # (packages/d2b). The pre-v1.0 bash CLI was RETIRED in;
   # ships the daemon-native Rust CLI as the only
   # `d2b` binary on the host.
   d2bCliSourcePackage = d2bHostTools.d2b;
-  d2bCliPackage = if prebuilt ? d2b then prebuilt.d2b else d2bCliSourcePackage;
+  d2bCliPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "d2b";
+    fallback = if prebuilt ? d2b then prebuilt.d2b else d2bCliSourcePackage;
+  };
 
   netVmNames = map
     (envName: cfg.envs.${envName}.netName or "sys-${envName}-net")
@@ -98,7 +106,14 @@ let
   # check-then-act patterns. Lives in d2b-host because it
   # only depends on libc + nix; no IPC; no async runtime.
   d2bActivationHelperSourcePackage = d2bHostTools.activationHelper;
-  d2bActivationHelperPackage = if prebuilt ? "d2b-activation-helper" then prebuilt."d2b-activation-helper" else d2bActivationHelperSourcePackage;
+  d2bActivationHelperPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "activationHelper";
+    fallback =
+      if prebuilt ? "d2b-activation-helper"
+      then prebuilt."d2b-activation-helper"
+      else d2bActivationHelperSourcePackage;
+  };
 
   d2bGatewayRuntimeSourcePackage = d2bHostTools.gatewayRuntime;
   d2bGatewayRuntimePackage = if prebuilt ? "d2b-gateway-runtime" then prebuilt."d2b-gateway-runtime" else d2bGatewayRuntimeSourcePackage;

--- a/nixos-modules/lib.nix
+++ b/nixos-modules/lib.nix
@@ -65,6 +65,68 @@ let
       }
     ];
 
+  hostToolOverrideKeys = [
+    "d2b"
+    "d2bd"
+    "broker"
+    "activationHelper"
+    "hostActivationHelper"
+    "cutoverRunner"
+    "unsafeLocalHelper"
+    "resourceCompiler"
+    "waylandProxy"
+  ];
+
+  formatHostToolOverrideKeys = keys:
+    if keys == [ ] then "<none>" else lib.concatStringsSep ", " keys;
+
+  validateHostToolOverrides = overrides:
+    if builtins.isNull overrides then
+      null
+    else if !builtins.isAttrs overrides then
+      throw "d2b: d2bHostToolOverrides must be null or an attribute set"
+    else
+      let
+        keys = builtins.attrNames overrides;
+        missing = lib.filter
+          (key: !(builtins.elem key keys))
+          hostToolOverrideKeys;
+        unknown = lib.filter
+          (key: !(builtins.elem key hostToolOverrideKeys))
+          keys;
+        nullValues = lib.filter
+          (key: builtins.isNull overrides.${key})
+          keys;
+      in
+      if keys == [ ] then
+        throw "d2b: d2bHostToolOverrides must not be empty"
+      else if missing != [ ] || unknown != [ ] then
+        throw ''
+          d2b: d2bHostToolOverrides must contain exactly the host-tool keys
+          (${formatHostToolOverrideKeys hostToolOverrideKeys}); missing:
+          ${formatHostToolOverrideKeys missing}; unknown:
+          ${formatHostToolOverrideKeys unknown}
+        ''
+      else if nullValues != [ ] then
+        throw ''
+          d2b: d2bHostToolOverrides values must be non-null packages; null:
+          ${formatHostToolOverrideKeys nullValues}
+        ''
+      else
+        overrides;
+
+  selectHostToolPackage =
+    { overrides ? null, key, fallback }:
+    if !(builtins.elem key hostToolOverrideKeys) then
+      throw "d2b: unknown d2bHostToolOverrides selector key '${key}'"
+    else
+      let
+        validatedOverrides = validateHostToolOverrides overrides;
+      in
+      if builtins.isNull validatedOverrides
+      then fallback
+      else validatedOverrides.${key};
+
   # d2b_read_audio_state <vm>
   # ------------------------------------------------------------
   # Fail-closed reader for /var/lib/d2b/<vm>/audio-state.json.
@@ -131,6 +193,7 @@ rec {
   inherit d2bReadAudioState;
   inherit hasConfiguredLocalVmLaunch privateConfiguredWorkloadCounts;
   inherit privateConfiguredWorkloadLimits privateConfiguredWorkloadCountAssertions;
+  inherit selectHostToolPackage;
 
   cleanRustPackagesSource = packagesPath:
     lib.cleanSourceWith {

--- a/nixos-modules/options-host-sccache.nix
+++ b/nixos-modules/options-host-sccache.nix
@@ -12,9 +12,10 @@
       root:nixbld with setgid mode 2770 so Nix build users can share
       compiler outputs without exposing a caller-owned home directory.
 
-      This is opt-in because it changes host-wide Nix daemon policy.
-      The repository's host-integration Make target still requires an
-      explicit D2B_HOST_SCCACHE=1 before it uses the cache.
+      This is opt-in because it changes host-wide Nix daemon policy. It remains
+      available for Nix source builds that use the d2b host-tool derivations;
+      the Bazel-backed host-integration lane supplies its tools separately and
+      does not require this option.
     '';
   };
 }

--- a/nixos-modules/processes-json.nix
+++ b/nixos-modules/processes-json.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, d2bHostTools, ... }:
+{ config, lib, pkgs, d2bHostTools, d2bHostToolOverrides ? null, ... }:
 
 let
   clean = builtins.unsafeDiscardStringContext;
@@ -33,8 +33,12 @@ let
   # The filter is tied to the checked-out policy implementation and is cheap
   # enough to build in the eval smoke fixtures. Keep it source-built even when
   # other host tools use release prebuilts so missing release assets cannot
-  # break local validation.
-  d2bWaylandProxyPackage = d2bWaylandProxySourcePackage;
+  # break local validation. The private test-only override remains available.
+  d2bWaylandProxyPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "waylandProxy";
+    fallback = d2bWaylandProxySourcePackage;
+  };
   d2bWaylandProxyBinary = "${d2bWaylandProxyPackage}/bin/d2b-wayland-proxy";
 
   backendPort = envName: cfg._index.usbip.backendPorts.${envName};

--- a/nixos-modules/resource-compiler.nix
+++ b/nixos-modules/resource-compiler.nix
@@ -4,10 +4,15 @@
 # consumer's ambient PATH. This keeps the Nix build hermetic and ensures the
 # Rust implementation, its Cargo lock, and the bundle derivation move
 # together.
-{ config, lib, pkgs, d2bHostTools, ... }:
+{ config, lib, pkgs, d2bHostTools, d2bHostToolOverrides ? null, ... }:
 
 let
-  compilerPackage = d2bHostTools.resourceCompiler;
+  d2bLib = import ./lib.nix { inherit lib; };
+  compilerPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "resourceCompiler";
+    fallback = d2bHostTools.resourceCompiler;
+  };
 
   resourceTypes = import ./generated/resource-types.nix;
   semanticResourceTypes = import ./generated/semantic-resource-types.nix;

--- a/nixos-modules/rust-host-tools.nix
+++ b/nixos-modules/rust-host-tools.nix
@@ -148,7 +148,7 @@ let
     exec "$@"
   '';
 
-  # Constant sandbox path so pure CI and host-int realize the same host-tool
+  # Constant sandbox path for Nix source builds that use these host-tool
   # derivations. The directory is absent in the default sandbox, so the
   # wrapper falls back to rustc. A host that enables the d2b site cache option
   # exposes this fixed path through the Nix daemon's global sandbox settings.

--- a/nixos-modules/unsafe-local-helper.nix
+++ b/nixos-modules/unsafe-local-helper.nix
@@ -1,16 +1,21 @@
-{ config, lib, pkgs, d2bHostTools, ... }:
+{ config, lib, pkgs, d2bHostTools, d2bHostToolOverrides ? null, ... }:
 
 let
   cfg = config.d2b;
+  d2bLib = import ./lib.nix { inherit lib; };
   prebuilt =
     if cfg.site.usePrebuiltHostTools
     then import ./prebuilt-packages.nix { inherit pkgs lib; }
     else { };
   sourcePackage = d2bHostTools.unsafeLocalHelper;
-  helperPackage =
-    if prebuilt != null && prebuilt ? "d2b-unsafe-local-helper"
-    then prebuilt."d2b-unsafe-local-helper"
-    else sourcePackage;
+  helperPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "unsafeLocalHelper";
+    fallback =
+      if prebuilt != null && prebuilt ? "d2b-unsafe-local-helper"
+      then prebuilt."d2b-unsafe-local-helper"
+      else sourcePackage;
+  };
   unsafeLocalRealms = lib.filter
     (realm:
       lib.any

--- a/packages/d2b-provider-volume-local/nix/store.nix
+++ b/packages/d2b-provider-volume-local/nix/store.nix
@@ -43,7 +43,7 @@
 # namespace where /nix/store is lazily unmounted. Inside that
 # namespace /nix/store is just a directory on the root mount, so
 # hardlinks succeed.
-{ config, lib, pkgs, d2bHostTools, ... }:
+{ config, lib, pkgs, d2bHostTools, d2bHostToolOverrides ? null, ... }:
 
 let
   cfg = config.d2b;
@@ -55,7 +55,14 @@ let
     then import ../../../nixos-modules/prebuilt-packages.nix { inherit pkgs lib; }
     else { };
   activationHelperSourcePackage = d2bHostTools.activationHelper;
-  activationHelperPackage = if prebuilt ? "d2b-activation-helper" then prebuilt."d2b-activation-helper" else activationHelperSourcePackage;
+  activationHelperPackage = d2bLib.selectHostToolPackage {
+    overrides = d2bHostToolOverrides;
+    key = "activationHelper";
+    fallback =
+      if prebuilt ? "d2b-activation-helper"
+      then prebuilt."d2b-activation-helper"
+      else activationHelperSourcePackage;
+  };
   activationHelper = "${activationHelperPackage}/bin/d2b-activation-helper";
 
   # spectrum-ch package (cloud-hypervisor v52 with virtio-gpu patches).

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,7 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-policy` | composed Bazel source, workspace/lock, supply-chain, and changelog policy suites | local + CI |
 | `make test-performance-budgets` | advisory performance canary; without `D2B_PERF_STABLE=1` it reports `SKIP` and enforces nothing | local + CI |
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
-| `make test-host-integration` | type-10 runNixOSTest VM checks; set `D2B_VM_CHECK=<name>` for one named check | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
+| `make test-host-integration` | type-10 runNixOSTest VM checks; locally builds nine host tools with Bazel, injects them into the checks, and optionally uploads successful output closures to Attic | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
 | `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; CI forces `D2B_BAZEL_PROFILE=local` | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
@@ -78,6 +78,15 @@ scheduling; Make and CI are thin aliases over one suite label per public
 target. Cargo manifests and `Cargo.lock` remain rules_rs metadata authority,
 while standalone crate Cargo commands are not documented or required gate
 evidence.
+
+`make test-host-integration` first builds the fixed nine host tools with local
+Bazel, injects the staged bundle into the selected NixOS `vmChecks`, and then
+uploads all successful output closures to configured Attic in one operation.
+If Attic or its configuration is unavailable, the lane reports an explicit
+skip and continues. If present configuration is invalid or unusable, the lane
+fails closed; an upload failure is also fatal. Set `D2B_VM_CHECK=<name>` for
+one named check. Repeating the same command without source changes is the warm
+run and should execute zero Rust compilation actions.
 
 Run these aliases directly from a normal Nix-enabled checkout. Make enters
 the pinned `.#bazel` shell automatically when the explicit d2b shell contract

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,7 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-policy` | composed Bazel source, workspace/lock, supply-chain, and changelog policy suites | local + CI |
 | `make test-performance-budgets` | advisory performance canary; without `D2B_PERF_STABLE=1` it reports `SKIP` and enforces nothing | local + CI |
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
-| `make test-host-integration` | type-10 runNixOSTest VM checks; locally builds nine host tools with Bazel, injects them into the checks, and optionally uploads successful output closures to Attic | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
+| `make test-host-integration` | type-10 runNixOSTest VM checks; locally builds nine host tools with Bazel, injects them into the checks, and optionally uploads their built dependency closures to Attic | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
 | `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; CI forces `D2B_BAZEL_PROFILE=local` | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
@@ -81,7 +81,9 @@ evidence.
 
 `make test-host-integration` first builds the fixed nine host tools with local
 Bazel, injects the staged bundle into the selected NixOS `vmChecks`, and then
-uploads all successful output closures to configured Attic in one operation.
+uploads their built dependency closures to configured Attic in one operation.
+The `vmCheck` result paths are excluded so capability skips are never cached as
+passing test results.
 If Attic or its configuration is unavailable, the lane reports an explicit
 skip and continues. If present configuration is invalid or unusable, the lane
 fails closed; an upload failure is also fatal. Set `D2B_VM_CHECK=<name>` for


### PR DESCRIPTION
## Summary

`make test-host-integration` now uses the repository's Bazel-built host binaries inside the NixOS VM checks instead of compiling the same Rust tools again through Nix. The test-only handoff is fail-closed, keeps normal release and source package selection unchanged, and normalizes the fixed nine-tool bundle for the VM runtime.

Configured Attic hosts cache the built dependency closures after successful checks. The VM test result paths are excluded so a capability `SKIP` or `BLOCKED` cannot be substituted as a passing test on another host. Hosts without Attic continue with an explicit cache skip.

The obsolete host-integration-only sccache switch is removed. Generic sccache support remains available for other Nix source builds.

## Validation evidence

- [x] **Focused tests for the changed components** were run:
  - `D2B_HOST_VM_CHECK=daemon-smoke make test-host-integration` passed on a cold run and uploaded the closure through Attic.
  - The identical unchanged run passed with 693 Bazel action-cache hits, one internal action, and zero Rust compilation actions.
  - Recursive derivation inspection confirmed the VM input closure contains `d2b-bazel-host-tools` and contains no Nix Rust derivation for the nine overridden host tools.
- [x] **Wider lanes are conditional.** `make test-host-integration` was run across the full VM set. The only failure was the existing `cutover-rehearsal` consent-digest assertion; the Bazel handoff checks and focused host lane passed.
- [x] **Changed tests are owner-local:** no new test target, gate, harness, or evidence script was added. The existing type-10 host-integration lane remains the behavior owner.
- [x] **Changelog updated** through `changelog.d/refactor-bazel-host-integration-binaries.md`; stale host-lane sccache fragments were removed or narrowed.
- [x] **Docs + CI updated in lockstep:** contributor and test guidance now describe local Bazel binaries, Attic dependency caching, and the retired target knob. CI did not change because this remains a conditional local host lane.

## Notes

Planning choices preserved: the test-only handoff, local Bazel execution, action-level warm proof, and manual VM-lane validation were user-directed; the fixed nine-tool bundle and host-lane sccache retirement were user-approved.
