### PR TITLE
test: exercise PR babysitter repair loop

### DIFF
--- a/changelog.d/pr-babysit-live-acceptance.md
+++ b/changelog.d/pr-babysit-live-acceptance.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Exercise target-only PR babysitting on a disposable same-repository branch.

--- a/packages/xtask/tests/buildbuddy_config.rs
+++ b/packages/xtask/tests/buildbuddy_config.rs
@@ -14,6 +14,11 @@ use serde_json::Value;
 
 static REPO_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
+#[test]
+fn pr_babysit_live_acceptance_requires_repair() {
+    assert!(false, "intentional PR babysitter repair-loop failure");
+}
+
 fn repo_root() -> &'static Path {
     REPO_ROOT
         .get_or_init(|| {


### PR DESCRIPTION
## Summary

Exercise the target-only Gas City PR babysitter on a disposable same-repository branch. The initial head deliberately contains one failing `buildbuddy_config` test so the bounded repair loop must remove it, run `make check`, commit locally, pass independent review, push once, and resume watching on the new SHA.

## Validation evidence

- [x] **Focused failure confirmed:** `bazel test --config=local //packages/xtask:buildbuddy_config` fails only at `pr_babysit_live_acceptance_requires_repair`.
- [x] **Baseline signoff passed before fault injection:** all 469 `make check` tests passed under the credential-isolated validator.
- [x] **Changed tests are owner-local:** the injected assertion is in the existing `//packages/xtask:buildbuddy_config` target.
- [x] **Changelog updated:** disposable fragment included.
- [x] **Docs + CI:** no product contract or CI configuration changes.

## Notes

This PR is disposable acceptance evidence. It must not be merged. The expected terminal outcome is a green, merge-ready PR after one native repair iteration; the branch will then be closed and deleted.
