### PR TITLE
build: default Bazel and Make to BuildBuddy remote

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,12 +19,25 @@ build --stamp=no
 build --noslim_profile
 build --experimental_profile_include_target_label
 build --experimental_profile_include_primary_output
+# Developer build and test commands use BuildBuddy unless a caller selects
+# another profile explicitly.
+build --config=remote
 # The local profile is the exact same target graph without any provider
 # endpoints. The bazel-check facade supplies the local repository-content
 # option outside the remote profiles.
 build:local --remote_executor=
 build:local --remote_cache=
 build:local --bes_backend=
+build:local --bes_results_url=
+build:local --credential_helper=
+build:local --remote_instance_name=
+build:local --platforms=
+build:local --extra_execution_platforms=
+build:local --extra_toolchains=
+build:local --@rules_rust//rust/settings:extra_rustc_flag=
+build:local --@rules_rust//rust/settings:extra_exec_rustc_flag=
+build:local --action_env=PATH
+build:local --test_env=PATH
 
 # Remote profiles use the d2b BuildBuddy workspace. Authentication is
 # the credential helper only. Direct API-key headers leak into BEP.

--- a/.bazelrc
+++ b/.bazelrc
@@ -29,7 +29,9 @@ build:local --remote_executor=
 build:local --remote_cache=
 build:local --bes_backend=
 build:local --bes_results_url=
-build:local --credential_helper=
+# Bazel rejects an empty credential-helper path; override the remote scope
+# with a helper that cannot provide credentials.
+build:local --credential_helper=d2b.buildbuddy.io=/bin/false
 build:local --remote_instance_name=
 build:local --platforms=
 build:local --extra_execution_platforms=

--- a/.bazelrc
+++ b/.bazelrc
@@ -36,8 +36,8 @@ build:local --remote_instance_name=
 build:local --platforms=
 build:local --extra_execution_platforms=
 build:local --extra_toolchains=
-build:local --@rules_rust//rust/settings:extra_rustc_flag=
-build:local --@rules_rust//rust/settings:extra_exec_rustc_flag=
+build:local --@rules_rust//rust/settings:extra_rustc_flags=
+build:local --@rules_rust//rust/settings:extra_exec_rustc_flags=
 build:local --action_env=PATH
 build:local --test_env=PATH
 
@@ -53,8 +53,8 @@ build:remote --remote_instance_name=d2b/developer/linux-x86_64/rules_rs/worker-v
 build:remote --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 build:remote --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 build:remote --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64
-build:remote --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=bfd
-build:remote --@rules_rust//rust/settings:extra_exec_rustc_flag=-Clink-arg=-fuse-ld=bfd
+build:remote --@rules_rust//rust/settings:extra_rustc_flags=-Clink-arg=-fuse-ld=bfd
+build:remote --@rules_rust//rust/settings:extra_exec_rustc_flags=-Clink-arg=-fuse-ld=bfd
 build:remote --action_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 build:remote --test_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 build:remote --strategy=TestRunner=local
@@ -75,8 +75,8 @@ build:trusted-seed --remote_instance_name=d2b/trusted-seed/linux-x86_64/rules_rs
 build:trusted-seed --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 build:trusted-seed --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 build:trusted-seed --extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64
-build:trusted-seed --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=bfd
-build:trusted-seed --@rules_rust//rust/settings:extra_exec_rustc_flag=-Clink-arg=-fuse-ld=bfd
+build:trusted-seed --@rules_rust//rust/settings:extra_rustc_flags=-Clink-arg=-fuse-ld=bfd
+build:trusted-seed --@rules_rust//rust/settings:extra_exec_rustc_flags=-Clink-arg=-fuse-ld=bfd
 build:trusted-seed --action_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 build:trusted-seed --test_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 build:trusted-seed --strategy=TestRunner=local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,12 +144,13 @@ settings or claim atomic base binding.
 ## Critical subsystem index
 
 `make check` invokes the public Bazel suite facade and its nested Layer-1
-component and package suites. Bare local runs use the BuildBuddy profile for
-eligible actions and automatically fall back to local execution when no
-credential is available; CI runs the same suite graph through the local profile
-with no BuildBuddy credential. Make aliases are thin facade entry points,
-while Cargo manifests and lockfiles remain rules_rs metadata authority rather
-than contributor workflow entry points.
+component and package suites. Bare developer Bazel commands and Make aliases
+use the `.bazelrc` BuildBuddy `remote` default for eligible actions and
+automatically fall back to local execution when no credential is available; CI
+runs the same suite graph through the explicit local profile with no BuildBuddy
+credential. Make aliases are thin facade entry points, while Cargo manifests
+and lockfiles remain rules_rs metadata authority rather than contributor
+workflow entry points.
 
 The full invariants are in
 [`docs/contributing/critical-subsystems.md`](./docs/contributing/critical-subsystems.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,12 @@ and public conditional integration targets.
 
 `make check` invokes the public Bazel suite facade. Nested component and
 package-level suites own the complete Layer-1 graph. A developer host uses
-BuildBuddy for eligible actions; GitHub Layer-1 runs the same graph locally
-with `D2B_BAZEL_PROFILE=local` and `D2B_BAZEL_UNTRUSTED=1`. CI only needs Nix
-installed; Make selects the pinned shell and preserves those profile and trust
-variables. Cargo manifests and `Cargo.lock` remain rules_rs metadata
-authority, but Cargo is not a contributor or CI gate.
+BuildBuddy for eligible actions by default through `.bazelrc`; GitHub Layer-1
+runs the same graph locally with `D2B_BAZEL_PROFILE=local` and
+`D2B_BAZEL_UNTRUSTED=1`. CI only needs Nix installed; Make selects the pinned
+shell and preserves those profile and trust variables. Cargo manifests and
+`Cargo.lock` remain rules_rs metadata authority, but Cargo is not a contributor
+or CI gate.
 
 The `make test-lint` gate requires the declared `D2B_SHELLCHECK_BIN` and fails
 closed instead of using a host-provided shellcheck.

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,12 @@ SYSTEM ?= $(shell nix eval --extra-experimental-features 'nix-command flakes' \
 #   make heavy-flake-check  full flake realization.
 # ===========================================================================
 
-## Public Bazel aliases invoke `bazel test` directly. Default profile is
-## BuildBuddy `remote`. PR/CI sets D2B_BAZEL_PROFILE=local (no wrapper).
-D2B_BAZEL_PROFILE ?= remote
+## Public Bazel aliases invoke `bazel test` directly. The .bazelrc default is
+## BuildBuddy `remote`; PR/CI sets D2B_BAZEL_PROFILE=local (no wrapper).
+D2B_BAZEL_PROFILE_ARG = $(if $(strip $(D2B_BAZEL_PROFILE)),--config=$(D2B_BAZEL_PROFILE))
 D2B_BAZEL_TEST_TAG_FILTERS ?= -manual,-gpu,-kvm
 BAZEL_BIN ?= $(if $(D2B_BAZEL_BIN),$(D2B_BAZEL_BIN),bazel)
-D2B_BAZEL_TEST = $(BAZEL_BIN) test --config=$(D2B_BAZEL_PROFILE) --test_tag_filters="$(D2B_BAZEL_TEST_TAG_FILTERS)" --test_env=D2B_REPO_ROOT="$(CURDIR)" --test_env=D2B_BAZEL_BIN="$(BAZEL_BIN)" --test_env=D2B_PROJECT_SHELL=d2b --test_env=D2B_SHELLCHECK_BIN="$(D2B_SHELLCHECK_BIN)" --test_env=PATH="$(PATH)" --test_output=errors
+D2B_BAZEL_TEST = $(BAZEL_BIN) test $(D2B_BAZEL_PROFILE_ARG) --test_tag_filters="$(D2B_BAZEL_TEST_TAG_FILTERS)" --test_env=D2B_REPO_ROOT="$(CURDIR)" --test_env=D2B_BAZEL_BIN="$(BAZEL_BIN)" --test_env=D2B_PROJECT_SHELL=d2b --test_env=D2B_SHELLCHECK_BIN="$(D2B_SHELLCHECK_BIN)" --test_env=PATH="$(PATH)" --test_output=errors
 export D2B_BAZEL_PROFILE D2B_BAZEL_TEST_TAG_FILTERS
 
 ## check-ci - run the Layer-1 gate, then the conditional container lane.

--- a/changelog.d/d2b-o7a.md
+++ b/changelog.d/d2b-o7a.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Developer Bazel commands and public Make aliases now default to BuildBuddy remote execution, while CI continues to select local execution.

--- a/docs/contributing/gates-and-lints.md
+++ b/docs/contributing/gates-and-lints.md
@@ -138,12 +138,14 @@ make test-unit
 make check
 ```
 
-Local aliases use the BuildBuddy `remote` profile when credentials and trust
-permit it. CI invokes the same public Make aliases after installing Nix and
-sets `D2B_BAZEL_PROFILE=local`; public Make aliases run `bazel test
---config=$(D2B_BAZEL_PROFILE)` directly with no `tests/tools/bazel-check`
-wrapper. `tests/tools/bazel-check` remains the BuildBuddy credential helper
-only. Post-dispatch, analysis, policy, build, and test failures fail closed.
+Bare developer Bazel commands and public Make aliases use the BuildBuddy
+`remote` profile by default through `.bazelrc`; Make passes an explicit
+`--config=$(D2B_BAZEL_PROFILE)` only when that variable is set. CI invokes the
+same public Make aliases after installing Nix and sets
+`D2B_BAZEL_PROFILE=local`. Public Make aliases run `bazel test` directly with no
+`tests/tools/bazel-check` wrapper. `tests/tools/bazel-check` remains the
+BuildBuddy credential helper only. Post-dispatch, analysis, policy, build, and
+test failures fail closed.
 
 The committed fixed workflow exposes one stable required `check` result. A
 guarded performance skip is advisory and is not validation evidence.

--- a/docs/reference/bazel-buildbuddy.md
+++ b/docs/reference/bazel-buildbuddy.md
@@ -86,6 +86,12 @@ The committed `.bazelrc` defines:
 | `remote` | Developer BuildBuddy execution and cache |
 | `trusted-seed` | Protected `v3` cache seeding with synchronous uploads |
 
+Bare Bazel build and test commands, along with public Make aliases, select the
+`remote` profile by default through `.bazelrc`. Set
+`D2B_BAZEL_PROFILE=local` to opt into local execution; Make passes an explicit
+profile only when that variable is set. GitHub Layer-1 jobs set the local
+profile themselves.
+
 Remote profiles use the BuildBuddy Linux worker contract, Ubuntu GCC
 toolchain, minimal output downloads, compressed cache blobs, zero Bazel remote
 retries, and a bounded job count. Nix, fixture, hardware, and other local-only actions are tagged `local` or

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -458,8 +458,8 @@ fn developer_defaults_and_local_opt_out_are_explicit() {
         "--platforms=@toolchains_buildbuddy//platforms:linux_x86_64",
         "--extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64",
         "--extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64",
-        "--@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=bfd",
-        "--@rules_rust//rust/settings:extra_exec_rustc_flag=-Clink-arg=-fuse-ld=bfd",
+        "--@rules_rust//rust/settings:extra_rustc_flags=-Clink-arg=-fuse-ld=bfd",
+        "--@rules_rust//rust/settings:extra_exec_rustc_flags=-Clink-arg=-fuse-ld=bfd",
         "--action_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "--test_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     ] {
@@ -480,8 +480,8 @@ fn developer_defaults_and_local_opt_out_are_explicit() {
         "--platforms=",
         "--extra_execution_platforms=",
         "--extra_toolchains=",
-        "--@rules_rust//rust/settings:extra_rustc_flag=",
-        "--@rules_rust//rust/settings:extra_exec_rustc_flag=",
+        "--@rules_rust//rust/settings:extra_rustc_flags=",
+        "--@rules_rust//rust/settings:extra_exec_rustc_flags=",
         "--action_env=PATH",
         "--test_env=PATH",
     ] {
@@ -578,13 +578,13 @@ fn committed_profiles_deny_first_party_rust_warnings_and_guard_facade_logs() {
     for profile in ["remote", "trusted-seed"] {
         assert!(
             bazelrc.contains(&format!(
-                "build:{profile} --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=bfd"
+                "build:{profile} --@rules_rust//rust/settings:extra_rustc_flags=-Clink-arg=-fuse-ld=bfd"
             )),
             "{profile} target Rust actions must override the deprecated gold linker"
         );
         assert!(
             bazelrc.contains(&format!(
-                "build:{profile} --@rules_rust//rust/settings:extra_exec_rustc_flag=-Clink-arg=-fuse-ld=bfd"
+                "build:{profile} --@rules_rust//rust/settings:extra_exec_rustc_flags=-Clink-arg=-fuse-ld=bfd"
             )),
             "{profile} exec Rust actions must override the deprecated gold linker"
         );

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -441,6 +441,85 @@ fn committed_profiles_share_authentication_and_worker_policy() {
 }
 
 #[test]
+fn developer_defaults_and_local_opt_out_are_explicit() {
+    let bazelrc = read_text(".bazelrc");
+    assert!(
+        bazelrc.lines().any(|line| line.trim() == "build --config=remote"),
+        "bare Bazel build and test commands must select the remote profile"
+    );
+
+    for option in [
+        "--remote_executor=grpcs://d2b.buildbuddy.io",
+        "--remote_cache=grpcs://d2b.buildbuddy.io",
+        "--bes_backend=grpcs://d2b.buildbuddy.io",
+        "--bes_results_url=https://d2b.buildbuddy.io/invocation/",
+        "--credential_helper=d2b.buildbuddy.io=%workspace%/tests/tools/bazel-check",
+        "--remote_instance_name=d2b/developer/linux-x86_64/rules_rs/worker-v1/minimal/lock-v1",
+        "--platforms=@toolchains_buildbuddy//platforms:linux_x86_64",
+        "--extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64",
+        "--extra_toolchains=@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64",
+        "--@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=bfd",
+        "--@rules_rust//rust/settings:extra_exec_rustc_flag=-Clink-arg=-fuse-ld=bfd",
+        "--action_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "--test_env=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    ] {
+        let expected = format!("build:remote {option}");
+        assert!(
+            bazelrc.lines().any(|line| line.trim() == expected),
+            "remote profile must retain {option}"
+        );
+    }
+
+    for option in [
+        "--remote_executor=",
+        "--remote_cache=",
+        "--bes_backend=",
+        "--bes_results_url=",
+        "--credential_helper=",
+        "--remote_instance_name=",
+        "--platforms=",
+        "--extra_execution_platforms=",
+        "--extra_toolchains=",
+        "--@rules_rust//rust/settings:extra_rustc_flag=",
+        "--@rules_rust//rust/settings:extra_exec_rustc_flag=",
+        "--action_env=PATH",
+        "--test_env=PATH",
+    ] {
+        let expected = format!("build:local {option}");
+        assert!(
+            bazelrc.lines().any(|line| line.trim() == expected),
+            "local profile must neutralize {option}"
+        );
+    }
+
+    let makefile = read_text("Makefile");
+    assert!(
+        !makefile.contains("D2B_BAZEL_PROFILE ?= remote"),
+        "Make must leave the default profile to .bazelrc"
+    );
+    assert!(
+        makefile.contains(
+            "D2B_BAZEL_PROFILE_ARG = $(if $(strip $(D2B_BAZEL_PROFILE)),--config=$(D2B_BAZEL_PROFILE))"
+        ),
+        "Make must pass a profile only when the caller sets one"
+    );
+    assert!(
+        makefile.contains("D2B_BAZEL_TEST = $(BAZEL_BIN) test $(D2B_BAZEL_PROFILE_ARG)"),
+        "public Make aliases must use the conditional profile argument"
+    );
+    assert!(
+        !makefile.contains("D2B_BAZEL_TEST = $(BAZEL_BIN) test --config=remote"),
+        "Make must not hard-code the remote profile"
+    );
+
+    let workflow = read_text(".github/workflows/pr-l1-static-fast.yml");
+    assert!(
+        workflow.contains("D2B_BAZEL_PROFILE: local"),
+        "Layer-1 CI must continue to opt into the local profile"
+    );
+}
+
+#[test]
 fn source_hygiene_fails_when_declared_shellcheck_is_missing() {
     let scratch = repo_root().join(".scratch").join(format!(
         "tier0-shellcheck-missing-test-{}-{}",

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -475,7 +475,7 @@ fn developer_defaults_and_local_opt_out_are_explicit() {
         "--remote_cache=",
         "--bes_backend=",
         "--bes_results_url=",
-        "--credential_helper=",
+        "--credential_helper=d2b.buildbuddy.io=/bin/false",
         "--remote_instance_name=",
         "--platforms=",
         "--extra_execution_platforms=",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -148,10 +148,12 @@ caching, and aggregation. Make targets and fixed CI jobs are thin aliases over
 one facade suite per public target and must not grow local fan-out, discovery,
 sharding, or rollup logic.
 
-Public Make aliases run `bazel test --config=$(D2B_BAZEL_PROFILE)` directly.
-Do not wrap `make check` or `make test-*` through `tests/tools/bazel-check`.
-That script remains the BuildBuddy credential helper only. Default profile is
-`remote`; PR gates set `D2B_BAZEL_PROFILE=local`.
+Public Make aliases run `bazel test` directly and pass
+`--config=$(D2B_BAZEL_PROFILE)` only when the caller sets that variable.
+Otherwise `.bazelrc` supplies the `remote` default. Do not wrap `make check` or
+`make test-*` through `tests/tools/bazel-check`. That script remains the
+BuildBuddy credential helper only. PR gates set
+`D2B_BAZEL_PROFILE=local`.
 
 Bazel is the only supported contributor build and test interface. Cargo
 manifests and the root `Cargo.lock` own Rust package and dependency facts;

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,16 +68,17 @@ The source-hygiene gate fails closed when `D2B_SHELLCHECK_BIN` is unavailable.
 | `make test-integration` | type-9 podman container tests | conditional local host lane (podman; not the PR pipeline) |
 | `make test-host-integration` | type-10 runNixOSTest VM checks; locally builds eight host tools with Bazel, injects them into the checks, and optionally uploads their built dependency closures to Attic | conditional local NixOS host lane (KVM; TCG fallback; not the PR pipeline) |
 | `make check-fast` | compatibility alias for `make check` | local + CI |
-| `make bazel-check` | Bazel aggregate suite used by `make check`. Defaults to BuildBuddy remotely; CI forces `D2B_BAZEL_PROFILE=local` | local or remote |
+| `make bazel-check` | Bazel aggregate suite used by `make check`. Developer Bazel and public Make aliases default to BuildBuddy remote through `.bazelrc`; CI sets `D2B_BAZEL_PROFILE=local` | local or remote |
 | `make heavy-gate-build && bazel-bin/packages/xtask/xtask heavy-gate -- env D2B_LIVE=1 bash tests/integration/live/<x>.sh` | type-11 live-host tests, through the heavy-gate semaphore | **manual, against a deployed d2b host** |
 
 `make check`, `make test-unit`, and `make bazel-check` invoke the same nested
 suite graph through one public facade label. Public Make aliases run
-`bazel test --config=$(D2B_BAZEL_PROFILE)` directly. Bazel owns Layer-1
-scheduling; Make and CI are thin aliases over one suite label per public
-target. Cargo manifests and `Cargo.lock` remain rules_rs metadata authority,
-while standalone crate Cargo commands are not documented or required gate
-evidence.
+`bazel test` directly, passing `--config=$(D2B_BAZEL_PROFILE)` only when that
+variable is set; otherwise `.bazelrc` supplies the BuildBuddy `remote` default.
+Bazel owns Layer-1 scheduling; Make and CI are thin aliases over one suite
+label per public target. Cargo manifests and `Cargo.lock` remain rules_rs
+metadata authority, while standalone crate Cargo commands are not documented
+or required gate evidence.
 
 `make test-host-integration` first builds the fixed eight host tools with local
 Bazel, injects the staged bundle into the selected NixOS `vmChecks`, and then

--- a/tests/golden/bazel/cache-policy.json
+++ b/tests/golden/bazel/cache-policy.json
@@ -74,7 +74,7 @@
       "tests/tools/bazel-check"
     ],
     "allowedSecurityDigests": [
-      "sha256:2e7d025a487ec36344becd663ab8181dd68d689f75e84a7da39e25eac7b44ec5"
+      "sha256:8cf550134ab6d12803208f8a8a672b1240a7cb320d46cbd1afb73a8e6b1b14c8"
     ],
     "untrustedCredential": "none",
     "trustedCredential": "credential-helper"


### PR DESCRIPTION
## Summary

Default developer Bazel commands and public Make aliases to the committed BuildBuddy `remote` profile. CI Layer-1 jobs keep an explicit `D2B_BAZEL_PROFILE=local` override.

This publishes bead `d2b-vxc` (source anchor `d2b-o7a`) to `v3` by pull request only.

## Changes

- `.bazelrc` selects `build --config=remote` as the workspace default without a CLI `--config`.
- `build:local` clears remote executor, cache, BES, credential helper, worker platform/PATH, and worker-only Rust linker flags.
- Makefile no longer defaults `D2B_BAZEL_PROFILE` to `remote`; it passes `--config` only when that variable is already set.
- Hermetic xtask assertions, docs, and `changelog.d/d2b-o7a.md` updated.
- `.github/workflows/pr-l1-static-fast.yml` stays on the existing explicit local override.

## Validation

Recorded at `fef37f00d8a842e7f0c0f3d9b40b89a5443be412`:

```text
nix develop --no-write-lock-file .#bazel -c bazel test --config=local //packages/xtask:buildbuddy_config
# passed

nix develop --no-write-lock-file .#bazel -c env D2B_BAZEL_PROFILE=local make test-policy
# 20/20 policy targets passed
```

Hermetic file assertions only. No live BuildBuddy round-trip.

## Merge

Target `v3`. Merge remains human-owned. Do not merge or force-push from automation.
